### PR TITLE
Release/v1.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish to npm
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    name: Build & Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Publishing version $PKG_VERSION"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Publish to npm (Trusted Publishing via OIDC)
+        run: npm publish --provenance --access public
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/miikaok/34b7e6013b428e289db442d3d28f4f14/raw/m365-atlas-coverage.json)](https://github.com/miikaok/atlas/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/m365-atlas)](https://www.npmjs.com/package/m365-atlas)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](./LICENSE)
+[![Socket Badge](https://badge.socket.dev/npm/package/m365-atlas)](https://socket.dev/npm/package/m365-atlas)
 
 An open-source CLI backup and restore engine for Microsoft 365 mailboxes. Built with per-tenant envelope encryption, content-addressed deduplication, multi-layer integrity validation, and efficient delta synchronization for scalable, secure operations against S3-compatible object storage.
 

--- a/README.md
+++ b/README.md
@@ -10,23 +10,25 @@ An open-source CLI backup and restore engine for Microsoft 365 mailboxes. Built 
 
 ## Highlights
 
-🔐 **Per-tenant encryption** — Each tenant gets a unique AES-256-GCM key derived via scrypt. Even if storage is breached, data stays encrypted and requires that tenant’s passphrase to decrypt.
+🔐 **Per-tenant encryption** — Each tenant gets a unique AES-256-GCM key derived via scrypt. Even if storage is breached, data stays encrypted and requires that tenant's passphrase to decrypt.
 
-🧊 **Storage-level immutability (WORM)** — Atlas uses S3/MinIO Object Lock with time-based retention enforced by storage itself, not app metadata. Lock policies are also recorded in manifests for auditing.
+🧊 **Storage-level immutability (WORM)** — S3/MinIO Object Lock with time-based retention enforced by storage itself, not app metadata.
 
-🧬 **Content-addressed deduplication** — Messages and attachments are stored by SHA-256 hash per mailbox. Identical files (e.g., the same PDF in 50 emails) are stored once. Dedup happens before encryption.
+🧬 **Content-addressed deduplication** — Messages and attachments are stored by SHA-256 hash per mailbox. Identical files are stored once.
 
 📎 **Attachment backup & restore** — Attachments are fetched via Graph API, deduplicated, and encrypted with message data. Large files use chunked upload sessions during restore.
 
-🛡️ **Multi-layer integrity checks** — SHA-256 in manifests, Content-MD5 on uploads, and AES-GCM auth tags ensure transport and at-rest integrity. atlas verify validates all layers.
+🛡️ **Multi-layer integrity checks** — SHA-256 in manifests, Content-MD5 on uploads, and AES-GCM auth tags ensure transport and at-rest integrity.
 
-🔄 **Delta sync with fallback** — Uses Microsoft Graph delta queries for incremental backups. If a run was interrupted, Atlas detects it and safely falls back to a full scan.
+🔄 **Delta sync with fallback** — Microsoft Graph delta queries for incremental backups with automatic full-scan fallback on interrupted runs.
 
-📊 **Live progress dashboard** — ANSI dashboard shows all folders in real time with ETA, speed, and states like active, synced, completed, empty, or interrupted.
+📨 **EML export** — Save backed-up emails as standard `.eml` files in compressed zip archives with Outlook-compatible folder structure and SHA-256 verification.
 
-🙈 **Data protection by default** — Email subjects are hidden in atlas list unless -S is used, preventing accidental exposure during admin tasks.
+📊 **Live progress dashboard** — ANSI dashboard shows all folders in real time with ETA, speed, and per-folder status.
 
-🧩 **Hexagonal architecture** — Ports-and-adapters with dependency injection. Swap storage or mail connectors without touching core logic.
+🧩 **Typed SDK** — Programmatic API for embedding in other Node.js applications via `m365-atlas/sdk`.
+
+🏗️ **Hexagonal architecture** — Ports-and-adapters with dependency injection. Swap storage or mail connectors without touching core logic.
 
 ## Architecture
 
@@ -54,10 +56,10 @@ src/
 │   ├── storage-s3/        # S3 object storage, manifest repo, bucket manager
 │   └── tenant-context.factory.ts
 ├── cli/
-│   └── commands/          # backup, list, read, verify, restore, delete
+│   └── commands/          # backup, list, read, verify, restore, save, delete
 ├── domain/                # Manifest, Snapshot, Tenant, BackupObject (pure data)
 ├── ports/                 # ObjectStorage, MailboxConnector, RestoreConnector, ManifestRepository, KeyService
-├── services/              # MailboxSyncService, RestoreService, CatalogService, DeletionService, helpers
+├── services/              # MailboxSyncService, RestoreService, SaveService, CatalogService, helpers
 └── utils/                 # config loader, logger
 ```
 
@@ -77,18 +79,17 @@ cp .env.example .env
 # first backup
 atlas backup --mailbox user@company.com
 
-# optional: check immutable backup readiness first
-atlas storage-check --lock-mode governance --retention-days 30
-
-# immutable backup (governance retention)
-atlas backup --mailbox user@company.com --retention-days 30 --lock-mode governance
-
 # list what was backed up
 atlas list
 
 # restore a folder from backup
 atlas restore -m user@company.com -f Inbox
+
+# save as EML zip archive
+atlas save -m user@company.com -o backup.zip
 ```
+
+> **Full CLI and SDK reference:** See [docs/USAGE.md](./docs/USAGE.md) for complete command options, examples, and programmatic API documentation.
 
 ## Configuration
 
@@ -120,160 +121,39 @@ Register an application in Azure Portal with these **Application** permissions (
 | `User.Read.All`        | Enumerate users / resolve mailbox IDs                   |
 | `MailboxSettings.Read` | Read mailbox metadata and folder structure              |
 
-> `Mail.ReadWrite` is only required for `atlas restore`. Backup, list, and read operations work with `Mail.Read` alone.
+> `Mail.ReadWrite` is only required for `atlas restore`. Backup, list, read, save, and verify operations work with `Mail.Read` alone.
 
 After adding permissions, click **Grant admin consent for [your tenant]** in the API Permissions blade. The app authenticates using OAuth2 Client Credentials flow (`@azure/identity` `ClientSecretCredential`).
 
-## CLI reference
+## Security model
 
-### `atlas backup`
+Atlas uses envelope encryption to isolate tenants cryptographically:
 
-Back up mailboxes from M365 tenant to object storage. Displays a real-time multi-line dashboard showing all folders with per-folder and global ETA. Ctrl+C saves partial progress so the next run resumes from where it stopped.
-
-```bash
-atlas backup --mailbox user@company.com              # incremental backup
-atlas backup --mailbox user@company.com --full        # force full sync (ignore delta state)
-atlas backup --mailbox user@company.com -f Inbox Sent # specific folders only
-atlas backup --mailbox user@company.com -P 50         # larger page size for fewer API round-trips
-atlas backup --mailbox user@company.com --retention-days 30 --lock-mode governance
-atlas backup --mailbox user@company.com --retention-days 365 --lock-mode compliance
-atlas backup -t <tenant-id> -m user@company.com       # explicit tenant
+```
+Master passphrase (env var)
+    |
+    v
+scrypt(passphrase, tenant_id, N=16384, r=8, p=1)  -->  KEK (256-bit, per-tenant)
+    |
+    v
+KEK wraps/unwraps a random DEK (AES-256-GCM)
+    |
+    v
+DEK encrypts all data + manifests for that tenant
 ```
 
-| Option                   | Description                                          |
-| ------------------------ | ---------------------------------------------------- |
-| `-m, --mailbox <id>`     | Mailbox to back up                                   |
-| `-f, --folder <name...>` | Filter to specific folder(s) by display name         |
-| `--full`                 | Ignore saved delta links, run full enumeration       |
-| `-P, --page-size <n>`    | Graph API page size per delta request (1-100, default 25) |
-| `--retention-days <n>`   | Apply Object Lock retention for `n` days             |
-| `--lock-mode <mode>`     | Object Lock mode (`governance` or `compliance`)      |
-| `--require-immutability` | Fail if immutability cannot be enforced              |
-| `-t, --tenant <id>`      | Override tenant ID from config                       |
+- **KEK** (Key Encryption Key) -- derived deterministically from the passphrase and tenant ID. Never stored; re-derived on every run.
+- **DEK** (Data Encryption Key) -- random 256-bit key, generated once per tenant and stored wrapped (encrypted with KEK) at `_meta/dek.enc` in the tenant's S3 bucket.
+- **Ciphertext format** -- `[12-byte IV][16-byte GCM auth tag][ciphertext]`. Every encrypt operation uses a fresh random IV.
+- **Manifest encryption** -- manifests (containing email subjects and message metadata) are encrypted with the same DEK, ensuring subject lines and folder names are never exposed at rest.
 
-> **Page size tuning:** The `--page-size` flag controls how many messages are requested per Graph API delta page via the `Prefer: odata.maxpagesize` header. This is a *hint* -- the server may return fewer items when response payloads are large (e.g. messages with heavy HTML bodies or many inline images). Lower values reduce memory pressure and allow partial progress to be saved more frequently during interrupts. Higher values reduce HTTP round-trips but increase per-page processing time. The default of 25 is a balanced starting point; adjust based on your mailbox characteristics.
+Integrity is validated at three layers:
 
-> **Immutability behavior:** `--retention-days` makes the backup immutable-requested. Atlas resolves retention to an internal UTC `retain_until`, probes bucket capability (versioning + Object Lock), and fails fast when unsupported instead of silently downgrading to mutable writes.
-
-### `atlas storage-check`
-
-Validate immutable backup readiness without running a backup.
-
-```bash
-atlas storage-check
-atlas storage-check --lock-mode governance --retention-days 30
-atlas storage-check --lock-mode compliance --retention-days 365
-```
-
-| Option                 | Description                                            |
-| ---------------------- | ------------------------------------------------------ |
-| `--lock-mode <mode>`   | Planned Object Lock mode (`governance` or `compliance`) |
-| `--retention-days <n>` | Planned retention period in days                       |
-| `-t, --tenant <id>`    | Override tenant ID                                     |
-
-### `atlas list`
-
-Browse backed-up data at three zoom levels. Subjects are hidden by default for data protection.
-
-```bash
-atlas list                              # all mailboxes with summary stats
-atlas list -m user@company.com          # all snapshots for a mailbox
-atlas list -s <snapshot-id>             # messages inside a snapshot (first 50)
-atlas list -s <snapshot-id> --all       # all messages
-atlas list -s <snapshot-id> -S          # reveal email subjects
-```
-
-| Option                  | Description                                                   |
-| ----------------------- | ------------------------------------------------------------- |
-| `-m, --mailbox <email>` | Show snapshots for this mailbox                               |
-| `-s, --snapshot <id>`   | Show messages inside this snapshot                            |
-| `--all`                 | Show all messages (default caps at 50)                        |
-| `-S, --subjects`        | Reveal email subjects (hidden by default for data protection) |
-| `-t, --tenant <id>`     | Override tenant ID                                            |
-
-### `atlas read`
-
-Decrypt and display a single backed-up message. Messages are referenced by their `#` index from `atlas list` output. If the message has attachments, their metadata (name, MIME type, size) is listed below the body.
-
-```bash
-atlas read -s <snapshot-id> --message 34        # formatted view (by index)
-atlas read -s <snapshot-id> --message 34 --raw  # full JSON
-```
-
-| Option                | Description                                               |
-| --------------------- | --------------------------------------------------------- |
-| `-s, --snapshot <id>` | Snapshot containing the message                           |
-| `--message <ref>`     | Message `#` from `atlas list`, or full Graph message ID   |
-| `--raw`               | Output full JSON blob instead of formatted headers + body |
-| `-t, --tenant <id>`   | Override tenant ID                                        |
-
-### `atlas verify`
-
-Verify integrity of a backup snapshot. Downloads every object, decrypts, recomputes SHA-256, and compares against the manifest checksum.
-
-```bash
-atlas verify -s <snapshot-id>
-```
-
-### `atlas restore`
-
-Restore emails from backup to an M365 mailbox. Two modes of operation:
-
-**Snapshot mode** -- restore from a specific snapshot:
-
-```bash
-atlas restore -s <snapshot-id>                          # full snapshot to original mailbox
-atlas restore -s <snapshot-id> -f Inbox                 # restore one folder only
-atlas restore -s <snapshot-id> --message 42             # restore a single message by index
-atlas restore -s <snapshot-id> -m target@company.com    # restore to a different mailbox
-```
-
-**Mailbox mode** -- aggregate all snapshots for a mailbox, deduplicate, and restore:
-
-```bash
-atlas restore -m user@company.com                                    # full mailbox restore
-atlas restore -m user@company.com -f Inbox                           # only the Inbox folder
-atlas restore -m user@company.com --start-date 2026-01-01            # from Jan 1 onward
-atlas restore -m user@company.com --start-date 2026-01-01 --end-date 2026-06-30  # date range
-atlas restore -m user@company.com -T other@company.com               # cross-mailbox restore
-atlas restore -m user@company.com -T other@company.com -f Inbox      # cross-mailbox + folder
-```
-
-| Option                      | Description                                                   |
-| --------------------------- | ------------------------------------------------------------- |
-| `-s, --snapshot <id>`       | Restore from a specific snapshot                              |
-| `-m, --mailbox <email>`     | Restore from all snapshots for this mailbox                   |
-| `-T, --target <email>`      | Target mailbox for cross-mailbox restore (defaults to source) |
-| `-f, --folder <name>`       | Restore only messages from this folder                        |
-| `--message <ref>`           | Restore a single message by `#` index from `atlas list`       |
-| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date               |
-| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date              |
-| `-t, --tenant <id>`         | Override tenant ID                                            |
-
-Either `--snapshot` or `--mailbox` is required. When using mailbox mode, entries are deduplicated across snapshots (newest version of each message wins). Cross-mailbox restores preserve the original folder names from the source mailbox.
-
-Restored messages retain their original received/sent timestamps, appear as received mail (not drafts), and include all backed-up attachments. Large attachments (>3 MB) use Graph upload sessions with chunked transfer. A multi-line dashboard shows restore progress with per-folder status and ETA.
-
-### `atlas delete`
-
-Delete backed-up data with confirmation prompt.
-
-```bash
-atlas delete -m user@company.com        # delete all data + manifests for a mailbox
-atlas delete -s <snapshot-id>           # delete one snapshot manifest (data objects retained)
-atlas delete --purge                    # delete EVERYTHING in the tenant bucket
-atlas delete --purge -y                 # skip confirmation prompt
-```
-
-| Option                  | Description                                                    |
-| ----------------------- | -------------------------------------------------------------- |
-| `-m, --mailbox <email>` | Delete all data, attachments, and manifests for a mailbox      |
-| `-s, --snapshot <id>`   | Delete a single snapshot manifest                              |
-| `--purge`               | Delete all data, manifests, and encryption keys (irreversible) |
-| `-y, --yes`             | Skip confirmation prompt                                       |
-| `-t, --tenant <id>`     | Override tenant ID                                             |
-
-When Object Lock retention protects objects, delete commands return non-zero and report retained items separately from generic failures. In versioned buckets, Atlas attempts version-level deletion and reports immutable leftovers transparently.
+| Layer     | Mechanism                           | When                               |
+| --------- | ----------------------------------- | ---------------------------------- |
+| Plaintext | SHA-256 checksum stored in manifest | Backup, verify, restore, save      |
+| Transport | `Content-MD5` header on S3 PUT      | Upload (S3 rejects mismatches)     |
+| At-rest   | AES-256-GCM authentication tag      | Every decrypt (tamper = exception) |
 
 ## Object Lock immutability
 
@@ -313,60 +193,15 @@ This means newer snapshots can reference older versions whose retention window w
 - `--lock-mode compliance` is stronger but operationally harder to reverse.
 - Purge in immutable environments means "attempt full deletion and report leftovers", not guaranteed immediate destruction.
 
-## Security model
-
-Atlas uses envelope encryption to isolate tenants cryptographically:
-
-```
-Master passphrase (env var)
-    |
-    v
-scrypt(passphrase, tenant_id, N=16384, r=8, p=1)  -->  KEK (256-bit, per-tenant)
-    |
-    v
-KEK wraps/unwraps a random DEK (AES-256-GCM)
-    |
-    v
-DEK encrypts all data + manifests for that tenant
-```
-
-- **KEK** (Key Encryption Key) -- derived deterministically from the passphrase and tenant ID. Never stored; re-derived on every run.
-- **DEK** (Data Encryption Key) -- random 256-bit key, generated once per tenant and stored wrapped (encrypted with KEK) at `_meta/dek.enc` in the tenant's S3 bucket.
-- **Ciphertext format** -- `[12-byte IV][16-byte GCM auth tag][ciphertext]`. Every encrypt operation uses a fresh random IV.
-- **Manifest encryption** -- manifests (containing email subjects and message metadata) are encrypted with the same DEK, ensuring subject lines and folder names are never exposed at rest.
-
-Integrity is validated at three layers:
-
-| Layer     | Mechanism                           | When                               |
-| --------- | ----------------------------------- | ---------------------------------- |
-| Plaintext | SHA-256 checksum stored in manifest | Backup, verify, restore            |
-| Transport | `Content-MD5` header on S3 PUT      | Upload (S3 rejects mismatches)     |
-| At-rest   | AES-256-GCM authentication tag      | Every decrypt (tamper = exception) |
-
 ## Delta sync
 
 Backups use Microsoft Graph [delta queries](https://learn.microsoft.com/en-us/graph/delta-query-messages) for incremental sync:
 
 1. **Initial run** -- requests `/users/{id}/mailFolders/{id}/messages/delta` with `$select` including `body`. The API returns all messages across paginated responses. The final `@odata.deltaLink` is saved in the manifest.
-2. **Subsequent runs** -- sends the saved `deltaLink`. The API returns only messages created, modified, or deleted since the last sync. Folders with no changes show as "synced" (yellow `[==]` in the dashboard).
+2. **Subsequent runs** -- sends the saved `deltaLink`. The API returns only messages created, modified, or deleted since the last sync.
 3. **Stale-delta safeguard** -- if a saved delta link returns 0 items but the previous manifest had 0 entries (indicating an interrupted prior backup), Atlas discards the link and runs a full enumeration automatically.
 4. **Force full** -- `atlas backup --full` ignores all saved delta links.
-5. **Graceful interruption** -- Ctrl+C during a backup sets an interrupt flag, saves all already-stored objects and completed delta links into a partial manifest, and marks interrupted folders in the dashboard. The next incremental run picks up from the completed state.
-
-Message bodies are fetched inline via the delta `$select` parameter, avoiding per-message API calls. Page size is configurable via `--page-size` (default 25); the Graph API treats this as a maximum hint and may return smaller pages for large payloads. Transient Graph API errors (429, 503, 504) are retried with exponential backoff.
-
-## Restore architecture
-
-The restore flow reads encrypted data from S3, decrypts it, and pushes it back to the target mailbox via the Microsoft Graph API:
-
-1. Load manifest(s) -- either a single snapshot or all snapshots for a mailbox (deduplicated by `object_id`, newest wins)
-2. Optionally filter by date range (`--start-date` / `--end-date`) and folder name
-3. Create a `Restore-<timestamp>` root folder in the target mailbox
-4. Recreate the original folder structure as subfolders under the restore root
-5. For each message: decrypt from S3, strip Graph read-only fields, set MAPI extended properties for original timestamps, create via Graph API
-6. For each attachment: decrypt from S3, upload inline (< 3 MB) or via upload session (>= 3 MB)
-
-Cross-mailbox restores (`-T` flag) look up folder names from the **source** mailbox and create them in the **target** mailbox, preserving the original folder names regardless of the target's locale.
+5. **Graceful interruption** -- Ctrl+C during a backup sets an interrupt flag, saves all already-stored objects and completed delta links into a partial manifest, and marks interrupted folders in the dashboard.
 
 ## Storage layout
 
@@ -379,7 +214,6 @@ atlas-{tenant_id}/
 ├── data/
 │   └── {mailbox_id}/
 │       ├── {sha256_a}                  # encrypted message (content-addressed)
-│       ├── {sha256_b}
 │       └── ...
 ├── attachments/
 │   └── {mailbox_id}/
@@ -390,77 +224,6 @@ atlas-{tenant_id}/
         ├── {snapshot_id_1}.json        # encrypted manifest
         └── {snapshot_id_2}.json
 ```
-
-- **Content-addressed keys** -- `data/{mailbox}/{SHA-256 of plaintext}` for messages, `attachments/{mailbox}/{SHA-256}` for file attachments. Deduplication is performed per-mailbox using content-addressed storage. Identical messages across snapshots are stored once.
-- **Manifests** -- encrypted JSON containing snapshot metadata, per-message checksums, sizes, storage keys, folder IDs, attachment metadata, and delta links for the next incremental sync.
-
-## Programmatic SDK
-
-Atlas can be used as a typed library in other Node.js applications. The SDK is available as a separate subpath import:
-
-```bash
-npm add m365-atlas
-```
-
-```typescript
-import { createAtlasInstance } from 'm365-atlas/sdk';
-
-const atlas = createAtlasInstance({
-  tenantId: 'your-azure-tenant-id',
-  clientId: 'app-client-id',
-  clientSecret: 'app-client-secret',
-  s3Endpoint: 'http://localhost:9000',
-  s3AccessKey: 'minioadmin',
-  s3SecretKey: 'minioadmin',
-  encryptionPassphrase: 'my-secret-passphrase',
-});
-```
-
-All config is explicit -- no environment variables or config files are read. The tenant is bound at creation time, so every method operates within that tenant scope.
-
-The SDK uses standard ES6 camelCase naming. All methods are async and return Promises. Backup and restore operations are mailbox-scoped for controlled batching in job runners:
-
-```typescript
-// backup a single mailbox (long-running)
-const result = await atlas.backupMailbox('user@company.com', { force_full: true });
-
-// list backed-up mailboxes
-const mailboxes = await atlas.listMailboxes();
-
-// list snapshots for a mailbox
-const snapshots = await atlas.listSnapshots('user@company.com');
-
-// verify snapshot integrity
-const verification = await atlas.verifySnapshot('snapshot-id');
-
-// restore from a specific snapshot (long-running)
-const restore = await atlas.restoreSnapshot('snapshot-id', { folder_name: 'Inbox' });
-
-// restore all snapshots for a mailbox (long-running)
-const fullRestore = await atlas.restoreMailbox('user@company.com');
-
-// read a single message
-const message = await atlas.readMessage('snapshot-id', 'msg-42');
-
-// delete mailbox data
-const deletion = await atlas.deleteMailboxData('user@company.com');
-
-// check storage readiness
-const check = await atlas.checkStorage({ mode: 'GOVERNANCE', retention_days: 30 });
-```
-
-For batch processing multiple mailboxes, create one instance and iterate:
-
-```typescript
-const mailboxIds = ['alice@company.com', 'bob@company.com', 'carol@company.com'];
-
-for (const mailboxId of mailboxIds) {
-  const result = await atlas.backupMailbox(mailboxId);
-  console.log(`${mailboxId}: snapshot ${result.snapshot.id}`);
-}
-```
-
-The SDK exports its own types via `m365-atlas/sdk`. Domain types, port interfaces, and result types are available from the root `m365-atlas` import for advanced use cases.
 
 ## Development
 
@@ -497,9 +260,10 @@ Tests use Vitest with `@vitest/coverage-v8`. Services are tested via Inversify c
 
 - [x] **Outlook mailbox backup** with delta sync, content-addressed deduplication, and attachment handling
 - [x] **Outlook mailbox restore** with original timestamps, folder structure, cross-mailbox support, and chunked attachment upload
-- [x] **CLI interface** -- backup, restore, verify, list, read, delete, and storage-check commands
+- [x] **EML export (save)** -- save backed-up emails as `.eml` files in compressed zip archives with Outlook folder structure, SHA-256 verification, and attachment embedding
+- [x] **CLI interface** -- backup, restore, save, verify, list, read, delete, and storage-check commands
 - [x] **S3 Object Lock / retention policies** -- GOVERNANCE and COMPLIANCE mode with storage-enforced immutability
-- [x] **Typed programmatic SDK** -- `m365-atlas/sdk` subpath with camelCase ES6 API for embedding in other applications
+- [x] **Typed programmatic SDK** -- `m365-atlas/sdk` subpath with camelCase ES6 API including save operations
 - [x] **Repository docs** -- contributing guide, issue/PR templates, code conventions
 
 ### Up next

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -42,13 +42,13 @@ atlas backup -t <tenant-id> -m user@company.com       # explicit tenant
 | `-m, --mailbox <id>`     | Mailbox to back up                                   |
 | `-f, --folder <name...>` | Filter to specific folder(s) by display name         |
 | `--full`                 | Ignore saved delta links, run full enumeration       |
-| `-P, --page-size <n>`    | Graph API page size per delta request (1-100, default 25) |
+| `-P, --page-size <n>`    | Graph API page size per delta request (1-100, default 10) |
 | `--retention-days <n>`   | Apply Object Lock retention for `n` days             |
 | `--lock-mode <mode>`     | Object Lock mode (`governance` or `compliance`)      |
 | `--require-immutability` | Fail if immutability cannot be enforced              |
 | `-t, --tenant <id>`      | Override tenant ID from config                       |
 
-> **Page size tuning:** The `--page-size` flag controls how many messages are requested per Graph API delta page via the `Prefer: odata.maxpagesize` header. This is a *hint* -- the server may return fewer items when response payloads are large (e.g. messages with heavy HTML bodies or many inline images). Lower values reduce memory pressure and allow partial progress to be saved more frequently during interrupts. Higher values reduce HTTP round-trips but increase per-page processing time. The default of 25 is a balanced starting point; adjust based on your mailbox characteristics.
+> **Page size tuning:** The `--page-size` flag controls how many messages are requested per Graph API delta page via the `Prefer: odata.maxpagesize` header. This is a *hint* -- the server may return fewer items when response payloads are large (e.g. messages with heavy HTML bodies or many inline images). Lower values reduce memory pressure and allow partial progress to be saved more frequently during interrupts. Higher values reduce HTTP round-trips but increase per-page processing time. The default of 10 is a conservative starting point that works well across most mailbox sizes; increase if you have many small messages and want fewer HTTP round-trips.
 
 > **Immutability behavior:** `--retention-days` makes the backup immutable-requested. Atlas resolves retention to an internal UTC `retain_until`, probes bucket capability (versioning + Object Lock), and fails fast when unsupported instead of silently downgrading to mutable writes.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,343 @@
+# Usage Guide
+
+Complete reference for the Atlas CLI commands and programmatic SDK.
+
+## Table of Contents
+
+- [CLI Reference](#cli-reference)
+  - [atlas backup](#atlas-backup)
+  - [atlas storage-check](#atlas-storage-check)
+  - [atlas list](#atlas-list)
+  - [atlas read](#atlas-read)
+  - [atlas verify](#atlas-verify)
+  - [atlas restore](#atlas-restore)
+  - [atlas save](#atlas-save)
+  - [atlas delete](#atlas-delete)
+- [Programmatic SDK](#programmatic-sdk)
+  - [Installation](#installation)
+  - [Creating an instance](#creating-an-instance)
+  - [Available methods](#available-methods)
+  - [Batch processing](#batch-processing)
+
+---
+
+## CLI Reference
+
+### `atlas backup`
+
+Back up mailboxes from M365 tenant to object storage. Displays a real-time multi-line dashboard showing all folders with per-folder and global ETA. Ctrl+C saves partial progress so the next run resumes from where it stopped.
+
+```bash
+atlas backup --mailbox user@company.com              # incremental backup
+atlas backup --mailbox user@company.com --full        # force full sync (ignore delta state)
+atlas backup --mailbox user@company.com -f Inbox Sent # specific folders only
+atlas backup --mailbox user@company.com -P 50         # larger page size for fewer API round-trips
+atlas backup --mailbox user@company.com --retention-days 30 --lock-mode governance
+atlas backup --mailbox user@company.com --retention-days 365 --lock-mode compliance
+atlas backup -t <tenant-id> -m user@company.com       # explicit tenant
+```
+
+| Option                   | Description                                          |
+| ------------------------ | ---------------------------------------------------- |
+| `-m, --mailbox <id>`     | Mailbox to back up                                   |
+| `-f, --folder <name...>` | Filter to specific folder(s) by display name         |
+| `--full`                 | Ignore saved delta links, run full enumeration       |
+| `-P, --page-size <n>`    | Graph API page size per delta request (1-100, default 25) |
+| `--retention-days <n>`   | Apply Object Lock retention for `n` days             |
+| `--lock-mode <mode>`     | Object Lock mode (`governance` or `compliance`)      |
+| `--require-immutability` | Fail if immutability cannot be enforced              |
+| `-t, --tenant <id>`      | Override tenant ID from config                       |
+
+> **Page size tuning:** The `--page-size` flag controls how many messages are requested per Graph API delta page via the `Prefer: odata.maxpagesize` header. This is a *hint* -- the server may return fewer items when response payloads are large (e.g. messages with heavy HTML bodies or many inline images). Lower values reduce memory pressure and allow partial progress to be saved more frequently during interrupts. Higher values reduce HTTP round-trips but increase per-page processing time. The default of 25 is a balanced starting point; adjust based on your mailbox characteristics.
+
+> **Immutability behavior:** `--retention-days` makes the backup immutable-requested. Atlas resolves retention to an internal UTC `retain_until`, probes bucket capability (versioning + Object Lock), and fails fast when unsupported instead of silently downgrading to mutable writes.
+
+### `atlas storage-check`
+
+Validate immutable backup readiness without running a backup.
+
+```bash
+atlas storage-check
+atlas storage-check --lock-mode governance --retention-days 30
+atlas storage-check --lock-mode compliance --retention-days 365
+```
+
+| Option                 | Description                                            |
+| ---------------------- | ------------------------------------------------------ |
+| `--lock-mode <mode>`   | Planned Object Lock mode (`governance` or `compliance`) |
+| `--retention-days <n>` | Planned retention period in days                       |
+| `-t, --tenant <id>`    | Override tenant ID                                     |
+
+### `atlas list`
+
+Browse backed-up data at three zoom levels. Subjects are hidden by default for data protection.
+
+```bash
+atlas list                              # all mailboxes with summary stats
+atlas list -m user@company.com          # all snapshots for a mailbox
+atlas list -s <snapshot-id>             # messages inside a snapshot (first 50)
+atlas list -s <snapshot-id> --all       # all messages
+atlas list -s <snapshot-id> -S          # reveal email subjects
+```
+
+| Option                  | Description                                                   |
+| ----------------------- | ------------------------------------------------------------- |
+| `-m, --mailbox <email>` | Show snapshots for this mailbox                               |
+| `-s, --snapshot <id>`   | Show messages inside this snapshot                            |
+| `--all`                 | Show all messages (default caps at 50)                        |
+| `-S, --subjects`        | Reveal email subjects (hidden by default for data protection) |
+| `-t, --tenant <id>`     | Override tenant ID                                            |
+
+### `atlas read`
+
+Decrypt and display a single backed-up message. Messages are referenced by their `#` index from `atlas list` output. If the message has attachments, their metadata (name, MIME type, size) is listed below the body.
+
+```bash
+atlas read -s <snapshot-id> --message 34        # formatted view (by index)
+atlas read -s <snapshot-id> --message 34 --raw  # full JSON
+```
+
+| Option                | Description                                               |
+| --------------------- | --------------------------------------------------------- |
+| `-s, --snapshot <id>` | Snapshot containing the message                           |
+| `--message <ref>`     | Message `#` from `atlas list`, or full Graph message ID   |
+| `--raw`               | Output full JSON blob instead of formatted headers + body |
+| `-t, --tenant <id>`   | Override tenant ID                                        |
+
+### `atlas verify`
+
+Verify integrity of a backup snapshot. Downloads every object, decrypts, recomputes SHA-256, and compares against the manifest checksum.
+
+```bash
+atlas verify -s <snapshot-id>
+```
+
+### `atlas restore`
+
+Restore emails from backup to an M365 mailbox. Two modes of operation:
+
+**Snapshot mode** -- restore from a specific snapshot:
+
+```bash
+atlas restore -s <snapshot-id>                          # full snapshot to original mailbox
+atlas restore -s <snapshot-id> -f Inbox                 # restore one folder only
+atlas restore -s <snapshot-id> --message 42             # restore a single message by index
+atlas restore -s <snapshot-id> -m target@company.com    # restore to a different mailbox
+```
+
+**Mailbox mode** -- aggregate all snapshots for a mailbox, deduplicate, and restore:
+
+```bash
+atlas restore -m user@company.com                                    # full mailbox restore
+atlas restore -m user@company.com -f Inbox                           # only the Inbox folder
+atlas restore -m user@company.com --start-date 2026-01-01            # from Jan 1 onward
+atlas restore -m user@company.com --start-date 2026-01-01 --end-date 2026-06-30  # date range
+atlas restore -m user@company.com -T other@company.com               # cross-mailbox restore
+atlas restore -m user@company.com -T other@company.com -f Inbox      # cross-mailbox + folder
+```
+
+| Option                      | Description                                                   |
+| --------------------------- | ------------------------------------------------------------- |
+| `-s, --snapshot <id>`       | Restore from a specific snapshot                              |
+| `-m, --mailbox <email>`     | Restore from all snapshots for this mailbox                   |
+| `-T, --target <email>`      | Target mailbox for cross-mailbox restore (defaults to source) |
+| `-f, --folder <name>`       | Restore only messages from this folder                        |
+| `--message <ref>`           | Restore a single message by `#` index from `atlas list`       |
+| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date               |
+| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date              |
+| `-t, --tenant <id>`         | Override tenant ID                                            |
+
+Either `--snapshot` or `--mailbox` is required. When using mailbox mode, entries are deduplicated across snapshots (newest version of each message wins). Cross-mailbox restores preserve the original folder names from the source mailbox.
+
+Restored messages retain their original received/sent timestamps, appear as received mail (not drafts), and include all backed-up attachments. Large attachments (>3 MB) use Graph upload sessions with chunked transfer. A multi-line dashboard shows restore progress with per-folder status and ETA.
+
+### `atlas save`
+
+Export backed-up emails as standard `.eml` files (RFC 5322, same format Outlook uses for email downloads) in a compressed zip archive. Messages include all backed-up attachments embedded as MIME parts. By default, every message and attachment is SHA-256 verified after decryption before being written to the archive.
+
+**Snapshot mode** -- save from a specific snapshot:
+
+```bash
+atlas save -s <snapshot-id>                              # full snapshot
+atlas save -s <snapshot-id> -f Inbox                     # save one folder only
+atlas save -s <snapshot-id> --message 42                 # save a single message
+atlas save -s <snapshot-id> -o ~/Downloads/backup.zip    # custom output path
+atlas save -s <snapshot-id> --skip-verify                # skip integrity checks
+```
+
+**Mailbox mode** -- aggregate all snapshots for a mailbox:
+
+```bash
+atlas save -m user@company.com                                           # full mailbox
+atlas save -m user@company.com -f Inbox                                  # only Inbox
+atlas save -m user@company.com --start-date 2026-01-01                   # from Jan 1 onward
+atlas save -m user@company.com --start-date 2026-01-01 --end-date 2026-06-30  # date range
+```
+
+| Option                      | Description                                                     |
+| --------------------------- | --------------------------------------------------------------- |
+| `-s, --snapshot <id>`       | Save from a specific snapshot                                   |
+| `-m, --mailbox <email>`     | Save from all snapshots for this mailbox                        |
+| `-f, --folder <name>`       | Save only messages from this folder                             |
+| `--message <ref>`           | Save a single message by `#` index from `atlas list`            |
+| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date                 |
+| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date                |
+| `-o, --output <path>`       | Output file path (default: `Restore-<timestamp>.zip`)           |
+| `--skip-verify`             | Skip SHA-256 integrity checks (faster on low-power systems)     |
+| `-t, --tenant <id>`         | Override tenant ID                                              |
+
+The zip archive mirrors the Outlook folder hierarchy:
+
+```
+Restore-2026-03-10T14-30-00.zip
+  Inbox/
+    2026-03-10_143022_Meeting-with-client.eml
+    2026-03-10_090115_Weekly-report.eml
+  Sent Items/
+    2026-03-09_161200_Re-Project-update.eml
+  Archive/
+    2026-01-15_080000_Old-thread.eml
+```
+
+EML filenames use the format `YYYY-MM-DD_HHmmss_Sanitized-subject.eml` with timestamps from `receivedDateTime` for natural chronological sorting. Duplicate filenames within a folder get numeric suffixes (`_1`, `_2`).
+
+If the output file already exists, Atlas prompts `Overwrite? [Y/n]` before proceeding.
+
+### `atlas delete`
+
+Delete backed-up data with confirmation prompt.
+
+```bash
+atlas delete -m user@company.com        # delete all data + manifests for a mailbox
+atlas delete -s <snapshot-id>           # delete one snapshot manifest (data objects retained)
+atlas delete --purge                    # delete EVERYTHING in the tenant bucket
+atlas delete --purge -y                 # skip confirmation prompt
+```
+
+| Option                  | Description                                                    |
+| ----------------------- | -------------------------------------------------------------- |
+| `-m, --mailbox <email>` | Delete all data, attachments, and manifests for a mailbox      |
+| `-s, --snapshot <id>`   | Delete a single snapshot manifest                              |
+| `--purge`               | Delete all data, manifests, and encryption keys (irreversible) |
+| `-y, --yes`             | Skip confirmation prompt                                       |
+| `-t, --tenant <id>`     | Override tenant ID                                             |
+
+When Object Lock retention protects objects, delete commands return non-zero and report retained items separately from generic failures. In versioned buckets, Atlas attempts version-level deletion and reports immutable leftovers transparently.
+
+---
+
+## Programmatic SDK
+
+Atlas can be used as a typed library in other Node.js applications. The SDK is available as a separate subpath import.
+
+### Installation
+
+```bash
+npm add m365-atlas
+```
+
+### Creating an instance
+
+```typescript
+import { createAtlasInstance } from 'm365-atlas/sdk';
+
+const atlas = createAtlasInstance({
+  tenantId: 'your-azure-tenant-id',
+  clientId: 'app-client-id',
+  clientSecret: 'app-client-secret',
+  s3Endpoint: 'http://localhost:9000',
+  s3AccessKey: 'minioadmin',
+  s3SecretKey: 'minioadmin',
+  encryptionPassphrase: 'my-secret-passphrase',
+});
+```
+
+All config is explicit -- no environment variables or config files are read. The tenant is bound at creation time, so every method operates within that tenant scope.
+
+The SDK uses standard ES6 camelCase naming. All methods are async and return Promises. Backup and restore operations are mailbox-scoped for controlled batching in job runners.
+
+### Available methods
+
+```typescript
+// backup a single mailbox (long-running)
+const result = await atlas.backupMailbox('user@company.com', { force_full: true });
+
+// list backed-up mailboxes
+const mailboxes = await atlas.listMailboxes();
+
+// list snapshots for a mailbox
+const snapshots = await atlas.listSnapshots('user@company.com');
+
+// verify snapshot integrity
+const verification = await atlas.verifySnapshot('snapshot-id');
+
+// restore from a specific snapshot (long-running)
+const restore = await atlas.restoreSnapshot('snapshot-id', { folder_name: 'Inbox' });
+
+// restore all snapshots for a mailbox (long-running)
+const fullRestore = await atlas.restoreMailbox('user@company.com');
+
+// save snapshot as EML zip archive
+const save = await atlas.saveSnapshot('snapshot-id', {
+  folder_name: 'Inbox',
+  output_path: 'backup.zip',
+});
+
+// save all snapshots for a mailbox as EML zip archive
+const fullSave = await atlas.saveMailbox('user@company.com', {
+  output_path: 'full-backup.zip',
+  skip_integrity_check: true,  // optional: skip SHA-256 verification
+});
+
+// read a single message
+const message = await atlas.readMessage('snapshot-id', 'msg-42');
+
+// delete mailbox data
+const deletion = await atlas.deleteMailboxData('user@company.com');
+
+// check storage readiness
+const check = await atlas.checkStorage({ mode: 'GOVERNANCE', retention_days: 30 });
+```
+
+#### Save options
+
+The `saveSnapshot` and `saveMailbox` methods accept the following options:
+
+| Option                 | Type      | Description                                                  |
+| ---------------------- | --------- | ------------------------------------------------------------ |
+| `folder_name`          | `string`  | Save only messages from this folder                          |
+| `message_ref`          | `string`  | Save a single message by index or ID                         |
+| `start_date`           | `Date`    | Include snapshots on or after this date                      |
+| `end_date`             | `Date`    | Include snapshots on or before this date                     |
+| `output_path`          | `string`  | Output zip file path (default: `Restore-<timestamp>.zip`)    |
+| `skip_integrity_check` | `boolean` | Skip SHA-256 verification (default: `false`)                 |
+
+Both methods return a `SaveResult`:
+
+```typescript
+interface SaveResult {
+  snapshot_id: string;
+  saved_count: number;
+  attachment_count: number;
+  error_count: number;
+  errors: string[];
+  output_path: string;
+  total_bytes: number;
+  integrity_failures: string[];
+}
+```
+
+### Batch processing
+
+For batch processing multiple mailboxes, create one instance and iterate sequentially. Each backup/restore/save operation makes hundreds or thousands of Microsoft Graph API requests internally, so running mailboxes in parallel with `Promise.all` would overwhelm the API and trigger throttling (HTTP 429). Sequential loops ensure reliable throughput:
+
+```typescript
+const mailboxIds = ['alice@company.com', 'bob@company.com', 'carol@company.com'];
+
+for (const mailboxId of mailboxIds) {
+  const result = await atlas.backupMailbox(mailboxId);
+  console.log(`${mailboxId}: snapshot ${result.snapshot.id}`);
+}
+```
+
+The SDK exports its own types via `m365-atlas/sdk`. Domain types, port interfaces, and result types are available from the root `m365-atlas` import for advanced use cases.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "m365-atlas",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "An open-source CLI backup engine for Microsoft 365 mailboxes, designed with per-tenant encryption, content-addressed storage, and efficient delta synchronization for scalable, secure backups.",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "node": ">=20"
   },
   "devDependencies": {
+    "@types/archiver": "^7.0.0",
     "@types/node": "^25.3.5",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.0.3",
@@ -81,10 +82,12 @@
     "@aws-sdk/client-s3": "^3.1004.0",
     "@azure/identity": "^4.13.0",
     "@microsoft/microsoft-graph-client": "^3.0.7",
+    "archiver": "^7.0.1",
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
     "inversify": "^7.11.0",
+    "mimetext": "^3.0.28",
     "reflect-metadata": "^0.2.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@microsoft/microsoft-graph-client':
         specifier: ^3.0.7
         version: 3.0.7(@azure/identity@4.13.0)
+      archiver:
+        specifier: ^7.0.1
+        version: 7.0.1
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -29,10 +32,16 @@ importers:
       inversify:
         specifier: ^7.11.0
         version: 7.11.0(reflect-metadata@0.2.2)
+      mimetext:
+        specifier: ^3.0.28
+        version: 3.0.28
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
     devDependencies:
+      '@types/archiver':
+        specifier: ^7.0.0
+        version: 7.0.0
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -305,6 +314,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  '@babel/runtime-corejs3@7.29.0':
+    resolution: {integrity: sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
@@ -554,6 +567,10 @@ packages:
     peerDependencies:
       reflect-metadata: ~0.2.2
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -590,6 +607,10 @@ packages:
 
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -1052,6 +1073,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/archiver@7.0.0':
+    resolution: {integrity: sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1072,6 +1096,9 @@ packages:
 
   '@types/node@25.3.5':
     resolution: {integrity: sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==}
+
+  '@types/readdir-glob@1.1.5':
+    resolution: {integrity: sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==}
 
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
@@ -1174,6 +1201,10 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1195,9 +1226,17 @@ packages:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -1206,6 +1245,14 @@ packages:
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
+
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1218,15 +1265,73 @@ packages:
   ast-v8-to-istanbul@0.3.12:
     resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
+  b4a@1.8.0:
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.5.5:
+    resolution: {integrity: sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.7.1:
+    resolution: {integrity: sha512-ebvMaS5BgZKmJlvuWh14dg9rbUI84QeV3WlWn6Ph6lFI8jJoh7ADtVTyD2c93euwbe+zgi0DVrl4YmqXeM9aIA==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.8.1:
+    resolution: {integrity: sha512-bSeR8RfvbRwDpD7HWZvn8M3uYNDrk7m9DQjYOFkENZlXW8Ju/MPaqUPQq5LqJ3kyjEm07siTaAQ7wBKCU59oHg==}
+    peerDependencies:
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.3.2:
+    resolution: {integrity: sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
@@ -1236,8 +1341,15 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -1263,12 +1375,38 @@ packages:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
+  core-js-pure@3.48.0:
+    resolution: {integrity: sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1314,11 +1452,20 @@ packages:
       oxc-resolver:
         optional: true
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -1397,8 +1544,19 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1406,6 +1564,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -1448,6 +1609,10 @@ packages:
   flatted@3.3.4:
     resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1463,6 +1628,14 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1487,6 +1660,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1503,6 +1679,9 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   inversify@7.11.0:
     resolution: {integrity: sha512-yZDprSSr8TyVeMGI/AOV4ws6gwjX22hj9Z8/oHAVpJORY6WRFTcUzhnZtibBUHEw2U8ArvHcR+i863DplQ3Cwg==}
 
@@ -1514,6 +1693,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
@@ -1532,9 +1715,16 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1550,6 +1740,12 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -1580,6 +1776,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1619,9 +1819,15 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1637,6 +1843,17 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mimetext@3.0.28:
+    resolution: {integrity: sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -1644,6 +1861,18 @@ packages:
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1655,6 +1884,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -1679,6 +1912,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1686,6 +1922,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1714,12 +1954,29 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
@@ -1767,6 +2024,9 @@ packages:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -1808,9 +2068,20 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  streamx@2.23.0:
+    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -1819,6 +2090,16 @@ packages:
   string-width@8.2.0:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
     engines: {node: '>=20'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
@@ -1830,6 +2111,15 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  tar-stream@3.1.8:
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1926,6 +2216,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -2018,6 +2311,14 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
@@ -2034,6 +2335,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
 
 snapshots:
 
@@ -2588,6 +2893,10 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.0-rc.2
 
+  '@babel/runtime-corejs3@7.29.0':
+    dependencies:
+      core-js-pure: 3.48.0
+
   '@babel/runtime@7.28.6': {}
 
   '@babel/types@7.29.0':
@@ -2765,6 +3074,15 @@ snapshots:
     dependencies:
       reflect-metadata: 0.2.2
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2794,6 +3112,9 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.115.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -3268,6 +3589,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/archiver@7.0.0':
+    dependencies:
+      '@types/readdir-glob': 1.1.5
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -3286,6 +3611,10 @@ snapshots:
   '@types/node@25.3.5':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/readdir-glob@1.1.5':
+    dependencies:
+      '@types/node': 25.3.5
 
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@10.0.3)(typescript@5.9.3))(eslint@10.0.3)(typescript@5.9.3)':
     dependencies:
@@ -3439,6 +3768,10 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3458,11 +3791,41 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
+  ansi-regex@5.0.1: {}
+
   ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
 
   ansis@4.2.0: {}
+
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.17.23
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.8
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
 
   assertion-error@2.0.1: {}
 
@@ -3478,11 +3841,56 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  async@3.2.6: {}
+
+  b4a@1.8.0: {}
+
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.5.5:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.8.1(bare-events@2.8.2)
+      bare-url: 2.3.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.7.1: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.7.1
+
+  bare-stream@2.8.1(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.23.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-url@2.3.2:
+    dependencies:
+      bare-path: 3.0.0
+
+  base64-js@1.5.1: {}
 
   birpc@4.0.0: {}
 
   bowser@2.14.1: {}
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.4:
     dependencies:
@@ -3492,7 +3900,14 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  buffer-crc32@1.0.0: {}
+
   buffer-equal-constant-time@1.0.1: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-name@4.1.0:
     dependencies:
@@ -3513,9 +3928,34 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.0
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   colorette@2.0.20: {}
 
   commander@14.0.3: {}
+
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  core-js-pure@3.48.0: {}
+
+  core-util-is@1.0.3: {}
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3544,11 +3984,17 @@ snapshots:
 
   dts-resolver@2.1.3: {}
 
+  eastasianwidth@0.2.0: {}
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
 
   emoji-regex@10.6.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
 
@@ -3665,11 +4111,23 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@5.0.4: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  events@3.3.0: {}
 
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -3706,6 +4164,11 @@ snapshots:
 
   flatted@3.3.4: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -3718,6 +4181,17 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
 
@@ -3741,6 +4215,8 @@ snapshots:
 
   husky@9.1.7: {}
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -3748,6 +4224,8 @@ snapshots:
   import-without-cache@0.2.5: {}
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   inversify@7.11.0(reflect-metadata@0.2.2):
     dependencies:
@@ -3760,6 +4238,8 @@ snapshots:
   is-docker@3.0.0: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
@@ -3775,9 +4255,13 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-stream@2.0.1: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -3793,6 +4277,14 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  js-base64@3.7.8: {}
 
   js-tokens@10.0.0: {}
 
@@ -3831,6 +4323,10 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
 
   levn@0.4.1:
     dependencies:
@@ -3873,6 +4369,8 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
+  lodash@4.17.23: {}
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.3.0
@@ -3880,6 +4378,8 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  lru-cache@10.4.3: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -3900,17 +4400,42 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mimetext@3.0.28:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@babel/runtime-corejs3': 7.29.0
+      js-base64: 3.7.8
+      mime-types: 2.1.35
+
   mimic-function@5.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.4
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minipass@7.1.3: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  normalize-path@3.0.0: {}
 
   obug@2.1.1: {}
 
@@ -3942,9 +4467,16 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -3964,9 +4496,35 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  process-nextick-args@2.0.1: {}
+
+  process@0.11.10: {}
+
   punycode@2.3.1: {}
 
   quansync@1.0.0: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
 
   reflect-metadata@0.2.2: {}
 
@@ -4050,6 +4608,8 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   semver@7.7.4: {}
@@ -4080,7 +4640,28 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  streamx@2.23.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-argv@0.3.2: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
@@ -4093,6 +4674,18 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
@@ -4102,6 +4695,30 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  tar-stream@3.1.8:
+    dependencies:
+      b4a: 1.8.0
+      bare-fs: 4.5.5
+      fast-fifo: 1.3.2
+      streamx: 2.23.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.23.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
 
   tinybench@2.9.0: {}
 
@@ -4185,6 +4802,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  util-deprecate@1.0.2: {}
+
   uuid@8.3.2: {}
 
   vite@7.3.1(@types/node@25.3.5)(yaml@2.8.2):
@@ -4248,6 +4867,18 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -4261,3 +4892,9 @@ snapshots:
   yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0

--- a/src/adapters/m365/graph-error-helpers.ts
+++ b/src/adapters/m365/graph-error-helpers.ts
@@ -43,6 +43,30 @@ export function rethrow_if_access_denied(err: unknown): void {
   throw new Error(hint);
 }
 
+/**
+ * Detects MailboxNotEnabledForRESTAPI from Graph and rethrows with
+ * actionable guidance about reassigning an Exchange Online license.
+ */
+export function rethrow_if_mailbox_not_licensed(err: unknown): void {
+  const graph_err = err as Record<string, unknown>;
+  const code = String(graph_err.code ?? '');
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (code === 'MailboxNotEnabledForRESTAPI' || message.includes('MailboxNotEnabledForRESTAPI')) {
+    throw new Error(
+      `The mailbox is not licensed for API access (MailboxNotEnabledForRESTAPI).\n` +
+        `This typically happens when the user's Exchange Online license has been removed.\n` +
+        `The mailbox data is retained for 30 days after license removal, but cannot be\n` +
+        `accessed via the Graph API until a license is reassigned.\n\n` +
+        `To back up or restore this mailbox:\n` +
+        `  1. Reassign an Exchange Online license to the user in Microsoft 365 admin center\n` +
+        `  2. Wait a few minutes for the mailbox to reconnect\n` +
+        `  3. Run the operation again\n` +
+        `  4. Remove the license after the operation completes (if desired)`,
+    );
+  }
+}
+
 /** Returns true when the error carries a transient HTTP status (429, 503, 504). */
 export function is_transient_error(err: unknown): boolean {
   const status = (err as Record<string, unknown>).statusCode;

--- a/src/adapters/m365/graph-error-helpers.ts
+++ b/src/adapters/m365/graph-error-helpers.ts
@@ -1,6 +1,20 @@
+import { logger } from '@/utils/logger';
+
 const RETRYABLE_STATUS_CODES = new Set([429, 503, 504]);
-const MAX_RETRIES = 4;
+const NETWORK_ERROR_CODES = new Set([
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EPIPE',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+const MAX_RETRIES = 6;
 const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 60_000;
 
 /**
  * Detects Graph errors that indicate an invalid/expired delta token.
@@ -74,18 +88,57 @@ export function is_transient_error(err: unknown): boolean {
 }
 
 /**
- * Wraps a Graph API call with exponential backoff retries for transient errors.
- * Respects the Retry-After header from 429 responses when available.
+ * Returns true for network-level errors (socket timeout, DNS failure,
+ * connection reset) that are worth retrying.
+ */
+export function is_network_error(err: unknown): boolean {
+  const code = (err as Record<string, unknown>).code;
+  if (typeof code === 'string' && NETWORK_ERROR_CODES.has(code)) return true;
+
+  const message = err instanceof Error ? err.message : String(err);
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('socket hang up') ||
+    lower.includes('network request failed') ||
+    lower.includes('econnreset') ||
+    lower.includes('etimedout') ||
+    lower.includes('fetch failed')
+  );
+}
+
+/** Returns true when an error is retryable (transient HTTP or network error). */
+export function is_retryable_error(err: unknown): boolean {
+  return is_transient_error(err) || is_network_error(err);
+}
+
+/**
+ * Wraps any async network call with exponential backoff + jitter for both
+ * transient HTTP errors (429, 503, 504) and network-level errors (ETIMEDOUT,
+ * ECONNRESET, socket hang up, etc.).
+ *
+ * Retries up to MAX_RETRIES times. Respects Retry-After on 429. Delays are
+ * capped at MAX_DELAY_MS. Each retry is logged for observability.
+ *
+ * This function is designed to be reusable across backup, restore, save, and
+ * any other operation that communicates over the network.
  */
 export async function with_graph_retry<T>(fn: () => Promise<T>): Promise<T> {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       return await fn();
     } catch (err) {
-      if (!is_transient_error(err) || attempt === MAX_RETRIES) throw err;
+      if (!is_retryable_error(err) || attempt === MAX_RETRIES) throw err;
 
       const retry_after = extract_retry_after(err);
-      const delay = retry_after ?? BASE_DELAY_MS * 2 ** attempt;
+      const base = retry_after ?? BASE_DELAY_MS * 2 ** attempt;
+      const jitter = Math.random() * BASE_DELAY_MS;
+      const delay = Math.min(base + jitter, MAX_DELAY_MS);
+
+      const reason = describe_error(err);
+      logger.debug(
+        `Retry ${attempt + 1}/${MAX_RETRIES} in ${(delay / 1000).toFixed(1)}s -- ${reason}`,
+      );
+
       await sleep(delay);
     }
   }
@@ -100,6 +153,13 @@ function extract_retry_after(err: unknown): number | undefined {
   if (!value) return undefined;
   const seconds = parseInt(value, 10);
   return isNaN(seconds) ? undefined : seconds * 1000;
+}
+
+function describe_error(err: unknown): string {
+  const graph_err = err as Record<string, unknown>;
+  if (graph_err.statusCode) return `HTTP ${graph_err.statusCode}`;
+  if (graph_err.code) return String(graph_err.code);
+  return err instanceof Error ? err.message.slice(0, 80) : 'unknown';
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/adapters/m365/graph-mailbox-connector.adapter.ts
+++ b/src/adapters/m365/graph-mailbox-connector.adapter.ts
@@ -13,6 +13,7 @@ import { logger } from '@/utils/logger';
 import {
   is_invalid_delta_error,
   rethrow_if_access_denied,
+  rethrow_if_mailbox_not_licensed,
   with_graph_retry,
 } from './graph-error-helpers';
 import type {
@@ -116,6 +117,7 @@ export class GraphMailboxConnector implements MailboxConnector {
       const folder_records = await this.collect_all_pages<GraphFolderRecord>(url);
       return filter_and_map_folders(folder_records);
     } catch (err) {
+      rethrow_if_mailbox_not_licensed(err);
       rethrow_if_access_denied(err);
       throw err;
     }
@@ -151,6 +153,7 @@ export class GraphMailboxConnector implements MailboxConnector {
         ps,
       );
     } catch (err) {
+      rethrow_if_mailbox_not_licensed(err);
       rethrow_if_access_denied(err);
       if (is_invalid_delta_error(err)) {
         logger.debug('fetch_delta: invalid delta token, falling back to full sync');
@@ -173,6 +176,7 @@ export class GraphMailboxConnector implements MailboxConnector {
 
       return this.graph_message_to_mail_message(response);
     } catch (err) {
+      rethrow_if_mailbox_not_licensed(err);
       rethrow_if_access_denied(err);
       throw err;
     }
@@ -193,6 +197,7 @@ export class GraphMailboxConnector implements MailboxConnector {
       const records = await this.collect_all_pages<GraphAttachmentRecord>(url);
       return map_file_attachments(records);
     } catch (err) {
+      rethrow_if_mailbox_not_licensed(err);
       rethrow_if_access_denied(err);
       throw err;
     }

--- a/src/adapters/m365/graph-mailbox-connector.adapter.ts
+++ b/src/adapters/m365/graph-mailbox-connector.adapter.ts
@@ -85,7 +85,9 @@ export class GraphMailboxConnector implements MailboxConnector {
   async list_mailboxes(_tenant_id: string): Promise<string[]> {
     try {
       const url = '/users?$select=id,mail,displayName&$filter=mail ne null&$top=999';
-      const user_records = await this.collect_all_pages<GraphUserRecord>(url);
+      const user_records = await with_graph_retry(() =>
+        this.collect_all_pages<GraphUserRecord>(url),
+      );
       return extract_user_ids(user_records);
     } catch (err) {
       rethrow_if_access_denied(err);
@@ -114,7 +116,9 @@ export class GraphMailboxConnector implements MailboxConnector {
       const url =
         `/users/${mailbox_id}/mailFolders` +
         '?$select=id,displayName,parentFolderId,totalItemCount&$top=250';
-      const folder_records = await this.collect_all_pages<GraphFolderRecord>(url);
+      const folder_records = await with_graph_retry(() =>
+        this.collect_all_pages<GraphFolderRecord>(url),
+      );
       return filter_and_map_folders(folder_records);
     } catch (err) {
       rethrow_if_mailbox_not_licensed(err);
@@ -141,7 +145,7 @@ export class GraphMailboxConnector implements MailboxConnector {
         ? `fetch_delta: resuming from saved delta link`
         : `fetch_delta: starting initial full sync`,
     );
-    const ps = page_size ?? 25;
+    const ps = page_size ?? 10;
 
     try {
       return await this.execute_delta_sync(
@@ -170,9 +174,12 @@ export class GraphMailboxConnector implements MailboxConnector {
     message_id: string,
   ): Promise<MailMessage> {
     try {
-      const response = (await this._client
-        .api(`/users/${mailbox_id}/messages/${message_id}`)
-        .get()) as GraphDeltaMessage;
+      const response = await with_graph_retry(
+        () =>
+          this._client
+            .api(`/users/${mailbox_id}/messages/${message_id}`)
+            .get() as Promise<GraphDeltaMessage>,
+      );
 
       return this.graph_message_to_mail_message(response);
     } catch (err) {
@@ -194,7 +201,9 @@ export class GraphMailboxConnector implements MailboxConnector {
   ): Promise<MessageAttachment[]> {
     try {
       const url = `/users/${mailbox_id}/messages/${message_id}/attachments`;
-      const records = await this.collect_all_pages<GraphAttachmentRecord>(url);
+      const records = await with_graph_retry(() =>
+        this.collect_all_pages<GraphAttachmentRecord>(url),
+      );
       return map_file_attachments(records);
     } catch (err) {
       rethrow_if_mailbox_not_licensed(err);
@@ -223,11 +232,14 @@ export class GraphMailboxConnector implements MailboxConnector {
     folder_id: string,
     page_size: number,
   ): Promise<GraphPageResponse> {
-    return (await this._client
-      .api(this.delta_path(mailbox_id, folder_id))
-      .header('Prefer', `odata.maxpagesize=${page_size}`)
-      .select(DELTA_SELECT_FIELDS)
-      .get()) as GraphPageResponse;
+    return with_graph_retry(
+      () =>
+        this._client
+          .api(this.delta_path(mailbox_id, folder_id))
+          .header('Prefer', `odata.maxpagesize=${page_size}`)
+          .select(DELTA_SELECT_FIELDS)
+          .get() as Promise<GraphPageResponse>,
+    );
   }
 
   /**
@@ -238,10 +250,13 @@ export class GraphMailboxConnector implements MailboxConnector {
     full_url: string,
     page_size: number,
   ): Promise<GraphPageResponse> {
-    return (await this._client
-      .api(full_url)
-      .header('Prefer', `odata.maxpagesize=${page_size}`)
-      .get()) as GraphPageResponse;
+    return with_graph_retry(
+      () =>
+        this._client
+          .api(full_url)
+          .header('Prefer', `odata.maxpagesize=${page_size}`)
+          .get() as Promise<GraphPageResponse>,
+    );
   }
 
   /**
@@ -255,7 +270,7 @@ export class GraphMailboxConnector implements MailboxConnector {
     prev_delta_link: string | undefined,
     delta_reset: boolean,
     on_page?: DeltaPageCallback,
-    page_size = 25,
+    page_size = 10,
   ): Promise<DeltaSyncResult> {
     const is_initial = !prev_delta_link;
     const messages: MailMessage[] = [];

--- a/src/adapters/m365/graph-mailbox-connector.adapter.ts
+++ b/src/adapters/m365/graph-mailbox-connector.adapter.ts
@@ -10,9 +10,21 @@ import type {
   DeltaPageCallback,
 } from '@/ports/mailbox/connector.port';
 import { logger } from '@/utils/logger';
-import { is_invalid_delta_error, rethrow_if_access_denied } from './graph-error-helpers';
-
-const EXCLUDED_FOLDERS = new Set(['drafts', 'outbox', 'recoverableitemsdeletions', 'junkemail']);
+import {
+  is_invalid_delta_error,
+  rethrow_if_access_denied,
+  with_graph_retry,
+} from './graph-error-helpers';
+import type {
+  GraphUserRecord,
+  GraphFolderRecord,
+  GraphAttachmentRecord,
+} from './graph-mailbox-response-mappers';
+import {
+  extract_user_ids,
+  filter_and_map_folders,
+  map_file_attachments,
+} from './graph-mailbox-response-mappers';
 
 /**
  * Fields to request from the delta endpoint so each page contains
@@ -50,19 +62,6 @@ interface GraphPageResponse {
   '@odata.deltaLink'?: string;
 }
 
-interface GraphUserRecord {
-  id?: string;
-  mail?: string;
-  displayName?: string;
-}
-
-interface GraphFolderRecord {
-  id?: string;
-  displayName?: string;
-  parentFolderId?: string;
-  totalItemCount?: number;
-}
-
 interface GraphDeltaMessage {
   id?: string;
   subject?: string;
@@ -72,16 +71,6 @@ interface GraphDeltaMessage {
   parentFolderId?: string;
   '@removed'?: { reason: string };
   [key: string]: unknown;
-}
-
-interface GraphAttachmentRecord {
-  '@odata.type'?: string;
-  id?: string;
-  name?: string;
-  contentType?: string;
-  size?: number;
-  isInline?: boolean;
-  contentBytes?: string;
 }
 
 @injectable()
@@ -96,8 +85,20 @@ export class GraphMailboxConnector implements MailboxConnector {
     try {
       const url = '/users?$select=id,mail,displayName&$filter=mail ne null&$top=999';
       const user_records = await this.collect_all_pages<GraphUserRecord>(url);
-      return this.extract_user_ids(user_records);
+      return extract_user_ids(user_records);
     } catch (err) {
+      rethrow_if_access_denied(err);
+      throw err;
+    }
+  }
+
+  /** Checks whether a mailbox exists in the tenant via GET /users/{id}. */
+  async mailbox_exists(_tenant_id: string, mailbox_id: string): Promise<boolean> {
+    try {
+      await with_graph_retry(() => this._client.api(`/users/${mailbox_id}?$select=id`).get());
+      return true;
+    } catch (err) {
+      if ((err as Record<string, unknown>).statusCode === 404) return false;
       rethrow_if_access_denied(err);
       throw err;
     }
@@ -113,7 +114,7 @@ export class GraphMailboxConnector implements MailboxConnector {
         `/users/${mailbox_id}/mailFolders` +
         '?$select=id,displayName,parentFolderId,totalItemCount&$top=250';
       const folder_records = await this.collect_all_pages<GraphFolderRecord>(url);
-      return this.filter_and_map_folders(folder_records);
+      return filter_and_map_folders(folder_records);
     } catch (err) {
       rethrow_if_access_denied(err);
       throw err;
@@ -190,47 +191,11 @@ export class GraphMailboxConnector implements MailboxConnector {
     try {
       const url = `/users/${mailbox_id}/messages/${message_id}/attachments`;
       const records = await this.collect_all_pages<GraphAttachmentRecord>(url);
-      return this.map_file_attachments(records);
+      return map_file_attachments(records);
     } catch (err) {
       rethrow_if_access_denied(err);
       throw err;
     }
-  }
-
-  /** Filters to fileAttachment, decodes base64 content, warns on missing bytes. */
-  private map_file_attachments(records: GraphAttachmentRecord[]): MessageAttachment[] {
-    const results: MessageAttachment[] = [];
-
-    for (const r of records) {
-      if (r['@odata.type'] !== '#microsoft.graph.fileAttachment') continue;
-
-      if (!r.contentBytes) {
-        logger.warn(
-          `Attachment "${r.name ?? '?'}" (${r.size ?? 0} bytes) has no contentBytes -- ` +
-            `likely exceeds Graph API inline limit (>4MB). Metadata recorded, binary skipped.`,
-        );
-        results.push({
-          attachment_id: r.id ?? '',
-          name: r.name ?? '',
-          content_type: r.contentType ?? 'application/octet-stream',
-          size_bytes: r.size ?? 0,
-          is_inline: r.isInline === true,
-          content: Buffer.alloc(0),
-        });
-        continue;
-      }
-
-      results.push({
-        attachment_id: r.id ?? '',
-        name: r.name ?? '',
-        content_type: r.contentType ?? 'application/octet-stream',
-        size_bytes: r.size ?? 0,
-        is_inline: r.isInline === true,
-        content: Buffer.from(r.contentBytes, 'base64'),
-      });
-    }
-
-    return results;
   }
 
   // ---------------------------------------------------------------------------
@@ -362,22 +327,5 @@ export class GraphMailboxConnector implements MailboxConnector {
     }
 
     return all_items;
-  }
-
-  /** Extracts non-null user IDs from Graph user records. */
-  private extract_user_ids(users: GraphUserRecord[]): string[] {
-    return users.filter((u) => u.id).map((u) => u.id!);
-  }
-
-  /** Filters out excluded system folders and maps to our MailFolder type. */
-  private filter_and_map_folders(folders: GraphFolderRecord[]): MailFolder[] {
-    return folders
-      .filter((f) => f.id && !EXCLUDED_FOLDERS.has((f.displayName ?? '').toLowerCase()))
-      .map((f) => ({
-        folder_id: f.id!,
-        display_name: f.displayName ?? '',
-        parent_folder_id: f.parentFolderId ?? undefined,
-        total_item_count: f.totalItemCount ?? 0,
-      }));
   }
 }

--- a/src/adapters/m365/graph-mailbox-response-mappers.ts
+++ b/src/adapters/m365/graph-mailbox-response-mappers.ts
@@ -1,0 +1,80 @@
+import type { MailFolder, MessageAttachment } from '@/ports/mailbox/connector.port';
+import { logger } from '@/utils/logger';
+
+const EXCLUDED_FOLDERS = new Set(['drafts', 'outbox', 'recoverableitemsdeletions', 'junkemail']);
+
+export interface GraphUserRecord {
+  id?: string;
+  mail?: string;
+  displayName?: string;
+}
+
+export interface GraphFolderRecord {
+  id?: string;
+  displayName?: string;
+  parentFolderId?: string;
+  totalItemCount?: number;
+}
+
+export interface GraphAttachmentRecord {
+  '@odata.type'?: string;
+  id?: string;
+  name?: string;
+  contentType?: string;
+  size?: number;
+  isInline?: boolean;
+  contentBytes?: string;
+}
+
+/** Extracts non-null user IDs from Graph user records. */
+export function extract_user_ids(users: GraphUserRecord[]): string[] {
+  return users.filter((u) => u.id).map((u) => u.id!);
+}
+
+/** Filters out excluded system folders and maps to our MailFolder type. */
+export function filter_and_map_folders(folders: GraphFolderRecord[]): MailFolder[] {
+  return folders
+    .filter((f) => f.id && !EXCLUDED_FOLDERS.has((f.displayName ?? '').toLowerCase()))
+    .map((f) => ({
+      folder_id: f.id!,
+      display_name: f.displayName ?? '',
+      parent_folder_id: f.parentFolderId ?? undefined,
+      total_item_count: f.totalItemCount ?? 0,
+    }));
+}
+
+/** Filters to fileAttachment, decodes base64 content, warns on missing bytes. */
+export function map_file_attachments(records: GraphAttachmentRecord[]): MessageAttachment[] {
+  const results: MessageAttachment[] = [];
+
+  for (const r of records) {
+    if (r['@odata.type'] !== '#microsoft.graph.fileAttachment') continue;
+
+    if (!r.contentBytes) {
+      logger.warn(
+        `Attachment "${r.name ?? '?'}" (${r.size ?? 0} bytes) has no contentBytes -- ` +
+          `likely exceeds Graph API inline limit (>4MB). Metadata recorded, binary skipped.`,
+      );
+      results.push({
+        attachment_id: r.id ?? '',
+        name: r.name ?? '',
+        content_type: r.contentType ?? 'application/octet-stream',
+        size_bytes: r.size ?? 0,
+        is_inline: r.isInline === true,
+        content: Buffer.alloc(0),
+      });
+      continue;
+    }
+
+    results.push({
+      attachment_id: r.id ?? '',
+      name: r.name ?? '',
+      content_type: r.contentType ?? 'application/octet-stream',
+      size_bytes: r.size ?? 0,
+      is_inline: r.isInline === true,
+      content: Buffer.from(r.contentBytes, 'base64'),
+    });
+  }
+
+  return results;
+}

--- a/src/adapters/m365/graph-restore-connector.adapter.ts
+++ b/src/adapters/m365/graph-restore-connector.adapter.ts
@@ -7,8 +7,11 @@ import type {
   UploadSession,
 } from '@/ports/restore/connector.port';
 import type { MailFolder } from '@/ports/mailbox/connector.port';
-import { rethrow_if_access_denied } from './graph-error-helpers';
-import { with_graph_retry } from './graph-error-helpers';
+import {
+  rethrow_if_access_denied,
+  rethrow_if_mailbox_not_licensed,
+  with_graph_retry,
+} from './graph-error-helpers';
 import { logger } from '@/utils/logger';
 
 const LARGE_ATTACHMENT_THRESHOLD = 3 * 1024 * 1024;
@@ -57,6 +60,7 @@ export class GraphRestoreConnector implements RestoreConnector {
         total_item_count: response.totalItemCount ?? 0,
       };
     } catch (err) {
+      rethrow_if_mailbox_not_licensed(err);
       rethrow_if_access_denied(err);
       throw err;
     }
@@ -79,6 +83,7 @@ export class GraphRestoreConnector implements RestoreConnector {
       if (!response.id) throw new Error('Graph returned no message ID after create');
       return response.id;
     } catch (err) {
+      rethrow_if_mailbox_not_licensed(err);
       rethrow_if_access_denied(err);
       throw err;
     }
@@ -108,6 +113,7 @@ export class GraphRestoreConnector implements RestoreConnector {
     try {
       await with_graph_retry(() => this._client.api(url).post(payload));
     } catch (err) {
+      rethrow_if_mailbox_not_licensed(err);
       rethrow_if_access_denied(err);
       throw err;
     }
@@ -138,6 +144,7 @@ export class GraphRestoreConnector implements RestoreConnector {
       if (!response.uploadUrl) throw new Error('Graph returned no uploadUrl for session');
       return { upload_url: response.uploadUrl, expiration: response.expirationDateTime ?? '' };
     } catch (err) {
+      rethrow_if_mailbox_not_licensed(err);
       rethrow_if_access_denied(err);
       throw err;
     }

--- a/src/adapters/sdk/atlas-instance.adapter.ts
+++ b/src/adapters/sdk/atlas-instance.adapter.ts
@@ -7,6 +7,7 @@ import type { RestoreUseCase } from '@/ports/restore/use-case.port';
 import type { CatalogUseCase } from '@/ports/catalog/use-case.port';
 import type { DeletionUseCase } from '@/ports/deletion/use-case.port';
 import type { StorageCheckUseCase } from '@/ports/storage-check/use-case.port';
+import type { SaveUseCase } from '@/ports/save/use-case.port';
 import {
   BACKUP_USE_CASE_TOKEN,
   VERIFICATION_USE_CASE_TOKEN,
@@ -14,6 +15,7 @@ import {
   CATALOG_USE_CASE_TOKEN,
   DELETION_USE_CASE_TOKEN,
   STORAGE_CHECK_USE_CASE_TOKEN,
+  SAVE_USE_CASE_TOKEN,
 } from '@/ports/tokens/use-case.tokens';
 
 /** Creates a tenant-bound Atlas SDK instance from explicit configuration values. */
@@ -27,6 +29,7 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
   const catalogUseCase = container.get<CatalogUseCase>(CATALOG_USE_CASE_TOKEN);
   const deletionUseCase = container.get<DeletionUseCase>(DELETION_USE_CASE_TOKEN);
   const storageCheckUseCase = container.get<StorageCheckUseCase>(STORAGE_CHECK_USE_CASE_TOKEN);
+  const saveUseCase = container.get<SaveUseCase>(SAVE_USE_CASE_TOKEN);
 
   return {
     async backupMailbox(mailboxId, options) {
@@ -40,6 +43,12 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     },
     async restoreMailbox(mailboxId, options) {
       return await restoreUseCase.restore_mailbox(tenantId, mailboxId, options);
+    },
+    async saveSnapshot(snapshotId, options) {
+      return await saveUseCase.save_snapshot(tenantId, snapshotId, options);
+    },
+    async saveMailbox(mailboxId, options) {
+      return await saveUseCase.save_mailbox(tenantId, mailboxId, options);
     },
     async listMailboxes() {
       return await catalogUseCase.list_mailboxes(tenantId);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { register_list_command } from '@/cli/commands/list.command';
 import { register_read_command } from '@/cli/commands/read.command';
 import { register_delete_command } from '@/cli/commands/delete.command';
 import { register_storage_check_command } from '@/cli/commands/storage-check.command';
+import { register_save_command } from '@/cli/commands/save.command';
 import { logger } from '@/utils/logger';
 import type { Container } from 'inversify';
 
@@ -40,6 +41,7 @@ function register_commands(program: Command): void {
   register_read_command(program, get_container);
   register_delete_command(program, get_container);
   register_storage_check_command(program, get_container);
+  register_save_command(program, get_container);
 }
 
 /** Handles top-level unhandled errors from command execution. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,7 +67,7 @@ function log_s3_connection_hint(err: Record<string, unknown>, message: string): 
     code === 'ENOTFOUND' ||
     code === 'ETIMEDOUT' ||
     lower_message.includes('econnrefused') ||
-    lower_message.includes('connect') ||
+    lower_message.includes('econnreset') ||
     lower_message.includes('socket hang up');
 
   if (!is_connection_error) return;

--- a/src/cli/commands/backup.command.ts
+++ b/src/cli/commands/backup.command.ts
@@ -51,7 +51,7 @@ function resolve_tenant_id(container: Container, options: BackupOptions): string
 
 /** Builds SyncOptions from CLI flags. */
 function build_sync_options(options: BackupOptions): SyncOptions {
-  const page_size = Math.max(1, Math.min(100, parseInt(options.pageSize ?? '25', 10) || 25));
+  const page_size = Math.max(1, Math.min(100, parseInt(options.pageSize ?? '10', 10) || 10));
   const object_lock_request = build_object_lock_request(options);
   const object_lock_policy = build_object_lock_policy(options);
   return {

--- a/src/cli/commands/backup.command.ts
+++ b/src/cli/commands/backup.command.ts
@@ -35,7 +35,7 @@ export function register_backup_command(program: Command, get_container: Contain
     .option('-m, --mailbox <id>', 'specific mailbox to back up (backs up all if omitted)')
     .option('-f, --folder <name...>', 'specific folder(s) to back up (e.g. -f Inbox "Sent Items")')
     .option('--full', 'force a full backup, ignoring saved delta state from prior runs')
-    .option('-P, --page-size <n>', 'Graph API page size per delta request (1-100)', '25')
+    .option('-P, --page-size <n>', 'Graph API page size per delta request (1-100)', '10')
     .option('--retention-days <n>', 'apply object lock retention for N days')
     .option('--lock-mode <mode>', 'Object Lock mode: governance|compliance')
     .option('--require-immutability', 'fail when immutability cannot be enforced')

--- a/src/cli/commands/save.command.ts
+++ b/src/cli/commands/save.command.ts
@@ -1,0 +1,183 @@
+import { existsSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import type { Container } from 'inversify';
+import type { AtlasConfig } from '@/utils/config';
+import { ATLAS_CONFIG_TOKEN } from '@/utils/config';
+import type { SaveUseCase, SaveResult, SaveOptions } from '@/ports/save/use-case.port';
+import { SAVE_USE_CASE_TOKEN } from '@/ports/tokens/use-case.tokens';
+import { logger } from '@/utils/logger';
+
+type ContainerFactory = () => Container;
+
+interface CliSaveOptions {
+  snapshot?: string;
+  tenant?: string;
+  mailbox?: string;
+  folder?: string;
+  message?: string;
+  startDate?: string;
+  endDate?: string;
+  output?: string;
+  skipVerify?: boolean;
+}
+
+/** Registers the `atlas save` subcommand. */
+export function register_save_command(program: Command, get_container: ContainerFactory): void {
+  program
+    .command('save')
+    .description('Save backed-up emails as EML files in a compressed zip archive')
+    .option('-s, --snapshot <id>', 'save from a specific snapshot')
+    .option('-m, --mailbox <email>', 'save from all snapshots for this mailbox')
+    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .option('-f, --folder <name>', 'save only messages from this folder')
+    .option('--message <ref>', 'save a single message by # from atlas list, or full ID')
+    .option('--start-date <YYYY-MM-DD>', 'include snapshots created on or after this date')
+    .option('--end-date <YYYY-MM-DD>', 'include snapshots created on or before this date')
+    .option('-o, --output <path>', 'output zip file path (default: Restore-<timestamp>.zip)')
+    .option('--skip-verify', 'skip SHA-256 integrity checks (faster on low-power systems)')
+    .action((options: CliSaveOptions) => {
+      validate_save_options(options);
+      return execute_save(get_container(), options);
+    });
+}
+
+function validate_save_options(options: CliSaveOptions): void {
+  if (!options.snapshot && !options.mailbox) {
+    logger.error('Either --snapshot (-s) or --mailbox (-m) is required.');
+    process.exit(1);
+  }
+  if ((options.startDate || options.endDate) && options.snapshot && !options.mailbox) {
+    logger.error('--start-date / --end-date can only be used with --mailbox (-m).');
+    process.exit(1);
+  }
+}
+
+function resolve_tenant_id(container: Container, options: CliSaveOptions): string {
+  if (options.tenant) return options.tenant;
+  const config = container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN);
+  return config.tenant_id;
+}
+
+function parse_date(value: string, label: string): Date {
+  const d = new Date(value + 'T00:00:00Z');
+  if (isNaN(d.getTime())) {
+    logger.error(`Invalid ${label}: "${value}". Expected YYYY-MM-DD.`);
+    process.exit(1);
+  }
+  return d;
+}
+
+async function confirm_overwrite(file_path: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(`File "${file_path}" already exists. Overwrite? [Y/n] `, (answer) => {
+      rl.close();
+      const trimmed = answer.trim().toLowerCase();
+      resolve(trimmed === '' || trimmed === 'y' || trimmed === 'yes');
+    });
+  });
+}
+
+async function execute_save(container: Container, options: CliSaveOptions): Promise<void> {
+  const tenant_id = resolve_tenant_id(container, options);
+  const save_service = container.get<SaveUseCase>(SAVE_USE_CASE_TOKEN);
+
+  logger.banner('Atlas Save');
+  logger.info(`Tenant: ${tenant_id}`);
+
+  const save_options = build_save_options(options);
+
+  if (save_options.output_path && existsSync(save_options.output_path)) {
+    const proceed = await confirm_overwrite(save_options.output_path);
+    if (!proceed) {
+      logger.info('Cancelled.');
+      return;
+    }
+  }
+
+  if (options.snapshot && !options.mailbox) {
+    return execute_snapshot_save(save_service, tenant_id, options, save_options);
+  }
+
+  return execute_mailbox_save(save_service, tenant_id, options, save_options);
+}
+
+function build_save_options(options: CliSaveOptions): SaveOptions {
+  return {
+    ...(options.folder && { folder_name: options.folder }),
+    ...(options.message && { message_ref: options.message }),
+    ...(options.output && { output_path: options.output }),
+    ...(options.skipVerify && { skip_integrity_check: true }),
+    ...(options.startDate && { start_date: parse_date(options.startDate, '--start-date') }),
+    ...(options.endDate && { end_date: parse_date(options.endDate, '--end-date') }),
+  };
+}
+
+async function execute_snapshot_save(
+  service: SaveUseCase,
+  tenant_id: string,
+  cli_options: CliSaveOptions,
+  save_options: SaveOptions,
+): Promise<void> {
+  logger.info(`Snapshot: ${chalk.cyan(cli_options.snapshot!)}`);
+  if (cli_options.folder) logger.info(`Folder filter: ${chalk.cyan(cli_options.folder)}`);
+  if (cli_options.message) logger.info(`Message: ${chalk.cyan(cli_options.message)}`);
+
+  const result = await service.save_snapshot(tenant_id, cli_options.snapshot!, save_options);
+  report_save_result(result);
+}
+
+async function execute_mailbox_save(
+  service: SaveUseCase,
+  tenant_id: string,
+  cli_options: CliSaveOptions,
+  save_options: SaveOptions,
+): Promise<void> {
+  const mailbox_id = cli_options.mailbox!.toLowerCase();
+  logger.info(`Mailbox: ${chalk.cyan(mailbox_id)}`);
+
+  if (cli_options.startDate) logger.info(`Start date: ${chalk.cyan(cli_options.startDate)}`);
+  if (cli_options.endDate) logger.info(`End date:   ${chalk.cyan(cli_options.endDate)}`);
+  if (cli_options.folder) logger.info(`Folder filter: ${chalk.cyan(cli_options.folder)}`);
+
+  const result = await service.save_mailbox(tenant_id, mailbox_id, save_options);
+  report_save_result(result);
+}
+
+function report_save_result(result: SaveResult): void {
+  const size_mb = (result.total_bytes / (1024 * 1024)).toFixed(1);
+  const att_info =
+    result.attachment_count > 0
+      ? ` + ${chalk.cyan(String(result.attachment_count))} attachments`
+      : '';
+
+  if (result.error_count === 0 && result.integrity_failures.length === 0) {
+    logger.success(
+      `Saved ${chalk.green(String(result.saved_count))} messages${att_info}` +
+        ` (${chalk.cyan(size_mb + ' MB')}) to ${chalk.cyan(result.output_path)}`,
+    );
+    return;
+  }
+
+  if (result.integrity_failures.length > 0) {
+    logger.warn(
+      `${chalk.yellow(String(result.integrity_failures.length))} integrity check failures`,
+    );
+  }
+
+  if (result.error_count > 0) {
+    logger.warn(
+      `Saved ${result.saved_count} messages with ` +
+        `${chalk.yellow(String(result.error_count))} errors`,
+    );
+    for (const err of result.errors.slice(0, 10)) {
+      logger.error(`  - ${err}`);
+    }
+    if (result.errors.length > 10) {
+      logger.error(`  ... and ${result.errors.length - 10} more`);
+    }
+    process.exitCode = 1;
+  }
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -13,6 +13,7 @@ import {
   CATALOG_USE_CASE_TOKEN,
   DELETION_USE_CASE_TOKEN,
   STORAGE_CHECK_USE_CASE_TOKEN,
+  SAVE_USE_CASE_TOKEN,
 } from '@/ports/tokens/use-case.tokens';
 import { GraphMailboxConnector } from '@/adapters/m365/graph-mailbox-connector.adapter';
 import { GraphRestoreConnector } from '@/adapters/m365/graph-restore-connector.adapter';
@@ -26,6 +27,7 @@ import { RestoreService } from '@/services/restore/restore.service';
 import { CatalogService } from '@/services/catalog/catalog.service';
 import { DeletionService } from '@/services/deletion/deletion.service';
 import { StorageCheckService } from '@/services/storage-check/storage-check.service';
+import { SaveService } from '@/services/save/save.service';
 import type { AtlasConfig } from '@/utils/config';
 import { load_config, ATLAS_CONFIG_TOKEN } from '@/utils/config';
 
@@ -83,4 +85,6 @@ function bind_services(container: Container): void {
   container.bind(DELETION_USE_CASE_TOKEN).toService(DeletionService);
   container.bind(StorageCheckService).toSelf();
   container.bind(STORAGE_CHECK_USE_CASE_TOKEN).toService(StorageCheckService);
+  container.bind(SaveService).toSelf();
+  container.bind(SAVE_USE_CASE_TOKEN).toService(SaveService);
 }

--- a/src/ports/atlas/use-case.port.ts
+++ b/src/ports/atlas/use-case.port.ts
@@ -1,6 +1,7 @@
 import type { SyncOptions, SyncResult } from '@/ports/backup/use-case.port';
 import type { VerificationResult } from '@/ports/verification/use-case.port';
 import type { RestoreOptions, RestoreResult } from '@/ports/restore/use-case.port';
+import type { SaveOptions, SaveResult } from '@/ports/save/use-case.port';
 import type { MailboxSummary, ReadMessageResult } from '@/ports/catalog/use-case.port';
 import type { Manifest } from '@/domain/manifest';
 import type { DeletionResult } from '@/ports/deletion/use-case.port';
@@ -22,6 +23,8 @@ export interface AtlasInstance {
   verifySnapshot(snapshotId: string): Promise<VerificationResult>;
   restoreSnapshot(snapshotId: string, options?: RestoreOptions): Promise<RestoreResult>;
   restoreMailbox(mailboxId: string, options?: RestoreOptions): Promise<RestoreResult>;
+  saveSnapshot(snapshotId: string, options?: SaveOptions): Promise<SaveResult>;
+  saveMailbox(mailboxId: string, options?: SaveOptions): Promise<SaveResult>;
   listMailboxes(): Promise<MailboxSummary[]>;
   listSnapshots(mailboxId: string): Promise<Manifest[]>;
   getSnapshotDetail(snapshotId: string): Promise<Manifest | undefined>;

--- a/src/ports/mailbox/connector.port.ts
+++ b/src/ports/mailbox/connector.port.ts
@@ -47,6 +47,9 @@ export interface MessageAttachment {
 export interface MailboxConnector {
   list_mailboxes(tenant_id: string): Promise<string[]>;
 
+  /** Returns true if the mailbox exists in the tenant, false otherwise. */
+  mailbox_exists(tenant_id: string, mailbox_id: string): Promise<boolean>;
+
   list_mail_folders(tenant_id: string, mailbox_id: string): Promise<MailFolder[]>;
 
   /**

--- a/src/ports/save/use-case.port.ts
+++ b/src/ports/save/use-case.port.ts
@@ -1,0 +1,27 @@
+export interface SaveOptions {
+  readonly folder_name?: string;
+  readonly message_ref?: string;
+  readonly start_date?: Date;
+  readonly end_date?: Date;
+  readonly output_path?: string;
+  readonly skip_integrity_check?: boolean;
+}
+
+export interface SaveResult {
+  readonly snapshot_id: string;
+  readonly saved_count: number;
+  readonly attachment_count: number;
+  readonly error_count: number;
+  readonly errors: string[];
+  readonly output_path: string;
+  readonly total_bytes: number;
+  readonly integrity_failures: string[];
+}
+
+export interface SaveUseCase {
+  /** Saves messages from a single snapshot to a zip archive of EML files. */
+  save_snapshot(tenant_id: string, snapshot_id: string, options?: SaveOptions): Promise<SaveResult>;
+
+  /** Saves messages from all snapshots for a mailbox, merged and deduplicated. */
+  save_mailbox(tenant_id: string, mailbox_id: string, options?: SaveOptions): Promise<SaveResult>;
+}

--- a/src/ports/tokens/use-case.tokens.ts
+++ b/src/ports/tokens/use-case.tokens.ts
@@ -4,3 +4,4 @@ export const RESTORE_USE_CASE_TOKEN = Symbol.for('RestoreUseCase');
 export const CATALOG_USE_CASE_TOKEN = Symbol.for('CatalogUseCase');
 export const DELETION_USE_CASE_TOKEN = Symbol.for('DeletionUseCase');
 export const STORAGE_CHECK_USE_CASE_TOKEN = Symbol.for('StorageCheckUseCase');
+export const SAVE_USE_CASE_TOKEN = Symbol.for('SaveUseCase');

--- a/src/services/backup/mailbox-sync.service.ts
+++ b/src/services/backup/mailbox-sync.service.ts
@@ -53,6 +53,7 @@ export class MailboxSyncService implements BackupUseCase {
     options: SyncOptions = {},
   ): Promise<SyncResult> {
     mailbox_id = mailbox_id.toLowerCase();
+    await this.assert_mailbox_exists(tenant_id, mailbox_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     const snapshot = create_pending_snapshot(tenant_id, mailbox_id);
     const sync_start = Date.now();
@@ -198,6 +199,17 @@ export class MailboxSyncService implements BackupUseCase {
     if (options.force_full) return 'full';
     if (Object.keys(saved_links).length > 0) return 'incremental';
     return 'initial';
+  }
+
+  /** Fails fast if the mailbox does not exist in the tenant. */
+  private async assert_mailbox_exists(tenant_id: string, mailbox_id: string): Promise<void> {
+    const exists = await this._connector.mailbox_exists(tenant_id, mailbox_id);
+    if (!exists) {
+      throw new Error(
+        `Mailbox "${mailbox_id}" does not exist in the tenant. ` +
+          `Verify the email address and try again.`,
+      );
+    }
   }
 
   /**

--- a/src/services/restore/restore.service.ts
+++ b/src/services/restore/restore.service.ts
@@ -59,6 +59,8 @@ export class RestoreService implements RestoreUseCase {
     const source_mailbox = manifest.mailbox_id;
     const target_mailbox = options.target_mailbox?.toLowerCase() ?? source_mailbox;
 
+    await this.assert_mailbox_exists(tenant_id, target_mailbox);
+
     const entries = await this.resolve_entries(ctx, manifest, source_mailbox, tenant_id, options);
     if (entries.length === 0) {
       logger.warn('No entries to restore');
@@ -92,6 +94,8 @@ export class RestoreService implements RestoreUseCase {
   ): Promise<RestoreResult> {
     const ctx = await this._tenant_factory.create(tenant_id);
     const target = options.target_mailbox?.toLowerCase() ?? mailbox_id;
+
+    await this.assert_mailbox_exists(tenant_id, target);
 
     const manifests = await this.load_mailbox_manifests(ctx, mailbox_id, options);
     if (manifests.length === 0) {
@@ -309,6 +313,17 @@ export class RestoreService implements RestoreUseCase {
       };
     } finally {
       process.removeListener('SIGINT', on_sigint);
+    }
+  }
+
+  /** Fails fast if the target mailbox does not exist in the tenant. */
+  private async assert_mailbox_exists(tenant_id: string, mailbox_id: string): Promise<void> {
+    const exists = await this._connector.mailbox_exists(tenant_id, mailbox_id);
+    if (!exists) {
+      throw new Error(
+        `Mailbox "${mailbox_id}" does not exist in the tenant. ` +
+          `Verify the email address and try again.`,
+      );
     }
   }
 

--- a/src/services/save/eml-builder.ts
+++ b/src/services/save/eml-builder.ts
@@ -1,0 +1,165 @@
+import { createMimeMessage } from 'mimetext';
+
+interface GraphRecipient {
+  emailAddress?: { name?: string; address?: string };
+}
+
+interface DecryptedAttachment {
+  readonly name: string;
+  readonly content_type: string;
+  readonly content: Buffer;
+  readonly is_inline: boolean;
+}
+
+/**
+ * Converts a decrypted Graph API message JSON and its attachments
+ * into an RFC-5322 compliant EML buffer.
+ */
+export function build_eml(
+  message_json: Record<string, unknown>,
+  attachments: DecryptedAttachment[],
+): Buffer {
+  const msg = createMimeMessage();
+
+  const from = extract_email_address(message_json['from'] as GraphRecipient | undefined);
+  if (from) msg.setSender(from);
+
+  const to = extract_recipient_list(message_json['toRecipients'] as GraphRecipient[] | undefined);
+  if (to.length > 0) msg.setTo(to);
+
+  const cc = extract_recipient_list(message_json['ccRecipients'] as GraphRecipient[] | undefined);
+  if (cc.length > 0) msg.setCc(cc);
+
+  const bcc = extract_recipient_list(message_json['bccRecipients'] as GraphRecipient[] | undefined);
+  if (bcc.length > 0) msg.setBcc(bcc);
+
+  const subject = (message_json['subject'] as string) ?? '(no subject)';
+  msg.setSubject(subject);
+
+  set_date_header(msg, message_json);
+  set_message_id_header(msg, message_json);
+
+  add_body(msg, message_json);
+
+  for (const att of attachments) {
+    msg.addAttachment({
+      filename: att.name,
+      contentType: att.content_type,
+      data: att.content.toString('base64'),
+      inline: att.is_inline,
+    });
+  }
+
+  return Buffer.from(msg.asRaw(), 'utf-8');
+}
+
+/**
+ * Generates a filesystem-safe filename from a received timestamp and subject.
+ * Format: 2026-03-10_143022_Meeting-with-client.eml
+ */
+export function build_eml_filename(
+  received_date_time: string | undefined,
+  subject: string | undefined,
+): string {
+  const ts = format_timestamp(received_date_time);
+  const safe_subject = sanitize_subject(subject ?? 'no-subject');
+  return `${ts}_${safe_subject}.eml`;
+}
+
+/** Deduplicates a filename within a folder by appending _1, _2, etc. */
+export function deduplicate_filename(filename: string, used_names: Set<string>): string {
+  if (!used_names.has(filename)) {
+    used_names.add(filename);
+    return filename;
+  }
+
+  const dot = filename.lastIndexOf('.');
+  const base = dot > 0 ? filename.slice(0, dot) : filename;
+  const ext = dot > 0 ? filename.slice(dot) : '';
+
+  let counter = 1;
+  let candidate = `${base}_${counter}${ext}`;
+  while (used_names.has(candidate)) {
+    counter++;
+    candidate = `${base}_${counter}${ext}`;
+  }
+  used_names.add(candidate);
+  return candidate;
+}
+
+function extract_email_address(
+  recipient: GraphRecipient | undefined,
+): { name: string; addr: string } | undefined {
+  const addr = recipient?.emailAddress?.address;
+  if (!addr) return undefined;
+  return { name: recipient?.emailAddress?.name ?? '', addr };
+}
+
+function extract_recipient_list(
+  recipients: GraphRecipient[] | undefined,
+): Array<{ name: string; addr: string }> {
+  if (!recipients) return [];
+  return recipients
+    .map((r) => extract_email_address(r))
+    .filter((r): r is { name: string; addr: string } => r !== undefined);
+}
+
+function set_date_header(
+  msg: ReturnType<typeof createMimeMessage>,
+  json: Record<string, unknown>,
+): void {
+  const received = json['receivedDateTime'] as string | undefined;
+  const sent = json['sentDateTime'] as string | undefined;
+  const date_str = received ?? sent;
+  if (date_str) {
+    msg.setHeader('Date', new Date(date_str).toUTCString());
+  }
+}
+
+function set_message_id_header(
+  msg: ReturnType<typeof createMimeMessage>,
+  json: Record<string, unknown>,
+): void {
+  const msg_id = json['internetMessageId'] as string | undefined;
+  if (msg_id) {
+    msg.setHeader('Message-ID', msg_id);
+  }
+}
+
+function add_body(msg: ReturnType<typeof createMimeMessage>, json: Record<string, unknown>): void {
+  const body = json['body'] as { contentType?: string; content?: string } | undefined;
+  if (!body?.content) return;
+
+  const content_type = body.contentType?.toLowerCase() === 'html' ? 'text/html' : 'text/plain';
+  msg.addMessage({ contentType: content_type, data: body.content });
+}
+
+function format_timestamp(date_str: string | undefined): string {
+  if (!date_str) return 'unknown';
+  try {
+    const d = new Date(date_str);
+    const yyyy = d.getUTCFullYear();
+    const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(d.getUTCDate()).padStart(2, '0');
+    const hh = String(d.getUTCHours()).padStart(2, '0');
+    const mi = String(d.getUTCMinutes()).padStart(2, '0');
+    const ss = String(d.getUTCSeconds()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}_${hh}${mi}${ss}`;
+  } catch {
+    return 'unknown';
+  }
+}
+
+const MAX_SUBJECT_LENGTH = 80;
+
+function sanitize_subject(subject: string): string {
+  return (
+    subject
+      .replace(/[<>:"/\\|?*\x00-\x1f]/g, '')
+      .replace(/\.{2,}/g, '.')
+      .replace(/\s+/g, '-')
+      .replace(/-{2,}/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, MAX_SUBJECT_LENGTH) || 'untitled'
+  );
+}

--- a/src/services/save/save-entry-processor.ts
+++ b/src/services/save/save-entry-processor.ts
@@ -1,0 +1,254 @@
+import chalk from 'chalk';
+import type { TenantContext } from '@/ports/tenant/context.port';
+import type { ManifestEntry, AttachmentEntry } from '@/domain/manifest';
+import type { SaveResult } from '@/ports/save/use-case.port';
+import { build_eml, build_eml_filename, deduplicate_filename } from '@/services/save/eml-builder';
+import { verify_checksum } from '@/services/save/save-integrity-validator';
+import {
+  create_save_archive,
+  add_eml_to_archive,
+  finalize_archive,
+} from '@/services/save/save-zip-writer';
+import type { SaveProgressDashboard } from '@/services/save/save-progress-dashboard';
+import { calc_rate } from '@/services/shared/progress-rate';
+import { logger } from '@/utils/logger';
+
+interface DecryptedAttachment {
+  readonly name: string;
+  readonly content_type: string;
+  readonly content: Buffer;
+  readonly is_inline: boolean;
+}
+
+/** Processes all grouped entries into a zip archive, updating the dashboard. */
+export async function save_entries_to_archive(
+  ctx: TenantContext,
+  output_path: string,
+  skip_integrity: boolean,
+  groups: Map<string, ManifestEntry[]>,
+  folder_map: Map<string, string>,
+  dashboard: SaveProgressDashboard,
+  is_interrupted: () => boolean,
+): Promise<Omit<SaveResult, 'snapshot_id'>> {
+  const { archive, promise } = create_save_archive(output_path);
+
+  let global_saved = 0;
+  let global_att = 0;
+  let global_errors = 0;
+  let integrity_ok = 0;
+  let integrity_fail = 0;
+  const all_errors: string[] = [];
+  const integrity_failures: string[] = [];
+  const start = Date.now();
+  const global_total = [...groups.values()].reduce((s, g) => s + g.length, 0);
+
+  let folder_index = 0;
+  for (const [fid, folder_items] of groups) {
+    if (is_interrupted()) break;
+    dashboard.mark_active(folder_index);
+
+    const folder_name = folder_map.get(fid) ?? 'Unknown';
+    const used_names = new Set<string>();
+    let folder_saved = 0;
+    let folder_att = 0;
+
+    for (const entry of folder_items) {
+      if (is_interrupted()) break;
+
+      try {
+        const result = await process_single_entry(
+          ctx,
+          entry,
+          folder_name,
+          skip_integrity,
+          archive,
+          used_names,
+        );
+
+        folder_saved++;
+        folder_att += result.attachment_count;
+        integrity_ok += result.integrity_ok;
+        integrity_fail += result.integrity_fail;
+        integrity_failures.push(...result.integrity_failures);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        all_errors.push(`${entry.object_id}: ${msg}`);
+        global_errors++;
+      }
+
+      global_saved =
+        global_saved - folder_saved + folder_saved + (global_saved - global_saved + folder_saved);
+      const gp = count_processed_before(groups, folder_index) + folder_saved;
+      const rate = calc_rate(gp, Date.now() - start);
+      const eta = rate > 0 ? (global_total - gp) / rate : 0;
+
+      dashboard.update_active(
+        folder_index,
+        folder_saved,
+        folder_att,
+        integrity_ok,
+        integrity_fail,
+        rate,
+        eta,
+      );
+      dashboard.update_total(gp, global_total, rate, eta);
+    }
+
+    if (!is_interrupted()) {
+      dashboard.mark_done(folder_index, folder_saved, folder_att);
+    }
+
+    global_saved = count_processed_before(groups, folder_index) + folder_saved;
+    global_att += folder_att;
+    folder_index++;
+  }
+
+  await finalize_archive(archive);
+  const total_bytes = await promise;
+
+  log_save_summary(global_saved, global_att, global_errors, total_bytes, start);
+
+  return {
+    saved_count: global_saved,
+    attachment_count: global_att,
+    error_count: global_errors,
+    errors: all_errors,
+    output_path,
+    total_bytes,
+    integrity_failures,
+  };
+}
+
+interface EntryResult {
+  attachment_count: number;
+  integrity_ok: number;
+  integrity_fail: number;
+  integrity_failures: string[];
+}
+
+async function process_single_entry(
+  ctx: TenantContext,
+  entry: ManifestEntry,
+  folder_name: string,
+  skip_integrity: boolean,
+  archive: Parameters<typeof add_eml_to_archive>[0],
+  used_names: Set<string>,
+): Promise<EntryResult> {
+  const result: EntryResult = {
+    attachment_count: 0,
+    integrity_ok: 0,
+    integrity_fail: 0,
+    integrity_failures: [],
+  };
+
+  const ciphertext = await ctx.storage.get(entry.storage_key);
+  const plaintext = ctx.decrypt(ciphertext);
+
+  if (!skip_integrity && entry.checksum) {
+    if (!verify_checksum(plaintext, entry.checksum)) {
+      result.integrity_fail++;
+      result.integrity_failures.push(`message:${entry.object_id}`);
+      logger.warn(`Integrity check failed for message ${entry.object_id}`);
+    } else {
+      result.integrity_ok++;
+    }
+  }
+
+  const message_json = JSON.parse(plaintext.toString('utf-8')) as Record<string, unknown>;
+  const attachments = await decrypt_entry_attachments(ctx, entry, skip_integrity, result);
+
+  const eml_buffer = build_eml(message_json, attachments);
+  const received = message_json['receivedDateTime'] as string | undefined;
+  const subject = message_json['subject'] as string | undefined;
+  const raw_filename = build_eml_filename(received, subject);
+  const filename = deduplicate_filename(raw_filename, used_names);
+
+  add_eml_to_archive(archive, folder_name, filename, eml_buffer);
+  result.attachment_count = attachments.length;
+
+  return result;
+}
+
+async function decrypt_entry_attachments(
+  ctx: TenantContext,
+  entry: ManifestEntry,
+  skip_integrity: boolean,
+  result: EntryResult,
+): Promise<DecryptedAttachment[]> {
+  if (!entry.attachments || entry.attachments.length === 0) return [];
+
+  const decrypted: DecryptedAttachment[] = [];
+
+  for (const att of entry.attachments) {
+    if (!att.storage_key) continue;
+
+    try {
+      const content = await decrypt_and_verify_attachment(ctx, att, skip_integrity, result);
+      decrypted.push({
+        name: att.name,
+        content_type: att.content_type,
+        content,
+        is_inline: att.is_inline,
+      });
+    } catch (err) {
+      logger.warn(
+        `Failed to decrypt attachment "${att.name}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return decrypted;
+}
+
+async function decrypt_and_verify_attachment(
+  ctx: TenantContext,
+  att: AttachmentEntry,
+  skip_integrity: boolean,
+  result: EntryResult,
+): Promise<Buffer> {
+  const ciphertext = await ctx.storage.get(att.storage_key);
+  const plaintext = ctx.decrypt(ciphertext);
+
+  if (!skip_integrity && att.checksum) {
+    if (!verify_checksum(plaintext, att.checksum)) {
+      result.integrity_fail++;
+      result.integrity_failures.push(`attachment:${att.attachment_id}`);
+      logger.warn(`Integrity check failed for attachment "${att.name}"`);
+    } else {
+      result.integrity_ok++;
+    }
+  }
+
+  return plaintext;
+}
+
+function count_processed_before(
+  groups: Map<string, ManifestEntry[]>,
+  folder_index: number,
+): number {
+  let count = 0;
+  let i = 0;
+  for (const [, items] of groups) {
+    if (i >= folder_index) break;
+    count += items.length;
+    i++;
+  }
+  return count;
+}
+
+function log_save_summary(
+  saved: number,
+  attachments: number,
+  errors: number,
+  total_bytes: number,
+  start: number,
+): void {
+  const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+  const size_mb = (total_bytes / (1024 * 1024)).toFixed(1);
+  logger.info(
+    `${chalk.green(String(saved))} saved, ` +
+      `${chalk.cyan(String(attachments))} attachments, ` +
+      `${chalk.red(String(errors))} errors, ` +
+      `${chalk.cyan(size_mb + ' MB')} -- ${elapsed}s`,
+  );
+}

--- a/src/services/save/save-integrity-validator.ts
+++ b/src/services/save/save-integrity-validator.ts
@@ -1,0 +1,19 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/** Returns the SHA-256 hex digest of the given buffer. */
+export function compute_sha256(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+/**
+ * Compares a buffer's SHA-256 against an expected hex digest.
+ * Uses constant-time comparison when lengths match to prevent timing attacks.
+ */
+export function verify_checksum(data: Buffer, expected_checksum: string): boolean {
+  const actual = compute_sha256(data);
+  if (actual.length !== expected_checksum.length) return false;
+
+  const actual_buf = Buffer.from(actual, 'utf8');
+  const expected_buf = Buffer.from(expected_checksum, 'utf8');
+  return timingSafeEqual(actual_buf, expected_buf);
+}

--- a/src/services/save/save-progress-dashboard.ts
+++ b/src/services/save/save-progress-dashboard.ts
@@ -1,0 +1,213 @@
+import chalk from 'chalk';
+import { format_duration } from '@/services/shared/progress-rate';
+
+type FolderStatus = 'pending' | 'active' | 'done' | 'skipped' | 'interrupted' | 'error';
+
+interface FolderRow {
+  name: string;
+  total_items: number;
+  status: FolderStatus;
+  saved: number;
+  attachments: number;
+  integrity_ok: number;
+  integrity_fail: number;
+  rate: number;
+  eta_seconds: number;
+  error_message: string;
+}
+
+interface TotalRow {
+  global_processed: number;
+  global_total: number;
+  rate: number;
+  eta_seconds: number;
+}
+
+/**
+ * Multi-line ANSI dashboard for save-to-zip progress.
+ * Shows all folders simultaneously, redrawn in-place each update.
+ */
+export class SaveProgressDashboard {
+  private readonly _rows: FolderRow[];
+  private readonly _total: TotalRow;
+  private readonly _is_tty: boolean;
+  private _rendered = false;
+  private readonly _line_count: number;
+
+  constructor(folders: { name: string; total_items: number }[]) {
+    this._is_tty = !!process.stdout.isTTY;
+    this._rows = folders.map((f) => ({
+      name: f.name,
+      total_items: f.total_items,
+      status: 'pending',
+      saved: 0,
+      attachments: 0,
+      integrity_ok: 0,
+      integrity_fail: 0,
+      rate: 0,
+      eta_seconds: 0,
+      error_message: '',
+    }));
+    this._total = { global_processed: 0, global_total: 0, rate: 0, eta_seconds: 0 };
+    this._line_count = this._rows.length + 1;
+    this.render();
+  }
+
+  mark_active(index: number): void {
+    const row = this._rows[index];
+    if (!row) return;
+    row.status = 'active';
+    this.render();
+  }
+
+  update_active(
+    index: number,
+    saved: number,
+    attachments: number,
+    integrity_ok: number,
+    integrity_fail: number,
+    rate: number,
+    eta_seconds: number,
+  ): void {
+    const row = this._rows[index];
+    if (!row) return;
+    row.saved = saved;
+    row.attachments = attachments;
+    row.integrity_ok = integrity_ok;
+    row.integrity_fail = integrity_fail;
+    row.rate = rate;
+    row.eta_seconds = eta_seconds;
+    this.render();
+  }
+
+  mark_done(index: number, saved: number, attachments: number): void {
+    const row = this._rows[index];
+    if (!row) return;
+    row.saved = saved;
+    row.attachments = attachments;
+    row.status = row.total_items === 0 ? 'skipped' : 'done';
+    if (!this._is_tty) this.log_non_tty(row);
+    this.render();
+  }
+
+  mark_all_pending_interrupted(): void {
+    for (const row of this._rows) {
+      if (row.status === 'pending' || row.status === 'active') {
+        row.status = 'interrupted';
+        if (!this._is_tty) this.log_non_tty(row);
+      }
+    }
+    this.render();
+  }
+
+  mark_error(index: number, message: string): void {
+    const row = this._rows[index];
+    if (!row) return;
+    row.status = 'error';
+    row.error_message = message;
+    if (!this._is_tty) this.log_non_tty(row);
+    this.render();
+  }
+
+  update_total(
+    global_processed: number,
+    global_total: number,
+    rate: number,
+    eta_seconds: number,
+  ): void {
+    this._total.global_processed = global_processed;
+    this._total.global_total = global_total;
+    this._total.rate = rate;
+    this._total.eta_seconds = eta_seconds;
+  }
+
+  finish(actual_total?: number): void {
+    if (actual_total !== undefined) {
+      this._total.global_processed = actual_total;
+      this._total.global_total = actual_total;
+    }
+    this.render();
+  }
+
+  private log_non_tty(row: FolderRow): void {
+    if (row.status === 'skipped') {
+      console.log(`  [--] ${row.name} -- 0 items -- skipped`);
+    } else if (row.status === 'done') {
+      const att = row.attachments > 0 ? `, ${row.attachments} att` : '';
+      const fail = row.integrity_fail > 0 ? chalk.red(` (${row.integrity_fail} failed)`) : '';
+      console.log(`  [ok] ${row.name} -- ${row.saved} saved${att}${fail}`);
+    } else if (row.status === 'interrupted') {
+      console.log(`  [~~] ${row.name} -- interrupted`);
+    } else if (row.status === 'error') {
+      console.log(`  [!!] ${row.name} -- ERROR: ${row.error_message}`);
+    }
+  }
+
+  private render(): void {
+    if (!this._is_tty) return;
+
+    const lines = this._rows.map((r) => format_folder_row(r));
+    lines.push(format_total_row(this._total));
+
+    if (this._rendered) {
+      process.stdout.write(`\x1b[${this._line_count}A`);
+    }
+
+    for (const line of lines) {
+      process.stdout.write(`\r  ${line}\x1b[K\n`);
+    }
+
+    this._rendered = true;
+  }
+}
+
+function pad_name(name: string, width = 28): string {
+  return name.length > width ? name.slice(0, width - 1) + '~' : name.padEnd(width);
+}
+
+function format_folder_row(row: FolderRow): string {
+  const name = pad_name(row.name);
+
+  switch (row.status) {
+    case 'pending':
+      return chalk.gray(`[  ] ${name} ${row.total_items} items`);
+
+    case 'active': {
+      const fail = row.integrity_fail > 0 ? chalk.red(` ${row.integrity_fail}!`) : '';
+      return chalk.cyan(
+        `[>>] ${name} ${row.saved}/${row.total_items}${fail}` +
+          ` | ${row.rate.toFixed(1)} msg/s` +
+          ` | ETA ${format_duration(row.eta_seconds)}`,
+      );
+    }
+
+    case 'done': {
+      const att = row.attachments > 0 ? `, ${row.attachments} att` : '';
+      const fail = row.integrity_fail > 0 ? chalk.red(` (${row.integrity_fail} failed)`) : '';
+      return chalk.green(`[ok] ${name} ${row.saved} saved${att}${fail}`);
+    }
+
+    case 'skipped':
+      return chalk.gray(`[--] ${name} 0 items -- skipped`);
+
+    case 'interrupted':
+      return chalk.yellow(`[~~] ${name} -- interrupted`);
+
+    case 'error':
+      return chalk.red(`[!!] ${name} ERROR: ${row.error_message}`);
+  }
+}
+
+function format_total_row(t: TotalRow): string {
+  if (t.global_total === 0) {
+    return chalk.white('---- TOTAL                          --');
+  }
+  const done = t.global_processed >= t.global_total;
+  const eta_str = done ? 'done' : `ETA ${format_duration(t.eta_seconds)}`;
+  return chalk.white(
+    `---- TOTAL${' '.repeat(18)} ` +
+      `${t.global_processed}/${t.global_total}` +
+      ` | ${t.rate.toFixed(1)} msg/s` +
+      ` | ${eta_str}`,
+  );
+}

--- a/src/services/save/save-zip-writer.ts
+++ b/src/services/save/save-zip-writer.ts
@@ -1,0 +1,47 @@
+import { createWriteStream } from 'node:fs';
+import archiver from 'archiver';
+
+export interface SaveArchive {
+  readonly archive: archiver.Archiver;
+  readonly promise: Promise<number>;
+}
+
+/** Creates a zip archive with maximum compression, streaming to the output path. */
+export function create_save_archive(output_path: string): SaveArchive {
+  const output = createWriteStream(output_path);
+  const archive = archiver('zip', { zlib: { level: 9 } });
+
+  const promise = new Promise<number>((resolve, reject) => {
+    output.on('close', () => resolve(archive.pointer()));
+    archive.on('error', reject);
+    output.on('error', reject);
+  });
+
+  archive.pipe(output);
+  return { archive, promise };
+}
+
+/** Appends an EML buffer to the archive under folder_name/filename. */
+export function add_eml_to_archive(
+  archive: archiver.Archiver,
+  folder_name: string,
+  filename: string,
+  content: Buffer,
+): void {
+  const path = `${sanitize_path_segment(folder_name)}/${filename}`;
+  archive.append(content, { name: path });
+}
+
+/** Finalizes the archive. The returned promise resolves to total bytes written. */
+export async function finalize_archive(archive: archiver.Archiver): Promise<void> {
+  await archive.finalize();
+}
+
+function sanitize_path_segment(segment: string): string {
+  return (
+    segment
+      .replace(/[<>:"/\\|?*\x00-\x1f]/g, '_')
+      .replace(/\.{2,}/g, '.')
+      .replace(/^\.+|\.+$/g, '') || 'Unknown'
+  );
+}

--- a/src/services/save/save.service.ts
+++ b/src/services/save/save.service.ts
@@ -1,0 +1,241 @@
+import { inject, injectable } from 'inversify';
+import chalk from 'chalk';
+import type { TenantContextFactory, TenantContext } from '@/ports/tenant/context.port';
+import type { ManifestRepository } from '@/ports/storage/manifest-repository.port';
+import type { MailboxConnector } from '@/ports/mailbox/connector.port';
+import type { Manifest, ManifestEntry } from '@/domain/manifest';
+import type { SaveUseCase, SaveResult, SaveOptions } from '@/ports/save/use-case.port';
+import {
+  build_folder_map,
+  group_entries_by_folder,
+  filter_entries_by_folder_name,
+  count_unique_folders,
+} from '@/services/restore/folder-restore-planner';
+import {
+  filter_manifests_by_date,
+  merge_snapshot_entries,
+} from '@/services/restore/manifest-entry-merger';
+import { backfill_missing_folder_ids } from '@/services/restore/restore-execution-orchestrator';
+import { SaveProgressDashboard } from '@/services/save/save-progress-dashboard';
+import { logger } from '@/utils/logger';
+import {
+  TENANT_CONTEXT_FACTORY_TOKEN,
+  MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_CONNECTOR_TOKEN,
+} from '@/ports/tokens/outgoing.tokens';
+import { save_entries_to_archive } from '@/services/save/save-entry-processor';
+
+@injectable()
+export class SaveService implements SaveUseCase {
+  private _interrupted = false;
+
+  constructor(
+    @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
+    @inject(MANIFEST_REPOSITORY_TOKEN) private readonly _manifests: ManifestRepository,
+    @inject(MAILBOX_CONNECTOR_TOKEN) private readonly _connector: MailboxConnector,
+  ) {}
+
+  async save_snapshot(
+    tenant_id: string,
+    snapshot_id: string,
+    options: SaveOptions = {},
+  ): Promise<SaveResult> {
+    const ctx = await this._tenant_factory.create(tenant_id);
+    const manifest = await this.load_manifest(ctx, snapshot_id);
+    const mailbox_id = manifest.mailbox_id;
+
+    const entries = await this.resolve_entries(ctx, manifest, mailbox_id, tenant_id, options);
+    if (entries.length === 0) {
+      logger.warn('No entries to save');
+      return this.empty_result(snapshot_id, options.output_path ?? '');
+    }
+
+    return this.save_batch(ctx, tenant_id, mailbox_id, snapshot_id, entries, options);
+  }
+
+  async save_mailbox(
+    tenant_id: string,
+    mailbox_id: string,
+    options: SaveOptions = {},
+  ): Promise<SaveResult> {
+    const ctx = await this._tenant_factory.create(tenant_id);
+    const manifests = await this.load_mailbox_manifests(ctx, mailbox_id, options);
+
+    if (manifests.length === 0) {
+      logger.warn('No snapshots found for this mailbox in the given date range');
+      return this.empty_result('mailbox', options.output_path ?? '');
+    }
+
+    const entries = merge_snapshot_entries(manifests);
+
+    if (options.folder_name) {
+      await backfill_missing_folder_ids(ctx, entries);
+    }
+
+    const filtered = await this.apply_entry_filters(entries, mailbox_id, tenant_id, options);
+    if (filtered.length === 0) {
+      logger.warn('No entries to save after filtering');
+      return this.empty_result('mailbox', options.output_path ?? '');
+    }
+
+    logger.info(
+      `Aggregated ${chalk.cyan(String(manifests.length))} snapshots -- ` +
+        `${chalk.cyan(String(filtered.length))} unique messages`,
+    );
+
+    return this.save_batch(ctx, tenant_id, mailbox_id, 'mailbox', filtered, options);
+  }
+
+  private async load_manifest(ctx: TenantContext, snapshot_id: string): Promise<Manifest> {
+    const manifest = await this._manifests.find_by_snapshot(ctx, snapshot_id);
+    if (!manifest) throw new Error(`No manifest found for snapshot ${snapshot_id}`);
+    return manifest;
+  }
+
+  private async load_mailbox_manifests(
+    ctx: TenantContext,
+    mailbox_id: string,
+    options: SaveOptions,
+  ): Promise<Manifest[]> {
+    const all = await this._manifests.list_all_manifests(ctx);
+    const for_mailbox = all
+      .filter((m) => m.mailbox_id === mailbox_id)
+      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+    return filter_manifests_by_date(for_mailbox, options.start_date, options.end_date);
+  }
+
+  private async resolve_entries(
+    ctx: TenantContext,
+    manifest: Manifest,
+    mailbox_id: string,
+    tenant_id: string,
+    options: SaveOptions,
+  ): Promise<ManifestEntry[]> {
+    if (options.message_ref) {
+      const entry = this.resolve_single_entry(manifest, options.message_ref);
+      return entry ? [entry] : [];
+    }
+
+    if (options.folder_name) {
+      await backfill_missing_folder_ids(ctx, manifest.entries);
+      const folder_map = await build_folder_map(this._connector, tenant_id, mailbox_id);
+      return filter_entries_by_folder_name(manifest.entries, options.folder_name, folder_map);
+    }
+
+    return manifest.entries;
+  }
+
+  private resolve_single_entry(manifest: Manifest, ref: string): ManifestEntry | undefined {
+    const index = Number(ref);
+    if (Number.isInteger(index) && index >= 1) return manifest.entries[index - 1];
+    return manifest.entries.find((e) => e.object_id === ref);
+  }
+
+  private async apply_entry_filters(
+    entries: ManifestEntry[],
+    mailbox_id: string,
+    tenant_id: string,
+    options: SaveOptions,
+  ): Promise<ManifestEntry[]> {
+    if (options.folder_name) {
+      const folder_map = await build_folder_map(this._connector, tenant_id, mailbox_id);
+      return filter_entries_by_folder_name(entries, options.folder_name, folder_map);
+    }
+    return entries;
+  }
+
+  private async save_batch(
+    ctx: TenantContext,
+    tenant_id: string,
+    mailbox_id: string,
+    snapshot_id: string,
+    entries: ManifestEntry[],
+    options: SaveOptions,
+  ): Promise<SaveResult> {
+    const folder_map = await build_folder_map(this._connector, tenant_id, mailbox_id);
+    await backfill_missing_folder_ids(ctx, entries);
+
+    const groups = group_entries_by_folder(entries);
+    const output_path = options.output_path ?? build_default_output_path();
+    const skip_integrity = options.skip_integrity_check ?? false;
+
+    logger.info(
+      `Saving ${entries.length} messages across ` +
+        `${count_unique_folders(entries)} folders to ${chalk.cyan(output_path)}`,
+    );
+
+    if (skip_integrity) {
+      logger.warn('Integrity verification is DISABLED (--skip-verify)');
+    }
+
+    const dashboard = new SaveProgressDashboard(
+      [...groups.entries()].map(([fid, items]) => ({
+        name: folder_map.get(fid) ?? fid.slice(0, 12),
+        total_items: items.length,
+      })),
+    );
+
+    return this.execute_save_loop(
+      ctx,
+      snapshot_id,
+      output_path,
+      skip_integrity,
+      groups,
+      folder_map,
+      dashboard,
+    );
+  }
+
+  private async execute_save_loop(
+    ctx: TenantContext,
+    snapshot_id: string,
+    output_path: string,
+    skip_integrity: boolean,
+    groups: Map<string, ManifestEntry[]>,
+    folder_map: Map<string, string>,
+    dashboard: SaveProgressDashboard,
+  ): Promise<SaveResult> {
+    this._interrupted = false;
+    const on_sigint = (): void => {
+      this._interrupted = true;
+    };
+    process.on('SIGINT', on_sigint);
+
+    try {
+      const result = await save_entries_to_archive(
+        ctx,
+        output_path,
+        skip_integrity,
+        groups,
+        folder_map,
+        dashboard,
+        () => this._interrupted,
+      );
+
+      if (this._interrupted) dashboard.mark_all_pending_interrupted();
+      dashboard.finish(result.saved_count);
+
+      return { ...result, snapshot_id };
+    } finally {
+      process.removeListener('SIGINT', on_sigint);
+    }
+  }
+
+  private empty_result(snapshot_id: string, output_path: string): SaveResult {
+    return {
+      snapshot_id,
+      saved_count: 0,
+      attachment_count: 0,
+      error_count: 0,
+      errors: [],
+      output_path,
+      total_bytes: 0,
+      integrity_failures: [],
+    };
+  }
+}
+
+function build_default_output_path(): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  return `Restore-${ts}.zip`;
+}

--- a/tests/unit/adapters/graph-error-helpers.test.ts
+++ b/tests/unit/adapters/graph-error-helpers.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  rethrow_if_access_denied,
+  rethrow_if_mailbox_not_licensed,
+  is_invalid_delta_error,
+  is_transient_error,
+} from '@/adapters/m365/graph-error-helpers';
+
+describe('rethrow_if_mailbox_not_licensed', () => {
+  it('throws with actionable message when error code is MailboxNotEnabledForRESTAPI', () => {
+    const err = { code: 'MailboxNotEnabledForRESTAPI', statusCode: 403, message: '' };
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).toThrow('not licensed for API access');
+  });
+
+  it('throws when MailboxNotEnabledForRESTAPI appears in error message', () => {
+    const err = new Error('The mailbox is not enabled (MailboxNotEnabledForRESTAPI)');
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).toThrow(
+      'Reassign an Exchange Online license',
+    );
+  });
+
+  it('does not throw for unrelated errors', () => {
+    const err = { code: 'ErrorItemNotFound', statusCode: 404, message: 'Not found' };
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).not.toThrow();
+  });
+
+  it('does not throw for access denied errors (handled separately)', () => {
+    const err = { code: 'ErrorAccessDenied', statusCode: 403, message: 'Forbidden' };
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).not.toThrow();
+  });
+});
+
+describe('rethrow_if_access_denied', () => {
+  it('throws with permission guidance on 403', () => {
+    const err = { statusCode: 403 };
+
+    expect(() => rethrow_if_access_denied(err)).toThrow('403 Forbidden');
+  });
+
+  it('does not throw for non-403 errors', () => {
+    const err = { statusCode: 404 };
+
+    expect(() => rethrow_if_access_denied(err)).not.toThrow();
+  });
+});
+
+describe('is_invalid_delta_error', () => {
+  it('detects syncStateNotFound', () => {
+    expect(is_invalid_delta_error(new Error('SyncStateNotFound'))).toBe(true);
+  });
+
+  it('detects resyncRequired', () => {
+    expect(is_invalid_delta_error(new Error('resyncRequired'))).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(is_invalid_delta_error(new Error('timeout'))).toBe(false);
+  });
+});
+
+describe('is_transient_error', () => {
+  it.each([429, 503, 504])('returns true for status %i', (status) => {
+    expect(is_transient_error({ statusCode: status })).toBe(true);
+  });
+
+  it('returns false for 400', () => {
+    expect(is_transient_error({ statusCode: 400 })).toBe(false);
+  });
+});

--- a/tests/unit/adapters/graph-error-helpers.test.ts
+++ b/tests/unit/adapters/graph-error-helpers.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   rethrow_if_access_denied,
   rethrow_if_mailbox_not_licensed,
   is_invalid_delta_error,
   is_transient_error,
+  is_network_error,
+  is_retryable_error,
+  with_graph_retry,
 } from '@/adapters/m365/graph-error-helpers';
 
 describe('rethrow_if_mailbox_not_licensed', () => {
@@ -69,5 +72,141 @@ describe('is_transient_error', () => {
 
   it('returns false for 400', () => {
     expect(is_transient_error({ statusCode: 400 })).toBe(false);
+  });
+});
+
+describe('is_network_error', () => {
+  it.each(['ETIMEDOUT', 'ECONNRESET', 'ECONNREFUSED', 'ENOTFOUND', 'EPIPE', 'EAI_AGAIN'])(
+    'returns true for error code %s',
+    (code) => {
+      expect(is_network_error({ code })).toBe(true);
+    },
+  );
+
+  it('returns true for "socket hang up" message', () => {
+    expect(is_network_error(new Error('socket hang up'))).toBe(true);
+  });
+
+  it('returns true for "fetch failed" message', () => {
+    expect(is_network_error(new Error('fetch failed'))).toBe(true);
+  });
+
+  it('returns true for ECONNRESET in error message', () => {
+    expect(is_network_error(new Error('read ECONNRESET'))).toBe(true);
+  });
+
+  it('returns false for a 404 HTTP error', () => {
+    expect(is_network_error({ statusCode: 404 })).toBe(false);
+  });
+
+  it('returns false for a business logic error', () => {
+    expect(is_network_error(new Error('Mailbox not found'))).toBe(false);
+  });
+});
+
+describe('is_retryable_error', () => {
+  it('returns true for transient HTTP errors', () => {
+    expect(is_retryable_error({ statusCode: 429 })).toBe(true);
+  });
+
+  it('returns true for network errors', () => {
+    expect(is_retryable_error({ code: 'ETIMEDOUT' })).toBe(true);
+  });
+
+  it('returns false for non-retryable errors', () => {
+    expect(is_retryable_error({ statusCode: 400 })).toBe(false);
+  });
+});
+
+describe('with_graph_retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns result on first success', async () => {
+    const result = await with_graph_retry(() => Promise.resolve('ok'));
+    expect(result).toBe('ok');
+  });
+
+  it('retries on transient HTTP error and succeeds', async () => {
+    let calls = 0;
+    const fn = (): Promise<string> => {
+      calls++;
+      if (calls === 1) return Promise.reject({ statusCode: 503, message: 'Service Unavailable' });
+      return Promise.resolve('recovered');
+    };
+
+    const promise = with_graph_retry(fn);
+    await vi.advanceTimersByTimeAsync(60_000);
+    const result = await promise;
+
+    expect(result).toBe('recovered');
+    expect(calls).toBe(2);
+  });
+
+  it('retries on network error and succeeds', async () => {
+    let calls = 0;
+    const fn = (): Promise<string> => {
+      calls++;
+      if (calls <= 2) {
+        const err = new Error('socket hang up');
+        (err as Record<string, unknown>).code = 'ECONNRESET';
+        return Promise.reject(err);
+      }
+      return Promise.resolve('recovered');
+    };
+
+    const promise = with_graph_retry(fn);
+    await vi.advanceTimersByTimeAsync(120_000);
+    const result = await promise;
+
+    expect(result).toBe('recovered');
+    expect(calls).toBe(3);
+  });
+
+  it('throws non-retryable error immediately without retrying', async () => {
+    const fn = vi.fn().mockRejectedValue({ statusCode: 400, message: 'Bad Request' });
+
+    await expect(with_graph_retry(fn)).rejects.toEqual({
+      statusCode: 400,
+      message: 'Bad Request',
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws after exhausting all retries', async () => {
+    const err = { statusCode: 429, message: 'Too Many Requests' };
+    const fn = vi.fn().mockRejectedValue(err);
+
+    const promise = with_graph_retry(fn).catch((e: unknown) => e);
+    for (let i = 0; i < 7; i++) {
+      await vi.advanceTimersByTimeAsync(60_000);
+    }
+
+    const result = await promise;
+    expect(result).toEqual(err);
+    expect(fn).toHaveBeenCalledTimes(7);
+  });
+
+  it('respects Retry-After header', async () => {
+    let calls = 0;
+    const fn = (): Promise<string> => {
+      calls++;
+      if (calls === 1) {
+        return Promise.reject({ statusCode: 429, headers: { 'retry-after': '2' } });
+      }
+      return Promise.resolve('ok');
+    };
+
+    const promise = with_graph_retry(fn);
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await promise;
+
+    expect(result).toBe('ok');
+    expect(calls).toBe(2);
   });
 });

--- a/tests/unit/adapters/sdk/atlas-instance.adapter.test.ts
+++ b/tests/unit/adapters/sdk/atlas-instance.adapter.test.ts
@@ -7,6 +7,7 @@ import type { RestoreUseCase, RestoreResult } from '@/ports/restore/use-case.por
 import type { CatalogUseCase, MailboxSummary } from '@/ports/catalog/use-case.port';
 import type { DeletionUseCase, DeletionResult } from '@/ports/deletion/use-case.port';
 import type { StorageCheckUseCase, StorageCheckResult } from '@/ports/storage-check/use-case.port';
+import type { SaveUseCase, SaveResult } from '@/ports/save/use-case.port';
 import type { Manifest } from '@/domain/manifest';
 
 const TENANT_ID = 'test-tenant-id';
@@ -39,6 +40,10 @@ const mock_deletion: DeletionUseCase = {
   purge_tenant: vi.fn(),
 };
 const mock_storage_check: StorageCheckUseCase = { check_storage: vi.fn() };
+const mock_save: SaveUseCase = {
+  save_snapshot: vi.fn(),
+  save_mailbox: vi.fn(),
+};
 
 vi.mock('@/container', () => ({
   create_container_from_config: vi.fn(() => ({
@@ -51,6 +56,7 @@ vi.mock('@/container', () => ({
         CatalogUseCase: mock_catalog,
         DeletionUseCase: mock_deletion,
         StorageCheckUseCase: mock_storage_check,
+        SaveUseCase: mock_save,
       };
       return map[key!];
     }),
@@ -178,6 +184,42 @@ describe('createAtlasInstance', () => {
         'user@test.com',
         undefined,
       );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveSnapshot
+  // ---------------------------------------------------------------------------
+
+  describe('saveSnapshot', () => {
+    it('delegates to SaveUseCase.save_snapshot with bound tenant_id', async () => {
+      const save_result = { saved_count: 7 } as unknown as SaveResult;
+      vi.mocked(mock_save.save_snapshot).mockResolvedValue(save_result);
+
+      const result = await atlas.saveSnapshot('snap-1', { folder_name: 'Inbox' });
+
+      expect(result).toBe(save_result);
+      expect(mock_save.save_snapshot).toHaveBeenCalledWith(TENANT_ID, 'snap-1', {
+        folder_name: 'Inbox',
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveMailbox
+  // ---------------------------------------------------------------------------
+
+  describe('saveMailbox', () => {
+    it('delegates to SaveUseCase.save_mailbox with bound tenant_id', async () => {
+      const save_result = { saved_count: 40 } as unknown as SaveResult;
+      vi.mocked(mock_save.save_mailbox).mockResolvedValue(save_result);
+
+      const result = await atlas.saveMailbox('user@test.com', { output_path: 'out.zip' });
+
+      expect(result).toBe(save_result);
+      expect(mock_save.save_mailbox).toHaveBeenCalledWith(TENANT_ID, 'user@test.com', {
+        output_path: 'out.zip',
+      });
     });
   });
 
@@ -317,11 +359,15 @@ describe('createAtlasInstance', () => {
       vi.mocked(mock_deletion.delete_mailbox_data).mockResolvedValue({} as DeletionResult);
       vi.mocked(mock_deletion.delete_snapshot).mockResolvedValue({} as DeletionResult);
       vi.mocked(mock_storage_check.check_storage).mockResolvedValue({} as StorageCheckResult);
+      vi.mocked(mock_save.save_snapshot).mockResolvedValue({} as SaveResult);
+      vi.mocked(mock_save.save_mailbox).mockResolvedValue({} as SaveResult);
 
       expect(atlas.backupMailbox('m')).toBeInstanceOf(Promise);
       expect(atlas.verifySnapshot('s')).toBeInstanceOf(Promise);
       expect(atlas.restoreSnapshot('s')).toBeInstanceOf(Promise);
       expect(atlas.restoreMailbox('m')).toBeInstanceOf(Promise);
+      expect(atlas.saveSnapshot('s')).toBeInstanceOf(Promise);
+      expect(atlas.saveMailbox('m')).toBeInstanceOf(Promise);
       expect(atlas.listMailboxes()).toBeInstanceOf(Promise);
       expect(atlas.listSnapshots('m')).toBeInstanceOf(Promise);
       expect(atlas.getSnapshotDetail('s')).toBeInstanceOf(Promise);

--- a/tests/unit/services/attachment-sync.test.ts
+++ b/tests/unit/services/attachment-sync.test.ts
@@ -72,6 +72,7 @@ describe('MailboxSyncService – attachment backup', () => {
 
     mock_connector = {
       list_mailboxes: vi.fn().mockResolvedValue([]),
+      mailbox_exists: vi.fn().mockResolvedValue(true),
       list_mail_folders: vi
         .fn()
         .mockResolvedValue([

--- a/tests/unit/services/delta-safeguard.test.ts
+++ b/tests/unit/services/delta-safeguard.test.ts
@@ -77,6 +77,7 @@ describe('MailboxSyncService – force_full / stale-delta safeguard', () => {
 
     mock_connector = {
       list_mailboxes: vi.fn().mockResolvedValue([]),
+      mailbox_exists: vi.fn().mockResolvedValue(true),
       list_mail_folders: vi.fn().mockResolvedValue([make_folder('Inbox', 'folder-1')]),
       fetch_delta: vi.fn().mockResolvedValue(make_delta([])),
       fetch_message: vi.fn(),

--- a/tests/unit/services/mailbox-sync-object-lock.test.ts
+++ b/tests/unit/services/mailbox-sync-object-lock.test.ts
@@ -56,6 +56,7 @@ describe('MailboxSyncService object lock', () => {
 
     mock_connector = {
       list_mailboxes: vi.fn().mockResolvedValue([]),
+      mailbox_exists: vi.fn().mockResolvedValue(true),
       list_mail_folders: vi
         .fn()
         .mockResolvedValue([{ folder_id: 'folder-1', display_name: 'Inbox', total_item_count: 1 }]),

--- a/tests/unit/services/mailbox-sync.service.test.ts
+++ b/tests/unit/services/mailbox-sync.service.test.ts
@@ -85,6 +85,7 @@ describe('MailboxSyncService', () => {
 
     mock_connector = {
       list_mailboxes: vi.fn().mockResolvedValue([]),
+      mailbox_exists: vi.fn().mockResolvedValue(true),
       list_mail_folders: vi.fn().mockResolvedValue([make_folder('Inbox', 'folder-1')]),
       fetch_delta: vi.fn().mockResolvedValue(make_delta([])),
       fetch_message: vi.fn(),
@@ -109,6 +110,16 @@ describe('MailboxSyncService', () => {
     container.bind(MailboxSyncService).toSelf();
 
     service = container.get(MailboxSyncService);
+  });
+
+  it('throws when mailbox does not exist in the tenant', async () => {
+    (mock_connector.mailbox_exists as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    await expect(service.sync_mailbox('t', 'nobody@test.com')).rejects.toThrow(
+      'does not exist in the tenant',
+    );
+
+    expect(mock_connector.list_mail_folders).not.toHaveBeenCalled();
   });
 
   it('creates tenant context for the given tenant', async () => {

--- a/tests/unit/services/restore.service.test.ts
+++ b/tests/unit/services/restore.service.test.ts
@@ -89,6 +89,7 @@ describe('RestoreService', () => {
 
     mock_connector = {
       list_mailboxes: vi.fn(),
+      mailbox_exists: vi.fn().mockResolvedValue(true),
       list_mail_folders: vi.fn().mockResolvedValue(folders),
       fetch_delta: vi.fn(),
       fetch_message: vi.fn(),
@@ -119,6 +120,29 @@ describe('RestoreService', () => {
     container.bind(RestoreService).toSelf();
 
     service = container.get(RestoreService);
+  });
+
+  it('throws when target mailbox does not exist', async () => {
+    const manifest = make_manifest([make_entry('msg-1', 'f1')]);
+    (mock_manifests.find_by_snapshot as ReturnType<typeof vi.fn>).mockResolvedValue(manifest);
+    (mock_connector.mailbox_exists as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    await expect(
+      service.restore_snapshot('test-tenant', 'snap-1', { target_mailbox: 'nobody@test.com' }),
+    ).rejects.toThrow('does not exist in the tenant');
+
+    expect(mock_restore.create_mail_folder).not.toHaveBeenCalled();
+    expect(mock_restore.create_message).not.toHaveBeenCalled();
+  });
+
+  it('throws when source mailbox does not exist (no target override)', async () => {
+    const manifest = make_manifest([make_entry('msg-1', 'f1')]);
+    (mock_manifests.find_by_snapshot as ReturnType<typeof vi.fn>).mockResolvedValue(manifest);
+    (mock_connector.mailbox_exists as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    await expect(service.restore_snapshot('test-tenant', 'snap-1')).rejects.toThrow(
+      'does not exist in the tenant',
+    );
   });
 
   it('throws when manifest not found', async () => {
@@ -204,6 +228,18 @@ describe('RestoreService', () => {
   });
 
   describe('restore_mailbox', () => {
+    it('throws when target mailbox does not exist', async () => {
+      (mock_connector.mailbox_exists as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+      await expect(
+        service.restore_mailbox('test-tenant', 'user@test.com', {
+          target_mailbox: 'nobody@test.com',
+        }),
+      ).rejects.toThrow('does not exist in the tenant');
+
+      expect(mock_restore.create_mail_folder).not.toHaveBeenCalled();
+    });
+
     it('returns empty when no snapshots for mailbox', async () => {
       (mock_manifests.list_all_manifests as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 

--- a/tests/unit/services/save/eml-builder.test.ts
+++ b/tests/unit/services/save/eml-builder.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { build_eml, build_eml_filename, deduplicate_filename } from '@/services/save/eml-builder';
+
+describe('build_eml', () => {
+  const minimal_message: Record<string, unknown> = {
+    subject: 'Test Subject',
+    from: { emailAddress: { name: 'Alice', address: 'alice@example.com' } },
+    toRecipients: [{ emailAddress: { name: 'Bob', address: 'bob@example.com' } }],
+    body: { contentType: 'text', content: 'Hello world' },
+    receivedDateTime: '2026-03-10T14:30:22Z',
+    sentDateTime: '2026-03-10T14:30:00Z',
+    internetMessageId: '<abc123@example.com>',
+  };
+
+  it('produces a buffer containing EML headers', () => {
+    const result = build_eml(minimal_message, []);
+    const text = result.toString('utf-8');
+
+    expect(text).toContain('alice@example.com');
+    expect(text).toContain('bob@example.com');
+    expect(text).toContain('Subject:');
+  });
+
+  it('includes plain text body', () => {
+    const result = build_eml(minimal_message, []);
+    const text = result.toString('utf-8');
+    expect(text).toContain('Hello world');
+  });
+
+  it('handles HTML body', () => {
+    const msg = { ...minimal_message, body: { contentType: 'HTML', content: '<b>Bold</b>' } };
+    const result = build_eml(msg, []);
+    const text = result.toString('utf-8');
+    expect(text).toContain('<b>Bold</b>');
+  });
+
+  it('includes attachments', () => {
+    const attachment = {
+      name: 'file.pdf',
+      content_type: 'application/pdf',
+      content: Buffer.from('pdf-content'),
+      is_inline: false,
+    };
+    const result = build_eml(minimal_message, [attachment]);
+    const text = result.toString('utf-8');
+    expect(text).toContain('file.pdf');
+  });
+
+  it('handles message with no to-recipients gracefully', () => {
+    const msg = {
+      ...minimal_message,
+      toRecipients: undefined,
+    };
+    const result = build_eml(msg as Record<string, unknown>, []);
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.toString('utf-8')).toContain('alice@example.com');
+  });
+
+  it('sets Date header from receivedDateTime', () => {
+    const result = build_eml(minimal_message, []);
+    const text = result.toString('utf-8');
+    expect(text).toContain('Date:');
+  });
+
+  it('sets Message-ID header', () => {
+    const result = build_eml(minimal_message, []);
+    const text = result.toString('utf-8');
+    expect(text).toContain('Message-ID');
+  });
+
+  it('handles cc and bcc recipients', () => {
+    const msg = {
+      ...minimal_message,
+      ccRecipients: [{ emailAddress: { name: 'Carol', address: 'carol@example.com' } }],
+      bccRecipients: [{ emailAddress: { name: 'Dave', address: 'dave@example.com' } }],
+    };
+    const result = build_eml(msg, []);
+    const text = result.toString('utf-8');
+    expect(text).toContain('carol@example.com');
+    expect(text).toContain('dave@example.com');
+  });
+});
+
+describe('build_eml_filename', () => {
+  it('formats timestamp and subject correctly', () => {
+    const result = build_eml_filename('2026-03-10T14:30:22Z', 'Meeting with client');
+    expect(result).toBe('2026-03-10_143022_Meeting-with-client.eml');
+  });
+
+  it('uses "unknown" timestamp when date is undefined', () => {
+    const result = build_eml_filename(undefined, 'Test');
+    expect(result).toBe('unknown_Test.eml');
+  });
+
+  it('uses "no-subject" when subject is undefined', () => {
+    const result = build_eml_filename('2026-03-10T14:30:22Z', undefined);
+    expect(result).toBe('2026-03-10_143022_no-subject.eml');
+  });
+
+  it('sanitizes special characters from subject', () => {
+    const result = build_eml_filename('2026-03-10T14:30:22Z', 'Re: Hello <World> / test');
+    expect(result).not.toContain('<');
+    expect(result).not.toContain('>');
+    expect(result).not.toContain('/');
+    expect(result).toMatch(/\.eml$/);
+  });
+
+  it('truncates long subjects to 80 characters', () => {
+    const long_subject = 'A'.repeat(200);
+    const result = build_eml_filename('2026-03-10T14:30:22Z', long_subject);
+    const name_part = result.replace('2026-03-10_143022_', '').replace('.eml', '');
+    expect(name_part.length).toBeLessThanOrEqual(80);
+  });
+});
+
+describe('deduplicate_filename', () => {
+  it('returns original name when no collision', () => {
+    const used = new Set<string>();
+    expect(deduplicate_filename('test.eml', used)).toBe('test.eml');
+  });
+
+  it('appends _1 on first collision', () => {
+    const used = new Set(['test.eml']);
+    expect(deduplicate_filename('test.eml', used)).toBe('test_1.eml');
+  });
+
+  it('increments suffix on repeated collisions', () => {
+    const used = new Set(['test.eml', 'test_1.eml', 'test_2.eml']);
+    expect(deduplicate_filename('test.eml', used)).toBe('test_3.eml');
+  });
+
+  it('adds used name to the set', () => {
+    const used = new Set<string>();
+    deduplicate_filename('a.eml', used);
+    expect(used.has('a.eml')).toBe(true);
+  });
+});

--- a/tests/unit/services/save/save-integrity-validator.test.ts
+++ b/tests/unit/services/save/save-integrity-validator.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { compute_sha256, verify_checksum } from '@/services/save/save-integrity-validator';
+
+describe('compute_sha256', () => {
+  it('returns hex digest matching node crypto', () => {
+    const data = Buffer.from('hello world');
+    const expected = createHash('sha256').update(data).digest('hex');
+    expect(compute_sha256(data)).toBe(expected);
+  });
+
+  it('returns different digest for different input', () => {
+    const a = compute_sha256(Buffer.from('aaa'));
+    const b = compute_sha256(Buffer.from('bbb'));
+    expect(a).not.toBe(b);
+  });
+
+  it('handles empty buffer', () => {
+    const result = compute_sha256(Buffer.alloc(0));
+    expect(result).toHaveLength(64);
+  });
+});
+
+describe('verify_checksum', () => {
+  it('returns true when checksum matches', () => {
+    const data = Buffer.from('test content');
+    const checksum = createHash('sha256').update(data).digest('hex');
+    expect(verify_checksum(data, checksum)).toBe(true);
+  });
+
+  it('returns false when checksum does not match', () => {
+    const data = Buffer.from('test content');
+    const wrong = 'a'.repeat(64);
+    expect(verify_checksum(data, wrong)).toBe(false);
+  });
+
+  it('returns false when expected has different length', () => {
+    const data = Buffer.from('test content');
+    expect(verify_checksum(data, 'tooshort')).toBe(false);
+  });
+});

--- a/tests/unit/services/save/save-zip-writer.test.ts
+++ b/tests/unit/services/save/save-zip-writer.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { unlinkSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  create_save_archive,
+  add_eml_to_archive,
+  finalize_archive,
+} from '@/services/save/save-zip-writer';
+
+function temp_path(name: string): string {
+  return join(tmpdir(), `atlas-test-${Date.now()}-${name}.zip`);
+}
+
+describe('save-zip-writer', () => {
+  const created_files: string[] = [];
+
+  afterEach(() => {
+    for (const f of created_files) {
+      try {
+        if (existsSync(f)) unlinkSync(f);
+      } catch {
+        /* cleanup best-effort */
+      }
+    }
+    created_files.length = 0;
+  });
+
+  it('creates a zip file at the given path', async () => {
+    const path = temp_path('create');
+    created_files.push(path);
+
+    const { archive, promise } = create_save_archive(path);
+    add_eml_to_archive(archive, 'Inbox', 'test.eml', Buffer.from('EML content'));
+    await finalize_archive(archive);
+    const bytes = await promise;
+
+    expect(existsSync(path)).toBe(true);
+    expect(bytes).toBeGreaterThan(0);
+  });
+
+  it('creates valid archive with multiple entries', async () => {
+    const path = temp_path('multi');
+    created_files.push(path);
+
+    const { archive, promise } = create_save_archive(path);
+    add_eml_to_archive(archive, 'Inbox', 'a.eml', Buffer.from('Message A'));
+    add_eml_to_archive(archive, 'Sent Items', 'b.eml', Buffer.from('Message B'));
+    add_eml_to_archive(archive, 'Inbox', 'c.eml', Buffer.from('Message C'));
+    await finalize_archive(archive);
+    const bytes = await promise;
+
+    expect(bytes).toBeGreaterThan(0);
+  });
+
+  it('handles empty archive', async () => {
+    const path = temp_path('empty');
+    created_files.push(path);
+
+    const { archive, promise } = create_save_archive(path);
+    await finalize_archive(archive);
+    const bytes = await promise;
+
+    expect(bytes).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/services/save/save.service.test.ts
+++ b/tests/unit/services/save/save.service.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { SaveService } from '@/services/save/save.service';
+import {
+  MAILBOX_CONNECTOR_TOKEN,
+  MANIFEST_REPOSITORY_TOKEN,
+  TENANT_CONTEXT_FACTORY_TOKEN,
+} from '@/ports/tokens/outgoing.tokens';
+import type { MailboxConnector } from '@/ports/mailbox/connector.port';
+import type { ManifestRepository } from '@/ports/storage/manifest-repository.port';
+import type { TenantContext, TenantContextFactory } from '@/ports/tenant/context.port';
+import type { Manifest, ManifestEntry } from '@/domain/manifest';
+
+vi.mock('@/services/save/save-entry-processor', () => ({
+  save_entries_to_archive: vi.fn().mockResolvedValue({
+    saved_count: 2,
+    attachment_count: 1,
+    error_count: 0,
+    errors: [],
+    output_path: 'test.zip',
+    total_bytes: 1024,
+    integrity_failures: [],
+  }),
+}));
+
+vi.mock('@/services/save/save-progress-dashboard', () => {
+  return {
+    SaveProgressDashboard: class {
+      mark_active = vi.fn();
+      update_active = vi.fn();
+      mark_done = vi.fn();
+      mark_error = vi.fn();
+      update_total = vi.fn();
+      finish = vi.fn();
+      mark_all_pending_interrupted = vi.fn();
+    },
+  };
+});
+
+function make_entry(id: string, folder_id: string): ManifestEntry {
+  return {
+    object_id: id,
+    storage_key: `data/user/${id}`,
+    checksum: 'abc',
+    size_bytes: 100,
+    subject: `Subject ${id}`,
+    folder_id,
+  };
+}
+
+function make_manifest(
+  entries: ManifestEntry[],
+  opts?: { snapshot_id?: string; mailbox_id?: string; created_at?: Date },
+): Manifest {
+  return {
+    id: 'manifest-1',
+    tenant_id: 'test-tenant',
+    mailbox_id: opts?.mailbox_id ?? 'user@test.com',
+    snapshot_id: opts?.snapshot_id ?? 'snap-1',
+    created_at: opts?.created_at ?? new Date(),
+    total_objects: entries.length,
+    total_size_bytes: entries.reduce((s, e) => s + e.size_bytes, 0),
+    delta_links: {},
+    entries,
+  };
+}
+
+describe('SaveService', () => {
+  let container: Container;
+  let mock_context: TenantContext;
+  let mock_manifests: ManifestRepository;
+  let mock_connector: MailboxConnector;
+  let service: SaveService;
+
+  beforeEach(() => {
+    container = new Container();
+
+    mock_context = {
+      storage: {
+        get: vi.fn().mockResolvedValue(Buffer.from('encrypted')),
+        put: vi.fn(),
+        exists: vi.fn(),
+        delete: vi.fn(),
+      },
+      decrypt: vi.fn((buf: Buffer) => buf),
+      encrypt: vi.fn((buf: Buffer) => buf),
+    } as unknown as TenantContext;
+
+    const mock_factory: TenantContextFactory = {
+      create: vi.fn().mockResolvedValue(mock_context),
+    };
+
+    mock_manifests = {
+      find_by_snapshot: vi.fn(),
+      list_all_manifests: vi.fn().mockResolvedValue([]),
+      save: vi.fn(),
+      list_snapshots: vi.fn().mockResolvedValue([]),
+      delete_snapshot: vi.fn(),
+    } as unknown as ManifestRepository;
+
+    mock_connector = {
+      list_mailboxes: vi.fn().mockResolvedValue([]),
+      mailbox_exists: vi.fn().mockResolvedValue(true),
+      list_mail_folders: vi.fn().mockResolvedValue([
+        { folder_id: 'f1', display_name: 'Inbox' },
+        { folder_id: 'f2', display_name: 'Sent Items' },
+      ]),
+      fetch_delta: vi.fn(),
+      fetch_message: vi.fn(),
+      fetch_attachments: vi.fn(),
+    } as unknown as MailboxConnector;
+
+    container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
+    container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+    container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
+    container.bind(SaveService).toSelf();
+
+    service = container.get(SaveService);
+  });
+
+  describe('save_snapshot', () => {
+    it('saves messages from a snapshot', async () => {
+      const entries = [make_entry('msg-1', 'f1'), make_entry('msg-2', 'f1')];
+      const manifest = make_manifest(entries);
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(manifest);
+
+      const result = await service.save_snapshot('test-tenant', 'snap-1');
+
+      expect(result.saved_count).toBe(2);
+      expect(result.snapshot_id).toBe('snap-1');
+    });
+
+    it('returns empty result when no entries', async () => {
+      const manifest = make_manifest([]);
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(manifest);
+
+      const result = await service.save_snapshot('test-tenant', 'snap-1');
+
+      expect(result.saved_count).toBe(0);
+    });
+
+    it('throws when manifest not found', async () => {
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
+        undefined as unknown as Manifest,
+      );
+
+      await expect(service.save_snapshot('test-tenant', 'snap-bad')).rejects.toThrow(
+        'No manifest found',
+      );
+    });
+  });
+
+  describe('save_mailbox', () => {
+    it('merges snapshots and saves messages', async () => {
+      const entries = [make_entry('msg-1', 'f1')];
+      const manifest = make_manifest(entries, { mailbox_id: 'user@test.com' });
+      vi.mocked(mock_manifests.list_all_manifests).mockResolvedValue([manifest]);
+
+      const result = await service.save_mailbox('test-tenant', 'user@test.com');
+
+      expect(result.saved_count).toBe(2);
+    });
+
+    it('returns empty result when no snapshots', async () => {
+      vi.mocked(mock_manifests.list_all_manifests).mockResolvedValue([]);
+
+      const result = await service.save_mailbox('test-tenant', 'user@test.com');
+
+      expect(result.saved_count).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The pull request contains changes for the new release, version `v1.1.0`, of the package and includes one UX improvement for a pre-existing issue (#1).

## Changes

### New: `atlas save` command

- Export backed-up emails as RFC 5322 .eml files in a compressed zip archive
- Mirrors Outlook folder structure (Inbox/, Sent Items/, etc.)
- EML files include all backed-up attachments as embedded MIME parts
- SHA-256 integrity verification on every message and attachment before writing to zip
- `--skip-verify` flag to disable integrity checks on low-power systems
- Overwrite protection prompts Y/n when output file already exists
- Same filtering options as restore: `--snapshot`, `--mailbox`, `--folder`, `--message`, `--start-date`, `--end-date`, `--output`
- Live ANSI progress dashboard with per-folder status and integrity check counts
- Wired into the SDK as `saveSnapshot()` and `saveMailbox()`

### New: Mailbox existence validation

- Backup and restore now verify the target mailbox exists before starting
- `MailboxNotEnabledForRESTAPI` errors surface a clear, actionable message about reassigning an Exchange Online license

### Improved: Graph API retry resilience

- with_graph_retry now catches network-level errors (ETIMEDOUT, ECONNRESET, socket hang up, etc.) in addition to HTTP 429/503/504
- Increased max retries from 4 to 6 with jitter to prevent thundering herd
- Applied to all backup connector Graph calls (previously only restore was wrapped)
- Each retry is logged for observability

### Changed: Default page size

- Reduced default Graph API delta page size from 25 to 10 for better reliability with large messages
Docs

### Other changes

- Extracted full CLI and SDK reference into docs/USAGE.md
- Slimmed README.md to a focused overview with link to the usage guide
- Updated roadmap, architecture tree, and security table

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
