### PR TITLE
feat: add snapshot-based S3 replication and disaster recovery

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -17,5 +17,24 @@ services:
       timeout: 5s
       retries: 5
 
+  minio-secondary:
+    image: minio/minio:latest
+    container_name: atlas-minio-secondary
+    ports:
+      - "9004:9000"
+      - "9005:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    volumes:
+      - minio_secondary_data:/data
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
 volumes:
   minio_data:
+  minio_secondary_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,5 +17,24 @@ services:
       timeout: 5s
       retries: 5
 
+  minio-secondary:
+    image: minio/minio:latest
+    container_name: atlas-minio-secondary
+    ports:
+      - "9004:9000"
+      - "9005:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    volumes:
+      - minio_secondary_data:/data
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
 volumes:
   minio_data:
+  minio_secondary_data:

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
           { text: 'Immutability & Object Lock', link: '/operations/immutability' },
           { text: 'Delta Sync', link: '/operations/delta-sync' },
           { text: 'Storage Layout', link: '/operations/storage-layout' },
+          { text: 'Replication', link: '/operations/replication' },
         ],
       },
       {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,3 +60,31 @@ chmod 600 .env atlas.config.json
 
 Never commit these files to version control. The included `.gitignore` already excludes `.env`, but verify that your config file is also excluded. In multi-user environments, ensure only the service account running Atlas can read these files.
 :::
+
+## Replication Target Config
+
+The `atlas replicate` and `atlas rehydrate` commands accept a `--target-config` or `--source-config` flag pointing to a JSON file with S3 credentials for a secondary storage target:
+
+```json
+{
+  "target_id": "offsite-dr",
+  "s3_endpoint": "http://offsite:9000",
+  "s3_access_key": "offsite-key",
+  "s3_secret_key": "offsite-secret",
+  "s3_region": "us-east-1"
+}
+```
+
+| Field          | Required | Description                                          |
+| -------------- | -------- | ---------------------------------------------------- |
+| `target_id`    | no       | Stable human-readable ID (auto-derived if omitted)   |
+| `s3_endpoint`  | yes      | S3 endpoint URL for the target                       |
+| `s3_access_key`| yes      | S3 access key for the target                         |
+| `s3_secret_key`| yes      | S3 secret key for the target                         |
+| `s3_region`    | no       | S3 region (default: `us-east-1`)                     |
+
+The encryption passphrase is **not** included in this file. Atlas uses the shared encryption model -- the passphrase from the main configuration applies to all targets.
+
+::: danger Secure Target Config Files
+Target config files contain S3 credentials. Apply the same file permission restrictions as the main config file (`chmod 600`). Never commit them to version control.
+:::

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ Never commit these files to version control. The included `.gitignore` already e
 
 ## Replication Target Config
 
-The `atlas replicate` and `atlas rehydrate` commands accept a `--target-config` or `--source-config` flag pointing to a JSON file with S3 credentials for a secondary storage target:
+The `atlas replicate` command accepts `--target-config` and the `atlas rehydrate` command accepts `--source-config`, both pointing to a JSON file with S3 credentials for a secondary storage target:
 
 ```json
 {

--- a/docs/operations/replication.md
+++ b/docs/operations/replication.md
@@ -1,0 +1,239 @@
+# Replication
+
+Atlas supports snapshot-level replication to one or more secondary S3-compatible storage targets. Replication is a first-class engine feature -- not a wrapper around `mc mirror` or provider-specific tools.
+
+## How Replication Works
+
+```
+Primary storage          Replication service          Secondary target(s)
+     │                         │                            │
+     │  1. Read manifest       │                            │
+     │◄────────────────────────│                            │
+     │                         │                            │
+     │  2. Read data objects   │  3. Write missing objects  │
+     │◄────────────────────────│───────────────────────────►│
+     │                         │                            │
+     │                         │  4. Write manifest (last)  │
+     │                         │───────────────────────────►│
+     │                         │                            │
+     │  5. Write status sidecar│                            │
+     │◄────────────────────────│                            │
+```
+
+1. The replication service reads the snapshot manifest from primary storage.
+2. For each object (messages and attachments) referenced by the manifest, it checks whether the target already has the object.
+3. Missing objects are copied as raw ciphertext -- no decryption or re-encryption occurs.
+4. The manifest file is always copied last, ensuring a crash never leaves a manifest referencing missing objects.
+5. A durable status sidecar is written to primary storage recording the outcome.
+
+Replication is **idempotent**. Running it again for the same snapshot skips all objects that already exist on the target. This makes it safe to retry after failures or interruptions.
+
+## Primary-Is-Truth Principle
+
+::: danger Primary Is Authoritative
+Primary storage is always the source of truth during normal operation. Secondary targets receive data only through replication. Never run `atlas backup` directly against a replica target -- Atlas writes a marker file on targets and warns if this is attempted.
+:::
+
+Replication is one-directional: primary to target. There is no bidirectional sync and no automatic conflict resolution. If you need to recover data from a secondary target (disaster recovery), use `atlas rehydrate` -- a separate, explicit operation described below.
+
+## Shared Encryption Model
+
+Atlas uses a shared encryption model for replication. All targets use the same master passphrase and the same per-tenant Data Encryption Key (DEK). This means:
+
+- Ciphertext is copied byte-for-byte -- no decryption or re-encryption during replication.
+- Replication is fast because it only involves object reads and writes, not cryptographic operations.
+- The wrapped DEK (`_meta/dek.enc`) is copied to the target on first replication.
+
+::: warning Passphrase Compromise
+Because the same passphrase protects all copies, compromising the passphrase compromises data on every target. Mitigate this with separate IAM credentials per storage target -- an attacker who compromises one target's S3 keys cannot reach another target's data, even though the encryption keys are the same.
+:::
+
+## DEK Mismatch Protection
+
+Before every replication, Atlas validates that the source and target share the same encryption key. If you purge and re-initialize a tenant on primary (generating a new DEK), Atlas refuses to replicate to a target that still holds objects encrypted with the old key:
+
+```
+Error: Target has a different encryption key than the source.
+Purge the target before replicating from a re-initialized primary.
+```
+
+This prevents silent data corruption where old objects on the target become permanently undecryptable.
+
+## Copy Ordering and Crash Safety
+
+Objects are always copied in this order:
+
+1. `_meta/dek.enc` (with mismatch validation)
+2. Data objects (`data/{mailbox}/{sha256}`)
+3. Attachment objects (`attachments/{mailbox}/{sha256}`)
+4. Manifest file (`manifests/{mailbox}/{snapshot_id}.json`) -- **always last**
+
+If replication crashes at any point, the target is left in a safe state: orphan data blobs exist (harmless, reclaimable), but no manifest ever references missing objects. Rerunning replication picks up where it left off.
+
+## Replication Status
+
+Replication status is persisted as encrypted sidecar files in the primary tenant bucket:
+
+```
+atlas-{tenant_id}/
+└── _meta/
+    └── replication/
+        └── {mailbox_id}/
+            └── {snapshot_id}/
+                └── {target_id}.json
+```
+
+Each sidecar records: target ID, status (COMPLETED/PARTIAL/FAILED), object counts, byte counts, timestamps, manifest checksums, and the last error. Query status with:
+
+```bash
+atlas replicate --status                          # all snapshots, all targets
+atlas replicate --status -m user@company.com      # filter by mailbox
+atlas replicate --status -s <snapshot-id>         # filter by snapshot
+```
+
+## CLI Usage
+
+### Replicate a Snapshot
+
+```bash
+atlas replicate -s <snapshot-id> \
+  --target-endpoint http://offsite:9000 \
+  --target-access-key <key> \
+  --target-secret-key <secret>
+```
+
+### Replicate All Snapshots for a Mailbox
+
+```bash
+atlas replicate -m user@company.com \
+  --target-endpoint http://offsite:9000 \
+  --target-access-key <key> \
+  --target-secret-key <secret>
+```
+
+Only unreplicated snapshots are copied (the service diffs manifest lists).
+
+### Using a Target Config File
+
+```bash
+atlas replicate -s <snapshot-id> --target-config ./offsite.json
+```
+
+The file contains S3 credentials for the target:
+
+```json
+{
+  "target_id": "offsite-dr",
+  "s3_endpoint": "http://offsite:9000",
+  "s3_access_key": "offsite-key",
+  "s3_secret_key": "offsite-secret",
+  "s3_region": "us-east-1"
+}
+```
+
+`target_id` is optional (derived from endpoint if omitted). The encryption passphrase is not in this file -- it comes from the main Atlas configuration (shared model).
+
+## SDK Usage
+
+```typescript
+import { createAtlasInstance, createStorageTarget } from 'm365-atlas/sdk';
+
+const atlas = createAtlasInstance({ /* primary config */ });
+
+const offsite = createStorageTarget({
+  targetId: 'offsite-dr',
+  s3Endpoint: 'http://offsite:9000',
+  s3AccessKey: 'offsite-key',
+  s3SecretKey: 'offsite-secret',
+  encryptionPassphrase: 'same-passphrase-as-primary',
+});
+
+// Replicate a snapshot
+const results = await atlas.replicateSnapshot('snapshot-id', [offsite]);
+
+// Replicate all unreplicated snapshots for a mailbox
+const mailboxResults = await atlas.replicateMailbox('user@company.com', [offsite]);
+
+// Query replication status
+const status = await atlas.getReplicationStatus('snapshot-id');
+```
+
+## Rehydration (Disaster Recovery)
+
+Rehydration is a separate, explicit operation for recovering data from a replica to primary. It is **not** a sync -- it copies exactly what the operator specifies.
+
+::: tip Rehydration Is a DR Operation
+Use `atlas rehydrate` only when primary storage has suffered data loss. After recovery, primary resumes as the source of truth. Delta links in restored manifests may be stale -- Atlas automatically falls back to full sync on the next backup.
+:::
+
+### Three Recovery Modes
+
+**Recover a specific snapshot:**
+
+```bash
+atlas rehydrate -s <snapshot-id> \
+  --source-endpoint http://offsite:9000 \
+  --source-access-key <key> \
+  --source-secret-key <secret>
+```
+
+**Recover all snapshots for a mailbox:**
+
+```bash
+atlas rehydrate -m user@company.com --source-config ./offsite.json
+```
+
+**Full tenant recovery:**
+
+```bash
+atlas rehydrate --all --source-config ./offsite.json
+```
+
+Rehydration skips snapshots that already exist on primary. It does not merge, diff, or resolve conflicts.
+
+### SDK Rehydration
+
+```typescript
+// Recover a single snapshot
+await atlas.rehydrateSnapshot('snapshot-id', offsite);
+
+// Recover a mailbox
+await atlas.rehydrateMailbox('user@company.com', offsite);
+
+// Full tenant DR
+await atlas.rehydrateTenant(offsite);
+```
+
+## Object Lock
+
+Object Lock policies are **not** replicated per-object. If you want immutable backups on a secondary target, configure Object Lock at the bucket level on that target independently. The replication service copies raw ciphertext without lock metadata.
+
+## Operational Runbook: Recovering from Primary Failure
+
+If primary storage fails and you need to restore from a replica:
+
+1. **Ensure primary bucket exists** and is accessible (even if empty).
+
+2. **Verify the passphrase** is the same one used when the replica was created.
+
+3. **Run full tenant rehydration:**
+   ```bash
+   atlas rehydrate --all --source-config ./offsite.json
+   ```
+
+4. **Verify recovered data:**
+   ```bash
+   atlas list                              # check recovered mailboxes
+   atlas verify -s <snapshot-id>           # verify integrity
+   ```
+
+5. **Run a fresh backup** to capture any changes since the last replication:
+   ```bash
+   atlas backup
+   ```
+   Stale delta links are handled automatically -- Atlas falls back to full sync.
+
+6. **Re-replicate** to ensure the secondary target is current:
+   ```bash
+   atlas replicate -m user@company.com --target-config ./offsite.json
+   ```

--- a/docs/operations/replication.md
+++ b/docs/operations/replication.md
@@ -31,7 +31,7 @@ Replication is **idempotent**. Running it again for the same snapshot skips all 
 ## Primary-Is-Truth Principle
 
 ::: danger Primary Is Authoritative
-Primary storage is always the source of truth during normal operation. Secondary targets receive data only through replication. Never run `atlas backup` directly against a replica target -- Atlas writes a marker file on targets and warns if this is attempted.
+Primary storage is always the source of truth during normal operation. Secondary targets receive data only through replication. Never run `atlas backup` directly against a replica target -- Atlas detects the replica marker file and logs a warning if this is attempted.
 :::
 
 Replication is one-directional: primary to target. There is no bidirectional sync and no automatic conflict resolution. If you need to recover data from a secondary target (disaster recovery), use `atlas rehydrate` -- a separate, explicit operation described below.
@@ -63,10 +63,11 @@ This prevents silent data corruption where old objects on the target become perm
 
 Objects are always copied in this order:
 
-1. `_meta/dek.enc` (with mismatch validation)
-2. Data objects (`data/{mailbox}/{sha256}`)
-3. Attachment objects (`attachments/{mailbox}/{sha256}`)
-4. Manifest file (`manifests/{mailbox}/{snapshot_id}.json`) -- **always last**
+1. **DEK validation** -- verifies source and target share the same encryption key
+2. `_meta/dek.enc` -- copied to target if not already present
+3. `_meta/replica.marker` -- written on target (skipped during rehydration to primary)
+4. Data and attachment objects -- copied in manifest order, skipping objects already on target
+5. Manifest file (`manifests/{mailbox}/{snapshot_id}.json`) -- **always last**
 
 If replication crashes at any point, the target is left in a safe state: orphan data blobs exist (harmless, reclaimable), but no manifest ever references missing objects. Rerunning replication picks up where it left off.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -318,7 +318,6 @@ atlas replicate -s <snapshot-id> \
   --target-secret-key <secret>
 
 atlas replicate -m user@company.com --target-config ./offsite.json
-atlas replicate -s <snapshot-id> --target-config ./offsite.json --verify
 
 atlas replicate --status
 atlas replicate --status -m user@company.com
@@ -334,7 +333,6 @@ atlas replicate --status -s <snapshot-id>
 | `--target-secret-key <key>`  | Target S3 secret key                                  |
 | `--target-region <region>`   | Target S3 region (default: `us-east-1`)               |
 | `--target-config <path>`     | Path to JSON file with target S3 credentials          |
-| `--verify`                   | Verify integrity on target after replication          |
 | `--status`                   | Show replication status instead of replicating        |
 | `-t, --tenant <id>`          | Override tenant ID                                    |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -306,3 +306,68 @@ atlas stats --json                     # raw JSON output
 | `-t, --tenant <id>`     | Override tenant ID from config             |
 
 The bucket-level overview shows total object counts and storage consumption across all mailboxes. The mailbox breakdown shows per-prefix statistics (data, attachments, manifests) so you can identify which mailboxes consume the most storage. Use `--json` for programmatic consumption in monitoring scripts or dashboards.
+
+## `atlas replicate`
+
+Replicate snapshots to a secondary S3-compatible storage target. Ciphertext is copied as-is (no decryption). Only unreplicated snapshots and missing objects are transferred.
+
+```bash
+atlas replicate -s <snapshot-id> \
+  --target-endpoint http://offsite:9000 \
+  --target-access-key <key> \
+  --target-secret-key <secret>
+
+atlas replicate -m user@company.com --target-config ./offsite.json
+atlas replicate -s <snapshot-id> --target-config ./offsite.json --verify
+
+atlas replicate --status
+atlas replicate --status -m user@company.com
+atlas replicate --status -s <snapshot-id>
+```
+
+| Option                       | Description                                           |
+| ---------------------------- | ----------------------------------------------------- |
+| `-s, --snapshot <id>`        | Replicate a specific snapshot                         |
+| `-m, --mailbox <email>`      | Replicate all unreplicated snapshots for a mailbox    |
+| `--target-endpoint <url>`    | Target S3 endpoint URL                                |
+| `--target-access-key <key>`  | Target S3 access key                                  |
+| `--target-secret-key <key>`  | Target S3 secret key                                  |
+| `--target-region <region>`   | Target S3 region (default: `us-east-1`)               |
+| `--target-config <path>`     | Path to JSON file with target S3 credentials          |
+| `--verify`                   | Verify integrity on target after replication          |
+| `--status`                   | Show replication status instead of replicating        |
+| `-t, --tenant <id>`          | Override tenant ID                                    |
+
+::: tip Target Config File
+The target config file is a JSON object with `s3_endpoint`, `s3_access_key`, `s3_secret_key`, and optionally `s3_region` and `target_id`. The encryption passphrase is shared from the main Atlas configuration.
+:::
+
+## `atlas rehydrate`
+
+Recover snapshots from a replica to primary storage. This is a disaster recovery operation -- not a bidirectional sync. Snapshots already on primary are skipped.
+
+```bash
+atlas rehydrate -s <snapshot-id> \
+  --source-endpoint http://offsite:9000 \
+  --source-access-key <key> \
+  --source-secret-key <secret>
+
+atlas rehydrate -m user@company.com --source-config ./offsite.json
+atlas rehydrate --all --source-config ./offsite.json
+```
+
+| Option                       | Description                                              |
+| ---------------------------- | -------------------------------------------------------- |
+| `-s, --snapshot <id>`        | Recover a specific snapshot from the replica             |
+| `-m, --mailbox <email>`      | Recover all snapshots for a mailbox from the replica     |
+| `--all`                      | Recover all mailboxes and snapshots (full tenant DR)     |
+| `--source-endpoint <url>`    | Source replica S3 endpoint URL                           |
+| `--source-access-key <key>`  | Source replica S3 access key                             |
+| `--source-secret-key <key>`  | Source replica S3 secret key                             |
+| `--source-region <region>`   | Source replica S3 region (default: `us-east-1`)          |
+| `--source-config <path>`     | Path to JSON file with source S3 credentials             |
+| `-t, --tenant <id>`          | Override tenant ID                                       |
+
+::: danger Rehydration Is Not Sync
+Rehydration copies explicitly selected data from a designated replica to primary. It does not merge, diff, or resolve conflicts. After rehydration, primary resumes as the source of truth. Delta links in recovered manifests may be stale -- Atlas falls back to full sync on the next backup automatically.
+:::

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -139,6 +139,57 @@ process.exit(failed.length > 0 ? 1 : 0);
 
 The non-zero exit code on failure integrates with cron (which can send alert emails on failure), systemd (which logs `FailureAction`), and CI/CD pipelines.
 
+## Backup, Replicate, and Report
+
+Back up each mailbox, immediately replicate the snapshot to an offsite target, and collect the results. This is the core loop for a 3-2-1 strategy -- adapt the reporting to whatever fits your stack (webhook, database row, structured log, email).
+
+```typescript
+import { createAtlasInstance, createStorageTarget } from 'm365-atlas/sdk';
+
+const atlas = createAtlasInstance({
+  tenantId: process.env.ATLAS_TENANT_ID!,
+  clientId: process.env.ATLAS_CLIENT_ID!,
+  clientSecret: process.env.ATLAS_CLIENT_SECRET!,
+  s3Endpoint: process.env.ATLAS_S3_ENDPOINT!,
+  s3AccessKey: process.env.ATLAS_S3_ACCESS_KEY!,
+  s3SecretKey: process.env.ATLAS_S3_SECRET_KEY!,
+  encryptionPassphrase: process.env.ATLAS_ENCRYPTION_PASSPHRASE!,
+});
+
+const offsite = createStorageTarget({
+  s3Endpoint: process.env.OFFSITE_S3_ENDPOINT!,
+  s3AccessKey: process.env.OFFSITE_S3_ACCESS_KEY!,
+  s3SecretKey: process.env.OFFSITE_S3_SECRET_KEY!,
+  encryptionPassphrase: process.env.ATLAS_ENCRYPTION_PASSPHRASE!,
+});
+
+const mailboxes = ['ceo@company.com', 'finance@company.com', 'legal@company.com'];
+const results = [];
+const replications: Promise<unknown>[] = [];
+
+for (const mailbox of mailboxes) {
+  try {
+    const backup = await atlas.backupMailbox(mailbox);
+
+    // Replication is S3-to-S3 only (no Graph API calls), so fire it off
+    // concurrently while the next mailbox backup runs.
+    replications.push(atlas.replicateSnapshot(backup.snapshot.id, [offsite]));
+
+    results.push({ mailbox, snapshot_id: backup.snapshot.id, stored: backup.summary.stored, ok: true });
+  } catch (err) {
+    results.push({ mailbox, ok: false, error: (err as Error).message });
+  }
+}
+
+await Promise.allSettled(replications);
+
+// results is a plain array -- send it wherever you want
+console.log(JSON.stringify(results, null, 2));
+process.exit(results.some((r) => !r.ok) ? 1 : 0);
+```
+
+Backups run sequentially to avoid Graph API throttling, but each replication fires off immediately without blocking the next backup. Replication is pure S3-to-S3 traffic (typically LAN or inter-datacenter fiber), so it runs concurrently in the background. `Promise.allSettled` at the end ensures all replications finish before the process exits. If the job crashes partway, the next run picks up naturally -- `backupMailbox` produces a delta snapshot and `replicateSnapshot` skips objects already on the target.
+
 ## Periodic Integrity Verification
 
 Run `verifySnapshot` on recent snapshots to confirm that data in S3 has not been corrupted or tampered with. This is the programmatic equivalent of `atlas verify`.

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -120,6 +120,49 @@ for (const mailboxId of mailboxIds) {
 }
 ```
 
+## Replication
+
+The SDK supports snapshot-level replication and disaster recovery rehydration. A `StorageTarget` represents a secondary S3 endpoint -- it only needs S3 credentials and the shared passphrase (no M365 credentials).
+
+```typescript
+import { createAtlasInstance, createStorageTarget } from 'm365-atlas/sdk';
+
+const atlas = createAtlasInstance({ /* primary config */ });
+
+const offsite = createStorageTarget({
+  targetId: 'offsite-dr',
+  s3Endpoint: 'http://offsite:9000',
+  s3AccessKey: 'offsite-key',
+  s3SecretKey: 'offsite-secret',
+  encryptionPassphrase: 'same-passphrase-as-primary',
+});
+
+// Replicate a snapshot to one or more targets
+const results = await atlas.replicateSnapshot('snapshot-id', [offsite]);
+
+// Replicate all unreplicated snapshots for a mailbox
+const mailboxResults = await atlas.replicateMailbox('user@company.com', [offsite]);
+
+// Query replication status
+const status = await atlas.getReplicationStatus('snapshot-id');
+
+// Disaster recovery: recover from a replica
+await atlas.rehydrateSnapshot('snapshot-id', offsite);
+await atlas.rehydrateMailbox('user@company.com', offsite);
+await atlas.rehydrateTenant(offsite);
+```
+
+`createStorageTarget` accepts a `StorageTargetConfig`:
+
+| Option                 | Type     | Description                                                    |
+| ---------------------- | -------- | -------------------------------------------------------------- |
+| `targetId`             | `string` | Stable human-readable ID (auto-derived from endpoint if omitted) |
+| `s3Endpoint`           | `string` | S3 endpoint URL                                                |
+| `s3AccessKey`          | `string` | S3 access key                                                  |
+| `s3SecretKey`          | `string` | S3 secret key                                                  |
+| `s3Region`             | `string` | S3 region (default: `us-east-1`)                               |
+| `encryptionPassphrase` | `string` | Must match the primary passphrase (shared encryption model)    |
+
 ## Exports
 
-The SDK exports its own types via `m365-atlas/sdk`. Domain types, port interfaces, and result types are available from the root `m365-atlas` import for advanced use cases. Status-related types (`MailboxStatusResult`, `FolderStatus`) are also exported from `m365-atlas/sdk`.
+The SDK exports its own types via `m365-atlas/sdk`. Domain types, port interfaces, and result types are available from the root `m365-atlas` import for advanced use cases. Status-related types (`MailboxStatusResult`, `FolderStatus`), replication types (`ReplicationResult`, `ReplicationStatusRecord`, `StorageTarget`, `StorageTargetConfig`), and `createStorageTarget` are also exported from `m365-atlas/sdk`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -109,3 +109,36 @@ Currently, `atlas verify` checks **message body entries** listed in the manifest
 ### Content-MD5 on Uploads
 
 Every object uploaded to S3 includes a `Content-MD5` header computed from the **ciphertext** (not the plaintext). This is a transport integrity check -- if a network error corrupts the data in flight, S3 will reject the upload with a checksum mismatch. This is separate from the application-layer SHA-256, which validates the original plaintext content.
+
+## Replication Security
+
+### Shared Encryption Model
+
+Atlas replication uses a shared encryption model: all storage targets (primary and secondary) share the same master passphrase and the same per-tenant DEK. Ciphertext is copied byte-for-byte during replication -- no decryption or re-encryption occurs.
+
+This means:
+
+- **One passphrase protects all copies.** Compromising the passphrase compromises data on every target.
+- **One DEK per tenant across all targets.** The wrapped DEK (`_meta/dek.enc`) is copied to each target on first replication.
+
+### Access Isolation
+
+While encryption keys are shared, **S3 access credentials should be separate per target**. Use independent IAM principals for each storage endpoint:
+
+- Primary MinIO: `atlas-primary` user with full read/write
+- Offsite MinIO: `atlas-offsite` user with full read/write
+- Cloud S3: dedicated IAM role with scoped permissions
+
+If an attacker compromises one target's S3 credentials, they can read that target's data (which is encrypted) but cannot reach other targets. Combined with a strong passphrase, this provides defense in depth.
+
+### DEK Mismatch Protection
+
+Atlas validates encryption key consistency before every replication and rehydration. If the primary tenant was purged and re-initialized (generating a new DEK), replication to a target with the old DEK is refused with an explicit error. This prevents a scenario where objects encrypted with different keys coexist on the same target, making older objects permanently undecryptable.
+
+### Replica Marker
+
+Atlas writes a marker file (`_meta/replica.marker`) on each target during first replication. If a user accidentally runs `atlas backup` against a replica target, Atlas detects the marker and logs a warning. This guards against accidental violation of the primary-is-truth principle, which could lead to data inconsistency.
+
+### Replication Status Encryption
+
+Replication status sidecar files stored under `_meta/replication/` in the primary bucket are encrypted with the tenant DEK. Target endpoints, checksums, and error messages are not exposed at rest in S3.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -265,3 +265,48 @@ sudo systemctl enable --now atlas-backup.timer
 ::: tip Off-Hours Scheduling
 For professional deployments, always schedule backups outside business hours. A nightly 2 AM run avoids competing with daytime internet usage and Microsoft Graph API traffic from other applications in your tenant.
 :::
+
+## Multi-Location Replication
+
+Atlas supports replicating completed snapshots to one or more secondary S3-compatible storage targets. This enables 3-2-1 backup strategies where data exists on multiple storage systems in multiple locations.
+
+### Deployment Patterns
+
+**Local MinIO primary + offsite MinIO replica:**
+
+Run a primary MinIO instance on your local backup server and a second MinIO instance at a remote site (colocation, another office, or a VPS). After each backup, replicate to the offsite target:
+
+```bash
+atlas backup -m user@company.com
+atlas replicate -m user@company.com --target-config ./offsite.json
+```
+
+**Local MinIO primary + cloud S3 replica:**
+
+Run MinIO locally for fast backups, then replicate to AWS S3, Backblaze B2, Wasabi, or any S3-compatible cloud storage for geographic redundancy:
+
+```json
+{
+  "target_id": "aws-us-east",
+  "s3_endpoint": "https://s3.us-east-1.amazonaws.com",
+  "s3_access_key": "AKIA...",
+  "s3_secret_key": "...",
+  "s3_region": "us-east-1"
+}
+```
+
+### Scheduling Replication
+
+Schedule replication after backups using a second cron entry or systemd timer:
+
+```cron
+# Nightly backup at 2 AM, replicate at 4 AM
+0 2 * * * /usr/bin/atlas backup >> /var/log/atlas-backup.log 2>&1
+0 4 * * * /usr/bin/atlas replicate -m user@company.com --target-config /etc/atlas/offsite.json >> /var/log/atlas-replicate.log 2>&1
+```
+
+### Bandwidth Considerations
+
+Replication transfers encrypted objects over the network. The first replication of a mailbox transfers all historical data (similar to an initial backup). Subsequent replications only transfer new snapshots. Plan bandwidth and scheduling accordingly -- replicating 50 GB of backup data to a remote site over a 10 Mbps upload link takes approximately 11 hours.
+
+See [Replication](/operations/replication) for full operational details, security model, and disaster recovery procedures.

--- a/src/adapters/sdk/atlas-instance.adapter.ts
+++ b/src/adapters/sdk/atlas-instance.adapter.ts
@@ -10,6 +10,7 @@ import type { StorageCheckUseCase } from '@/ports/storage-check/use-case.port';
 import type { SaveUseCase } from '@/ports/save/use-case.port';
 import type { StatsUseCase } from '@/ports/stats/use-case.port';
 import type { StatusUseCase } from '@/ports/status/use-case.port';
+import type { ReplicationUseCase } from '@/ports/replication/use-case.port';
 import {
   BACKUP_USE_CASE_TOKEN,
   VERIFICATION_USE_CASE_TOKEN,
@@ -20,6 +21,7 @@ import {
   SAVE_USE_CASE_TOKEN,
   STATS_USE_CASE_TOKEN,
   STATUS_USE_CASE_TOKEN,
+  REPLICATION_USE_CASE_TOKEN,
 } from '@/ports/tokens/use-case.tokens';
 
 /** Creates a tenant-bound Atlas SDK instance from explicit configuration values. */
@@ -36,6 +38,7 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
   const saveUseCase = container.get<SaveUseCase>(SAVE_USE_CASE_TOKEN);
   const statsUseCase = container.get<StatsUseCase>(STATS_USE_CASE_TOKEN);
   const statusUseCase = container.get<StatusUseCase>(STATUS_USE_CASE_TOKEN);
+  const replicationUseCase = container.get<ReplicationUseCase>(REPLICATION_USE_CASE_TOKEN);
 
   return {
     async backupMailbox(mailboxId, options) {
@@ -85,6 +88,24 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     },
     async checkMailboxStatus(mailboxId) {
       return await statusUseCase.check_mailbox_status(tenantId, mailboxId);
+    },
+    async replicateSnapshot(snapshotId, targets) {
+      return await replicationUseCase.replicate_snapshot(tenantId, snapshotId, targets);
+    },
+    async replicateMailbox(mailboxId, targets) {
+      return await replicationUseCase.replicate_mailbox(tenantId, mailboxId, targets);
+    },
+    async rehydrateSnapshot(snapshotId, source) {
+      return await replicationUseCase.rehydrate_snapshot(tenantId, snapshotId, source);
+    },
+    async rehydrateMailbox(mailboxId, source) {
+      return await replicationUseCase.rehydrate_mailbox(tenantId, mailboxId, source);
+    },
+    async rehydrateTenant(source) {
+      return await replicationUseCase.rehydrate_tenant(tenantId, source);
+    },
+    async getReplicationStatus(snapshotId) {
+      return await replicationUseCase.get_replication_status(tenantId, snapshotId);
     },
   };
 }

--- a/src/adapters/sdk/atlas-instance.adapter.ts
+++ b/src/adapters/sdk/atlas-instance.adapter.ts
@@ -107,6 +107,9 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     async getReplicationStatus(snapshotId) {
       return await replicationUseCase.get_replication_status(tenantId, snapshotId);
     },
+    async getReplicationStatusByMailbox(mailboxId) {
+      return await replicationUseCase.get_replication_status_by_mailbox(tenantId, mailboxId);
+    },
   };
 }
 

--- a/src/adapters/storage-s3/dek-validator.ts
+++ b/src/adapters/storage-s3/dek-validator.ts
@@ -1,0 +1,41 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { ObjectStorage } from '@/ports/storage/object-storage.port';
+import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
+
+const DEK_META_KEY = '_meta/dek.enc';
+
+export class DekMismatchError extends Error {
+  constructor() {
+    super(
+      'Target has a different encryption key than the source. ' +
+        'Purge the target before replicating from a re-initialized primary.',
+    );
+    this.name = 'DekMismatchError';
+  }
+}
+
+/**
+ * Validates that source and target share the same DEK.
+ * If the target has no dek.enc yet, validation passes (DEK will be copied).
+ * Throws DekMismatchError if both sides have a DEK and the raw bytes differ.
+ */
+export async function validate_dek_match(
+  source_storage: ObjectStorage,
+  target_storage: ObjectStorage,
+  passphrase: string,
+  tenant_id: string,
+): Promise<void> {
+  const target_has_dek = await target_storage.exists(DEK_META_KEY);
+  if (!target_has_dek) return;
+
+  const source_wrapped = await source_storage.get(DEK_META_KEY);
+  const target_wrapped = await target_storage.get(DEK_META_KEY);
+
+  const key_service = new EnvelopeKeyService(passphrase, tenant_id);
+  const source_dek = key_service.unwrap_dek(source_wrapped);
+  const target_dek = key_service.unwrap_dek(target_wrapped);
+
+  if (source_dek.length !== target_dek.length || !timingSafeEqual(source_dek, target_dek)) {
+    throw new DekMismatchError();
+  }
+}

--- a/src/adapters/storage-s3/s3-bucket-manager.ts
+++ b/src/adapters/storage-s3/s3-bucket-manager.ts
@@ -22,8 +22,12 @@ const _immutability_probe_cache = new Map<string, StorageImmutabilityProbeResult
  * multipart uploads, clean up expired delete markers). Existing buckets are
  * left untouched. Caches results in-process so subsequent calls are free.
  */
-export async function ensure_bucket_exists(client: S3Client, bucket: string): Promise<void> {
-  if (_checked_buckets.has(bucket)) return;
+export async function ensure_bucket_exists(
+  client: S3Client,
+  bucket: string,
+  skip_cache = false,
+): Promise<void> {
+  if (!skip_cache && _checked_buckets.has(bucket)) return;
 
   const exists = await bucket_exists(client, bucket);
   if (!exists) {

--- a/src/adapters/storage-target.factory.ts
+++ b/src/adapters/storage-target.factory.ts
@@ -1,0 +1,121 @@
+import { createHash } from 'node:crypto';
+import { S3Client } from '@aws-sdk/client-s3';
+import type { StorageTarget, StorageTargetConfig } from '@/ports/replication/storage-target.port';
+import type { TenantContext } from '@/ports/tenant/context.port';
+import { S3ObjectStorage } from '@/adapters/storage-s3/s3-object-storage.adapter';
+import { ensure_bucket_exists } from '@/adapters/storage-s3/s3-bucket-manager';
+import { tenant_bucket_name } from '@/adapters/storage-s3/tenant-bucket-name';
+import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
+
+const DEK_META_KEY = '_meta/dek.enc';
+
+/** SDK-facing camelCase config, consistent with AtlasInstanceConfig. */
+export interface StorageTargetSdkConfig {
+  readonly targetId?: string;
+  readonly s3Endpoint: string;
+  readonly s3AccessKey: string;
+  readonly s3SecretKey: string;
+  readonly s3Region?: string;
+  readonly encryptionPassphrase: string;
+}
+
+function derive_target_id(endpoint: string, region?: string): string {
+  const raw = `${endpoint}|${region ?? 'us-east-1'}`;
+  return createHash('sha256').update(raw).digest('hex').slice(0, 16);
+}
+
+function normalize_target_config(
+  config: StorageTargetSdkConfig | StorageTargetConfig,
+): StorageTargetConfig {
+  if ('s3_endpoint' in config) return config;
+  return {
+    target_id: config.targetId,
+    s3_endpoint: config.s3Endpoint,
+    s3_access_key: config.s3AccessKey,
+    s3_secret_key: config.s3SecretKey,
+    s3_region: config.s3Region,
+    encryption_passphrase: config.encryptionPassphrase,
+  };
+}
+
+/** Creates a lightweight storage-only target for replication. Accepts both camelCase (SDK) and snake_case (internal) config. */
+export function create_storage_target(
+  config: StorageTargetSdkConfig | StorageTargetConfig,
+): StorageTarget {
+  return new DefaultStorageTarget(normalize_target_config(config));
+}
+
+/**
+ * A storage-only target that wraps its own S3Client.
+ * Does NOT auto-generate a DEK -- the replication service is responsible
+ * for copying dek.enc from the source before any encrypted operations.
+ */
+class DefaultStorageTarget implements StorageTarget {
+  readonly target_id: string;
+  readonly endpoint: string;
+  private readonly _client: S3Client;
+  private readonly _passphrase: string;
+  private readonly _region: string;
+
+  constructor(config: StorageTargetConfig) {
+    this.target_id = config.target_id ?? derive_target_id(config.s3_endpoint, config.s3_region);
+    this.endpoint = config.s3_endpoint;
+    this._passphrase = config.encryption_passphrase;
+    this._region = config.s3_region ?? 'us-east-1';
+
+    this._client = new S3Client({
+      endpoint: config.s3_endpoint,
+      region: this._region,
+      credentials: {
+        accessKeyId: config.s3_access_key,
+        secretAccessKey: config.s3_secret_key,
+      },
+      forcePathStyle: true,
+    });
+  }
+
+  /**
+   * Creates a tenant context on this target.
+   * If no DEK exists yet (fresh target), encrypt/decrypt will throw --
+   * this is fine because replication copies raw ciphertext without decrypting.
+   * After the replication service copies dek.enc, subsequent calls will work.
+   */
+  async create_context(tenant_id: string): Promise<TenantContext> {
+    const bucket = tenant_bucket_name(tenant_id);
+    await ensure_bucket_exists(this._client, bucket, true);
+
+    const storage = new S3ObjectStorage(this._client, bucket);
+    const key_service = new EnvelopeKeyService(this._passphrase, tenant_id);
+    const dek = await this.try_load_dek(storage, key_service);
+
+    if (dek) {
+      return {
+        tenant_id,
+        storage,
+        encrypt: (data: Buffer): Buffer => key_service.encrypt(data, dek),
+        decrypt: (data: Buffer): Buffer => key_service.decrypt(data, dek),
+      };
+    }
+
+    return {
+      tenant_id,
+      storage,
+      encrypt: (): Buffer => {
+        throw new Error('Cannot encrypt: no DEK on target. Copy _meta/dek.enc first.');
+      },
+      decrypt: (): Buffer => {
+        throw new Error('Cannot decrypt: no DEK on target. Copy _meta/dek.enc first.');
+      },
+    };
+  }
+
+  private async try_load_dek(
+    storage: S3ObjectStorage,
+    key_service: EnvelopeKeyService,
+  ): Promise<Buffer | undefined> {
+    const exists = await storage.exists(DEK_META_KEY);
+    if (!exists) return undefined;
+    const wrapped = await storage.get(DEK_META_KEY);
+    return key_service.unwrap_dek(wrapped);
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,8 @@ import { register_save_command } from '@/cli/commands/save.command';
 import { register_stats_command } from '@/cli/commands/stats.command';
 import { register_mailboxes_command } from '@/cli/commands/mailboxes.command';
 import { register_status_command } from '@/cli/commands/status.command';
+import { register_replicate_command } from '@/cli/commands/replicate.command';
+import { register_rehydrate_command } from '@/cli/commands/rehydrate.command';
 import { logger } from '@/utils/logger';
 import type { Container } from 'inversify';
 
@@ -48,6 +50,8 @@ function register_commands(program: Command): void {
   register_stats_command(program, get_container);
   register_mailboxes_command(program, get_container);
   register_status_command(program, get_container);
+  register_replicate_command(program, get_container);
+  register_rehydrate_command(program, get_container);
 }
 
 /** Handles top-level unhandled errors from command execution. */

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -4,3 +4,5 @@ export { register_restore_command } from './restore.command';
 export { register_storage_check_command } from './storage-check.command';
 export { register_mailboxes_command } from './mailboxes.command';
 export { register_status_command } from './status.command';
+export { register_replicate_command } from './replicate.command';
+export { register_rehydrate_command } from './rehydrate.command';

--- a/src/cli/commands/rehydrate.command.ts
+++ b/src/cli/commands/rehydrate.command.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs';
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import type { Container } from 'inversify';
+import type { AtlasConfig } from '@/utils/config';
+import { ATLAS_CONFIG_TOKEN } from '@/utils/config';
+import type { ReplicationUseCase } from '@/ports/replication/use-case.port';
+import { REPLICATION_USE_CASE_TOKEN } from '@/ports/tokens/use-case.tokens';
+import { create_storage_target } from '@/adapters/storage-target.factory';
+import type { StorageTarget } from '@/ports/replication/storage-target.port';
+import type { ReplicationResult } from '@/domain/replication';
+import { format_bytes } from '@/cli/command-formatters';
+import { logger } from '@/utils/logger';
+
+type ContainerFactory = () => Container;
+
+interface RehydrateOptions {
+  snapshot?: string;
+  mailbox?: string;
+  all?: boolean;
+  tenant?: string;
+  sourceEndpoint?: string;
+  sourceAccessKey?: string;
+  sourceSecretKey?: string;
+  sourceRegion?: string;
+  sourceConfig?: string;
+}
+
+/** Registers the `atlas rehydrate` subcommand for disaster recovery. */
+export function register_rehydrate_command(
+  program: Command,
+  get_container: ContainerFactory,
+): void {
+  program
+    .command('rehydrate')
+    .description('Recover snapshots from a replica to primary (disaster recovery)')
+    .option('-s, --snapshot <id>', 'recover a specific snapshot')
+    .option('-m, --mailbox <id>', 'recover all snapshots for a mailbox')
+    .option('--all', 'recover all mailboxes and snapshots (full tenant DR)')
+    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .option('--source-endpoint <url>', 'source replica S3 endpoint URL')
+    .option('--source-access-key <key>', 'source replica S3 access key')
+    .option('--source-secret-key <key>', 'source replica S3 secret key')
+    .option('--source-region <region>', 'source replica S3 region')
+    .option('--source-config <path>', 'path to JSON file with source S3 credentials')
+    .action((options: RehydrateOptions) => execute_rehydrate(get_container(), options));
+}
+
+function resolve_tenant_id(container: Container, options: RehydrateOptions): string {
+  if (options.tenant) return options.tenant;
+  return container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
+}
+
+async function execute_rehydrate(container: Container, options: RehydrateOptions): Promise<void> {
+  const tenant_id = resolve_tenant_id(container, options);
+  const use_case = container.get<ReplicationUseCase>(REPLICATION_USE_CASE_TOKEN);
+  const source = build_source(container, options);
+
+  logger.banner('Atlas Rehydrate');
+  logger.info(`Tenant:  ${tenant_id}`);
+  logger.info(`Source:  ${source.endpoint} (${source.target_id})`);
+
+  let result: ReplicationResult;
+
+  if (options.snapshot) {
+    logger.info(`Mode:    recover snapshot ${chalk.cyan(options.snapshot)}`);
+    result = await use_case.rehydrate_snapshot(tenant_id, options.snapshot, source);
+  } else if (options.mailbox) {
+    logger.info(`Mode:    recover mailbox ${chalk.cyan(options.mailbox)}`);
+    result = await use_case.rehydrate_mailbox(tenant_id, options.mailbox, source);
+  } else if (options.all) {
+    logger.info(`Mode:    full tenant recovery`);
+    result = await use_case.rehydrate_tenant(tenant_id, source);
+  } else {
+    logger.error('One of --snapshot, --mailbox, or --all is required');
+    process.exitCode = 1;
+    return;
+  }
+
+  report_result(result);
+}
+
+function build_source(container: Container, options: RehydrateOptions): StorageTarget {
+  const config = container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN);
+
+  if (options.sourceConfig) {
+    const raw = readFileSync(options.sourceConfig, 'utf-8');
+    const file = JSON.parse(raw) as Record<string, string>;
+    return create_storage_target({
+      target_id: file.target_id,
+      s3_endpoint: file.s3_endpoint,
+      s3_access_key: file.s3_access_key,
+      s3_secret_key: file.s3_secret_key,
+      s3_region: file.s3_region,
+      encryption_passphrase: config.encryption_passphrase,
+    });
+  }
+
+  if (!options.sourceEndpoint || !options.sourceAccessKey || !options.sourceSecretKey) {
+    throw new Error(
+      'Source credentials required: provide --source-endpoint, --source-access-key, --source-secret-key ' +
+        'or --source-config <path>',
+    );
+  }
+
+  return create_storage_target({
+    s3_endpoint: options.sourceEndpoint,
+    s3_access_key: options.sourceAccessKey,
+    s3_secret_key: options.sourceSecretKey,
+    s3_region: options.sourceRegion,
+    encryption_passphrase: config.encryption_passphrase,
+  });
+}
+
+function report_result(result: ReplicationResult): void {
+  const status_text =
+    result.status === 'COMPLETED' ? chalk.green(result.status) : chalk.red(result.status);
+
+  logger.info(
+    `Result: ${status_text} -- ` +
+      `${result.objects_copied} copied, ${result.objects_skipped} skipped, ` +
+      `${result.objects_failed} failed (${format_bytes(result.bytes_copied)}, ${result.elapsed_ms}ms)`,
+  );
+
+  for (const err of result.errors) {
+    logger.error(`  ${err}`);
+  }
+
+  if (result.objects_failed > 0) process.exitCode = 1;
+}

--- a/src/cli/commands/replicate.command.ts
+++ b/src/cli/commands/replicate.command.ts
@@ -23,7 +23,6 @@ interface ReplicateOptions {
   targetSecretKey?: string;
   targetRegion?: string;
   targetConfig?: string;
-  verify?: boolean;
   status?: boolean;
 }
 
@@ -43,7 +42,6 @@ export function register_replicate_command(
     .option('--target-secret-key <key>', 'target S3 secret key')
     .option('--target-region <region>', 'target S3 region')
     .option('--target-config <path>', 'path to JSON file with target S3 credentials')
-    .option('--verify', 'verify integrity on target after replication')
     .option('--status', 'show replication status instead of replicating')
     .action((options: ReplicateOptions) => execute_replicate(get_container(), options));
 }

--- a/src/cli/commands/replicate.command.ts
+++ b/src/cli/commands/replicate.command.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from 'node:fs';
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import type { Container } from 'inversify';
+import type { AtlasConfig } from '@/utils/config';
+import { ATLAS_CONFIG_TOKEN } from '@/utils/config';
+import type { ReplicationUseCase } from '@/ports/replication/use-case.port';
+import { REPLICATION_USE_CASE_TOKEN } from '@/ports/tokens/use-case.tokens';
+import { create_storage_target } from '@/adapters/storage-target.factory';
+import type { StorageTarget } from '@/ports/replication/storage-target.port';
+import type { ReplicationResult, ReplicationStatusRecord } from '@/domain/replication';
+import { format_bytes } from '@/cli/command-formatters';
+import { logger } from '@/utils/logger';
+
+type ContainerFactory = () => Container;
+
+interface ReplicateOptions {
+  snapshot?: string;
+  mailbox?: string;
+  tenant?: string;
+  targetEndpoint?: string;
+  targetAccessKey?: string;
+  targetSecretKey?: string;
+  targetRegion?: string;
+  targetConfig?: string;
+  verify?: boolean;
+  status?: boolean;
+}
+
+/** Registers the `atlas replicate` subcommand. */
+export function register_replicate_command(
+  program: Command,
+  get_container: ContainerFactory,
+): void {
+  program
+    .command('replicate')
+    .description('Replicate snapshots to a secondary S3 storage target')
+    .option('-s, --snapshot <id>', 'replicate a specific snapshot')
+    .option('-m, --mailbox <id>', 'replicate all unreplicated snapshots for a mailbox')
+    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .option('--target-endpoint <url>', 'target S3 endpoint URL')
+    .option('--target-access-key <key>', 'target S3 access key')
+    .option('--target-secret-key <key>', 'target S3 secret key')
+    .option('--target-region <region>', 'target S3 region')
+    .option('--target-config <path>', 'path to JSON file with target S3 credentials')
+    .option('--verify', 'verify integrity on target after replication')
+    .option('--status', 'show replication status instead of replicating')
+    .action((options: ReplicateOptions) => execute_replicate(get_container(), options));
+}
+
+function resolve_tenant_id(container: Container, options: ReplicateOptions): string {
+  if (options.tenant) return options.tenant;
+  return container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
+}
+
+async function execute_replicate(container: Container, options: ReplicateOptions): Promise<void> {
+  const tenant_id = resolve_tenant_id(container, options);
+  const use_case = container.get<ReplicationUseCase>(REPLICATION_USE_CASE_TOKEN);
+
+  if (options.status) {
+    await show_status(use_case, tenant_id, options);
+    return;
+  }
+
+  const target = build_target(container, options);
+  logger.banner('Atlas Replicate');
+  logger.info(`Tenant:  ${tenant_id}`);
+  logger.info(`Target:  ${target.endpoint} (${target.target_id})`);
+
+  if (options.snapshot) {
+    const results = await use_case.replicate_snapshot(tenant_id, options.snapshot, [target]);
+    report_results(results);
+  } else if (options.mailbox) {
+    const results = await use_case.replicate_mailbox(tenant_id, options.mailbox, [target]);
+    report_results(results);
+  } else {
+    logger.error('Either --snapshot or --mailbox is required (or --status to view status)');
+    process.exitCode = 1;
+  }
+}
+
+function build_target(container: Container, options: ReplicateOptions): StorageTarget {
+  const config = container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN);
+
+  if (options.targetConfig) {
+    const raw = readFileSync(options.targetConfig, 'utf-8');
+    const file = JSON.parse(raw) as Record<string, string>;
+    return create_storage_target({
+      target_id: file.target_id,
+      s3_endpoint: file.s3_endpoint,
+      s3_access_key: file.s3_access_key,
+      s3_secret_key: file.s3_secret_key,
+      s3_region: file.s3_region,
+      encryption_passphrase: config.encryption_passphrase,
+    });
+  }
+
+  if (!options.targetEndpoint || !options.targetAccessKey || !options.targetSecretKey) {
+    throw new Error(
+      'Target credentials required: provide --target-endpoint, --target-access-key, --target-secret-key ' +
+        'or --target-config <path>',
+    );
+  }
+
+  return create_storage_target({
+    s3_endpoint: options.targetEndpoint,
+    s3_access_key: options.targetAccessKey,
+    s3_secret_key: options.targetSecretKey,
+    s3_region: options.targetRegion,
+    encryption_passphrase: config.encryption_passphrase,
+  });
+}
+
+function report_results(results: ReplicationResult[]): void {
+  for (const r of results) {
+    const status_text = r.status === 'COMPLETED' ? chalk.green(r.status) : chalk.red(r.status);
+
+    logger.info(
+      `Snapshot ${chalk.cyan(r.snapshot_id)} → ${r.target_id}: ${status_text} ` +
+        `(${r.objects_copied} copied, ${r.objects_skipped} skipped, ${r.objects_failed} failed, ` +
+        `${format_bytes(r.bytes_copied)}, ${r.elapsed_ms}ms)`,
+    );
+
+    for (const err of r.errors) {
+      logger.error(`  ${err}`);
+    }
+  }
+
+  const any_failed = results.some((r) => r.objects_failed > 0);
+  if (any_failed) process.exitCode = 1;
+}
+
+async function show_status(
+  use_case: ReplicationUseCase,
+  tenant_id: string,
+  options: ReplicateOptions,
+): Promise<void> {
+  logger.banner('Replication Status');
+
+  let records: ReplicationStatusRecord[];
+  if (options.snapshot) {
+    records = await use_case.get_replication_status(tenant_id, options.snapshot);
+  } else if (options.mailbox) {
+    records = await use_case.get_replication_status_by_mailbox(tenant_id, options.mailbox);
+  } else {
+    records = await use_case.get_replication_status(tenant_id);
+  }
+
+  if (records.length === 0) {
+    logger.info('No replication records found.');
+    return;
+  }
+
+  for (const r of records) {
+    const status_text = r.status === 'COMPLETED' ? chalk.green(r.status) : chalk.yellow(r.status);
+
+    logger.info(
+      `${r.mailbox_id} / ${chalk.cyan(r.snapshot_id)} → ${r.target_id}: ${status_text} ` +
+        `(${r.objects_copied}/${r.objects_total} objects, ${format_bytes(r.bytes_copied)})`,
+    );
+  }
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -6,6 +6,8 @@ import {
   TENANT_CONTEXT_FACTORY_TOKEN,
   RESTORE_CONNECTOR_TOKEN,
   MAILBOX_DISCOVERY_TOKEN,
+  DEK_VALIDATION_FN_TOKEN,
+  STORAGE_TARGET_FACTORY_TOKEN,
 } from '@/ports/tokens/outgoing.tokens';
 import {
   BACKUP_USE_CASE_TOKEN,
@@ -38,6 +40,8 @@ import { DefaultTenantBackupOrchestrator } from '@/services/backup/tenant-backup
 import { MailboxStatusService } from '@/services/status/mailbox-status.service';
 import { ReplicationService } from '@/services/replication/replication.service';
 import { GraphMailboxDiscoveryAdapter } from '@/adapters/m365/graph-mailbox-discovery.adapter';
+import { validate_dek_match } from '@/adapters/storage-s3/dek-validator';
+import { create_storage_target } from '@/adapters/storage-target.factory';
 import type { AtlasConfig } from '@/utils/config';
 import { load_config, ATLAS_CONFIG_TOKEN } from '@/utils/config';
 
@@ -80,6 +84,8 @@ function bind_adapters(container: Container): void {
   container.bind(TENANT_CONTEXT_FACTORY_TOKEN).to(DefaultTenantContextFactory).inSingletonScope();
   container.bind(MANIFEST_REPOSITORY_TOKEN).to(S3ManifestRepository).inSingletonScope();
   container.bind(MAILBOX_DISCOVERY_TOKEN).to(GraphMailboxDiscoveryAdapter).inSingletonScope();
+  container.bind(DEK_VALIDATION_FN_TOKEN).toConstantValue(validate_dek_match);
+  container.bind(STORAGE_TARGET_FACTORY_TOKEN).toConstantValue(create_storage_target);
 }
 
 /** Binds service classes so Inversify can auto-resolve their constructor dependencies. */

--- a/src/container.ts
+++ b/src/container.ts
@@ -18,6 +18,7 @@ import {
   STATS_USE_CASE_TOKEN,
   STATUS_USE_CASE_TOKEN,
   TENANT_ORCHESTRATOR_TOKEN,
+  REPLICATION_USE_CASE_TOKEN,
 } from '@/ports/tokens/use-case.tokens';
 import { GraphMailboxConnector } from '@/adapters/m365/graph-mailbox-connector.adapter';
 import { GraphRestoreConnector } from '@/adapters/m365/graph-restore-connector.adapter';
@@ -35,6 +36,7 @@ import { SaveService } from '@/services/save/save.service';
 import { StatsService } from '@/services/stats/stats.service';
 import { DefaultTenantBackupOrchestrator } from '@/services/backup/tenant-backup-orchestrator';
 import { MailboxStatusService } from '@/services/status/mailbox-status.service';
+import { ReplicationService } from '@/services/replication/replication.service';
 import { GraphMailboxDiscoveryAdapter } from '@/adapters/m365/graph-mailbox-discovery.adapter';
 import type { AtlasConfig } from '@/utils/config';
 import { load_config, ATLAS_CONFIG_TOKEN } from '@/utils/config';
@@ -102,4 +104,6 @@ function bind_services(container: Container): void {
   container.bind(STATUS_USE_CASE_TOKEN).toService(MailboxStatusService);
   container.bind(DefaultTenantBackupOrchestrator).toSelf();
   container.bind(TENANT_ORCHESTRATOR_TOKEN).toService(DefaultTenantBackupOrchestrator);
+  container.bind(ReplicationService).toSelf();
+  container.bind(REPLICATION_USE_CASE_TOKEN).toService(ReplicationService);
 }

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -14,3 +14,9 @@ export type {
 export type { RestoreRequest } from './restore-request';
 export { RestoreStatus } from './restore-request';
 export type { BucketStats, MailboxStats, FolderStats, MonthlyBreakdown } from './stats';
+export type {
+  ReplicationResult,
+  ReplicationObjectResult,
+  ReplicationStatusRecord,
+} from './replication';
+export { ReplicationStatus, ReplicationVerificationStatus } from './replication';

--- a/src/domain/replication.ts
+++ b/src/domain/replication.ts
@@ -29,6 +29,8 @@ export interface ReplicationResult {
   readonly elapsed_ms: number;
   readonly errors: string[];
   readonly verification_status: ReplicationVerificationStatus;
+  readonly source_manifest_checksum?: string;
+  readonly replicated_manifest_checksum?: string;
 }
 
 /** Durable sidecar record persisted at `_meta/replication/{mailbox}/{snapshot}/{target}.json`. */

--- a/src/domain/replication.ts
+++ b/src/domain/replication.ts
@@ -1,0 +1,53 @@
+export enum ReplicationStatus {
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  PARTIAL = 'PARTIAL',
+  FAILED = 'FAILED',
+}
+
+export enum ReplicationVerificationStatus {
+  PASSED = 'PASSED',
+  FAILED = 'FAILED',
+  SKIPPED = 'SKIPPED',
+}
+
+export interface ReplicationObjectResult {
+  readonly storage_key: string;
+  readonly outcome: 'copied' | 'skipped' | 'failed';
+  readonly error?: string;
+}
+
+export interface ReplicationResult {
+  readonly snapshot_id: string;
+  readonly target_id: string;
+  readonly status: ReplicationStatus;
+  readonly objects_total: number;
+  readonly objects_copied: number;
+  readonly objects_skipped: number;
+  readonly objects_failed: number;
+  readonly bytes_copied: number;
+  readonly elapsed_ms: number;
+  readonly errors: string[];
+  readonly verification_status: ReplicationVerificationStatus;
+}
+
+/** Durable sidecar record persisted at `_meta/replication/{mailbox}/{snapshot}/{target}.json`. */
+export interface ReplicationStatusRecord {
+  readonly target_id: string;
+  readonly target_endpoint: string;
+  readonly snapshot_id: string;
+  readonly mailbox_id: string;
+  readonly status: ReplicationStatus;
+  readonly started_at: string;
+  readonly completed_at?: string;
+  readonly objects_total: number;
+  readonly objects_copied: number;
+  readonly objects_skipped: number;
+  readonly objects_failed: number;
+  readonly bytes_total: number;
+  readonly bytes_copied: number;
+  readonly last_error?: string;
+  readonly verification_status?: ReplicationVerificationStatus;
+  readonly source_manifest_checksum: string;
+  readonly replicated_manifest_checksum: string;
+}

--- a/src/ports/atlas/use-case.port.ts
+++ b/src/ports/atlas/use-case.port.ts
@@ -45,4 +45,5 @@ export interface AtlasInstance {
   rehydrateMailbox(mailboxId: string, source: StorageTarget): Promise<ReplicationResult>;
   rehydrateTenant(source: StorageTarget): Promise<ReplicationResult>;
   getReplicationStatus(snapshotId?: string): Promise<ReplicationStatusRecord[]>;
+  getReplicationStatusByMailbox(mailboxId: string): Promise<ReplicationStatusRecord[]>;
 }

--- a/src/ports/atlas/use-case.port.ts
+++ b/src/ports/atlas/use-case.port.ts
@@ -8,6 +8,8 @@ import type { DeletionResult } from '@/ports/deletion/use-case.port';
 import type { StorageCheckRequest, StorageCheckResult } from '@/ports/storage-check/use-case.port';
 import type { BucketStats, MailboxStats } from '@/domain/stats';
 import type { MailboxStatusResult } from '@/ports/status/use-case.port';
+import type { ReplicationResult, ReplicationStatusRecord } from '@/domain/replication';
+import type { StorageTarget } from '@/ports/replication/storage-target.port';
 
 export interface AtlasInstanceConfig {
   readonly tenantId: string;
@@ -37,4 +39,10 @@ export interface AtlasInstance {
   getBucketStats(): Promise<BucketStats>;
   getMailboxStats(mailboxId: string): Promise<MailboxStats>;
   checkMailboxStatus(mailboxId: string): Promise<MailboxStatusResult>;
+  replicateSnapshot(snapshotId: string, targets: StorageTarget[]): Promise<ReplicationResult[]>;
+  replicateMailbox(mailboxId: string, targets: StorageTarget[]): Promise<ReplicationResult[]>;
+  rehydrateSnapshot(snapshotId: string, source: StorageTarget): Promise<ReplicationResult>;
+  rehydrateMailbox(mailboxId: string, source: StorageTarget): Promise<ReplicationResult>;
+  rehydrateTenant(source: StorageTarget): Promise<ReplicationResult>;
+  getReplicationStatus(snapshotId?: string): Promise<ReplicationStatusRecord[]>;
 }

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -45,6 +45,9 @@ export type {
 
 export type { StatsUseCase } from './stats/use-case.port';
 
+export type { ReplicationUseCase } from './replication/use-case.port';
+export type { StorageTarget, StorageTargetConfig } from './replication/storage-target.port';
+
 export {
   OBJECT_STORAGE_TOKEN,
   MAILBOX_CONNECTOR_TOKEN,
@@ -62,4 +65,5 @@ export {
   DELETION_USE_CASE_TOKEN,
   STORAGE_CHECK_USE_CASE_TOKEN,
   STATS_USE_CASE_TOKEN,
+  REPLICATION_USE_CASE_TOKEN,
 } from './tokens/use-case.tokens';

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -46,7 +46,12 @@ export type {
 export type { StatsUseCase } from './stats/use-case.port';
 
 export type { ReplicationUseCase } from './replication/use-case.port';
-export type { StorageTarget, StorageTargetConfig } from './replication/storage-target.port';
+export type {
+  StorageTarget,
+  StorageTargetConfig,
+  StorageTargetFactory,
+} from './replication/storage-target.port';
+export type { DekValidationFn } from './replication/dek-validation.port';
 
 export {
   OBJECT_STORAGE_TOKEN,
@@ -55,6 +60,8 @@ export {
   KEY_SERVICE_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
   RESTORE_CONNECTOR_TOKEN,
+  DEK_VALIDATION_FN_TOKEN,
+  STORAGE_TARGET_FACTORY_TOKEN,
 } from './tokens/outgoing.tokens';
 
 export {
@@ -64,6 +71,8 @@ export {
   CATALOG_USE_CASE_TOKEN,
   DELETION_USE_CASE_TOKEN,
   STORAGE_CHECK_USE_CASE_TOKEN,
+  SAVE_USE_CASE_TOKEN,
   STATS_USE_CASE_TOKEN,
+  STATUS_USE_CASE_TOKEN,
   REPLICATION_USE_CASE_TOKEN,
 } from './tokens/use-case.tokens';

--- a/src/ports/replication/dek-validation.port.ts
+++ b/src/ports/replication/dek-validation.port.ts
@@ -1,0 +1,12 @@
+import type { ObjectStorage } from '@/ports/storage/object-storage.port';
+
+/**
+ * Validates that source and target share the same DEK.
+ * Throws DekMismatchError if both sides have a DEK and the raw bytes differ.
+ */
+export type DekValidationFn = (
+  source_storage: ObjectStorage,
+  target_storage: ObjectStorage,
+  passphrase: string,
+  tenant_id: string,
+) => Promise<void>;

--- a/src/ports/replication/storage-target.port.ts
+++ b/src/ports/replication/storage-target.port.ts
@@ -15,3 +15,6 @@ export interface StorageTarget {
   /** Creates a tenant-scoped storage + crypto context on this target. */
   create_context(tenant_id: string): Promise<TenantContext>;
 }
+
+/** Creates a StorageTarget from configuration. */
+export type StorageTargetFactory = (config: StorageTargetConfig) => StorageTarget;

--- a/src/ports/replication/storage-target.port.ts
+++ b/src/ports/replication/storage-target.port.ts
@@ -1,0 +1,17 @@
+import type { TenantContext } from '@/ports/tenant/context.port';
+
+export interface StorageTargetConfig {
+  readonly target_id?: string;
+  readonly s3_endpoint: string;
+  readonly s3_access_key: string;
+  readonly s3_secret_key: string;
+  readonly s3_region?: string;
+  readonly encryption_passphrase: string;
+}
+
+export interface StorageTarget {
+  readonly target_id: string;
+  readonly endpoint: string;
+  /** Creates a tenant-scoped storage + crypto context on this target. */
+  create_context(tenant_id: string): Promise<TenantContext>;
+}

--- a/src/ports/replication/use-case.port.ts
+++ b/src/ports/replication/use-case.port.ts
@@ -1,0 +1,47 @@
+import type { ReplicationResult, ReplicationStatusRecord } from '@/domain/replication';
+import type { StorageTarget } from '@/ports/replication/storage-target.port';
+
+export interface ReplicationUseCase {
+  /** Replicates a single sealed snapshot to one or more targets. */
+  replicate_snapshot(
+    tenant_id: string,
+    snapshot_id: string,
+    targets: StorageTarget[],
+  ): Promise<ReplicationResult[]>;
+
+  /** Replicates all unreplicated snapshots for a mailbox to one or more targets. */
+  replicate_mailbox(
+    tenant_id: string,
+    mailbox_id: string,
+    targets: StorageTarget[],
+  ): Promise<ReplicationResult[]>;
+
+  /** DR: recover a specific snapshot from a designated replica to primary. */
+  rehydrate_snapshot(
+    tenant_id: string,
+    snapshot_id: string,
+    source: StorageTarget,
+  ): Promise<ReplicationResult>;
+
+  /** DR: recover all snapshots for a mailbox from a designated replica. */
+  rehydrate_mailbox(
+    tenant_id: string,
+    mailbox_id: string,
+    source: StorageTarget,
+  ): Promise<ReplicationResult>;
+
+  /** DR: recover all mailboxes and snapshots from a designated replica. */
+  rehydrate_tenant(tenant_id: string, source: StorageTarget): Promise<ReplicationResult>;
+
+  /** Queries durable replication status records, optionally filtered by snapshot. */
+  get_replication_status(
+    tenant_id: string,
+    snapshot_id?: string,
+  ): Promise<ReplicationStatusRecord[]>;
+
+  /** Queries durable replication status records for all snapshots of a mailbox. */
+  get_replication_status_by_mailbox(
+    tenant_id: string,
+    mailbox_id: string,
+  ): Promise<ReplicationStatusRecord[]>;
+}

--- a/src/ports/tokens/outgoing.tokens.ts
+++ b/src/ports/tokens/outgoing.tokens.ts
@@ -5,3 +5,5 @@ export const KEY_SERVICE_TOKEN = Symbol.for('KeyService');
 export const TENANT_CONTEXT_FACTORY_TOKEN = Symbol.for('TenantContextFactory');
 export const RESTORE_CONNECTOR_TOKEN = Symbol.for('RestoreConnector');
 export const MAILBOX_DISCOVERY_TOKEN = Symbol.for('MailboxDiscoveryService');
+export const DEK_VALIDATION_FN_TOKEN = Symbol.for('DekValidationFn');
+export const STORAGE_TARGET_FACTORY_TOKEN = Symbol.for('StorageTargetFactory');

--- a/src/ports/tokens/use-case.tokens.ts
+++ b/src/ports/tokens/use-case.tokens.ts
@@ -8,3 +8,4 @@ export const SAVE_USE_CASE_TOKEN = Symbol.for('SaveUseCase');
 export const STATS_USE_CASE_TOKEN = Symbol.for('StatsUseCase');
 export const STATUS_USE_CASE_TOKEN = Symbol.for('StatusUseCase');
 export const TENANT_ORCHESTRATOR_TOKEN = Symbol.for('TenantBackupOrchestrator');
+export const REPLICATION_USE_CASE_TOKEN = Symbol.for('ReplicationUseCase');

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,4 +1,8 @@
 export type { AtlasInstance, AtlasInstanceConfig } from '@/ports/atlas/use-case.port';
 export type { BucketStats, MailboxStats, FolderStats, MonthlyBreakdown } from '@/domain/stats';
 export type { MailboxStatusResult, FolderStatus } from '@/ports/status/use-case.port';
+export type { ReplicationResult, ReplicationStatusRecord } from '@/domain/replication';
+export type { StorageTarget, StorageTargetConfig } from '@/ports/replication/storage-target.port';
+export type { StorageTargetSdkConfig } from '@/adapters/storage-target.factory';
 export { createAtlasInstance } from '@/adapters/sdk/atlas-instance.adapter';
+export { create_storage_target as createStorageTarget } from '@/adapters/storage-target.factory';

--- a/src/services/backup/mailbox-sync.service.ts
+++ b/src/services/backup/mailbox-sync.service.ts
@@ -23,6 +23,7 @@ import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
 } from '@/ports/tokens/outgoing.tokens';
+import { logger } from '@/utils/logger';
 
 class NoopBackupProgressReporter implements BackupProgressReporter {
   set_status(): void {}
@@ -56,6 +57,7 @@ export class MailboxSyncService implements BackupUseCase {
     mailbox_id = mailbox_id.toLowerCase();
     await assert_mailbox_exists(this._connector, tenant_id, mailbox_id);
     const ctx = await this._tenant_factory.create(tenant_id);
+    await this.warn_if_replica(ctx);
     const snapshot = create_pending_snapshot(tenant_id, mailbox_id);
     const sync_start = Date.now();
     const should_interrupt: () => boolean = options.should_interrupt ?? always_false;
@@ -225,5 +227,20 @@ export class MailboxSyncService implements BackupUseCase {
     }
 
     return { folders: matched, warnings };
+  }
+
+  private async warn_if_replica(ctx: {
+    storage: { exists(key: string): Promise<boolean> };
+  }): Promise<void> {
+    try {
+      if (await ctx.storage.exists('_meta/replica.marker')) {
+        logger.warn(
+          'This storage target contains a replica marker (_meta/replica.marker). ' +
+            'Running backup against a replica is not recommended -- use the primary storage.',
+        );
+      }
+    } catch {
+      /* non-critical: do not block backup if marker check fails */
+    }
   }
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -4,3 +4,4 @@ export { RestoreService } from '@/services/restore/restore.service';
 export { CatalogService } from '@/services/catalog/catalog.service';
 export { DeletionService } from '@/services/deletion/deletion.service';
 export { StatsService } from '@/services/stats/stats.service';
+export { ReplicationService } from '@/services/replication/replication.service';

--- a/src/services/replication/rehydration-dek-helper.ts
+++ b/src/services/replication/rehydration-dek-helper.ts
@@ -1,6 +1,4 @@
 import type { StorageTarget } from '@/ports/replication/storage-target.port';
-import type { AtlasConfig } from '@/utils/config';
-import { create_storage_target } from '@/adapters/storage-target.factory';
 
 const DEK_META_KEY = '_meta/dek.enc';
 
@@ -8,30 +6,30 @@ const DEK_META_KEY = '_meta/dek.enc';
  * For rehydration to an empty primary, the TenantContextFactory auto-generates
  * a new random DEK on first access. This would conflict with the source's DEK.
  *
- * This helper uses raw S3 access (bypassing the factory) to check if primary
- * has a DEK. If not, it copies the source's DEK to primary BEFORE the factory
- * runs, so the factory loads the correct DEK instead of generating a new one.
+ * This helper checks if primary has a DEK. If not, it copies the source's DEK.
+ * If primary has a DEK but no manifests (auto-generated on an empty bucket),
+ * it overwrites with the source's DEK so rehydration can proceed.
  */
 export async function ensure_source_dek_on_primary(
-  config: AtlasConfig,
+  primary: StorageTarget,
   source: StorageTarget,
   tenant_id: string,
 ): Promise<void> {
-  const primary_raw = create_storage_target({
-    s3_endpoint: config.s3_endpoint,
-    s3_access_key: config.s3_access_key,
-    s3_secret_key: config.s3_secret_key,
-    s3_region: config.s3_region,
-    encryption_passphrase: config.encryption_passphrase,
-  });
-
-  const primary_ctx = await primary_raw.create_context(tenant_id);
-  const primary_has_dek = await primary_ctx.storage.exists(DEK_META_KEY);
-  if (primary_has_dek) return;
-
   const source_ctx = await source.create_context(tenant_id);
   const source_has_dek = await source_ctx.storage.exists(DEK_META_KEY);
   if (!source_has_dek) return;
+
+  const primary_ctx = await primary.create_context(tenant_id);
+  const primary_has_dek = await primary_ctx.storage.exists(DEK_META_KEY);
+
+  if (!primary_has_dek) {
+    const source_dek_blob = await source_ctx.storage.get(DEK_META_KEY);
+    await primary_ctx.storage.put(DEK_META_KEY, source_dek_blob);
+    return;
+  }
+
+  const has_manifests = (await primary_ctx.storage.list('manifests/')).length > 0;
+  if (has_manifests) return;
 
   const source_dek_blob = await source_ctx.storage.get(DEK_META_KEY);
   await primary_ctx.storage.put(DEK_META_KEY, source_dek_blob);

--- a/src/services/replication/rehydration-dek-helper.ts
+++ b/src/services/replication/rehydration-dek-helper.ts
@@ -1,0 +1,38 @@
+import type { StorageTarget } from '@/ports/replication/storage-target.port';
+import type { AtlasConfig } from '@/utils/config';
+import { create_storage_target } from '@/adapters/storage-target.factory';
+
+const DEK_META_KEY = '_meta/dek.enc';
+
+/**
+ * For rehydration to an empty primary, the TenantContextFactory auto-generates
+ * a new random DEK on first access. This would conflict with the source's DEK.
+ *
+ * This helper uses raw S3 access (bypassing the factory) to check if primary
+ * has a DEK. If not, it copies the source's DEK to primary BEFORE the factory
+ * runs, so the factory loads the correct DEK instead of generating a new one.
+ */
+export async function ensure_source_dek_on_primary(
+  config: AtlasConfig,
+  source: StorageTarget,
+  tenant_id: string,
+): Promise<void> {
+  const primary_raw = create_storage_target({
+    s3_endpoint: config.s3_endpoint,
+    s3_access_key: config.s3_access_key,
+    s3_secret_key: config.s3_secret_key,
+    s3_region: config.s3_region,
+    encryption_passphrase: config.encryption_passphrase,
+  });
+
+  const primary_ctx = await primary_raw.create_context(tenant_id);
+  const primary_has_dek = await primary_ctx.storage.exists(DEK_META_KEY);
+  if (primary_has_dek) return;
+
+  const source_ctx = await source.create_context(tenant_id);
+  const source_has_dek = await source_ctx.storage.exists(DEK_META_KEY);
+  if (!source_has_dek) return;
+
+  const source_dek_blob = await source_ctx.storage.get(DEK_META_KEY);
+  await primary_ctx.storage.put(DEK_META_KEY, source_dek_blob);
+}

--- a/src/services/replication/replication-integrity-verifier.ts
+++ b/src/services/replication/replication-integrity-verifier.ts
@@ -1,0 +1,70 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { TenantContext } from '@/ports/tenant/context.port';
+import type { Manifest } from '@/domain/manifest';
+import { ReplicationVerificationStatus } from '@/domain/replication';
+import { collect_storage_keys } from '@/services/replication/snapshot-replicator';
+
+export interface VerificationOutcome {
+  readonly status: ReplicationVerificationStatus;
+  readonly checked: number;
+  readonly failed_keys: string[];
+}
+
+/**
+ * Verifies integrity of a replicated snapshot on the target by
+ * decrypting each object and comparing its SHA-256 against the manifest checksum.
+ */
+export async function verify_replicated_snapshot(
+  target_ctx: TenantContext,
+  manifest: Manifest,
+): Promise<VerificationOutcome> {
+  const keys = collect_storage_keys(manifest);
+  const checksum_map = build_checksum_map(manifest);
+  const failed_keys: string[] = [];
+
+  for (const key of keys) {
+    const expected = checksum_map.get(key);
+    if (!expected) continue;
+
+    const is_valid = await verify_single_object(target_ctx, key, expected);
+    if (!is_valid) failed_keys.push(key);
+  }
+
+  return {
+    status:
+      failed_keys.length === 0
+        ? ReplicationVerificationStatus.PASSED
+        : ReplicationVerificationStatus.FAILED,
+    checked: keys.length,
+    failed_keys,
+  };
+}
+
+function build_checksum_map(manifest: Manifest): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const entry of manifest.entries) {
+    map.set(entry.storage_key, entry.checksum);
+    if (entry.attachments) {
+      for (const att of entry.attachments) {
+        map.set(att.storage_key, att.checksum);
+      }
+    }
+  }
+  return map;
+}
+
+async function verify_single_object(
+  ctx: TenantContext,
+  key: string,
+  expected_checksum: string,
+): Promise<boolean> {
+  try {
+    const ciphertext = await ctx.storage.get(key);
+    const plaintext = ctx.decrypt(ciphertext);
+    const actual = createHash('sha256').update(plaintext).digest('hex');
+    if (actual.length !== expected_checksum.length) return false;
+    return timingSafeEqual(Buffer.from(actual, 'utf8'), Buffer.from(expected_checksum, 'utf8'));
+  } catch {
+    return false;
+  }
+}

--- a/src/services/replication/replication-result-builder.ts
+++ b/src/services/replication/replication-result-builder.ts
@@ -10,6 +10,8 @@ export interface RawCopyResult {
   readonly objects_failed: number;
   readonly bytes_copied: number;
   readonly errors: string[];
+  readonly source_manifest_checksum?: string;
+  readonly replicated_manifest_checksum?: string;
 }
 
 export function build_replication_result(
@@ -37,6 +39,8 @@ export function build_replication_result(
     elapsed_ms,
     errors: raw.errors,
     verification_status: ReplicationVerificationStatus.SKIPPED,
+    source_manifest_checksum: raw.source_manifest_checksum,
+    replicated_manifest_checksum: raw.replicated_manifest_checksum,
   };
 }
 
@@ -77,7 +81,7 @@ export function to_status_record(
     bytes_copied: result.bytes_copied,
     last_error: result.errors.length > 0 ? result.errors[result.errors.length - 1] : undefined,
     verification_status: result.verification_status,
-    source_manifest_checksum: '',
-    replicated_manifest_checksum: '',
+    source_manifest_checksum: result.source_manifest_checksum ?? '',
+    replicated_manifest_checksum: result.replicated_manifest_checksum ?? '',
   };
 }

--- a/src/services/replication/replication-result-builder.ts
+++ b/src/services/replication/replication-result-builder.ts
@@ -1,0 +1,83 @@
+import type { ReplicationResult, ReplicationStatusRecord } from '@/domain/replication';
+import { ReplicationStatus, ReplicationVerificationStatus } from '@/domain/replication';
+import type { StorageTarget } from '@/ports/replication/storage-target.port';
+import type { Manifest } from '@/domain/manifest';
+
+/** Raw counts returned by the snapshot replicator. */
+export interface RawCopyResult {
+  readonly objects_copied: number;
+  readonly objects_skipped: number;
+  readonly objects_failed: number;
+  readonly bytes_copied: number;
+  readonly errors: string[];
+}
+
+export function build_replication_result(
+  raw: RawCopyResult,
+  snapshot_id: string,
+  target_id: string,
+  elapsed_ms: number,
+): ReplicationResult {
+  const status =
+    raw.objects_failed > 0
+      ? raw.objects_copied > 0
+        ? ReplicationStatus.PARTIAL
+        : ReplicationStatus.FAILED
+      : ReplicationStatus.COMPLETED;
+
+  return {
+    snapshot_id,
+    target_id,
+    status,
+    objects_total: raw.objects_copied + raw.objects_skipped + raw.objects_failed,
+    objects_copied: raw.objects_copied,
+    objects_skipped: raw.objects_skipped,
+    objects_failed: raw.objects_failed,
+    bytes_copied: raw.bytes_copied,
+    elapsed_ms,
+    errors: raw.errors,
+    verification_status: ReplicationVerificationStatus.SKIPPED,
+  };
+}
+
+export function build_skip_result(snapshot_id: string, target_id: string): ReplicationResult {
+  return {
+    snapshot_id,
+    target_id,
+    status: ReplicationStatus.COMPLETED,
+    objects_total: 0,
+    objects_copied: 0,
+    objects_skipped: 0,
+    objects_failed: 0,
+    bytes_copied: 0,
+    elapsed_ms: 0,
+    errors: [],
+    verification_status: ReplicationVerificationStatus.SKIPPED,
+  };
+}
+
+export function to_status_record(
+  result: ReplicationResult,
+  target: StorageTarget,
+  manifest: Manifest,
+): ReplicationStatusRecord {
+  return {
+    target_id: target.target_id,
+    target_endpoint: target.endpoint,
+    snapshot_id: manifest.snapshot_id,
+    mailbox_id: manifest.mailbox_id,
+    status: result.status,
+    started_at: new Date(Date.now() - result.elapsed_ms).toISOString(),
+    completed_at: new Date().toISOString(),
+    objects_total: result.objects_total,
+    objects_copied: result.objects_copied,
+    objects_skipped: result.objects_skipped,
+    objects_failed: result.objects_failed,
+    bytes_total: manifest.total_size_bytes,
+    bytes_copied: result.bytes_copied,
+    last_error: result.errors.length > 0 ? result.errors[result.errors.length - 1] : undefined,
+    verification_status: result.verification_status,
+    source_manifest_checksum: '',
+    replicated_manifest_checksum: '',
+  };
+}

--- a/src/services/replication/replication-status-repository.ts
+++ b/src/services/replication/replication-status-repository.ts
@@ -1,0 +1,85 @@
+import type { TenantContext } from '@/ports/tenant/context.port';
+import type { ReplicationStatusRecord } from '@/domain/replication';
+
+const STATUS_PREFIX = '_meta/replication/';
+
+/** Builds the S3 key for a replication status sidecar. */
+function status_key(mailbox_id: string, snapshot_id: string, target_id: string): string {
+  return `${STATUS_PREFIX}${mailbox_id}/${snapshot_id}/${target_id}.json`;
+}
+
+/** Persists an encrypted replication status sidecar to primary storage. */
+export async function save_replication_status(
+  ctx: TenantContext,
+  record: ReplicationStatusRecord,
+): Promise<void> {
+  const key = status_key(record.mailbox_id, record.snapshot_id, record.target_id);
+  const plaintext = Buffer.from(JSON.stringify(record), 'utf-8');
+  const ciphertext = ctx.encrypt(plaintext);
+  await ctx.storage.put(key, ciphertext);
+}
+
+/** Loads a single replication status sidecar, or undefined if not found. */
+export async function load_replication_status(
+  ctx: TenantContext,
+  mailbox_id: string,
+  snapshot_id: string,
+  target_id: string,
+): Promise<ReplicationStatusRecord | undefined> {
+  const key = status_key(mailbox_id, snapshot_id, target_id);
+  return decrypt_status_record(ctx, key);
+}
+
+/** Lists all replication status records across the entire tenant. */
+export async function list_all_replication_status(
+  ctx: TenantContext,
+): Promise<ReplicationStatusRecord[]> {
+  return list_and_decrypt(ctx, STATUS_PREFIX);
+}
+
+/** Lists replication status records for a specific mailbox. */
+export async function list_replication_status_by_mailbox(
+  ctx: TenantContext,
+  mailbox_id: string,
+): Promise<ReplicationStatusRecord[]> {
+  return list_and_decrypt(ctx, `${STATUS_PREFIX}${mailbox_id}/`);
+}
+
+/** Lists replication status records for a specific snapshot across all targets. */
+export async function list_replication_status_by_snapshot(
+  ctx: TenantContext,
+  snapshot_id: string,
+): Promise<ReplicationStatusRecord[]> {
+  const all = await list_all_replication_status(ctx);
+  return all.filter((r) => r.snapshot_id === snapshot_id);
+}
+
+async function list_and_decrypt(
+  ctx: TenantContext,
+  prefix: string,
+): Promise<ReplicationStatusRecord[]> {
+  const keys = await ctx.storage.list(prefix);
+  const records: ReplicationStatusRecord[] = [];
+
+  for (const key of keys) {
+    const record = await decrypt_status_record(ctx, key);
+    if (record) records.push(record);
+  }
+
+  return records;
+}
+
+async function decrypt_status_record(
+  ctx: TenantContext,
+  key: string,
+): Promise<ReplicationStatusRecord | undefined> {
+  try {
+    const exists = await ctx.storage.exists(key);
+    if (!exists) return undefined;
+    const ciphertext = await ctx.storage.get(key);
+    const plaintext = ctx.decrypt(ciphertext);
+    return JSON.parse(plaintext.toString('utf-8')) as ReplicationStatusRecord;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/services/replication/replication.service.ts
+++ b/src/services/replication/replication.service.ts
@@ -1,0 +1,266 @@
+import { inject, injectable } from 'inversify';
+import type { TenantContextFactory, TenantContext } from '@/ports/tenant/context.port';
+import type { ManifestRepository } from '@/ports/storage/manifest-repository.port';
+import type { ReplicationUseCase } from '@/ports/replication/use-case.port';
+import type { StorageTarget } from '@/ports/replication/storage-target.port';
+import type { ReplicationResult, ReplicationStatusRecord } from '@/domain/replication';
+import type { Manifest } from '@/domain/manifest';
+import {
+  TENANT_CONTEXT_FACTORY_TOKEN,
+  MANIFEST_REPOSITORY_TOKEN,
+} from '@/ports/tokens/outgoing.tokens';
+import { replicate_snapshot_to_target } from '@/services/replication/snapshot-replicator';
+import {
+  save_replication_status,
+  list_all_replication_status,
+  list_replication_status_by_mailbox,
+  list_replication_status_by_snapshot,
+} from '@/services/replication/replication-status-repository';
+import { ensure_source_dek_on_primary } from '@/services/replication/rehydration-dek-helper';
+import {
+  build_replication_result,
+  build_skip_result,
+  to_status_record,
+} from '@/services/replication/replication-result-builder';
+import type { AtlasConfig } from '@/utils/config';
+import { ATLAS_CONFIG_TOKEN } from '@/utils/config';
+
+@injectable()
+export class ReplicationService implements ReplicationUseCase {
+  constructor(
+    @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
+    @inject(MANIFEST_REPOSITORY_TOKEN) private readonly _manifests: ManifestRepository,
+    @inject(ATLAS_CONFIG_TOKEN) private readonly _config: AtlasConfig,
+  ) {}
+
+  async replicate_snapshot(
+    tenant_id: string,
+    snapshot_id: string,
+    targets: StorageTarget[],
+  ): Promise<ReplicationResult[]> {
+    const source_ctx = await this._tenant_factory.create(tenant_id);
+    const manifest = await this.require_manifest(source_ctx, snapshot_id);
+    const results: ReplicationResult[] = [];
+
+    for (const target of targets) {
+      const result = await this.copy_to_target(source_ctx, target, manifest, tenant_id);
+      await save_replication_status(source_ctx, to_status_record(result, target, manifest));
+      results.push(result);
+    }
+
+    return results;
+  }
+
+  async replicate_mailbox(
+    tenant_id: string,
+    mailbox_id: string,
+    targets: StorageTarget[],
+  ): Promise<ReplicationResult[]> {
+    const source_ctx = await this._tenant_factory.create(tenant_id);
+    const manifests = await this.list_mailbox_manifests(source_ctx, mailbox_id);
+    const results: ReplicationResult[] = [];
+
+    for (const target of targets) {
+      const target_ctx = await target.create_context(tenant_id);
+      const missing = await this.diff_manifests(manifests, target_ctx, mailbox_id);
+
+      for (const manifest of missing) {
+        const result = await this.copy_to_target(source_ctx, target, manifest, tenant_id);
+        await save_replication_status(source_ctx, to_status_record(result, target, manifest));
+        results.push(result);
+      }
+    }
+
+    return results;
+  }
+
+  async rehydrate_snapshot(
+    tenant_id: string,
+    snapshot_id: string,
+    source: StorageTarget,
+  ): Promise<ReplicationResult> {
+    await ensure_source_dek_on_primary(this._config, source, tenant_id);
+    const primary_ctx = await this._tenant_factory.create(tenant_id);
+    const source_ctx = await source.create_context(tenant_id);
+    const manifest = await this.require_manifest_from_ctx(source_ctx, snapshot_id);
+
+    const manifest_key = `manifests/${manifest.mailbox_id}/${snapshot_id}.json`;
+    if (await primary_ctx.storage.exists(manifest_key)) {
+      return build_skip_result(snapshot_id, source.target_id);
+    }
+
+    return this.copy_between(source_ctx, primary_ctx, manifest, source.target_id, tenant_id);
+  }
+
+  async rehydrate_mailbox(
+    tenant_id: string,
+    mailbox_id: string,
+    source: StorageTarget,
+  ): Promise<ReplicationResult> {
+    await ensure_source_dek_on_primary(this._config, source, tenant_id);
+    const primary_ctx = await this._tenant_factory.create(tenant_id);
+    const source_ctx = await source.create_context(tenant_id);
+    const manifests = await this.list_mailbox_manifests(source_ctx, mailbox_id);
+
+    return this.rehydrate_manifests(source_ctx, primary_ctx, manifests, source, tenant_id);
+  }
+
+  async rehydrate_tenant(tenant_id: string, source: StorageTarget): Promise<ReplicationResult> {
+    await ensure_source_dek_on_primary(this._config, source, tenant_id);
+    const primary_ctx = await this._tenant_factory.create(tenant_id);
+    const source_ctx = await source.create_context(tenant_id);
+    const all_manifests = await this._manifests.list_all_manifests(source_ctx);
+
+    return this.rehydrate_manifests(source_ctx, primary_ctx, all_manifests, source, tenant_id);
+  }
+
+  async get_replication_status(
+    tenant_id: string,
+    snapshot_id?: string,
+  ): Promise<ReplicationStatusRecord[]> {
+    const ctx = await this._tenant_factory.create(tenant_id);
+    if (snapshot_id) return list_replication_status_by_snapshot(ctx, snapshot_id);
+    return list_all_replication_status(ctx);
+  }
+
+  async get_replication_status_by_mailbox(
+    tenant_id: string,
+    mailbox_id: string,
+  ): Promise<ReplicationStatusRecord[]> {
+    const ctx = await this._tenant_factory.create(tenant_id);
+    return list_replication_status_by_mailbox(ctx, mailbox_id);
+  }
+
+  private async copy_to_target(
+    source_ctx: TenantContext,
+    target: StorageTarget,
+    manifest: Manifest,
+    tenant_id: string,
+  ): Promise<ReplicationResult> {
+    const start = Date.now();
+    const target_ctx = await target.create_context(tenant_id);
+    const rep = await replicate_snapshot_to_target(
+      source_ctx,
+      target_ctx,
+      manifest,
+      this._config.encryption_passphrase,
+      tenant_id,
+    );
+    return build_replication_result(
+      rep,
+      manifest.snapshot_id,
+      target.target_id,
+      Date.now() - start,
+    );
+  }
+
+  private async copy_between(
+    source_ctx: TenantContext,
+    target_ctx: TenantContext,
+    manifest: Manifest,
+    target_id: string,
+    tenant_id: string,
+  ): Promise<ReplicationResult> {
+    const start = Date.now();
+    const rep = await replicate_snapshot_to_target(
+      source_ctx,
+      target_ctx,
+      manifest,
+      this._config.encryption_passphrase,
+      tenant_id,
+    );
+    return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
+  }
+
+  private async rehydrate_manifests(
+    source_ctx: TenantContext,
+    primary_ctx: TenantContext,
+    manifests: Manifest[],
+    source: StorageTarget,
+    tenant_id: string,
+  ): Promise<ReplicationResult> {
+    const start = Date.now();
+    let total_copied = 0;
+    let total_skipped = 0;
+    let total_failed = 0;
+    let total_bytes = 0;
+    const all_errors: string[] = [];
+    let snapshot_count = 0;
+
+    for (const manifest of manifests) {
+      const key = `manifests/${manifest.mailbox_id}/${manifest.snapshot_id}.json`;
+      if (await primary_ctx.storage.exists(key)) {
+        total_skipped++;
+        continue;
+      }
+
+      const rep = await replicate_snapshot_to_target(
+        source_ctx,
+        primary_ctx,
+        manifest,
+        this._config.encryption_passphrase,
+        tenant_id,
+      );
+
+      total_copied += rep.objects_copied;
+      total_skipped += rep.objects_skipped;
+      total_failed += rep.objects_failed;
+      total_bytes += rep.bytes_copied;
+      all_errors.push(...rep.errors);
+      snapshot_count++;
+    }
+
+    const snapshot_label =
+      manifests.length === 1 ? manifests[0]!.snapshot_id : `${snapshot_count}-snapshots`;
+
+    return build_replication_result(
+      {
+        objects_copied: total_copied,
+        objects_skipped: total_skipped,
+        objects_failed: total_failed,
+        bytes_copied: total_bytes,
+        errors: all_errors,
+      },
+      snapshot_label,
+      source.target_id,
+      Date.now() - start,
+    );
+  }
+
+  private async require_manifest(ctx: TenantContext, snapshot_id: string): Promise<Manifest> {
+    const manifest = await this._manifests.find_by_snapshot(ctx, snapshot_id);
+    if (!manifest) throw new Error(`No manifest found for snapshot ${snapshot_id}`);
+    return manifest;
+  }
+
+  private async require_manifest_from_ctx(
+    ctx: TenantContext,
+    snapshot_id: string,
+  ): Promise<Manifest> {
+    const manifest = await this._manifests.find_by_snapshot(ctx, snapshot_id);
+    if (!manifest) throw new Error(`No manifest found for snapshot ${snapshot_id} on source`);
+    return manifest;
+  }
+
+  private async list_mailbox_manifests(
+    ctx: TenantContext,
+    mailbox_id: string,
+  ): Promise<Manifest[]> {
+    const all = await this._manifests.list_all_manifests(ctx);
+    return all
+      .filter((m) => m.mailbox_id === mailbox_id)
+      .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+  }
+
+  private async diff_manifests(
+    source_manifests: Manifest[],
+    target_ctx: TenantContext,
+    mailbox_id: string,
+  ): Promise<Manifest[]> {
+    const target_keys = await target_ctx.storage.list(`manifests/${mailbox_id}/`);
+    const target_snapshot_ids = new Set(
+      target_keys.map((k) => k.split('/').pop()?.replace('.json', '')).filter(Boolean) as string[],
+    );
+    return source_manifests.filter((m) => !target_snapshot_ids.has(m.snapshot_id));
+  }
+}

--- a/src/services/replication/replication.service.ts
+++ b/src/services/replication/replication.service.ts
@@ -2,12 +2,15 @@ import { inject, injectable } from 'inversify';
 import type { TenantContextFactory, TenantContext } from '@/ports/tenant/context.port';
 import type { ManifestRepository } from '@/ports/storage/manifest-repository.port';
 import type { ReplicationUseCase } from '@/ports/replication/use-case.port';
-import type { StorageTarget } from '@/ports/replication/storage-target.port';
+import type { StorageTarget, StorageTargetFactory } from '@/ports/replication/storage-target.port';
+import type { DekValidationFn } from '@/ports/replication/dek-validation.port';
 import type { ReplicationResult, ReplicationStatusRecord } from '@/domain/replication';
 import type { Manifest } from '@/domain/manifest';
 import {
   TENANT_CONTEXT_FACTORY_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  DEK_VALIDATION_FN_TOKEN,
+  STORAGE_TARGET_FACTORY_TOKEN,
 } from '@/ports/tokens/outgoing.tokens';
 import { replicate_snapshot_to_target } from '@/services/replication/snapshot-replicator';
 import {
@@ -31,6 +34,8 @@ export class ReplicationService implements ReplicationUseCase {
     @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
     @inject(MANIFEST_REPOSITORY_TOKEN) private readonly _manifests: ManifestRepository,
     @inject(ATLAS_CONFIG_TOKEN) private readonly _config: AtlasConfig,
+    @inject(DEK_VALIDATION_FN_TOKEN) private readonly _validate_dek: DekValidationFn,
+    @inject(STORAGE_TARGET_FACTORY_TOKEN) private readonly _target_factory: StorageTargetFactory,
   ) {}
 
   async replicate_snapshot(
@@ -79,7 +84,7 @@ export class ReplicationService implements ReplicationUseCase {
     snapshot_id: string,
     source: StorageTarget,
   ): Promise<ReplicationResult> {
-    await ensure_source_dek_on_primary(this._config, source, tenant_id);
+    await ensure_source_dek_on_primary(this.create_primary_target(), source, tenant_id);
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);
     const manifest = await this.require_manifest_from_ctx(source_ctx, snapshot_id);
@@ -89,7 +94,7 @@ export class ReplicationService implements ReplicationUseCase {
       return build_skip_result(snapshot_id, source.target_id);
     }
 
-    return this.copy_between(source_ctx, primary_ctx, manifest, source.target_id, tenant_id);
+    return this.copy_between(source_ctx, primary_ctx, manifest, source.target_id, tenant_id, true);
   }
 
   async rehydrate_mailbox(
@@ -97,7 +102,7 @@ export class ReplicationService implements ReplicationUseCase {
     mailbox_id: string,
     source: StorageTarget,
   ): Promise<ReplicationResult> {
-    await ensure_source_dek_on_primary(this._config, source, tenant_id);
+    await ensure_source_dek_on_primary(this.create_primary_target(), source, tenant_id);
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);
     const manifests = await this.list_mailbox_manifests(source_ctx, mailbox_id);
@@ -106,7 +111,7 @@ export class ReplicationService implements ReplicationUseCase {
   }
 
   async rehydrate_tenant(tenant_id: string, source: StorageTarget): Promise<ReplicationResult> {
-    await ensure_source_dek_on_primary(this._config, source, tenant_id);
+    await ensure_source_dek_on_primary(this.create_primary_target(), source, tenant_id);
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);
     const all_manifests = await this._manifests.list_all_manifests(source_ctx);
@@ -139,13 +144,13 @@ export class ReplicationService implements ReplicationUseCase {
   ): Promise<ReplicationResult> {
     const start = Date.now();
     const target_ctx = await target.create_context(tenant_id);
-    const rep = await replicate_snapshot_to_target(
-      source_ctx,
-      target_ctx,
-      manifest,
+    await this._validate_dek(
+      source_ctx.storage,
+      target_ctx.storage,
       this._config.encryption_passphrase,
       tenant_id,
     );
+    const rep = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest);
     return build_replication_result(
       rep,
       manifest.snapshot_id,
@@ -160,15 +165,18 @@ export class ReplicationService implements ReplicationUseCase {
     manifest: Manifest,
     target_id: string,
     tenant_id: string,
+    is_rehydration = false,
   ): Promise<ReplicationResult> {
     const start = Date.now();
-    const rep = await replicate_snapshot_to_target(
-      source_ctx,
-      target_ctx,
-      manifest,
+    await this._validate_dek(
+      source_ctx.storage,
+      target_ctx.storage,
       this._config.encryption_passphrase,
       tenant_id,
     );
+    const rep = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest, {
+      skip_marker: is_rehydration,
+    });
     return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
   }
 
@@ -180,6 +188,13 @@ export class ReplicationService implements ReplicationUseCase {
     tenant_id: string,
   ): Promise<ReplicationResult> {
     const start = Date.now();
+    await this._validate_dek(
+      source_ctx.storage,
+      primary_ctx.storage,
+      this._config.encryption_passphrase,
+      tenant_id,
+    );
+
     let total_copied = 0;
     let total_skipped = 0;
     let total_failed = 0;
@@ -194,13 +209,9 @@ export class ReplicationService implements ReplicationUseCase {
         continue;
       }
 
-      const rep = await replicate_snapshot_to_target(
-        source_ctx,
-        primary_ctx,
-        manifest,
-        this._config.encryption_passphrase,
-        tenant_id,
-      );
+      const rep = await replicate_snapshot_to_target(source_ctx, primary_ctx, manifest, {
+        skip_marker: true,
+      });
 
       total_copied += rep.objects_copied;
       total_skipped += rep.objects_skipped;
@@ -262,5 +273,15 @@ export class ReplicationService implements ReplicationUseCase {
       target_keys.map((k) => k.split('/').pop()?.replace('.json', '')).filter(Boolean) as string[],
     );
     return source_manifests.filter((m) => !target_snapshot_ids.has(m.snapshot_id));
+  }
+
+  private create_primary_target(): StorageTarget {
+    return this._target_factory({
+      s3_endpoint: this._config.s3_endpoint,
+      s3_access_key: this._config.s3_access_key,
+      s3_secret_key: this._config.s3_secret_key,
+      s3_region: this._config.s3_region,
+      encryption_passphrase: this._config.encryption_passphrase,
+    });
   }
 }

--- a/src/services/replication/snapshot-replicator.ts
+++ b/src/services/replication/snapshot-replicator.ts
@@ -2,7 +2,6 @@ import { createHash } from 'node:crypto';
 import type { TenantContext } from '@/ports/tenant/context.port';
 import type { Manifest } from '@/domain/manifest';
 import type { ReplicationObjectResult } from '@/domain/replication';
-import { validate_dek_match } from '@/adapters/storage-s3/dek-validator';
 
 const DEK_META_KEY = '_meta/dek.enc';
 const REPLICA_MARKER_KEY = '_meta/replica.marker';
@@ -32,25 +31,26 @@ export function collect_storage_keys(manifest: Manifest): string[] {
   return keys;
 }
 
+export interface ReplicateOptions {
+  readonly skip_marker?: boolean;
+}
+
 /**
  * Replicates a single snapshot from source to target.
+ * Callers must validate DEK match before invoking.
  *
- * Ordering guarantees:
- *   1. DEK validation + copy
- *   2. Replica marker
- *   3. Data + attachment objects
- *   4. Manifest (always last)
+ * Order: DEK copy -> replica marker -> data+attachments -> manifest (always last).
  */
 export async function replicate_snapshot_to_target(
   source_ctx: TenantContext,
   target_ctx: TenantContext,
   manifest: Manifest,
-  passphrase: string,
-  tenant_id: string,
+  options: ReplicateOptions = {},
 ): Promise<SnapshotReplicationResult> {
-  await validate_dek_match(source_ctx.storage, target_ctx.storage, passphrase, tenant_id);
   await ensure_dek_on_target(source_ctx, target_ctx);
-  await ensure_replica_marker(target_ctx, source_ctx.tenant_id);
+  if (!options.skip_marker) {
+    await ensure_replica_marker(target_ctx, source_ctx.tenant_id);
+  }
 
   const storage_keys = collect_storage_keys(manifest);
   const object_results: ReplicationObjectResult[] = [];

--- a/src/services/replication/snapshot-replicator.ts
+++ b/src/services/replication/snapshot-replicator.ts
@@ -1,0 +1,142 @@
+import { createHash } from 'node:crypto';
+import type { TenantContext } from '@/ports/tenant/context.port';
+import type { Manifest } from '@/domain/manifest';
+import type { ReplicationObjectResult } from '@/domain/replication';
+import { validate_dek_match } from '@/adapters/storage-s3/dek-validator';
+
+const DEK_META_KEY = '_meta/dek.enc';
+const REPLICA_MARKER_KEY = '_meta/replica.marker';
+
+export interface SnapshotReplicationResult {
+  readonly object_results: ReplicationObjectResult[];
+  readonly objects_copied: number;
+  readonly objects_skipped: number;
+  readonly objects_failed: number;
+  readonly bytes_copied: number;
+  readonly errors: string[];
+  readonly source_manifest_checksum: string;
+  readonly replicated_manifest_checksum: string;
+}
+
+/** Collects every storage key (data + attachments) referenced by a manifest. */
+export function collect_storage_keys(manifest: Manifest): string[] {
+  const keys: string[] = [];
+  for (const entry of manifest.entries) {
+    keys.push(entry.storage_key);
+    if (entry.attachments) {
+      for (const att of entry.attachments) {
+        keys.push(att.storage_key);
+      }
+    }
+  }
+  return keys;
+}
+
+/**
+ * Replicates a single snapshot from source to target.
+ *
+ * Ordering guarantees:
+ *   1. DEK validation + copy
+ *   2. Replica marker
+ *   3. Data + attachment objects
+ *   4. Manifest (always last)
+ */
+export async function replicate_snapshot_to_target(
+  source_ctx: TenantContext,
+  target_ctx: TenantContext,
+  manifest: Manifest,
+  passphrase: string,
+  tenant_id: string,
+): Promise<SnapshotReplicationResult> {
+  await validate_dek_match(source_ctx.storage, target_ctx.storage, passphrase, tenant_id);
+  await ensure_dek_on_target(source_ctx, target_ctx);
+  await ensure_replica_marker(target_ctx, source_ctx.tenant_id);
+
+  const storage_keys = collect_storage_keys(manifest);
+  const object_results: ReplicationObjectResult[] = [];
+  let objects_copied = 0;
+  let objects_skipped = 0;
+  let objects_failed = 0;
+  let bytes_copied = 0;
+  const errors: string[] = [];
+
+  for (const key of storage_keys) {
+    const result = await copy_object(source_ctx, target_ctx, key);
+    object_results.push(result);
+    if (result.outcome === 'copied') {
+      objects_copied++;
+      const data = await source_ctx.storage.get(key);
+      bytes_copied += data.length;
+    } else if (result.outcome === 'skipped') {
+      objects_skipped++;
+    } else {
+      objects_failed++;
+      if (result.error) errors.push(`${key}: ${result.error}`);
+    }
+  }
+
+  const manifest_key = `manifests/${manifest.mailbox_id}/${manifest.snapshot_id}.json`;
+  const source_manifest_blob = await source_ctx.storage.get(manifest_key);
+  const source_manifest_checksum = sha256_hex(source_manifest_blob);
+
+  await target_ctx.storage.put(manifest_key, source_manifest_blob);
+
+  const target_manifest_blob = await target_ctx.storage.get(manifest_key);
+  const replicated_manifest_checksum = sha256_hex(target_manifest_blob);
+
+  return {
+    object_results,
+    objects_copied,
+    objects_skipped,
+    objects_failed,
+    bytes_copied,
+    errors,
+    source_manifest_checksum,
+    replicated_manifest_checksum,
+  };
+}
+
+async function copy_object(
+  source_ctx: TenantContext,
+  target_ctx: TenantContext,
+  key: string,
+): Promise<ReplicationObjectResult> {
+  try {
+    const exists = await target_ctx.storage.exists(key);
+    if (exists) return { storage_key: key, outcome: 'skipped' };
+
+    const data = await source_ctx.storage.get(key);
+    await target_ctx.storage.put(key, data);
+    return { storage_key: key, outcome: 'copied' };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { storage_key: key, outcome: 'failed', error: message };
+  }
+}
+
+async function ensure_dek_on_target(
+  source_ctx: TenantContext,
+  target_ctx: TenantContext,
+): Promise<void> {
+  const target_has_dek = await target_ctx.storage.exists(DEK_META_KEY);
+  if (target_has_dek) return;
+
+  const dek_blob = await source_ctx.storage.get(DEK_META_KEY);
+  await target_ctx.storage.put(DEK_META_KEY, dek_blob);
+}
+
+async function ensure_replica_marker(ctx: TenantContext, source_tenant_id: string): Promise<void> {
+  const has_marker = await ctx.storage.exists(REPLICA_MARKER_KEY);
+  if (has_marker) return;
+
+  const marker = {
+    replicated_from_tenant: source_tenant_id,
+    created_at: new Date().toISOString(),
+  };
+  const data = Buffer.from(JSON.stringify(marker), 'utf-8');
+  await ctx.storage.put(REPLICA_MARKER_KEY, data);
+}
+
+function sha256_hex(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}

--- a/tests/unit/adapters/dek-validator.test.ts
+++ b/tests/unit/adapters/dek-validator.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { validate_dek_match, DekMismatchError } from '@/adapters/storage-s3/dek-validator';
+import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
+import type { ObjectStorage } from '@/ports/storage/object-storage.port';
+
+function make_storage(): ObjectStorage {
+  return {
+    put: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+    delete_version: vi.fn(),
+    exists: vi.fn(),
+    list: vi.fn(),
+    list_versions: vi.fn(),
+    probe_immutability: vi.fn(),
+  };
+}
+
+describe('validate_dek_match', () => {
+  const passphrase = 'test-passphrase';
+  const tenant_id = 'tenant-1';
+  let source_storage: ObjectStorage;
+  let target_storage: ObjectStorage;
+
+  beforeEach(() => {
+    source_storage = make_storage();
+    target_storage = make_storage();
+  });
+
+  it('passes when target has no dek.enc', async () => {
+    vi.mocked(target_storage.exists).mockResolvedValue(false);
+
+    await expect(
+      validate_dek_match(source_storage, target_storage, passphrase, tenant_id),
+    ).resolves.toBeUndefined();
+
+    expect(source_storage.get).not.toHaveBeenCalled();
+  });
+
+  it('passes when both sides have the same DEK', async () => {
+    const key_service = new EnvelopeKeyService(passphrase, tenant_id);
+    const dek = key_service.generate_dek();
+    const wrapped = key_service.wrap_dek(dek);
+
+    vi.mocked(target_storage.exists).mockResolvedValue(true);
+    vi.mocked(source_storage.get).mockResolvedValue(wrapped);
+    vi.mocked(target_storage.get).mockResolvedValue(wrapped);
+
+    await expect(
+      validate_dek_match(source_storage, target_storage, passphrase, tenant_id),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws DekMismatchError when DEKs differ', async () => {
+    const key_service = new EnvelopeKeyService(passphrase, tenant_id);
+    const dek_a = key_service.generate_dek();
+    const dek_b = key_service.generate_dek();
+    const wrapped_a = key_service.wrap_dek(dek_a);
+    const wrapped_b = key_service.wrap_dek(dek_b);
+
+    vi.mocked(target_storage.exists).mockResolvedValue(true);
+    vi.mocked(source_storage.get).mockResolvedValue(wrapped_a);
+    vi.mocked(target_storage.get).mockResolvedValue(wrapped_b);
+
+    await expect(
+      validate_dek_match(source_storage, target_storage, passphrase, tenant_id),
+    ).rejects.toThrow(DekMismatchError);
+  });
+});

--- a/tests/unit/adapters/storage-target.factory.test.ts
+++ b/tests/unit/adapters/storage-target.factory.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
+import { create_storage_target } from '@/adapters/storage-target.factory';
+import type { StorageTargetConfig } from '@/ports/replication/storage-target.port';
+
+const ks = new EnvelopeKeyService('test-pass', 'tenant-1');
+const dek = ks.generate_dek();
+const wrapped_dek = ks.wrap_dek(dek);
+
+let mock_exists_returns = true;
+vi.mock('@/adapters/storage-s3/s3-object-storage.adapter', () => ({
+  S3ObjectStorage: class MockS3ObjectStorage {
+    put = async (): Promise<void> => {};
+    get = async (): Promise<Buffer> => wrapped_dek;
+    delete = async (): Promise<void> => {};
+    delete_version = async (): Promise<void> => {};
+    exists = async (): Promise<boolean> => mock_exists_returns;
+    list = async (): Promise<string[]> => [];
+    list_versions = async (): Promise<string[]> => [];
+    probe_immutability = async (): Promise<Record<string, unknown>> => ({});
+  },
+}));
+
+vi.mock('@/adapters/storage-s3/s3-bucket-manager', () => ({
+  ensure_bucket_exists: async (): Promise<void> => {},
+}));
+
+vi.mock('@/adapters/storage-s3/tenant-bucket-name', () => ({
+  tenant_bucket_name: (id: string): string => `atlas-${id}`,
+}));
+
+describe('create_storage_target', () => {
+  const base_config: StorageTargetConfig = {
+    s3_endpoint: 'http://offsite:9000',
+    s3_access_key: 'access',
+    s3_secret_key: 'secret',
+    encryption_passphrase: 'test-pass',
+  };
+
+  it('creates a storage target with auto-derived target_id', () => {
+    const target = create_storage_target(base_config);
+
+    expect(target.target_id).toBeTruthy();
+    expect(target.target_id.length).toBe(16);
+    expect(target.endpoint).toBe('http://offsite:9000');
+  });
+
+  it('uses explicit target_id when provided', () => {
+    const target = create_storage_target({
+      ...base_config,
+      target_id: 'my-offsite',
+    });
+
+    expect(target.target_id).toBe('my-offsite');
+  });
+
+  it('creates a context with crypto when DEK exists', async () => {
+    mock_exists_returns = true;
+    const target = create_storage_target(base_config);
+    const ctx = await target.create_context('tenant-1');
+
+    expect(ctx.tenant_id).toBe('tenant-1');
+    expect(ctx.storage).toBeDefined();
+    expect(typeof ctx.encrypt).toBe('function');
+    expect(typeof ctx.decrypt).toBe('function');
+  });
+
+  it('creates a storage-only context when no DEK exists', async () => {
+    mock_exists_returns = false;
+    const target = create_storage_target(base_config);
+    const ctx = await target.create_context('tenant-1');
+
+    expect(ctx.tenant_id).toBe('tenant-1');
+    expect(ctx.storage).toBeDefined();
+    expect(() => ctx.encrypt(Buffer.from('x'))).toThrow('no DEK');
+    expect(() => ctx.decrypt(Buffer.from('x'))).toThrow('no DEK');
+    mock_exists_returns = true;
+  });
+
+  it('derives same target_id for same endpoint + region', () => {
+    const t1 = create_storage_target(base_config);
+    const t2 = create_storage_target(base_config);
+    expect(t1.target_id).toBe(t2.target_id);
+  });
+
+  it('derives different target_id for different endpoints', () => {
+    const t1 = create_storage_target(base_config);
+    const t2 = create_storage_target({
+      ...base_config,
+      s3_endpoint: 'http://other:9000',
+    });
+    expect(t1.target_id).not.toBe(t2.target_id);
+  });
+});

--- a/tests/unit/services/replication/replication-integrity-verifier.test.ts
+++ b/tests/unit/services/replication/replication-integrity-verifier.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHash } from 'node:crypto';
+import { verify_replicated_snapshot } from '@/services/replication/replication-integrity-verifier';
+import { ReplicationVerificationStatus } from '@/domain/replication';
+import type { Manifest, ManifestEntry } from '@/domain/manifest';
+import type { TenantContext } from '@/ports/tenant/context.port';
+import type { ObjectStorage } from '@/ports/storage/object-storage.port';
+
+function make_storage(): ObjectStorage {
+  return {
+    put: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+    delete_version: vi.fn(),
+    exists: vi.fn(),
+    list: vi.fn(),
+    list_versions: vi.fn(),
+    probe_immutability: vi.fn(),
+  };
+}
+
+function make_entry(key: string, plaintext: Buffer): ManifestEntry {
+  return {
+    object_id: `obj-${key}`,
+    storage_key: key,
+    checksum: createHash('sha256').update(plaintext).digest('hex'),
+    size_bytes: plaintext.length,
+  };
+}
+
+function make_manifest(entries: ManifestEntry[]): Manifest {
+  return {
+    id: 'manifest-1',
+    tenant_id: 'tenant-1',
+    mailbox_id: 'mbx-1',
+    snapshot_id: 'snap-1',
+    created_at: new Date('2026-01-01'),
+    total_objects: entries.length,
+    total_size_bytes: entries.reduce((s, e) => s + e.size_bytes, 0),
+    delta_links: {},
+    entries,
+  };
+}
+
+describe('verify_replicated_snapshot', () => {
+  let storage: ObjectStorage;
+  let ctx: TenantContext;
+
+  beforeEach(() => {
+    storage = make_storage();
+    ctx = {
+      tenant_id: 'tenant-1',
+      storage,
+      encrypt: vi.fn((d: Buffer) => d),
+      decrypt: vi.fn((d: Buffer) => d),
+    };
+  });
+
+  it('returns PASSED when all checksums match', async () => {
+    const plaintext = Buffer.from('hello world');
+    const entry = make_entry('data/mbx/hash-1', plaintext);
+    const manifest = make_manifest([entry]);
+
+    vi.mocked(storage.get).mockResolvedValue(plaintext);
+
+    const outcome = await verify_replicated_snapshot(ctx, manifest);
+
+    expect(outcome.status).toBe(ReplicationVerificationStatus.PASSED);
+    expect(outcome.checked).toBe(1);
+    expect(outcome.failed_keys).toEqual([]);
+  });
+
+  it('returns FAILED when checksum mismatches', async () => {
+    const plaintext = Buffer.from('hello world');
+    const entry = make_entry('data/mbx/hash-1', plaintext);
+    const manifest = make_manifest([entry]);
+
+    vi.mocked(storage.get).mockResolvedValue(Buffer.from('corrupted'));
+
+    const outcome = await verify_replicated_snapshot(ctx, manifest);
+
+    expect(outcome.status).toBe(ReplicationVerificationStatus.FAILED);
+    expect(outcome.failed_keys).toEqual(['data/mbx/hash-1']);
+  });
+
+  it('marks objects as failed when get throws', async () => {
+    const plaintext = Buffer.from('hello');
+    const entry = make_entry('data/mbx/hash-1', plaintext);
+    const manifest = make_manifest([entry]);
+
+    vi.mocked(storage.get).mockRejectedValue(new Error('read error'));
+
+    const outcome = await verify_replicated_snapshot(ctx, manifest);
+
+    expect(outcome.status).toBe(ReplicationVerificationStatus.FAILED);
+    expect(outcome.failed_keys).toContain('data/mbx/hash-1');
+  });
+});

--- a/tests/unit/services/replication/replication-status-repository.test.ts
+++ b/tests/unit/services/replication/replication-status-repository.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  save_replication_status,
+  load_replication_status,
+  list_all_replication_status,
+  list_replication_status_by_mailbox,
+} from '@/services/replication/replication-status-repository';
+import type { ReplicationStatusRecord } from '@/domain/replication';
+import { ReplicationStatus, ReplicationVerificationStatus } from '@/domain/replication';
+import type { TenantContext } from '@/ports/tenant/context.port';
+import type { ObjectStorage } from '@/ports/storage/object-storage.port';
+
+function make_storage(): ObjectStorage {
+  return {
+    put: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+    delete_version: vi.fn(),
+    exists: vi.fn(),
+    list: vi.fn(),
+    list_versions: vi.fn(),
+    probe_immutability: vi.fn(),
+  };
+}
+
+function make_context(storage: ObjectStorage): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage,
+    encrypt: vi.fn((data: Buffer) => Buffer.concat([Buffer.from('enc:'), data])),
+    decrypt: vi.fn((data: Buffer) => Buffer.from(data.toString().replace('enc:', ''))),
+  };
+}
+
+function make_record(overrides: Partial<ReplicationStatusRecord> = {}): ReplicationStatusRecord {
+  return {
+    target_id: overrides.target_id ?? 'offsite',
+    target_endpoint: overrides.target_endpoint ?? 'http://offsite:9000',
+    snapshot_id: overrides.snapshot_id ?? 'snap-1',
+    mailbox_id: overrides.mailbox_id ?? 'mbx-1',
+    status: overrides.status ?? ReplicationStatus.COMPLETED,
+    started_at: overrides.started_at ?? '2026-01-01T00:00:00Z',
+    completed_at: overrides.completed_at ?? '2026-01-01T00:05:00Z',
+    objects_total: overrides.objects_total ?? 10,
+    objects_copied: overrides.objects_copied ?? 8,
+    objects_skipped: overrides.objects_skipped ?? 2,
+    objects_failed: overrides.objects_failed ?? 0,
+    bytes_total: overrides.bytes_total ?? 1000,
+    bytes_copied: overrides.bytes_copied ?? 800,
+    verification_status: overrides.verification_status ?? ReplicationVerificationStatus.SKIPPED,
+    source_manifest_checksum: overrides.source_manifest_checksum ?? 'src-checksum',
+    replicated_manifest_checksum: overrides.replicated_manifest_checksum ?? 'rep-checksum',
+  };
+}
+
+describe('replication-status-repository', () => {
+  let storage: ObjectStorage;
+  let ctx: TenantContext;
+
+  beforeEach(() => {
+    storage = make_storage();
+    ctx = make_context(storage);
+  });
+
+  it('saves an encrypted status record', async () => {
+    const record = make_record();
+    await save_replication_status(ctx, record);
+
+    expect(storage.put).toHaveBeenCalledOnce();
+    const [key, data] = vi.mocked(storage.put).mock.calls[0]!;
+    expect(key).toBe('_meta/replication/mbx-1/snap-1/offsite.json');
+    expect(ctx.encrypt).toHaveBeenCalledWith(
+      expect.objectContaining(Buffer.from(JSON.stringify(record))),
+    );
+    expect(data).toBeInstanceOf(Buffer);
+  });
+
+  it('loads and decrypts a status record', async () => {
+    const record = make_record();
+    const plaintext = Buffer.from(JSON.stringify(record));
+    const encrypted = Buffer.concat([Buffer.from('enc:'), plaintext]);
+
+    vi.mocked(storage.exists).mockResolvedValue(true);
+    vi.mocked(storage.get).mockResolvedValue(encrypted);
+
+    const loaded = await load_replication_status(ctx, 'mbx-1', 'snap-1', 'offsite');
+
+    expect(loaded).toEqual(record);
+  });
+
+  it('returns undefined when status record does not exist', async () => {
+    vi.mocked(storage.exists).mockResolvedValue(false);
+
+    const loaded = await load_replication_status(ctx, 'mbx-1', 'snap-1', 'offsite');
+
+    expect(loaded).toBeUndefined();
+  });
+
+  it('lists all status records by prefix', async () => {
+    const record = make_record();
+    const plaintext = Buffer.from(JSON.stringify(record));
+    const encrypted = Buffer.concat([Buffer.from('enc:'), plaintext]);
+
+    vi.mocked(storage.list).mockResolvedValue(['_meta/replication/mbx-1/snap-1/offsite.json']);
+    vi.mocked(storage.exists).mockResolvedValue(true);
+    vi.mocked(storage.get).mockResolvedValue(encrypted);
+
+    const results = await list_all_replication_status(ctx);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.target_id).toBe('offsite');
+  });
+
+  it('filters by mailbox prefix', async () => {
+    const record = make_record({ mailbox_id: 'mbx-2' });
+    const plaintext = Buffer.from(JSON.stringify(record));
+    const encrypted = Buffer.concat([Buffer.from('enc:'), plaintext]);
+
+    vi.mocked(storage.list).mockResolvedValue(['_meta/replication/mbx-2/snap-1/offsite.json']);
+    vi.mocked(storage.exists).mockResolvedValue(true);
+    vi.mocked(storage.get).mockResolvedValue(encrypted);
+
+    const results = await list_replication_status_by_mailbox(ctx, 'mbx-2');
+
+    expect(results).toHaveLength(1);
+    expect(storage.list).toHaveBeenCalledWith('_meta/replication/mbx-2/');
+  });
+});

--- a/tests/unit/services/replication/replication.service.test.ts
+++ b/tests/unit/services/replication/replication.service.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ReplicationService } from '@/services/replication/replication.service';
+import { ReplicationStatus } from '@/domain/replication';
+import type { TenantContext, TenantContextFactory } from '@/ports/tenant/context.port';
+import type { ManifestRepository } from '@/ports/storage/manifest-repository.port';
+import type { ObjectStorage } from '@/ports/storage/object-storage.port';
+import type { Manifest, ManifestEntry } from '@/domain/manifest';
+import type { StorageTarget } from '@/ports/replication/storage-target.port';
+import type { AtlasConfig } from '@/utils/config';
+
+vi.mock('@/adapters/storage-s3/dek-validator', () => ({
+  validate_dek_match: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/services/replication/rehydration-dek-helper', () => ({
+  ensure_source_dek_on_primary: vi.fn().mockResolvedValue(undefined),
+}));
+
+function make_storage(): ObjectStorage {
+  return {
+    put: vi.fn(),
+    get: vi.fn().mockResolvedValue(Buffer.from('encrypted-blob')),
+    delete: vi.fn(),
+    delete_version: vi.fn(),
+    exists: vi.fn().mockResolvedValue(false),
+    list: vi.fn().mockResolvedValue([]),
+    list_versions: vi.fn(),
+    probe_immutability: vi.fn(),
+  };
+}
+
+function make_entry(key: string): ManifestEntry {
+  return {
+    object_id: `obj-${key}`,
+    storage_key: `data/mbx/${key}`,
+    checksum: 'abc',
+    size_bytes: 100,
+  };
+}
+
+function make_manifest(
+  snapshot_id: string,
+  mailbox_id = 'mbx-1',
+  entries: ManifestEntry[] = [],
+): Manifest {
+  return {
+    id: `manifest-${snapshot_id}`,
+    tenant_id: 'tenant-1',
+    mailbox_id,
+    snapshot_id,
+    created_at: new Date('2026-01-01'),
+    total_objects: entries.length,
+    total_size_bytes: entries.reduce((s, e) => s + e.size_bytes, 0),
+    delta_links: {},
+    entries,
+  };
+}
+
+describe('ReplicationService', () => {
+  let source_storage: ObjectStorage;
+  let target_storage: ObjectStorage;
+  let source_ctx: TenantContext;
+  let target_ctx: TenantContext;
+  let tenant_factory: TenantContextFactory;
+  let manifests: ManifestRepository;
+  let config: AtlasConfig;
+  let target: StorageTarget;
+  let service: ReplicationService;
+
+  beforeEach(() => {
+    source_storage = make_storage();
+    target_storage = make_storage();
+
+    source_ctx = {
+      tenant_id: 'tenant-1',
+      storage: source_storage,
+      encrypt: vi.fn((d: Buffer) => d),
+      decrypt: vi.fn((d: Buffer) => d),
+    };
+
+    target_ctx = {
+      tenant_id: 'tenant-1',
+      storage: target_storage,
+      encrypt: vi.fn((d: Buffer) => d),
+      decrypt: vi.fn((d: Buffer) => d),
+    };
+
+    tenant_factory = { create: vi.fn().mockResolvedValue(source_ctx) };
+
+    manifests = {
+      save: vi.fn(),
+      find_by_snapshot: vi.fn(),
+      find_latest_by_mailbox: vi.fn(),
+      list_all_manifests: vi.fn().mockResolvedValue([]),
+    };
+
+    config = {
+      tenant_id: 'tenant-1',
+      client_id: 'c',
+      client_secret: 's',
+      s3_endpoint: 'http://primary:9000',
+      s3_access_key: 'k',
+      s3_secret_key: 's',
+      s3_region: 'us-east-1',
+      encryption_passphrase: 'pass',
+    };
+
+    target = {
+      target_id: 'offsite',
+      endpoint: 'http://offsite:9000',
+      create_context: vi.fn().mockResolvedValue(target_ctx),
+    };
+
+    service = new ReplicationService(tenant_factory, manifests, config);
+  });
+
+  it('replicates a single snapshot to a target', async () => {
+    const entry = make_entry('hash-1');
+    const manifest = make_manifest('snap-1', 'mbx-1', [entry]);
+    vi.mocked(manifests.find_by_snapshot).mockResolvedValue(manifest);
+    vi.mocked(source_storage.get).mockResolvedValue(Buffer.from('data'));
+    vi.mocked(target_storage.get).mockResolvedValue(Buffer.from('data'));
+
+    const results = await service.replicate_snapshot('tenant-1', 'snap-1', [target]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.status).toBe(ReplicationStatus.COMPLETED);
+    expect(results[0]!.objects_copied).toBe(1);
+  });
+
+  it('throws when snapshot manifest is not found', async () => {
+    vi.mocked(manifests.find_by_snapshot).mockResolvedValue(undefined);
+
+    await expect(service.replicate_snapshot('tenant-1', 'snap-missing', [target])).rejects.toThrow(
+      'No manifest found',
+    );
+  });
+
+  it('replicate_mailbox diffs and only replicates missing snapshots', async () => {
+    const m1 = make_manifest('snap-1', 'mbx-1', [make_entry('a')]);
+    const m2 = make_manifest('snap-2', 'mbx-1', [make_entry('b')]);
+
+    vi.mocked(manifests.list_all_manifests).mockResolvedValue([m1, m2]);
+    vi.mocked(target_storage.list).mockResolvedValue(['manifests/mbx-1/snap-1.json']);
+    vi.mocked(source_storage.get).mockResolvedValue(Buffer.from('data'));
+    vi.mocked(target_storage.get).mockResolvedValue(Buffer.from('data'));
+
+    const results = await service.replicate_mailbox('tenant-1', 'mbx-1', [target]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.snapshot_id).toBe('snap-2');
+  });
+
+  it('rehydrate_snapshot skips when manifest exists on primary', async () => {
+    const manifest = make_manifest('snap-1', 'mbx-1', [make_entry('a')]);
+    vi.mocked(manifests.find_by_snapshot).mockResolvedValue(manifest);
+    vi.mocked(source_storage.exists).mockResolvedValue(true);
+
+    const source_target: StorageTarget = {
+      target_id: 'offsite',
+      endpoint: 'http://offsite:9000',
+      create_context: vi.fn().mockResolvedValue(target_ctx),
+    };
+
+    vi.mocked(target_storage.exists).mockResolvedValue(false);
+
+    const spy = vi.mocked(source_storage.exists);
+    spy.mockImplementation(async (key: string) => {
+      if (key === 'manifests/mbx-1/snap-1.json') return true;
+      return false;
+    });
+
+    const result = await service.rehydrate_snapshot('tenant-1', 'snap-1', source_target);
+
+    expect(result.status).toBe(ReplicationStatus.COMPLETED);
+    expect(result.objects_copied).toBe(0);
+  });
+
+  it('rehydrate_tenant copies all missing snapshots from source', async () => {
+    const m1 = make_manifest('snap-1', 'mbx-1', []);
+    const m2 = make_manifest('snap-2', 'mbx-2', []);
+
+    vi.mocked(manifests.list_all_manifests).mockImplementation(async (ctx) => {
+      if (ctx === target_ctx) return [m1, m2];
+      return [];
+    });
+    vi.mocked(source_storage.exists).mockResolvedValue(false);
+    vi.mocked(target_storage.exists).mockResolvedValue(false);
+    vi.mocked(source_storage.get).mockResolvedValue(Buffer.from('data'));
+    vi.mocked(target_storage.get).mockResolvedValue(Buffer.from('data'));
+
+    const source_target: StorageTarget = {
+      target_id: 'offsite',
+      endpoint: 'http://offsite:9000',
+      create_context: vi.fn().mockResolvedValue(target_ctx),
+    };
+
+    const result = await service.rehydrate_tenant('tenant-1', source_target);
+
+    expect(result.status).toBe(ReplicationStatus.COMPLETED);
+  });
+
+  it('get_replication_status returns empty when no sidecars exist', async () => {
+    vi.mocked(source_storage.list).mockResolvedValue([]);
+
+    const results = await service.get_replication_status('tenant-1');
+
+    expect(results).toEqual([]);
+  });
+});

--- a/tests/unit/services/replication/replication.service.test.ts
+++ b/tests/unit/services/replication/replication.service.test.ts
@@ -5,12 +5,9 @@ import type { TenantContext, TenantContextFactory } from '@/ports/tenant/context
 import type { ManifestRepository } from '@/ports/storage/manifest-repository.port';
 import type { ObjectStorage } from '@/ports/storage/object-storage.port';
 import type { Manifest, ManifestEntry } from '@/domain/manifest';
-import type { StorageTarget } from '@/ports/replication/storage-target.port';
+import type { StorageTarget, StorageTargetFactory } from '@/ports/replication/storage-target.port';
+import type { DekValidationFn } from '@/ports/replication/dek-validation.port';
 import type { AtlasConfig } from '@/utils/config';
-
-vi.mock('@/adapters/storage-s3/dek-validator', () => ({
-  validate_dek_match: vi.fn().mockResolvedValue(undefined),
-}));
 
 vi.mock('@/services/replication/rehydration-dek-helper', () => ({
   ensure_source_dek_on_primary: vi.fn().mockResolvedValue(undefined),
@@ -65,6 +62,8 @@ describe('ReplicationService', () => {
   let manifests: ManifestRepository;
   let config: AtlasConfig;
   let target: StorageTarget;
+  let validate_dek: DekValidationFn;
+  let target_factory: StorageTargetFactory;
   let service: ReplicationService;
 
   beforeEach(() => {
@@ -111,7 +110,15 @@ describe('ReplicationService', () => {
       create_context: vi.fn().mockResolvedValue(target_ctx),
     };
 
-    service = new ReplicationService(tenant_factory, manifests, config);
+    validate_dek = vi.fn().mockResolvedValue(undefined) as unknown as DekValidationFn;
+    target_factory = vi.fn().mockReturnValue(target) as unknown as StorageTargetFactory;
+    service = new ReplicationService(
+      tenant_factory,
+      manifests,
+      config,
+      validate_dek,
+      target_factory,
+    );
   });
 
   it('replicates a single snapshot to a target', async () => {

--- a/tests/unit/services/replication/snapshot-replicator.test.ts
+++ b/tests/unit/services/replication/snapshot-replicator.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  replicate_snapshot_to_target,
+  collect_storage_keys,
+} from '@/services/replication/snapshot-replicator';
+import type { Manifest, ManifestEntry, AttachmentEntry } from '@/domain/manifest';
+import type { TenantContext } from '@/ports/tenant/context.port';
+import type { ObjectStorage } from '@/ports/storage/object-storage.port';
+
+vi.mock('@/adapters/storage-s3/dek-validator', () => ({
+  validate_dek_match: vi.fn().mockResolvedValue(undefined),
+}));
+
+function make_storage(): ObjectStorage {
+  return {
+    put: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+    delete_version: vi.fn(),
+    exists: vi.fn(),
+    list: vi.fn(),
+    list_versions: vi.fn(),
+    probe_immutability: vi.fn(),
+  };
+}
+
+function make_context(storage: ObjectStorage, tenant_id = 'tenant-1'): TenantContext {
+  return {
+    tenant_id,
+    storage,
+    encrypt: vi.fn((data: Buffer) => data),
+    decrypt: vi.fn((data: Buffer) => data),
+  };
+}
+
+function make_entry(overrides: Partial<ManifestEntry> = {}): ManifestEntry {
+  return {
+    object_id: overrides.object_id ?? 'obj-1',
+    storage_key: overrides.storage_key ?? 'data/mailbox/key-1',
+    checksum: overrides.checksum ?? 'abc123',
+    size_bytes: overrides.size_bytes ?? 100,
+    subject: overrides.subject,
+    folder_id: overrides.folder_id,
+    attachments: overrides.attachments,
+  };
+}
+
+function make_attachment(overrides: Partial<AttachmentEntry> = {}): AttachmentEntry {
+  return {
+    attachment_id: overrides.attachment_id ?? 'att-1',
+    name: overrides.name ?? 'file.pdf',
+    content_type: overrides.content_type ?? 'application/pdf',
+    size_bytes: overrides.size_bytes ?? 50,
+    storage_key: overrides.storage_key ?? 'attachments/mailbox/att-key-1',
+    checksum: overrides.checksum ?? 'def456',
+    is_inline: overrides.is_inline ?? false,
+  };
+}
+
+function make_manifest(entries: ManifestEntry[]): Manifest {
+  return {
+    id: 'manifest-1',
+    tenant_id: 'tenant-1',
+    mailbox_id: 'mailbox-1',
+    snapshot_id: 'snapshot-1',
+    created_at: new Date('2026-01-01'),
+    total_objects: entries.length,
+    total_size_bytes: entries.reduce((sum, e) => sum + e.size_bytes, 0),
+    delta_links: {},
+    entries,
+  };
+}
+
+describe('collect_storage_keys', () => {
+  it('collects message and attachment keys', () => {
+    const att = make_attachment({ storage_key: 'attachments/mbx/att-hash' });
+    const entry = make_entry({
+      storage_key: 'data/mbx/msg-hash',
+      attachments: [att],
+    });
+    const manifest = make_manifest([entry]);
+
+    const keys = collect_storage_keys(manifest);
+
+    expect(keys).toEqual(['data/mbx/msg-hash', 'attachments/mbx/att-hash']);
+  });
+
+  it('returns empty for manifest with no entries', () => {
+    expect(collect_storage_keys(make_manifest([]))).toEqual([]);
+  });
+});
+
+describe('replicate_snapshot_to_target', () => {
+  let source_storage: ObjectStorage;
+  let target_storage: ObjectStorage;
+  let source_ctx: TenantContext;
+  let target_ctx: TenantContext;
+
+  beforeEach(() => {
+    source_storage = make_storage();
+    target_storage = make_storage();
+    source_ctx = make_context(source_storage);
+    target_ctx = make_context(target_storage);
+  });
+
+  it('copies missing objects and manifest to target', async () => {
+    const entry = make_entry({ storage_key: 'data/mailbox-1/hash-1' });
+    const manifest = make_manifest([entry]);
+    const data_blob = Buffer.from('encrypted-data');
+    const manifest_blob = Buffer.from('encrypted-manifest');
+
+    vi.mocked(target_storage.exists).mockResolvedValue(false);
+    vi.mocked(source_storage.get).mockImplementation(async (key: string) => {
+      if (key === 'data/mailbox-1/hash-1') return data_blob;
+      if (key === 'manifests/mailbox-1/snapshot-1.json') return manifest_blob;
+      return Buffer.alloc(0);
+    });
+    vi.mocked(target_storage.get).mockResolvedValue(manifest_blob);
+
+    const result = await replicate_snapshot_to_target(
+      source_ctx,
+      target_ctx,
+      manifest,
+      'pass',
+      'tenant-1',
+    );
+
+    expect(result.objects_copied).toBe(1);
+    expect(result.objects_skipped).toBe(0);
+    expect(result.objects_failed).toBe(0);
+    expect(target_storage.put).toHaveBeenCalledWith('data/mailbox-1/hash-1', data_blob);
+    expect(target_storage.put).toHaveBeenCalledWith(
+      'manifests/mailbox-1/snapshot-1.json',
+      manifest_blob,
+    );
+  });
+
+  it('skips objects that already exist on target', async () => {
+    const entry = make_entry({ storage_key: 'data/mailbox-1/hash-1' });
+    const manifest = make_manifest([entry]);
+    const manifest_blob = Buffer.from('encrypted-manifest');
+
+    vi.mocked(target_storage.exists).mockImplementation(async (key: string) => {
+      if (key === 'data/mailbox-1/hash-1') return true;
+      return false;
+    });
+    vi.mocked(source_storage.get).mockResolvedValue(manifest_blob);
+    vi.mocked(target_storage.get).mockResolvedValue(manifest_blob);
+
+    const result = await replicate_snapshot_to_target(
+      source_ctx,
+      target_ctx,
+      manifest,
+      'pass',
+      'tenant-1',
+    );
+
+    expect(result.objects_copied).toBe(0);
+    expect(result.objects_skipped).toBe(1);
+  });
+
+  it('copies dek.enc and replica marker to target when missing', async () => {
+    const manifest = make_manifest([]);
+    const dek_blob = Buffer.from('wrapped-dek');
+    const manifest_blob = Buffer.from('encrypted-manifest');
+
+    vi.mocked(target_storage.exists).mockResolvedValue(false);
+    vi.mocked(source_storage.get).mockImplementation(async (key: string) => {
+      if (key === '_meta/dek.enc') return dek_blob;
+      return manifest_blob;
+    });
+    vi.mocked(target_storage.get).mockResolvedValue(manifest_blob);
+
+    await replicate_snapshot_to_target(source_ctx, target_ctx, manifest, 'pass', 'tenant-1');
+
+    expect(target_storage.put).toHaveBeenCalledWith('_meta/dek.enc', dek_blob);
+    expect(target_storage.put).toHaveBeenCalledWith('_meta/replica.marker', expect.any(Buffer));
+  });
+
+  it('records failure for objects that throw during copy', async () => {
+    const entry = make_entry({ storage_key: 'data/mailbox-1/hash-fail' });
+    const manifest = make_manifest([entry]);
+    const manifest_blob = Buffer.from('encrypted-manifest');
+
+    vi.mocked(target_storage.exists).mockImplementation(async (key: string) => {
+      if (key === 'data/mailbox-1/hash-fail') return false;
+      return false;
+    });
+    vi.mocked(source_storage.get).mockImplementation(async (key: string) => {
+      if (key === 'data/mailbox-1/hash-fail') throw new Error('Network error');
+      return manifest_blob;
+    });
+    vi.mocked(target_storage.get).mockResolvedValue(manifest_blob);
+
+    const result = await replicate_snapshot_to_target(
+      source_ctx,
+      target_ctx,
+      manifest,
+      'pass',
+      'tenant-1',
+    );
+
+    expect(result.objects_failed).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Network error');
+  });
+});

--- a/tests/unit/services/replication/snapshot-replicator.test.ts
+++ b/tests/unit/services/replication/snapshot-replicator.test.ts
@@ -7,10 +7,6 @@ import type { Manifest, ManifestEntry, AttachmentEntry } from '@/domain/manifest
 import type { TenantContext } from '@/ports/tenant/context.port';
 import type { ObjectStorage } from '@/ports/storage/object-storage.port';
 
-vi.mock('@/adapters/storage-s3/dek-validator', () => ({
-  validate_dek_match: vi.fn().mockResolvedValue(undefined),
-}));
-
 function make_storage(): ObjectStorage {
   return {
     put: vi.fn(),
@@ -117,13 +113,7 @@ describe('replicate_snapshot_to_target', () => {
     });
     vi.mocked(target_storage.get).mockResolvedValue(manifest_blob);
 
-    const result = await replicate_snapshot_to_target(
-      source_ctx,
-      target_ctx,
-      manifest,
-      'pass',
-      'tenant-1',
-    );
+    const result = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest);
 
     expect(result.objects_copied).toBe(1);
     expect(result.objects_skipped).toBe(0);
@@ -147,13 +137,7 @@ describe('replicate_snapshot_to_target', () => {
     vi.mocked(source_storage.get).mockResolvedValue(manifest_blob);
     vi.mocked(target_storage.get).mockResolvedValue(manifest_blob);
 
-    const result = await replicate_snapshot_to_target(
-      source_ctx,
-      target_ctx,
-      manifest,
-      'pass',
-      'tenant-1',
-    );
+    const result = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest);
 
     expect(result.objects_copied).toBe(0);
     expect(result.objects_skipped).toBe(1);
@@ -171,7 +155,7 @@ describe('replicate_snapshot_to_target', () => {
     });
     vi.mocked(target_storage.get).mockResolvedValue(manifest_blob);
 
-    await replicate_snapshot_to_target(source_ctx, target_ctx, manifest, 'pass', 'tenant-1');
+    await replicate_snapshot_to_target(source_ctx, target_ctx, manifest);
 
     expect(target_storage.put).toHaveBeenCalledWith('_meta/dek.enc', dek_blob);
     expect(target_storage.put).toHaveBeenCalledWith('_meta/replica.marker', expect.any(Buffer));
@@ -192,13 +176,7 @@ describe('replicate_snapshot_to_target', () => {
     });
     vi.mocked(target_storage.get).mockResolvedValue(manifest_blob);
 
-    const result = await replicate_snapshot_to_target(
-      source_ctx,
-      target_ctx,
-      manifest,
-      'pass',
-      'tenant-1',
-    );
+    const result = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest);
 
     expect(result.objects_failed).toBe(1);
     expect(result.errors).toHaveLength(1);


### PR DESCRIPTION
## Summary

Introduces replication between any S3-compatible storage targets, enabling 3-2-1 backup strategies with deterministic, resumable, and verifiable snapshot-level copies.

Fixes: #9

## Changes

New capabilities:
- `atlas replicate` — copy snapshots to secondary S3 targets
- `atlas rehydrate` — recover from replica after primary data loss
- SDK methods: replicateSnapshot, replicateMailbox, rehydrateSnapshot, rehydrateMailbox, rehydrateTenant, getReplicationStatus
- Durable replication status sidecars in _meta/replication/
- DEK mismatch protection and replica marker safety gates
- Concurrent replication support (S3-to-S3, no Graph API)

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed