### PR TITLE
feat(sdk): expose typed progress events and AbortSignal cancellation

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -76,8 +76,6 @@ await atlas.replicateSnapshot('snapshot-id', [offsite]);
 
 Method names mirror the CLI structure: `atlas outlook backup` maps to `atlas.outlook.backup()`, `atlas onedrive backup` to `atlas.onedrive.backup()`, and so on. See [SDK Examples](/reference/examples) for production-ready patterns.
 
-`OneDriveBackupOptions.create_progress` takes the same reporter-factory hook documented under [Save Options](#save-options): the CLI injects its per-drive dashboard there, and SDK callers can plug their own observer (drive totals arrive via `set_row_total` once each delta is fetched). When omitted, progress is not reported.
-
 ## Progress and Cancellation
 
 Every Outlook, OneDrive, and SharePoint `backup`, `restore`, `save`, and `verify` method accepts two common options:
@@ -178,15 +176,14 @@ Graph **item** IDs (`file_id`, `item_id`) are case-sensitive and never folded. `
 
 `atlas.outlook.save` and `atlas.outlook.saveMailbox` accept the following options:
 
-| Option                 | Type                                    | Description                                                                                                                                                                                                                                                |
-| ---------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `folder_name`          | `string`                                | Save only this folder and its subfolders (name or path)                                                                                                                                                                                                    |
-| `message_ref`          | `string`                                | Save a single message by index or ID                                                                                                                                                                                                                       |
-| `start_date`           | `Date`                                  | Include snapshots on or after this date                                                                                                                                                                                                                    |
-| `end_date`             | `Date`                                  | Include snapshots on or before this date                                                                                                                                                                                                                   |
-| `output_path`          | `string`                                | Output zip file path (default: `Restore-<timestamp>.zip`)                                                                                                                                                                                                  |
-| `skip_integrity_check` | `boolean`                               | Skip SHA-256 verification (default: `false`)                                                                                                                                                                                                               |
-| `create_progress`      | `(folders) => TransferProgressReporter` | Progress reporter factory invoked with the folder list before the transfer starts; each reporter callback receives per-folder counts. The CLI injects its dashboard here; SDK callers can plug their own observer. When omitted, progress is not reported. |
+| Option                 | Type      | Description                                               |
+| ---------------------- | --------- | --------------------------------------------------------- |
+| `folder_name`          | `string`  | Save only this folder and its subfolders (name or path)   |
+| `message_ref`          | `string`  | Save a single message by index or ID                      |
+| `start_date`           | `Date`    | Include snapshots on or after this date                   |
+| `end_date`             | `Date`    | Include snapshots on or before this date                  |
+| `output_path`          | `string`  | Output zip file path (default: `Restore-<timestamp>.zip`) |
+| `skip_integrity_check` | `boolean` | Skip SHA-256 verification (default: `false`)              |
 
 Both methods return a `SaveResult`:
 
@@ -208,14 +205,13 @@ interface SaveResult {
 
 `atlas.outlook.restore` and `atlas.outlook.restoreMailbox` accept the following options:
 
-| Option            | Type                                    | Description                                                                                          |
-| ----------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `folder_name`     | `string`                                | Restore only this folder and its subfolders (name or path)                                           |
-| `message_ref`     | `string`                                | Restore a single message by index or ID                                                              |
-| `target_mailbox`  | `string`                                | Target mailbox for cross-mailbox restore                                                             |
-| `start_date`      | `Date`                                  | Include snapshots on or after this date                                                              |
-| `end_date`        | `Date`                                  | Include snapshots on or before this date                                                             |
-| `create_progress` | `(folders) => TransferProgressReporter` | Progress reporter factory; same contract as in Save Options. When omitted, progress is not reported. |
+| Option           | Type     | Description                                                |
+| ---------------- | -------- | ---------------------------------------------------------- |
+| `folder_name`    | `string` | Restore only this folder and its subfolders (name or path) |
+| `message_ref`    | `string` | Restore a single message by index or ID                    |
+| `target_mailbox` | `string` | Target mailbox for cross-mailbox restore                   |
+| `start_date`     | `Date`   | Include snapshots on or after this date                    |
+| `end_date`       | `Date`   | Include snapshots on or before this date                   |
 
 Both methods return a `RestoreResult`:
 

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -78,6 +78,49 @@ Method names mirror the CLI structure: `atlas outlook backup` maps to `atlas.out
 
 `OneDriveBackupOptions.create_progress` takes the same reporter-factory hook documented under [Save Options](#save-options): the CLI injects its per-drive dashboard there, and SDK callers can plug their own observer (drive totals arrive via `set_row_total` once each delta is fetched). When omitted, progress is not reported.
 
+## Progress and Cancellation
+
+Every Outlook, OneDrive, and SharePoint `backup`, `restore`, `save`, and `verify` method accepts two common options:
+
+```typescript
+const controller = new AbortController();
+
+const result = await atlas.outlook.backup('user@company.com', {
+  signal: controller.signal,
+  onProgress(event) {
+    console.log(event.phase, event.processed, event.total, event.current);
+    if (event.processed >= 1000) controller.abort();
+  },
+});
+
+if (result.interrupted) {
+  console.log('Stopped safely; rerun to continue from the last committed delta');
+}
+```
+
+| Option       | Type                                      | Description                                                                                     |
+| ------------ | ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `onProgress` | `(event: OperationProgressEvent) => void` | Receives discovery, per-item processing, finalization, and terminal progress events.            |
+| `signal`     | `AbortSignal`                             | Requests graceful cancellation. Atlas finishes the current item, then stops at a safe boundary. |
+
+`OperationProgressEvent` is stable across workloads:
+
+```typescript
+interface OperationProgressEvent {
+  operation: 'backup' | 'restore' | 'save' | 'verify';
+  workload: 'outlook' | 'onedrive' | 'sharepoint';
+  phase: 'discovering' | 'processing' | 'finalizing' | 'completed' | 'interrupted';
+  processed: number;
+  total?: number;
+  current?: string;
+  rate?: number;
+}
+```
+
+Cancellation returns normally with `interrupted: true`; it does not throw an abort error. Restore and save results contain partial counts, and save finalizes a valid zip with the completed files. A partially processed backup does not advance that folder, drive, or library's delta cursor, so the next run safely replays it. Completed units remain committed.
+
+The callback is optional and runs inline with the operation. Keep it fast; move network writes or database updates to your own queue.
+
 ## Outlook API Reference
 
 | Method                                | CLI equivalent                 | Description                                                                                        |
@@ -157,6 +200,7 @@ interface SaveResult {
   output_path: string;
   total_bytes: number;
   integrity_failures: string[];
+  interrupted: boolean;
 }
 ```
 
@@ -186,6 +230,7 @@ interface RestoreResult {
   verification_warnings: string[];
   restore_folder_name: string;
   graph_cost?: OperationCost; // SDK only
+  interrupted: boolean;
 }
 ```
 
@@ -458,6 +503,7 @@ For future OneDrive backup jobs, the `sharepoint_onedrive` pool is per-tenant. Y
 - Deletion types: `DeletionResult`
 - Replication types: `ReplicationResult`, `ReplicationStatusRecord`, `StorageTarget`, `StorageTargetConfig`
 - Factory functions: `createAtlasInstance`, `createStorageTarget`
+- Operation control types: `SdkOperationOptions`, `OperationProgressEvent`, `OperationProgressCallback`, `OperationProgressPhase`
 - Cost helpers: `getGraphCost`
 
 **Graph cost types:**

--- a/docs/superpowers/plans/2026-08-17-sdk-progress-cancellation.md
+++ b/docs/superpowers/plans/2026-08-17-sdk-progress-cancellation.md
@@ -1,0 +1,379 @@
+# SDK Progress and Cancellation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose typed progress events and graceful `AbortSignal` cancellation for Outlook, OneDrive, and SharePoint SDK backup, restore, save, and verify operations.
+
+**Architecture:** Public camelCase SDK options are adapted at the SDK boundary to additive internal progress and interruption hooks. Workload services poll cancellation only between durable work units, return partial results with `interrupted: true`, and preserve the previous delta cursor whenever cancellation leaves a drive or library incomplete.
+
+**Tech Stack:** TypeScript 5.9, Inversify ports/adapters, Vitest, pnpm/turbo, Microsoft Graph, MinIO/S3.
+
+---
+
+### Task 1: Public contracts and SDK option adaptation
+
+**Files:**
+- Create: `packages/types/src/ports/atlas/progress-event.port.ts`
+- Modify: `packages/types/src/ports/index.ts`
+- Modify: `packages/types/src/ports/atlas/outlook-api.port.ts`
+- Modify: `packages/types/src/ports/atlas/onedrive-api.port.ts`
+- Modify: `packages/types/src/ports/atlas/sharepoint-api.port.ts`
+- Modify: operation option/result ports under `packages/types/src/ports/{backup,restore,save,verification,onedrive,sharepoint}/`
+- Create: `packages/sdk/src/operation-options.ts`
+- Modify: `packages/sdk/src/outlook-api.factory.ts`
+- Modify: `packages/sdk/src/onedrive-api.factory.ts`
+- Modify: `packages/sdk/src/sharepoint-api.factory.ts`
+- Create: `packages/sdk/tests/unit/progress-and-cancellation.test.ts`
+
+- [ ] **Step 1: Write failing SDK contract tests**
+
+Add tests that call one method in each namespace with camelCase options and assert the resolved use-case receives internal hooks:
+
+```ts
+const controller = new AbortController();
+const on_progress = vi.fn();
+await api.backup('owner', { onProgress: on_progress, signal: controller.signal });
+const options = vi.mocked(use_case.backup).mock.calls[0]![2];
+expect(options.on_progress).toBe(on_progress);
+expect(options.should_interrupt?.()).toBe(false);
+controller.abort();
+expect(options.should_interrupt?.()).toBe(true);
+```
+
+Also add compile-time assignments proving all affected results require `interrupted` and progress events reject invalid operation/phase strings.
+
+- [ ] **Step 2: Run the SDK test and verify failure**
+
+Run: `pnpm --filter @wisecom/atlas-sdk exec vitest run tests/unit/progress-and-cancellation.test.ts`
+
+Expected: FAIL because `onProgress`, `signal`, and the adapter do not exist.
+
+- [ ] **Step 3: Add the common public contract**
+
+Implement and export:
+
+```ts
+interface OperationProgressBase {
+  readonly operation: 'backup' | 'restore' | 'save' | 'verify';
+  readonly workload: 'outlook' | 'onedrive' | 'sharepoint';
+  readonly processed: number;
+  readonly total?: number;
+  readonly current?: string;
+  readonly rate?: number;
+}
+
+export type OperationProgressEvent =
+  | (OperationProgressBase & { readonly phase: 'discovering' })
+  | (OperationProgressBase & { readonly phase: 'processing' })
+  | (OperationProgressBase & { readonly phase: 'finalizing' })
+  | (OperationProgressBase & { readonly phase: 'completed' })
+  | (OperationProgressBase & { readonly phase: 'interrupted' });
+
+export type OperationProgressPhase = OperationProgressEvent['phase'];
+export type OperationProgressCallback = (event: OperationProgressEvent) => void;
+
+export interface SdkOperationOptions {
+  readonly onProgress?: OperationProgressCallback;
+  readonly signal?: AbortSignal;
+}
+
+export interface OperationControlOptions {
+  readonly on_progress?: OperationProgressCallback;
+  readonly should_interrupt?: () => boolean;
+}
+```
+
+Extend every internal backup/restore/save/verify option interface with `OperationControlOptions`. Outlook SDK backup options omit `progress`, `should_interrupt`, and `should_force_stop`; OneDrive SDK backup options omit `create_progress`, `on_progress`, and `should_interrupt`; SharePoint SDK backup options omit `on_progress` and `should_interrupt`; restore/save/verify SDK options omit `progress`, `on_progress`, and `should_interrupt`. Add required `interrupted: boolean` to Outlook `SyncResult` and to the OneDrive/SharePoint backup, restore, save, and verification result contracts.
+
+- [ ] **Step 4: Implement the SDK adapter and update all factories**
+
+```ts
+export function adapt_operation_options<T extends SdkOperationOptions>(
+  options: T,
+): Omit<T, 'onProgress' | 'signal'> & OperationControlOptions {
+  const { onProgress: on_progress, signal, ...rest } = options;
+  return {
+    ...rest,
+    on_progress,
+    should_interrupt: signal ? () => signal.aborted : undefined,
+  };
+}
+```
+
+Apply it to backup, restore, save, and verify in all three namespace factories. Do not adapt short catalog/status/deletion calls.
+
+- [ ] **Step 5: Run SDK/types checks**
+
+Run:
+
+```bash
+pnpm --filter @wisecom/atlas-types build
+pnpm --filter @wisecom/atlas-sdk exec vitest run tests/unit/progress-and-cancellation.test.ts
+pnpm --filter @wisecom/atlas-sdk typecheck
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit the public-contract scope**
+
+```bash
+git add packages/types packages/sdk
+git commit -m "feat(sdk): add progress and cancellation contracts"
+```
+
+### Task 2: Outlook and shared verification progress/cancellation
+
+**Files:**
+- Create: `packages/core/src/services/shared/operation-progress.ts`
+- Modify: `packages/core/src/services/verification/verification.service.ts`
+- Modify: `packages/outlook/src/services/backup/mailbox-sync.service.ts`
+- Modify: `packages/outlook/src/services/restore/restore.service.ts`
+- Modify: `packages/outlook/src/services/restore/restore-loop-executor.ts`
+- Modify: `packages/outlook/src/services/save/save.service.ts`
+- Modify: `packages/outlook/src/services/save/save-entry-processor.ts`
+- Test: `packages/outlook/tests/unit/mailbox-sync.service.test.ts`
+- Test: `packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts`
+- Test: `packages/outlook/tests/unit/restore.service.test.ts`
+- Test: `packages/outlook/tests/unit/save.service.test.ts`
+- Test: `packages/core/tests/unit/services/verification.service.test.ts`
+
+- [ ] **Step 1: Write failing Outlook lifecycle and cancellation tests**
+
+For each operation, record events and abort after the first `processing` event:
+
+```ts
+const events: OperationProgressEvent[] = [];
+let interrupted = false;
+const result = await service.run('tenant', 'owner', {
+  on_progress: (event) => {
+    events.push(event);
+    if (event.phase === 'processing') interrupted = true;
+  },
+  should_interrupt: () => interrupted,
+});
+expect(result.interrupted).toBe(true);
+expect(events.at(-1)?.phase).toBe('interrupted');
+```
+
+Keep the existing issue #23 assertion: an interrupted Outlook backup does not persist the delta link past unprocessed messages.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run:
+
+```bash
+pnpm --filter @wisecom/atlas-outlook exec vitest run tests/unit/mailbox-sync.service.test.ts tests/unit/interrupt-delta-safeguard.test.ts tests/unit/restore.service.test.ts tests/unit/save.service.test.ts
+pnpm --filter @wisecom/atlas-core exec vitest run tests/unit/services/verification.service.test.ts
+```
+
+Expected: FAIL on missing events/result fields and absent cancellation polling.
+
+- [ ] **Step 3: Add a callback-safe event emitter**
+
+```ts
+export function emit_operation_progress(
+  callback: OperationProgressCallback | undefined,
+  event: OperationProgressEvent,
+): void {
+  try {
+    callback?.(event);
+  } catch (err) {
+    logger.debug(`Progress callback failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+```
+
+- [ ] **Step 4: Wire Outlook operations at existing safe points**
+
+Emit `discovering`, monotonic `processing`, `finalizing`, and one terminal event. Reuse Outlook backup's existing interruption predicates and reporter. Remove service-owned SIGINT registration from save; CLI signal handling remains in CLI adapters. Return partial counters with `interrupted: true` from restore/save/verify.
+
+- [ ] **Step 5: Run Outlook/core suites and typechecks**
+
+Run:
+
+```bash
+pnpm --filter @wisecom/atlas-outlook test
+pnpm --filter @wisecom/atlas-core test
+pnpm --filter @wisecom/atlas-outlook typecheck
+pnpm --filter @wisecom/atlas-core typecheck
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit the Outlook scope**
+
+```bash
+git add packages/core packages/outlook
+git commit -m "feat(outlook): report progress and graceful cancellation"
+```
+
+### Task 3: OneDrive progress, cancellation, and cursor safety
+
+**Files:**
+- Modify: `packages/onedrive/src/services/onedrive-backup.service.ts`
+- Modify: `packages/onedrive/src/services/onedrive-backup-drive-processor.ts`
+- Modify: `packages/onedrive/src/services/onedrive-backup-builders.ts`
+- Modify: `packages/onedrive/src/services/onedrive-restore.service.ts`
+- Modify: `packages/onedrive/src/services/onedrive-save.service.ts`
+- Modify: `packages/onedrive/src/services/onedrive-verification.service.ts`
+- Test: `packages/onedrive/tests/unit/services/onedrive-backup-drive-processor.test.ts`
+- Test: `packages/onedrive/tests/unit/services/onedrive-backup-determinism.test.ts`
+- Test: `packages/onedrive/tests/unit/services/onedrive-restore.service.test.ts`
+- Test: `packages/onedrive/tests/unit/services/onedrive-save.service.test.ts`
+- Test: `packages/onedrive/tests/unit/services/onedrive-verification.service.test.ts`
+
+- [ ] **Step 1: Write failing OneDrive cancellation tests**
+
+Model two changed items, abort after the first, and assert the second is untouched and the newly fetched delta link is not saved:
+
+```ts
+expect(result.interrupted).toBe(true);
+expect(connector.download_file).toHaveBeenCalledTimes(1);
+expect(delta_repository.save).not.toHaveBeenCalledWith(
+  expect.anything(),
+  expect.objectContaining({ delta_link: 'new-link' }),
+);
+expect(events.at(-1)?.phase).toBe('interrupted');
+```
+
+Add analogous partial-result tests for restore/save/verify and a completed-run event-order test.
+
+- [ ] **Step 2: Run focused OneDrive tests and verify failure**
+
+Run: `pnpm --filter @wisecom/atlas-onedrive exec vitest run tests/unit/services/onedrive-backup-drive-processor.test.ts tests/unit/services/onedrive-backup-determinism.test.ts tests/unit/services/onedrive-restore.service.test.ts tests/unit/services/onedrive-save.service.test.ts tests/unit/services/onedrive-verification.service.test.ts`
+
+Expected: FAIL on missing cancellation checks and interrupted results.
+
+- [ ] **Step 3: Add safe-point polling and event emission**
+
+Check `should_interrupt?.()` before each drive and item, and after each completed item. Return an explicit interrupted drive outcome so the orchestrator excludes that drive's new delta link from cursor persistence. Emit one terminal event at service level.
+
+- [ ] **Step 4: Add restore/save/verify partial results**
+
+Poll between entries only; finish the current remote request. Preserve completed counts, stop new work, and return `interrupted: true`.
+
+- [ ] **Step 5: Run OneDrive suite and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @wisecom/atlas-onedrive test
+pnpm --filter @wisecom/atlas-onedrive typecheck
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit the OneDrive scope**
+
+```bash
+git add packages/onedrive
+git commit -m "feat(onedrive): add progress and safe cancellation"
+```
+
+### Task 4: SharePoint progress, cancellation, and cursor safety
+
+**Files:**
+- Modify: `packages/sharepoint/src/services/sharepoint-backup.service.ts`
+- Modify: `packages/sharepoint/src/services/sharepoint-backup-library-processor.ts`
+- Modify: `packages/sharepoint/src/services/sharepoint-restore.service.ts`
+- Modify: `packages/sharepoint/src/services/sharepoint-save.service.ts`
+- Modify: `packages/sharepoint/src/services/sharepoint-verification.service.ts`
+- Test: `packages/sharepoint/tests/unit/services/sharepoint-backup-determinism.test.ts`
+- Test: `packages/sharepoint/tests/unit/services/sharepoint-restore.service.test.ts`
+- Test: `packages/sharepoint/tests/unit/services/sharepoint-save.service.test.ts`
+- Test: `packages/sharepoint/tests/unit/services/sharepoint-verification.service.test.ts`
+
+- [ ] **Step 1: Write failing SharePoint cancellation tests**
+
+Abort inside a library after its first item. Assert partial counts, an `interrupted` terminal event, and no persistence of that library's new delta link. Also prove a fully completed earlier library may keep its cursor.
+
+- [ ] **Step 2: Run focused SharePoint tests and verify failure**
+
+Run: `pnpm --filter @wisecom/atlas-sharepoint exec vitest run tests/unit/services/sharepoint-backup-determinism.test.ts tests/unit/services/sharepoint-restore.service.test.ts tests/unit/services/sharepoint-save.service.test.ts tests/unit/services/sharepoint-verification.service.test.ts`
+
+Expected: FAIL on absent cancellation behavior.
+
+- [ ] **Step 3: Implement library/item safe points**
+
+Propagate an interrupted library outcome. Skip delta mutation and final cursor persistence for incomplete libraries; keep completed-library cursors. Emit monotonic lifecycle events and return partial results.
+
+- [ ] **Step 4: Add restore/save/verify cancellation**
+
+Poll between entries and preserve existing item-level error isolation. Return `interrupted: true` without converting cancellation into an operational error.
+
+- [ ] **Step 5: Run SharePoint suite and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @wisecom/atlas-sharepoint test
+pnpm --filter @wisecom/atlas-sharepoint typecheck
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit the SharePoint scope**
+
+```bash
+git add packages/sharepoint
+git commit -m "feat(sharepoint): add progress and safe cancellation"
+```
+
+### Task 5: SDK documentation, regression checks, and live E2E
+
+**Files:**
+- Modify: `docs/reference/sdk.md`
+- Test: all workspace suites
+
+- [ ] **Step 1: Add SDK examples and reference tables**
+
+Document `onProgress`, `signal`, every event field/phase, graceful partial results, and safe-point semantics. Lead with a working example:
+
+```ts
+const controller = new AbortController();
+const result = await atlas.outlook.backup('user@example.com', {
+  signal: controller.signal,
+  onProgress(event) {
+    console.log(event.phase, event.processed, event.total);
+    if (event.processed >= 100) controller.abort();
+  },
+});
+console.log(result.interrupted);
+```
+
+- [ ] **Step 2: Run complete static and unit verification**
+
+Run:
+
+```bash
+pnpm run build
+pnpm run typecheck
+pnpm run test
+pnpm run lint
+pnpm run format:check
+pnpm run docs:build
+```
+
+Expected: all commands exit 0; only documented pre-existing warnings may remain.
+
+- [ ] **Step 3: Run live Wisecom/MinIO E2E**
+
+Use the secure Atlas config without exporting secrets. Record tenant/storage pre-state, then:
+
+1. Abort an Outlook SDK backup from its progress callback.
+2. Assert `interrupted === true`, monotonic events, and terminal `interrupted`.
+3. Rerun the same mailbox to completion and verify its completed manifest/content state.
+4. Abort OneDrive and SharePoint backups after a processing event; verify incomplete drive/library cursors did not advance.
+5. Exercise restore/save/verify callbacks against audit-created or existing read-only data, then permanently remove every tenant write.
+6. Purge audit-created storage objects, versions, and delete markers; restore MinIO to its original state.
+
+- [ ] **Step 4: Commit documentation after E2E confirms behavior**
+
+```bash
+git add docs/reference/sdk.md
+git commit -m "docs(sdk): document progress and cancellation"
+```
+
+- [ ] **Step 5: Review the final diff and open the PR**
+
+Confirm commit boundaries, no secrets/test-tenant names in the diff or PR, and a clean worktree. Push `feat/39-sdk-progress-abort` and open a PR against `release/v2.1.0-beta` with `Closes #39` in the body and exact verification evidence.

--- a/docs/superpowers/specs/2026-08-17-sdk-progress-cancellation-design.md
+++ b/docs/superpowers/specs/2026-08-17-sdk-progress-cancellation-design.md
@@ -1,0 +1,115 @@
+# SDK Progress and Cancellation Design
+
+## Goal
+
+Issue #39 adds typed progress callbacks and graceful `AbortSignal` cancellation to long-running SDK backup, restore, save, and verify operations for Outlook, OneDrive, and SharePoint.
+
+A cancelled operation returns its normal partial result with `interrupted: true`. It does not reject with `AbortError`, and it does not force-cancel an in-flight Graph or S3 request.
+
+## Public API
+
+SDK methods accept additive camelCase options:
+
+```ts
+await atlas.outlook.backup('user@example.com', {
+  onProgress: (event) => render_progress(event),
+  signal: abort_controller.signal,
+});
+```
+
+The SDK owns these public option wrappers rather than exposing internal snake_case service options or CLI reporter interfaces.
+
+`ProgressEvent` is a discriminated union with these common fields:
+
+- `operation`: `backup | restore | save | verify`
+- `workload`: `outlook | onedrive | sharepoint`
+- `phase`: `discovering | processing | finalizing | completed | interrupted`
+- `processed`: completed work units
+- `total`: known work units, or `undefined` before discovery completes
+- `current`: optional folder, file, drive, library, or snapshot label
+- `rate`: optional work units per second
+
+Operation-specific event members may narrow `current`, but consumers can render a useful progress bar from the common fields alone.
+
+All affected results expose `interrupted: boolean`. Existing fields and method signatures remain compatible.
+
+## Adapter Boundary
+
+SDK namespace factories translate public options into existing internal hooks:
+
+- `signal.aborted` becomes an interruption predicate.
+- `onProgress` receives events emitted at service safe points.
+- Existing CLI `BackupProgressReporter` and `TransferProgressReporter` adapters remain valid.
+
+The CLI does not need to adopt the SDK wrapper types. Public SDK naming remains camelCase; internal ports retain repository conventions.
+
+## Cancellation Semantics
+
+Cancellation is cooperative and checked between durable work units:
+
+- Outlook backup: between folders/pages/messages using the existing safe interruption hooks.
+- OneDrive backup: between drives and items.
+- SharePoint backup: between sites, libraries, and items.
+- Restore/save/verify: between messages, files, folders, manifests, or verification entries.
+
+An already-started Graph or S3 request finishes normally. The next safe-point check stops further work and emits one terminal `interrupted` event.
+
+A pre-aborted signal returns an interrupted zero-work result without beginning remote enumeration.
+
+## Delta Safety
+
+Outlook keeps the safe delta behavior implemented for issue #23.
+
+OneDrive and SharePoint must not persist a newly fetched delta link when cancellation leaves a drive or library partially processed. The previous persisted cursor remains authoritative. The next run re-enumerates those changes and content-addressed storage deduplicates completed objects.
+
+Completed drives or libraries may persist their cursor before cancellation is observed in a later unit.
+
+## Progress Ordering
+
+Each operation emits monotonic lifecycle events:
+
+1. `discovering`
+2. zero or more `processing`
+3. `finalizing` when durable result assembly begins
+4. exactly one terminal event: `completed` or `interrupted`
+
+`processed` never decreases within one operation. `total` may be absent during discovery, then becomes stable once known. Callback exceptions are isolated from the operation and do not fail backup or restore work.
+
+## Error Handling
+
+Cancellation and operational failure remain distinct:
+
+- Cancellation returns partial counts with `interrupted: true`.
+- Item-level failures continue through existing error accounting.
+- Fatal Graph, storage, crypto, or validation errors still reject.
+- Callback exceptions are ignored after optional debug logging.
+
+## Tests
+
+Focused contract tests cover:
+
+- typed SDK options and camelCase-to-internal adaptation;
+- lifecycle event order and monotonic counts;
+- pre-aborted and mid-operation signals;
+- graceful partial results for backup, restore, save, and verify;
+- Outlook, OneDrive, and SharePoint backup cursor preservation on partial work;
+- unchanged CLI reporter behavior.
+
+Full E2E validation uses the current Wisecom tenant and configured MinIO storage:
+
+1. Start an Outlook backup and abort from a progress callback.
+2. Assert `interrupted: true` and a terminal `interrupted` event.
+3. Rerun to completion and verify no delta/content loss.
+4. Exercise OneDrive and SharePoint progress callbacks and cancellation at safe points.
+5. Exercise restore/save/verify callbacks where tenant data permits.
+6. Remove every created tenant and storage artifact, including object versions and delete markers, and restore MinIO to its prior running state.
+
+## Documentation
+
+`docs/reference/sdk.md` documents:
+
+- option signatures for all three namespaces;
+- the `ProgressEvent` fields and phase ordering;
+- graceful cancellation and partial-result semantics;
+- an `AbortController` example;
+- the guarantee that cancellation waits for the current remote request to finish.

--- a/packages/cli/src/commands/outlook-backup.handler.tsx
+++ b/packages/cli/src/commands/outlook-backup.handler.tsx
@@ -109,6 +109,8 @@ async function backup_all_mailboxes(
 ): Promise<void> {
   const concurrency = Math.max(1, parseInt(options.concurrency ?? '4', 10) || 4);
   const page_size = Math.max(1, Math.min(100, parseInt(options.pageSize ?? '10', 10) || 10));
+  const object_lock_request = build_object_lock_request(options);
+  const object_lock_policy = build_object_lock_policy(options);
 
   logger.info(`Backing up all licensed and shared mailboxes (concurrency=${concurrency})`);
 
@@ -117,8 +119,8 @@ async function backup_all_mailboxes(
     concurrency,
     force_full: options.full ?? false,
     page_size,
-    object_lock_request: build_object_lock_request(options),
-    object_lock_policy: build_object_lock_policy(options),
+    ...(object_lock_request !== undefined && { object_lock_request }),
+    ...(object_lock_policy !== undefined && { object_lock_policy }),
   });
 
   const mailbox_errors = result.outcomes

--- a/packages/core/src/services/shared/operation-progress.ts
+++ b/packages/core/src/services/shared/operation-progress.ts
@@ -1,0 +1,53 @@
+import type { OperationControlOptions, OperationProgressEvent } from '@wisecom/atlas-types';
+
+type Operation = OperationProgressEvent['operation'];
+type Workload = OperationProgressEvent['workload'];
+
+/** Emits discovery progress and reports whether cancellation was requested. */
+export function begin_operation_progress(
+  control: OperationControlOptions,
+  operation: Operation,
+  workload: Workload,
+): boolean {
+  emit_operation_progress(control, { operation, workload, phase: 'discovering', processed: 0 });
+  return control.should_interrupt?.() === true;
+}
+
+/** Emits finalizing and exactly one terminal event, returning interruption state. */
+export function finish_operation_progress(
+  control: OperationControlOptions,
+  operation: Operation,
+  workload: Workload,
+  processed: number,
+  total?: number,
+  force_interrupted = false,
+): boolean {
+  emit_operation_progress(control, {
+    operation,
+    workload,
+    phase: 'finalizing',
+    processed,
+    ...(total === undefined ? {} : { total }),
+  });
+  const interrupted = force_interrupted || control.should_interrupt?.() === true;
+  emit_operation_progress(control, {
+    operation,
+    workload,
+    phase: interrupted ? 'interrupted' : 'completed',
+    processed,
+    ...(total === undefined ? {} : { total }),
+  });
+  return interrupted;
+}
+
+/** Calls a progress observer without allowing it to alter operation state. */
+export function emit_operation_progress(
+  control: OperationControlOptions,
+  event: OperationProgressEvent,
+): void {
+  try {
+    control.on_progress?.(event);
+  } catch {
+    // Progress observers are informational, never part of operation control.
+  }
+}

--- a/packages/core/src/services/verification/verification.service.ts
+++ b/packages/core/src/services/verification/verification.service.ts
@@ -11,6 +11,11 @@ import type {
 import { TENANT_CONTEXT_FACTORY_TOKEN, MANIFEST_REPOSITORY_TOKEN } from '@wisecom/atlas-types';
 import { merge_snapshot_entries } from '@/services/shared/manifest-entry-merger';
 import { ConcurrencySemaphore } from '@/services/shared/concurrency-semaphore';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@/services/shared/operation-progress';
 
 // S3 handles this easily; Graph limits don't apply -- verify never touches Graph.
 // ponytail: fixed constant, make configurable only if a backend ever chokes.
@@ -45,18 +50,24 @@ export class VerificationService implements VerificationUseCase {
     snapshot_id: string,
     options: VerificationOptions = {},
   ): Promise<VerificationResult> {
+    if (begin_operation_progress(options, 'verify', 'outlook')) {
+      finish_operation_progress(options, 'verify', 'outlook', 0, 0);
+      return {
+        snapshot_id,
+        total_checked: 0,
+        passed: 0,
+        failed: [],
+        unverifiable: [],
+        interrupted: true,
+        manifests_in_chain: 0,
+      };
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
-      options.on_progress?.({
-        operation: 'verify',
-        workload: 'outlook',
-        phase: 'discovering',
-        processed: 0,
-      });
       const chain = await this.load_manifest_chain(ctx, snapshot_id);
       const entries = merge_snapshot_entries(chain);
       const { items, unverifiable } = collect_check_items(entries);
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'verify',
         workload: 'outlook',
         phase: 'processing',
@@ -64,14 +75,14 @@ export class VerificationService implements VerificationUseCase {
         total: items.length,
       });
       const { failed, checked } = await this.check_all_items(ctx, items, options);
-      const interrupted = checked < items.length || options.should_interrupt?.() === true;
-      options.on_progress?.({
-        operation: 'verify',
-        workload: 'outlook',
-        phase: interrupted ? 'interrupted' : 'completed',
-        processed: checked,
-        total: items.length,
-      });
+      const interrupted = finish_operation_progress(
+        options,
+        'verify',
+        'outlook',
+        checked,
+        items.length,
+        checked < items.length,
+      );
       return {
         snapshot_id,
         total_checked: checked,
@@ -134,7 +145,7 @@ export class VerificationService implements VerificationUseCase {
               ? !(await this.object_exists(ctx, item))
               : await this.is_item_corrupt(ctx, item);
           checked++;
-          options.on_progress?.({
+          emit_operation_progress(options, {
             operation: 'verify',
             workload: 'outlook',
             phase: 'processing',

--- a/packages/core/src/services/verification/verification.service.ts
+++ b/packages/core/src/services/verification/verification.service.ts
@@ -47,16 +47,38 @@ export class VerificationService implements VerificationUseCase {
   ): Promise<VerificationResult> {
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
+      options.on_progress?.({
+        operation: 'verify',
+        workload: 'outlook',
+        phase: 'discovering',
+        processed: 0,
+      });
       const chain = await this.load_manifest_chain(ctx, snapshot_id);
       const entries = merge_snapshot_entries(chain);
       const { items, unverifiable } = collect_check_items(entries);
-      const failed = await this.check_all_items(ctx, items, options.fast === true);
+      options.on_progress?.({
+        operation: 'verify',
+        workload: 'outlook',
+        phase: 'processing',
+        processed: 0,
+        total: items.length,
+      });
+      const { failed, checked } = await this.check_all_items(ctx, items, options);
+      const interrupted = checked < items.length || options.should_interrupt?.() === true;
+      options.on_progress?.({
+        operation: 'verify',
+        workload: 'outlook',
+        phase: interrupted ? 'interrupted' : 'completed',
+        processed: checked,
+        total: items.length,
+      });
       return {
         snapshot_id,
-        total_checked: items.length,
-        passed: items.length - failed.length,
+        total_checked: checked,
+        passed: checked - failed.length,
         failed,
         unverifiable,
+        interrupted,
         manifests_in_chain: chain.length,
       };
     } finally {
@@ -98,22 +120,38 @@ export class VerificationService implements VerificationUseCase {
   private async check_all_items(
     ctx: TenantContext,
     items: CheckItem[],
-    fast: boolean,
-  ): Promise<string[]> {
+    options: VerificationOptions,
+  ): Promise<{ failed: string[]; checked: number }> {
     const semaphore = new ConcurrencySemaphore(VERIFY_CONCURRENCY);
+    let checked = 0;
     const corrupt = await Promise.all(
       items.map(async (item) => {
         await semaphore.acquire();
         try {
-          return fast
-            ? !(await this.object_exists(ctx, item))
-            : await this.is_item_corrupt(ctx, item);
+          if (options.should_interrupt?.() === true) return undefined;
+          const failed =
+            options.fast === true
+              ? !(await this.object_exists(ctx, item))
+              : await this.is_item_corrupt(ctx, item);
+          checked++;
+          options.on_progress?.({
+            operation: 'verify',
+            workload: 'outlook',
+            phase: 'processing',
+            processed: checked,
+            total: items.length,
+            current: item.id,
+          });
+          return failed;
         } finally {
           semaphore.release();
         }
       }),
     );
-    return items.filter((_, i) => corrupt[i]).map((item) => item.id);
+    return {
+      failed: items.filter((_, i) => corrupt[i] === true).map((item) => item.id),
+      checked,
+    };
   }
 
   /** Existence-only probe for fast mode; any error counts as missing. */

--- a/packages/core/tests/unit/services/verification.service.test.ts
+++ b/packages/core/tests/unit/services/verification.service.test.ts
@@ -268,4 +268,22 @@ describe('VerificationService', () => {
     expect(storage.get).not.toHaveBeenCalled();
     expect(context.decrypt).not.toHaveBeenCalled();
   });
+
+  it('does not start object reads after cancellation and returns partial counts', async () => {
+    const manifest = make_manifest([make_entry(), make_entry({ object_id: 'obj-2' })]);
+    vi.mocked(manifests.find_by_snapshot).mockResolvedValue(manifest);
+    const on_progress = vi.fn();
+
+    const result = await service.verify_snapshot_integrity('tenant-1', manifest.snapshot_id, {
+      should_interrupt: () => true,
+      on_progress,
+    });
+
+    expect(storage.get).not.toHaveBeenCalled();
+    expect(result.total_checked).toBe(0);
+    expect(result.interrupted).toBe(true);
+    expect(on_progress).toHaveBeenLastCalledWith(
+      expect.objectContaining({ operation: 'verify', workload: 'outlook', phase: 'interrupted' }),
+    );
+  });
 });

--- a/packages/core/tests/unit/services/verification.service.test.ts
+++ b/packages/core/tests/unit/services/verification.service.test.ts
@@ -279,6 +279,7 @@ describe('VerificationService', () => {
       on_progress,
     });
 
+    expect(tenant_factory.create).not.toHaveBeenCalled();
     expect(storage.get).not.toHaveBeenCalled();
     expect(result.total_checked).toBe(0);
     expect(result.interrupted).toBe(true);

--- a/packages/onedrive/src/services/onedrive-backup-builders.ts
+++ b/packages/onedrive/src/services/onedrive-backup-builders.ts
@@ -85,11 +85,13 @@ export function build_empty_result(
   versions_unavailable: number,
   errors: string[],
   warnings: string[],
+  interrupted: boolean,
   healthy: boolean,
 ): OneDriveBackupResult {
   return {
     owner_id,
     snapshot: undefined,
+    interrupted,
     summary: {
       drives_scanned,
       files_changed: 0,
@@ -161,11 +163,13 @@ export function build_success_result(
   versions_unavailable: number,
   errors: string[],
   warnings: string[],
+  interrupted: boolean,
   healthy: boolean,
 ): OneDriveBackupResult {
   return {
     owner_id,
     snapshot,
+    interrupted,
     summary: {
       drives_scanned,
       files_changed: snapshot.entries.length,

--- a/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
+++ b/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
@@ -8,6 +8,7 @@ import type {
   OneDriveFileVersionIndexRepository,
   OneDriveManifestEntry,
   TenantContext,
+  OperationControlOptions,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import {
@@ -50,6 +51,7 @@ export interface SingleDriveResult {
   /** Reason per item that failed this run. */
   errors: string[];
   package_report: PackageReport;
+  interrupted: boolean;
 }
 
 export interface DriveScanAccumulators {
@@ -61,6 +63,8 @@ export interface DriveScanAccumulators {
   failed_items: FailedItemLedger;
   /** Drive-level failures. Per-item failures live in `failed_items` instead. */
   errors: string[];
+  drives_scanned: number;
+  interrupted: boolean;
   package_report: PackageReportTotals;
 }
 
@@ -83,6 +87,7 @@ export async function scan_all_drives(
   version_stats: VersionStats,
   on_version_stats_update: (stored: number, unavailable: number, failed: number) => void,
   progress?: BackupProgressReporter,
+  control: OperationControlOptions = {},
 ): Promise<DriveScanAccumulators> {
   const accumulators: DriveScanAccumulators = {
     entries: [],
@@ -91,12 +96,19 @@ export async function scan_all_drives(
     deleted_items: 0,
     failed_items: { ...(previous_cursor?.failed_items ?? {}) },
     errors: [],
+    drives_scanned: 0,
+    interrupted: false,
     package_report: { notebooks_detected: 0, section_files_backed_up: 0, warnings: [] },
   };
 
   const totals: ScanProgressTotals = { processed: 0, total: 0, started_at: Date.now() };
 
   for (const [index, drive] of drives.entries()) {
+    if (control.should_interrupt?.() === true) {
+      accumulators.interrupted = true;
+      progress?.mark_all_pending_interrupted();
+      break;
+    }
     try {
       const prev_delta = force_full
         ? undefined
@@ -108,7 +120,18 @@ export async function scan_all_drives(
       progress?.mark_active(index);
 
       const versions_before = version_stats.total_versions_stored;
-      const on_item_processed = make_item_progress_callback(progress, index, totals);
+      const update_item_progress = make_item_progress_callback(progress, index, totals);
+      const on_item_processed = (item: OneDriveDeltaItem): void => {
+        update_item_progress();
+        control.on_progress?.({
+          operation: 'backup',
+          workload: 'onedrive',
+          phase: 'processing',
+          processed: totals.processed,
+          total: totals.total,
+          current: item.file_name,
+        });
+      };
 
       const drive_result = await process_single_drive(
         connector,
@@ -124,6 +147,7 @@ export async function scan_all_drives(
         version_stats,
         on_version_stats_update,
         on_item_processed,
+        control,
       );
 
       // Notebook accounting stands apart from the entry bookkeeping: a drive
@@ -131,6 +155,7 @@ export async function scan_all_drives(
       // incomplete, so it is folded in for every drive, failed or not.
       accumulate_package_report(accumulators.package_report, drive_result.package_report);
       accumulate_drive_result(accumulators, delta_link_by_drive, drive, drive_result);
+      accumulators.drives_scanned++;
 
       // Saved even when items failed: the successful entries are real, and the
       // ledger riding along is what keeps the failures from being forgotten.
@@ -141,13 +166,20 @@ export async function scan_all_drives(
         failed_items: accumulators.failed_items,
         updated_at: new Date().toISOString(),
       });
-      report_drive_success(
-        progress,
-        index,
-        delta.items.length === 0 && prev_delta !== undefined && drive_result.entries.length === 0,
-        drive_result,
-        version_stats.total_versions_stored - versions_before,
-      );
+      if (!drive_result.interrupted) {
+        report_drive_success(
+          progress,
+          index,
+          delta.items.length === 0 && prev_delta !== undefined && drive_result.entries.length === 0,
+          drive_result,
+          version_stats.total_versions_stored - versions_before,
+        );
+      }
+      if (drive_result.interrupted || control.should_interrupt?.() === true) {
+        accumulators.interrupted = true;
+        progress?.mark_all_pending_interrupted();
+        break;
+      }
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       logger.error(`Drive ${drive.drive_id} failed: ${reason}`);
@@ -171,8 +203,9 @@ function accumulate_drive_result(
   accumulators.files_deduplicated += drive_result.files_deduplicated;
   accumulators.deleted_items += drive_result.deleted_items;
   accumulators.failed_items = drive_result.failed_items;
+  accumulators.interrupted ||= drive_result.interrupted;
 
-  if (drive_result.delta_link) {
+  if (!drive_result.interrupted && drive_result.delta_link) {
     delta_link_by_drive[drive.drive_id] = drive_result.delta_link;
   }
   if (drive_result.errors.length > 0) {
@@ -210,7 +243,8 @@ export async function process_single_drive(
   failed_items: FailedItemLedger,
   version_stats: VersionStats,
   on_version_stats_update: (stored: number, unavailable: number, failed: number) => void,
-  on_item_processed?: () => void,
+  on_item_processed?: (item: OneDriveDeltaItem) => void,
+  control: OperationControlOptions = {},
 ): Promise<SingleDriveResult> {
   if (delta.reset_detected) {
     clear_file_tracking_on_reset(state);
@@ -241,12 +275,18 @@ export async function process_single_drive(
     deleted_items: 0,
     delta_link: delta.delta_link,
     failed_items: retry.ledger,
+    interrupted: false,
     errors: [],
     // Replaced once every item in this batch has been processed.
     package_report: { notebooks_detected: 0, section_files_backed_up: 0, warnings: [] },
   };
 
   for (const { item, from_delta } of queue) {
+    if (control.should_interrupt?.() === true) {
+      result.interrupted = true;
+      delete result.delta_link;
+      break;
+    }
     const outcome = await process_delta_item(
       connector,
       file_indexes,
@@ -259,7 +299,7 @@ export async function process_single_drive(
       on_version_stats_update,
     );
     // Progress rows were sized from the delta batch; retried items are extra.
-    if (from_delta) on_item_processed?.();
+    if (from_delta) on_item_processed?.(item);
 
     if (outcome.error) {
       logger.warn(`Drive ${drive.drive_id}: ${outcome.error}`);

--- a/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
+++ b/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
@@ -11,6 +11,7 @@ import type {
   OperationControlOptions,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { emit_operation_progress } from '@wisecom/atlas-core/services/shared/operation-progress';
 import {
   clear_item_failure,
   record_item_failure,
@@ -59,6 +60,7 @@ export interface DriveScanAccumulators {
   /** Drive-level failures. Per-item failures live in `failed_items` instead. */
   errors: string[];
   drives_scanned: number;
+  items_processed: number;
   interrupted: boolean;
   package_report: PackageReportTotals;
 }
@@ -92,6 +94,7 @@ export async function scan_all_drives(
     failed_items: { ...(previous_cursor?.failed_items ?? {}) },
     errors: [],
     drives_scanned: 0,
+    items_processed: 0,
     interrupted: false,
     package_report: { notebooks_detected: 0, section_files_backed_up: 0, warnings: [] },
   };
@@ -118,7 +121,8 @@ export async function scan_all_drives(
       const update_item_progress = make_item_progress_callback(progress, index, totals);
       const on_item_processed = (item: OneDriveDeltaItem): void => {
         update_item_progress();
-        control.on_progress?.({
+        accumulators.items_processed = totals.processed;
+        emit_operation_progress(control, {
           operation: 'backup',
           workload: 'onedrive',
           phase: 'processing',

--- a/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
+++ b/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
@@ -16,10 +16,7 @@ import {
   record_item_failure,
   type FailedItemLedger,
 } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
-import {
-  summarize_package_items,
-  type PackageReport,
-} from '@wisecom/atlas-core/services/shared/package-item-reporter';
+import type { PackageReport } from '@wisecom/atlas-core/services/shared/package-item-reporter';
 import {
   clear_file_tracking_on_reset,
   process_delta_item,
@@ -32,13 +29,11 @@ import {
   report_drive_success,
   type ScanProgressTotals,
 } from '@/services/onedrive-scan-progress';
-
-/** Package accounting summed across every drive in one run. */
-export interface PackageReportTotals {
-  notebooks_detected: number;
-  section_files_backed_up: number;
-  warnings: string[];
-}
+import {
+  accumulate_package_report,
+  summarize_processed_package_items,
+  type PackageReportTotals,
+} from '@/services/onedrive-package-report';
 
 export interface SingleDriveResult {
   entries: OneDriveManifestEntry[];
@@ -216,13 +211,6 @@ function accumulate_drive_result(
   }
 }
 
-/** Folds one drive's package report into the run-wide totals. */
-function accumulate_package_report(totals: PackageReportTotals, report: PackageReport): void {
-  totals.notebooks_detected += report.notebooks_detected;
-  totals.section_files_backed_up += report.section_files_backed_up;
-  totals.warnings.push(...report.warnings);
-}
-
 /**
  * Processes delta changes for a single OneDrive drive.
  *
@@ -258,10 +246,12 @@ export async function process_single_drive(
     drive.drive_id,
     failed_items,
     delta_item_ids,
+    control.should_interrupt,
   );
   // Ids that failed in THIS run drive notebook completeness; the ledger also
   // carries older failures, which say nothing about this batch.
   const failed_item_ids = new Set<string>();
+  const processed_delta_item_ids = new Set<string>();
 
   const queue: Array<{ item: OneDriveDeltaItem; from_delta: boolean }> = [
     ...retry.items.map((item) => ({ item, from_delta: false })),
@@ -275,14 +265,14 @@ export async function process_single_drive(
     deleted_items: 0,
     delta_link: delta.delta_link,
     failed_items: retry.ledger,
-    interrupted: false,
+    interrupted: retry.interrupted,
     errors: [],
     // Replaced once every item in this batch has been processed.
     package_report: { notebooks_detected: 0, section_files_backed_up: 0, warnings: [] },
   };
 
   for (const { item, from_delta } of queue) {
-    if (control.should_interrupt?.() === true) {
+    if (result.interrupted || control.should_interrupt?.() === true) {
       result.interrupted = true;
       delete result.delta_link;
       break;
@@ -300,6 +290,7 @@ export async function process_single_drive(
     );
     // Progress rows were sized from the delta batch; retried items are extra.
     if (from_delta) on_item_processed?.(item);
+    if (from_delta) processed_delta_item_ids.add(item.item_id);
 
     if (outcome.error) {
       logger.warn(`Drive ${drive.drive_id}: ${outcome.error}`);
@@ -321,6 +312,11 @@ export async function process_single_drive(
     if (outcome.entry) result.entries.push(outcome.entry);
   }
 
-  result.package_report = summarize_package_items(delta.items, failed_item_ids);
+  result.package_report = summarize_processed_package_items(
+    delta.items,
+    failed_item_ids,
+    processed_delta_item_ids,
+    result.interrupted,
+  );
   return result;
 }

--- a/packages/onedrive/src/services/onedrive-backup.service.ts
+++ b/packages/onedrive/src/services/onedrive-backup.service.ts
@@ -163,7 +163,9 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
       // hold the run unhealthy until the ledger is empty.
       warnings.push(...describe_failed_items(scan_result.failed_items));
       const healthy =
-        scan_result.errors.length === 0 && Object.keys(scan_result.failed_items).length === 0;
+        !scan_result.interrupted &&
+        scan_result.errors.length === 0 &&
+        Object.keys(scan_result.failed_items).length === 0;
 
       let result: OneDriveBackupResult;
       if (scan_result.entries.length === 0) {

--- a/packages/onedrive/src/services/onedrive-backup.service.ts
+++ b/packages/onedrive/src/services/onedrive-backup.service.ts
@@ -1,5 +1,10 @@
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { randomBytes } from 'node:crypto';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 import { inject, injectable } from 'inversify';
 import type {
   BackupProgressReporter,
@@ -52,13 +57,11 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
     options: OneDriveBackupOptions = {},
   ): Promise<OneDriveBackupResult> {
     owner_id = normalize_owner_id(owner_id);
+    if (begin_operation_progress(options, 'backup', 'onedrive')) {
+      finish_operation_progress(options, 'backup', 'onedrive', 0, 0);
+      return build_empty_result(owner_id, 0, 0, 0, 0, 0, 0, [], [], true, false);
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'backup',
-      workload: 'onedrive',
-      phase: 'discovering',
-      processed: 0,
-    });
     if (options.object_lock_request?.retention_days) {
       // Bucket default retention: every new object version (files, versions,
       // manifests, cursors) inherits the lock - no write path can forget it.
@@ -136,14 +139,14 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
         progress,
         options,
       );
-      const processed =
-        scan_result.files_stored + scan_result.files_deduplicated + scan_result.deleted_items;
-      options.on_progress?.({
+      const processed = scan_result.items_processed;
+      emit_operation_progress(options, {
         operation: 'backup',
         workload: 'onedrive',
         phase: 'finalizing',
         processed,
       });
+      scan_result.interrupted ||= options.should_interrupt?.() === true;
 
       const cursor: OneDriveDeltaCursor = {
         owner_id,
@@ -217,7 +220,7 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
         );
       }
 
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'backup',
         workload: 'onedrive',
         phase: scan_result.interrupted ? 'interrupted' : 'completed',

--- a/packages/onedrive/src/services/onedrive-backup.service.ts
+++ b/packages/onedrive/src/services/onedrive-backup.service.ts
@@ -27,10 +27,8 @@ import {
   persist_snapshot_backup,
 } from '@/services/onedrive-backup-builders';
 import { ensure_drives_discovered } from '@/services/onedrive-backup-file-processor';
-import {
-  scan_all_drives,
-  type PackageReportTotals,
-} from '@/services/onedrive-backup-drive-processor';
+import { scan_all_drives } from '@/services/onedrive-backup-drive-processor';
+import type { PackageReportTotals } from '@/services/onedrive-package-report';
 import { cleanup_stale_staging } from '@/services/onedrive-large-file-pipeline';
 import { describe_failed_items } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
 

--- a/packages/onedrive/src/services/onedrive-backup.service.ts
+++ b/packages/onedrive/src/services/onedrive-backup.service.ts
@@ -55,6 +55,12 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
   ): Promise<OneDriveBackupResult> {
     owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'backup',
+      workload: 'onedrive',
+      phase: 'discovering',
+      processed: 0,
+    });
     if (options.object_lock_request?.retention_days) {
       // Bucket default retention: every new object version (files, versions,
       // manifests, cursors) inherits the lock - no write path can forget it.
@@ -130,7 +136,16 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
         version_stats,
         update_version_stats,
         progress,
+        options,
       );
+      const processed =
+        scan_result.files_stored + scan_result.files_deduplicated + scan_result.deleted_items;
+      options.on_progress?.({
+        operation: 'backup',
+        workload: 'onedrive',
+        phase: 'finalizing',
+        processed,
+      });
 
       const cursor: OneDriveDeltaCursor = {
         owner_id,
@@ -150,11 +165,12 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
       const healthy =
         scan_result.errors.length === 0 && Object.keys(scan_result.failed_items).length === 0;
 
+      let result: OneDriveBackupResult;
       if (scan_result.entries.length === 0) {
         await this._cursors.save(ctx, cursor);
-        return build_empty_result(
+        result = build_empty_result(
           owner_id,
-          drives.length,
+          scan_result.drives_scanned,
           scan_result.files_stored,
           scan_result.files_deduplicated,
           scan_result.deleted_items,
@@ -162,43 +178,52 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
           total_versions_unavailable,
           scan_result.errors,
           warnings,
+          scan_result.interrupted,
+          healthy,
+        );
+      } else {
+        const snapshot = build_snapshot_manifest(
+          tenant_id,
+          owner_id,
+          scan_result.entries,
+          snapshot_id,
+          manifest_created_at,
+          options.owner_email,
+          options.owner_display_name,
+        );
+        await persist_snapshot_backup(
+          this._manifests,
+          this._file_indexes,
+          this._cursors,
+          ctx,
+          owner_id,
+          snapshot,
+          scan_result.entries,
+          cursor,
+        );
+        result = build_success_result(
+          owner_id,
+          snapshot,
+          scan_result.drives_scanned,
+          scan_result.files_stored,
+          scan_result.files_deduplicated,
+          scan_result.deleted_items,
+          total_versions_stored,
+          total_versions_unavailable,
+          scan_result.errors,
+          warnings,
+          scan_result.interrupted,
           healthy,
         );
       }
 
-      const snapshot = build_snapshot_manifest(
-        tenant_id,
-        owner_id,
-        scan_result.entries,
-        snapshot_id,
-        manifest_created_at,
-        options.owner_email,
-        options.owner_display_name,
-      );
-      await persist_snapshot_backup(
-        this._manifests,
-        this._file_indexes,
-        this._cursors,
-        ctx,
-        owner_id,
-        snapshot,
-        scan_result.entries,
-        cursor,
-      );
-
-      return build_success_result(
-        owner_id,
-        snapshot,
-        drives.length,
-        scan_result.files_stored,
-        scan_result.files_deduplicated,
-        scan_result.deleted_items,
-        total_versions_stored,
-        total_versions_unavailable,
-        scan_result.errors,
-        warnings,
-        healthy,
-      );
+      options.on_progress?.({
+        operation: 'backup',
+        workload: 'onedrive',
+        phase: scan_result.interrupted ? 'interrupted' : 'completed',
+        processed,
+      });
+      return result;
     } finally {
       progress?.finish();
       ctx.destroy();

--- a/packages/onedrive/src/services/onedrive-entry-filter.ts
+++ b/packages/onedrive/src/services/onedrive-entry-filter.ts
@@ -1,0 +1,15 @@
+import type { OneDriveManifestEntry } from '@wisecom/atlas-types';
+
+/** Filters manifest entries by file ID or full path, case-insensitively. */
+export function filter_onedrive_entries(
+  entries: readonly OneDriveManifestEntry[],
+  file_filter?: string[],
+): OneDriveManifestEntry[] {
+  if (!file_filter || file_filter.length === 0) return [...entries];
+  const selected = new Set(file_filter.map((value) => value.toLowerCase()));
+  return entries.filter(
+    (entry) =>
+      selected.has(entry.file_id.toLowerCase()) ||
+      selected.has(`${entry.parent_path}/${entry.file_name}`.toLowerCase()),
+  );
+}

--- a/packages/onedrive/src/services/onedrive-failed-item-retry.ts
+++ b/packages/onedrive/src/services/onedrive-failed-item-retry.ts
@@ -12,6 +12,7 @@ export interface RetryResolution {
   items: OneDriveDeltaItem[];
   /** Ledger with vanished items dropped and unreachable ones re-recorded. */
   ledger: FailedItemLedger;
+  interrupted: boolean;
 }
 
 /**
@@ -30,11 +31,13 @@ export async function resolve_retry_items(
   drive_id: string,
   ledger: FailedItemLedger,
   delta_item_ids: ReadonlySet<string>,
+  should_interrupt?: () => boolean,
 ): Promise<RetryResolution> {
   const items: OneDriveDeltaItem[] = [];
   let next_ledger = ledger;
 
   for (const record of retryable_items(ledger, drive_id)) {
+    if (should_interrupt?.() === true) return { items, ledger: next_ledger, interrupted: true };
     if (delta_item_ids.has(record.item_id)) continue;
 
     try {
@@ -56,5 +59,5 @@ export async function resolve_retry_items(
     }
   }
 
-  return { items, ledger: next_ledger };
+  return { items, ledger: next_ledger, interrupted: false };
 }

--- a/packages/onedrive/src/services/onedrive-package-report.ts
+++ b/packages/onedrive/src/services/onedrive-package-report.ts
@@ -1,0 +1,38 @@
+import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
+import {
+  summarize_package_items,
+  type PackageReport,
+} from '@wisecom/atlas-core/services/shared/package-item-reporter';
+
+/** Package accounting summed across every drive in one run. */
+export interface PackageReportTotals {
+  notebooks_detected: number;
+  section_files_backed_up: number;
+  warnings: string[];
+}
+
+/** Folds one drive's package report into the run-wide totals. */
+export function accumulate_package_report(
+  totals: PackageReportTotals,
+  report: PackageReport,
+): void {
+  totals.notebooks_detected += report.notebooks_detected;
+  totals.section_files_backed_up += report.section_files_backed_up;
+  totals.warnings.push(...report.warnings);
+}
+
+/** Marks unprocessed delta items incomplete when a drive is interrupted. */
+export function summarize_processed_package_items(
+  items: readonly OneDriveDeltaItem[],
+  failed_item_ids: ReadonlySet<string>,
+  processed_item_ids: ReadonlySet<string>,
+  interrupted: boolean,
+): PackageReport {
+  const incomplete_item_ids = new Set(failed_item_ids);
+  if (interrupted) {
+    for (const item of items) {
+      if (!processed_item_ids.has(item.item_id)) incomplete_item_ids.add(item.item_id);
+    }
+  }
+  return summarize_package_items(items, incomplete_item_ids);
+}

--- a/packages/onedrive/src/services/onedrive-restore-integrity.ts
+++ b/packages/onedrive/src/services/onedrive-restore-integrity.ts
@@ -1,0 +1,22 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/** Thrown when ciphertext decrypts but fails its AES-GCM authentication tag check. */
+export class OneDriveDecryptAuthError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'OneDriveDecryptAuthError';
+  }
+}
+
+/** Returns whether an error represents an AES-GCM authentication failure. */
+export function is_gcm_auth_failure(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes('Unsupported state') || message.toLowerCase().includes('auth');
+}
+
+/** Compares a plaintext buffer with its expected SHA-256 checksum. */
+export function plaintext_sha256_equals_expected(content: Buffer, expected_hex: string): boolean {
+  const actual_hex = createHash('sha256').update(content).digest('hex');
+  if (actual_hex.length !== expected_hex.length) return false;
+  return timingSafeEqual(Buffer.from(actual_hex, 'utf8'), Buffer.from(expected_hex, 'utf8'));
+}

--- a/packages/onedrive/src/services/onedrive-restore-result.ts
+++ b/packages/onedrive/src/services/onedrive-restore-result.ts
@@ -1,0 +1,13 @@
+import type { OneDriveRestoreResult } from '@wisecom/atlas-types';
+
+/** Builds the interrupted result returned before restore work starts. */
+export function empty_restore_result(snapshot_id: string): OneDriveRestoreResult {
+  return {
+    snapshot_id,
+    files_restored: 0,
+    folders_created: 0,
+    files_skipped: 0,
+    errors: [],
+    interrupted: true,
+  };
+}

--- a/packages/onedrive/src/services/onedrive-restore.service.ts
+++ b/packages/onedrive/src/services/onedrive-restore.service.ts
@@ -1,5 +1,4 @@
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
-import { createHash, timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
   OneDriveConnector,
@@ -22,16 +21,14 @@ import {
   stream_decrypt_from_storage,
   verify_streaming_checksum,
 } from '@/services/onedrive-restore-streaming';
+import {
+  is_gcm_auth_failure,
+  OneDriveDecryptAuthError,
+  plaintext_sha256_equals_expected,
+} from '@/services/onedrive-restore-integrity';
+import { filter_onedrive_entries } from '@/services/onedrive-entry-filter';
 
 const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
-
-/** Thrown when ciphertext decrypts with AES-GCM but fails the authentication tag check. */
-export class OneDriveDecryptAuthError extends Error {
-  constructor(message: string, options?: { cause?: unknown }) {
-    super(message, options);
-    this.name = 'OneDriveDecryptAuthError';
-  }
-}
 
 @injectable()
 export class OneDriveRestoreService implements OneDriveRestoreUseCase {
@@ -50,6 +47,12 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
   ): Promise<OneDriveRestoreResult> {
     owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'restore',
+      workload: 'onedrive',
+      phase: 'discovering',
+      processed: 0,
+    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, options.snapshot_id);
       if (!manifest) {
@@ -65,7 +68,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       const drive_id = primary_drive.drive_id;
 
       const conflict = options.conflict_behavior ?? 'rename';
-      const entries = this.filter_entries(manifest.entries, options.file_filter);
+      const entries = filter_onedrive_entries(manifest.entries, options.file_filter);
       const folder_ids = new Map<string, string>();
       folder_ids.set('/', 'root');
 
@@ -76,8 +79,16 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       const sorted_entries = [...entries].filter(
         (e) => e.change_type !== 'deleted' && e.storage_key,
       );
+      options.on_progress?.({
+        operation: 'restore',
+        workload: 'onedrive',
+        phase: 'processing',
+        processed: 0,
+        total: sorted_entries.length,
+      });
 
       for (const entry of sorted_entries) {
+        if (options.should_interrupt?.() === true) break;
         const result = await this.restore_single_entry(
           tenant_id,
           target_owner,
@@ -93,9 +104,25 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
           files_skipped++;
           if (result.error) errors.push(result.error);
         }
+        options.on_progress?.({
+          operation: 'restore',
+          workload: 'onedrive',
+          phase: 'processing',
+          processed: files_restored + files_skipped,
+          total: sorted_entries.length,
+          current: entry.file_name,
+        });
       }
 
       const folders_created = Math.max(0, folder_ids.size - 1);
+      const interrupted = options.should_interrupt?.() === true;
+      options.on_progress?.({
+        operation: 'restore',
+        workload: 'onedrive',
+        phase: interrupted ? 'interrupted' : 'completed',
+        processed: files_restored + files_skipped,
+        total: sorted_entries.length,
+      });
 
       return {
         snapshot_id: options.snapshot_id,
@@ -103,6 +130,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
         folders_created,
         files_skipped,
         errors,
+        interrupted,
       };
     } finally {
       ctx.destroy();
@@ -171,19 +199,6 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       logger.warn(`Skipped ${entry.file_name}: ${msg}`);
       return { restored: false, error: msg };
     }
-  }
-
-  private filter_entries(
-    entries: readonly OneDriveManifestEntry[],
-    file_filter?: string[],
-  ): OneDriveManifestEntry[] {
-    if (!file_filter || file_filter.length === 0) return [...entries];
-    const filter_set = new Set(file_filter.map((f) => f.toLowerCase()));
-    return entries.filter(
-      (e) =>
-        filter_set.has(e.file_id.toLowerCase()) ||
-        filter_set.has(`${e.parent_path}/${e.file_name}`.toLowerCase()),
-    );
   }
 
   private async ensure_folder_path(
@@ -301,16 +316,4 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       return undefined;
     }
   }
-}
-
-function is_gcm_auth_failure(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  const lower = msg.toLowerCase();
-  return msg.includes('Unsupported state') || lower.includes('auth');
-}
-
-function plaintext_sha256_equals_expected(content: Buffer, expected_hex: string): boolean {
-  const actual_hex = createHash('sha256').update(content).digest('hex');
-  if (actual_hex.length !== expected_hex.length) return false;
-  return timingSafeEqual(Buffer.from(actual_hex, 'utf8'), Buffer.from(expected_hex, 'utf8'));
 }

--- a/packages/onedrive/src/services/onedrive-restore.service.ts
+++ b/packages/onedrive/src/services/onedrive-restore.service.ts
@@ -1,4 +1,9 @@
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 import { inject, injectable } from 'inversify';
 import type {
   OneDriveConnector,
@@ -27,6 +32,7 @@ import {
   plaintext_sha256_equals_expected,
 } from '@/services/onedrive-restore-integrity';
 import { filter_onedrive_entries } from '@/services/onedrive-entry-filter';
+import { empty_restore_result } from '@/services/onedrive-restore-result';
 
 const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
 
@@ -46,13 +52,11 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
     options: OneDriveRestoreOptions,
   ): Promise<OneDriveRestoreResult> {
     owner_id = normalize_owner_id(owner_id);
+    if (begin_operation_progress(options, 'restore', 'onedrive')) {
+      finish_operation_progress(options, 'restore', 'onedrive', 0, 0);
+      return empty_restore_result(options.snapshot_id);
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'restore',
-      workload: 'onedrive',
-      phase: 'discovering',
-      processed: 0,
-    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, options.snapshot_id);
       if (!manifest) {
@@ -79,7 +83,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       const sorted_entries = [...entries].filter(
         (e) => e.change_type !== 'deleted' && e.storage_key,
       );
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'restore',
         workload: 'onedrive',
         phase: 'processing',
@@ -104,7 +108,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
           files_skipped++;
           if (result.error) errors.push(result.error);
         }
-        options.on_progress?.({
+        emit_operation_progress(options, {
           operation: 'restore',
           workload: 'onedrive',
           phase: 'processing',
@@ -115,14 +119,14 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       }
 
       const folders_created = Math.max(0, folder_ids.size - 1);
-      const interrupted = options.should_interrupt?.() === true;
-      options.on_progress?.({
-        operation: 'restore',
-        workload: 'onedrive',
-        phase: interrupted ? 'interrupted' : 'completed',
-        processed: files_restored + files_skipped,
-        total: sorted_entries.length,
-      });
+      const interrupted = finish_operation_progress(
+        options,
+        'restore',
+        'onedrive',
+        files_restored + files_skipped,
+        sorted_entries.length,
+        files_restored + files_skipped < sorted_entries.length,
+      );
 
       return {
         snapshot_id: options.snapshot_id,

--- a/packages/onedrive/src/services/onedrive-save.service.ts
+++ b/packages/onedrive/src/services/onedrive-save.service.ts
@@ -25,6 +25,7 @@ import {
   stream_decrypt_from_storage,
   verify_streaming_checksum,
 } from '@/services/onedrive-restore-streaming';
+import { filter_onedrive_entries } from '@/services/onedrive-entry-filter';
 
 @injectable()
 export class OneDriveSaveService implements OneDriveSaveUseCase {
@@ -42,17 +43,31 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
   ): Promise<FileSaveResult> {
     owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'save',
+      workload: 'onedrive',
+      phase: 'discovering',
+      processed: 0,
+    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, options.snapshot_id);
       if (!manifest) {
         throw new Error(`Snapshot ${options.snapshot_id} not found for owner ${owner_id}`);
       }
 
-      const entries = this.filter_entries(manifest.entries, options.file_filter);
+      const entries = filter_onedrive_entries(manifest.entries, options.file_filter);
       const restorable = entries.filter((e) => e.change_type !== 'deleted' && e.storage_key);
 
       if (restorable.length === 0) {
-        return this.empty_result(options.snapshot_id, options.output_path ?? '');
+        const interrupted = options.should_interrupt?.() === true;
+        options.on_progress?.({
+          operation: 'save',
+          workload: 'onedrive',
+          phase: interrupted ? 'interrupted' : 'completed',
+          processed: 0,
+          total: 0,
+        });
+        return this.empty_result(options.snapshot_id, options.output_path ?? '', interrupted);
       }
 
       const output_path =
@@ -60,35 +75,33 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
       const skip_integrity = options.skip_integrity_check ?? false;
       const { archive, promise } = create_file_archive(output_path);
 
-      let files_saved = 0;
-      let files_skipped = 0;
-      const errors: string[] = [];
       const integrity_failures: string[] = [];
+      const { files_saved, files_skipped, errors } = await this.save_restorable_entries_to_archive(
+        ctx,
+        archive,
+        restorable,
+        skip_integrity,
+        integrity_failures,
+        options,
+      );
 
-      for (const entry of restorable) {
-        try {
-          const content = await this.download_and_decrypt(
-            ctx,
-            entry,
-            skip_integrity,
-            integrity_failures,
-          );
-          if (!content) {
-            files_skipped++;
-            continue;
-          }
-          await add_file_to_archive(archive, entry.parent_path, entry.file_name, content);
-          files_saved++;
-          logger.info(`Saved: ${entry.parent_path}/${entry.file_name}`);
-        } catch (err) {
-          const msg = `${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`;
-          errors.push(msg);
-          files_skipped++;
-        }
-      }
-
+      options.on_progress?.({
+        operation: 'save',
+        workload: 'onedrive',
+        phase: 'finalizing',
+        processed: files_saved + files_skipped,
+        total: restorable.length,
+      });
       await finalize_file_archive(archive);
       const total_bytes = await promise;
+      const interrupted = options.should_interrupt?.() === true;
+      options.on_progress?.({
+        operation: 'save',
+        workload: 'onedrive',
+        phase: interrupted ? 'interrupted' : 'completed',
+        processed: files_saved + files_skipped,
+        total: restorable.length,
+      });
 
       return {
         snapshot_id: options.snapshot_id,
@@ -98,23 +111,64 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
         integrity_failures,
         output_path,
         total_bytes,
+        interrupted,
       };
     } finally {
       ctx.destroy();
     }
   }
 
-  private filter_entries(
-    entries: readonly OneDriveManifestEntry[],
-    file_filter?: string[],
-  ): OneDriveManifestEntry[] {
-    if (!file_filter || file_filter.length === 0) return [...entries];
-    const filter_set = new Set(file_filter.map((f) => f.toLowerCase()));
-    return entries.filter(
-      (e) =>
-        filter_set.has(e.file_id.toLowerCase()) ||
-        filter_set.has(`${e.parent_path}/${e.file_name}`.toLowerCase()),
-    );
+  /** Saves sequential entries until cancellation, reporting partial counts. */
+  private async save_restorable_entries_to_archive(
+    ctx: TenantContext,
+    archive: Parameters<typeof add_file_to_archive>[0],
+    entries: OneDriveManifestEntry[],
+    skip_integrity: boolean,
+    integrity_failures: string[],
+    options: FileSaveOptions,
+  ): Promise<{ files_saved: number; files_skipped: number; errors: string[] }> {
+    let files_saved = 0;
+    let files_skipped = 0;
+    const errors: string[] = [];
+    options.on_progress?.({
+      operation: 'save',
+      workload: 'onedrive',
+      phase: 'processing',
+      processed: 0,
+      total: entries.length,
+    });
+
+    for (const entry of entries) {
+      if (options.should_interrupt?.() === true) break;
+      try {
+        const content = await this.download_and_decrypt(
+          ctx,
+          entry,
+          skip_integrity,
+          integrity_failures,
+        );
+        if (!content) {
+          files_skipped++;
+        } else {
+          await add_file_to_archive(archive, entry.parent_path, entry.file_name, content);
+          files_saved++;
+          logger.info(`Saved: ${entry.parent_path}/${entry.file_name}`);
+        }
+      } catch (err) {
+        errors.push(`${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`);
+        files_skipped++;
+      }
+      options.on_progress?.({
+        operation: 'save',
+        workload: 'onedrive',
+        phase: 'processing',
+        processed: files_saved + files_skipped,
+        total: entries.length,
+        current: entry.file_name,
+      });
+    }
+
+    return { files_saved, files_skipped, errors };
   }
 
   private async download_and_decrypt(
@@ -169,7 +223,11 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
     }
   }
 
-  private empty_result(snapshot_id: string, output_path: string): FileSaveResult {
+  private empty_result(
+    snapshot_id: string,
+    output_path: string,
+    interrupted = false,
+  ): FileSaveResult {
     return {
       snapshot_id,
       files_saved: 0,
@@ -178,6 +236,7 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
       integrity_failures: [],
       output_path,
       total_bytes: 0,
+      interrupted,
     };
   }
 }

--- a/packages/onedrive/src/services/onedrive-save.service.ts
+++ b/packages/onedrive/src/services/onedrive-save.service.ts
@@ -1,4 +1,9 @@
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
@@ -42,13 +47,11 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
     options: FileSaveOptions,
   ): Promise<FileSaveResult> {
     owner_id = normalize_owner_id(owner_id);
+    if (begin_operation_progress(options, 'save', 'onedrive')) {
+      finish_operation_progress(options, 'save', 'onedrive', 0, 0);
+      return this.empty_result(options.snapshot_id, options.output_path ?? '', true);
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'save',
-      workload: 'onedrive',
-      phase: 'discovering',
-      processed: 0,
-    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, options.snapshot_id);
       if (!manifest) {
@@ -59,14 +62,7 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
       const restorable = entries.filter((e) => e.change_type !== 'deleted' && e.storage_key);
 
       if (restorable.length === 0) {
-        const interrupted = options.should_interrupt?.() === true;
-        options.on_progress?.({
-          operation: 'save',
-          workload: 'onedrive',
-          phase: interrupted ? 'interrupted' : 'completed',
-          processed: 0,
-          total: 0,
-        });
+        const interrupted = finish_operation_progress(options, 'save', 'onedrive', 0, 0);
         return this.empty_result(options.snapshot_id, options.output_path ?? '', interrupted);
       }
 
@@ -85,7 +81,7 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
         options,
       );
 
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'save',
         workload: 'onedrive',
         phase: 'finalizing',
@@ -94,8 +90,9 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
       });
       await finalize_file_archive(archive);
       const total_bytes = await promise;
-      const interrupted = options.should_interrupt?.() === true;
-      options.on_progress?.({
+      const interrupted =
+        files_saved + files_skipped < restorable.length || options.should_interrupt?.() === true;
+      emit_operation_progress(options, {
         operation: 'save',
         workload: 'onedrive',
         phase: interrupted ? 'interrupted' : 'completed',
@@ -130,7 +127,7 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
     let files_saved = 0;
     let files_skipped = 0;
     const errors: string[] = [];
-    options.on_progress?.({
+    emit_operation_progress(options, {
       operation: 'save',
       workload: 'onedrive',
       phase: 'processing',
@@ -158,7 +155,7 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
         errors.push(`${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`);
         files_skipped++;
       }
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'save',
         workload: 'onedrive',
         phase: 'processing',

--- a/packages/onedrive/src/services/onedrive-verification.service.ts
+++ b/packages/onedrive/src/services/onedrive-verification.service.ts
@@ -9,6 +9,7 @@ import type {
   OneDriveVerificationUseCase,
   TenantContext,
   TenantContextFactory,
+  VerificationOptions,
 } from '@wisecom/atlas-types';
 import {
   ONEDRIVE_FILE_VERSION_INDEX_REPOSITORY_TOKEN,
@@ -34,9 +35,16 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
     tenant_id: string,
     owner_id: string,
     snapshot_id: string,
+    options: VerificationOptions = {},
   ): Promise<OneDriveVerificationResult> {
     owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'verify',
+      workload: 'onedrive',
+      phase: 'discovering',
+      processed: 0,
+    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, snapshot_id);
       if (!manifest) {
@@ -46,8 +54,17 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
       const failed_file_ids: string[] = [];
       const index_issues: string[] = [];
       let total_checked = 0;
+      let processed = 0;
+      options.on_progress?.({
+        operation: 'verify',
+        workload: 'onedrive',
+        phase: 'processing',
+        processed: 0,
+        total: manifest.entries.length,
+      });
 
       for (const entry of manifest.entries) {
+        if (options.should_interrupt?.() === true) break;
         const idx = await this._indexes.find_by_file_id(ctx, manifest.owner_id, entry.file_id);
         const has_version = idx?.versions.some((v) => v.snapshot_id === snapshot_id);
         if (!has_version) {
@@ -56,12 +73,29 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
           );
         }
 
-        if (!this.entry_has_blob(entry)) continue;
-
-        total_checked++;
-        const corrupt = await this.is_blob_corrupt(ctx, entry);
-        if (corrupt) failed_file_ids.push(entry.file_id);
+        if (this.entry_has_blob(entry)) {
+          const corrupt = await this.is_blob_corrupt(ctx, entry);
+          total_checked++;
+          if (corrupt) failed_file_ids.push(entry.file_id);
+        }
+        processed++;
+        options.on_progress?.({
+          operation: 'verify',
+          workload: 'onedrive',
+          phase: 'processing',
+          processed,
+          total: manifest.entries.length,
+          current: entry.file_name,
+        });
       }
+      const interrupted = options.should_interrupt?.() === true;
+      options.on_progress?.({
+        operation: 'verify',
+        workload: 'onedrive',
+        phase: interrupted ? 'interrupted' : 'completed',
+        processed,
+        total: manifest.entries.length,
+      });
 
       return {
         snapshot_id,
@@ -69,6 +103,7 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
         passed: total_checked - failed_file_ids.length,
         failed_file_ids,
         index_issues,
+        interrupted,
       };
     } finally {
       ctx.destroy();

--- a/packages/onedrive/src/services/onedrive-verification.service.ts
+++ b/packages/onedrive/src/services/onedrive-verification.service.ts
@@ -1,4 +1,9 @@
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
@@ -38,13 +43,18 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
     options: VerificationOptions = {},
   ): Promise<OneDriveVerificationResult> {
     owner_id = normalize_owner_id(owner_id);
+    if (begin_operation_progress(options, 'verify', 'onedrive')) {
+      finish_operation_progress(options, 'verify', 'onedrive', 0, 0);
+      return {
+        snapshot_id,
+        total_checked: 0,
+        passed: 0,
+        failed_file_ids: [],
+        index_issues: [],
+        interrupted: true,
+      };
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'verify',
-      workload: 'onedrive',
-      phase: 'discovering',
-      processed: 0,
-    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, snapshot_id);
       if (!manifest) {
@@ -55,7 +65,7 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
       const index_issues: string[] = [];
       let total_checked = 0;
       let processed = 0;
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'verify',
         workload: 'onedrive',
         phase: 'processing',
@@ -79,7 +89,7 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
           if (corrupt) failed_file_ids.push(entry.file_id);
         }
         processed++;
-        options.on_progress?.({
+        emit_operation_progress(options, {
           operation: 'verify',
           workload: 'onedrive',
           phase: 'processing',
@@ -88,14 +98,14 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
           current: entry.file_name,
         });
       }
-      const interrupted = options.should_interrupt?.() === true;
-      options.on_progress?.({
-        operation: 'verify',
-        workload: 'onedrive',
-        phase: interrupted ? 'interrupted' : 'completed',
+      const interrupted = finish_operation_progress(
+        options,
+        'verify',
+        'onedrive',
         processed,
-        total: manifest.entries.length,
-      });
+        manifest.entries.length,
+        processed < manifest.entries.length,
+      );
 
       return {
         snapshot_id,

--- a/packages/onedrive/tests/unit/services/onedrive-backup-builders.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-backup-builders.test.ts
@@ -187,7 +187,7 @@ describe('build_snapshot_manifest', () => {
 
 describe('build_empty_result', () => {
   it('produces a result with snapshot undefined and given counters', () => {
-    const result = build_empty_result('owner-1', 2, 5, 3, 1, 4, 2, [], [], true);
+    const result = build_empty_result('owner-1', 2, 5, 3, 1, 4, 2, [], [], false, true);
 
     expect(result.owner_id).toBe('owner-1');
     expect(result.snapshot).toBeUndefined();
@@ -215,6 +215,7 @@ describe('build_empty_result', () => {
       0,
       ['timeout on file X'],
       [],
+      false,
       false,
     );
 

--- a/packages/onedrive/tests/unit/services/onedrive-backup-drive-processor.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-backup-drive-processor.test.ts
@@ -7,7 +7,13 @@ import type {
   OneDriveFileVersionIndexRepository,
   TenantContext,
 } from '@wisecom/atlas-types';
+import { process_delta_item } from '@/services/onedrive-delta-item-processor';
 import { scan_all_drives } from '@/services/onedrive-backup-drive-processor';
+
+vi.mock('@/services/onedrive-delta-item-processor', () => ({
+  clear_file_tracking_on_reset: vi.fn(),
+  process_delta_item: vi.fn(),
+}));
 
 const DRIVES: OneDriveDrive[] = [
   { drive_id: 'd1', drive_name: 'Documents' },
@@ -77,5 +83,66 @@ describe('scan_all_drives progress reporting', () => {
     ]);
     expect(result.errors).toHaveLength(1);
     expect(cursors.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops between items and retains the prior drive delta link', async () => {
+    let interrupted = false;
+    const items = ['item-1', 'item-2'].map((item_id) => ({
+      item_id,
+      drive_id: 'd1',
+      kind: 'file' as const,
+      file_name: `${item_id}.txt`,
+      parent_path: '/Documents',
+      size_bytes: 1,
+      deleted: false,
+    }));
+    const connector = {
+      fetch_delta: vi.fn().mockResolvedValue({
+        items,
+        delta_link: 'next-link',
+        reset_detected: false,
+      }),
+    } as unknown as OneDriveConnector;
+    vi.mocked(process_delta_item).mockResolvedValue({
+      files_stored: 1,
+      files_deduplicated: 0,
+      deleted_items: 0,
+    });
+    const cursors = { save: vi.fn() } as unknown as OneDriveDeltaCursorRepository;
+
+    const result = await scan_all_drives(
+      connector,
+      {} as OneDriveFileVersionIndexRepository,
+      cursors,
+      [DRIVES[0]!],
+      'tenant-1',
+      'owner-1',
+      'od-snap-test',
+      {} as TenantContext,
+      {
+        previous_path_by_file_id: {},
+        previous_name_by_file_id: {},
+        previous_etag_by_file_id: {},
+        previous_kind_by_file_id: {},
+      },
+      { d1: 'prev-link' },
+      { delta_link_by_drive: { d1: 'prev-link' } },
+      false,
+      { total_versions_stored: 0, total_versions_unavailable: 0, total_versions_failed: 0 },
+      () => {},
+      undefined,
+      {
+        should_interrupt: () => interrupted,
+        on_progress: () => {
+          interrupted = true;
+        },
+      },
+    );
+
+    expect(process_delta_item).toHaveBeenCalledOnce();
+    expect(result.interrupted).toBe(true);
+    expect(vi.mocked(cursors.save).mock.calls[0]![1].delta_link_by_drive).toEqual({
+      d1: 'prev-link',
+    });
   });
 });

--- a/packages/onedrive/tests/unit/services/onedrive-failed-item-ledger.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-failed-item-ledger.test.ts
@@ -159,12 +159,34 @@ describe('OneDrive persistent item failure (issue #34)', () => {
       poison_ids: ['p1'],
     });
 
-    const result = await harness.service.backup_onedrive('t', OWNER_ID);
+    const processed: number[] = [];
+    const result = await harness.service.backup_onedrive('t', OWNER_ID, {
+      on_progress: (event) => processed.push(event.processed),
+    });
 
     expect(result.snapshot?.entries.map((entry) => entry.file_id)).toEqual(['ok1', 'ok2']);
     expect(result.summary.files_stored).toBe(2);
     expect(drive_cursor(harness).delta_link_by_drive[DRIVE_ID]).toBe('delta-2');
     expect(harness.fetch_item_by_id).not.toHaveBeenCalled();
+    expect(processed.every((count, index) => index === 0 || count >= processed[index - 1]!)).toBe(
+      true,
+    );
+  });
+
+  it('keeps stored files and cursor state when a progress observer throws', async () => {
+    const harness = make_harness({
+      delta_items: [make_item('ok1', 'a.txt')],
+      delta_link: 'delta-2',
+    });
+
+    const result = await harness.service.backup_onedrive('t', OWNER_ID, {
+      on_progress: () => {
+        throw new Error('observer failed');
+      },
+    });
+
+    expect(result.snapshot?.entries.map((entry) => entry.file_id)).toEqual(['ok1']);
+    expect(drive_cursor(harness).delta_link_by_drive[DRIVE_ID]).toBe('delta-2');
   });
 
   it('records the failed item in the saved cursor and reports the run unhealthy', async () => {

--- a/packages/onedrive/tests/unit/services/onedrive-failed-item-ledger.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-failed-item-ledger.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi, type Mock } from 'vitest';
 import type {
   OneDriveDeltaCursor,
   OneDriveDeltaItem,
+  OneDriveConnector,
   TenantContext,
   TenantContextFactory,
 } from '@wisecom/atlas-types';
 import { MAX_FAILED_ITEM_ATTEMPTS } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
 import { OneDriveBackupService } from '@/services/onedrive-backup.service';
+import { resolve_retry_items } from '@/services/onedrive-failed-item-retry';
 
 // Issue #34: one persistently failing file must not freeze a drive's delta
 // cursor. The run keeps its successful entries, advances the delta link, and
@@ -256,5 +258,22 @@ describe('OneDrive persistent item failure (issue #34)', () => {
       expect.stringContaining(`PERMANENTLY SKIPPED after ${MAX_FAILED_ITEM_ATTEMPTS} attempts`),
     ]);
     expect(result.summary.healthy).toBe(false);
+  });
+  it('does not fetch another failed item after cancellation', async () => {
+    const fetch_item_by_id = vi.fn();
+    const connector = { fetch_item_by_id } as unknown as OneDriveConnector;
+
+    const result = await resolve_retry_items(
+      connector,
+      't',
+      OWNER_ID,
+      DRIVE_ID,
+      { p1: make_failure('p1', 1) },
+      new Set<string>(),
+      () => true,
+    );
+
+    expect(result.interrupted).toBe(true);
+    expect(fetch_item_by_id).not.toHaveBeenCalled();
   });
 });

--- a/packages/onedrive/tests/unit/services/onedrive-file-filter.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-file-filter.test.ts
@@ -6,10 +6,8 @@
  * before and 1 after.
  */
 import { describe, it, expect } from 'vitest';
-import 'reflect-metadata';
-import { OneDriveRestoreService } from '@/services/onedrive-restore.service';
-import { OneDriveSaveService } from '@/services/onedrive-save.service';
 import type { OneDriveManifestEntry } from '@wisecom/atlas-types';
+import { filter_onedrive_entries } from '@/services/onedrive-entry-filter';
 
 const ITEM_ID = '01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3';
 
@@ -21,37 +19,24 @@ const ENTRY = {
   storage_key: 'onedrive/data/o/abc',
 } as OneDriveManifestEntry;
 
-interface Filterable {
-  filter_entries(
-    entries: readonly OneDriveManifestEntry[],
-    file_filter?: string[],
-  ): OneDriveManifestEntry[];
-}
-
-/** `filter_entries` is private; both services must answer the same way. */
-const services: [string, Filterable][] = [
-  ['restore', OneDriveRestoreService.prototype as unknown as Filterable],
-  ['save', OneDriveSaveService.prototype as unknown as Filterable],
-];
-
-describe.each(services)('%s file_filter', (_name, service) => {
+describe('OneDrive file_filter', () => {
   it('matches an item id pasted verbatim from a listing', () => {
-    expect(service.filter_entries([ENTRY], [ITEM_ID])).toHaveLength(1);
+    expect(filter_onedrive_entries([ENTRY], [ITEM_ID])).toHaveLength(1);
   });
 
   it('matches an item id typed in any case', () => {
-    expect(service.filter_entries([ENTRY], [ITEM_ID.toLowerCase()])).toHaveLength(1);
+    expect(filter_onedrive_entries([ENTRY], [ITEM_ID.toLowerCase()])).toHaveLength(1);
   });
 
   it('still matches by path', () => {
-    expect(service.filter_entries([ENTRY], ['/documents/report.docx'])).toHaveLength(1);
+    expect(filter_onedrive_entries([ENTRY], ['/documents/report.docx'])).toHaveLength(1);
   });
 
   it('excludes what was not asked for', () => {
-    expect(service.filter_entries([ENTRY], ['/Documents/Other.docx'])).toHaveLength(0);
+    expect(filter_onedrive_entries([ENTRY], ['/Documents/Other.docx'])).toHaveLength(0);
   });
 
   it('returns everything when no filter is given', () => {
-    expect(service.filter_entries([ENTRY], [])).toHaveLength(1);
+    expect(filter_onedrive_entries([ENTRY], [])).toHaveLength(1);
   });
 });

--- a/packages/onedrive/tests/unit/services/onedrive-save.service.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-save.service.test.ts
@@ -201,5 +201,33 @@ describe('OneDriveSaveService', () => {
       expect(result.files_saved).toBe(1);
       expect(result.integrity_failures).toHaveLength(0);
     });
+
+    it('stops between files and returns partial counts when interrupted', async () => {
+      const manifest = make_manifest([
+        make_entry(),
+        make_entry({ file_id: 'file-2', file_name: 'budget.xlsx' }),
+      ]);
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(manifest);
+      let interrupted = false;
+      vi.mocked(mock_context.storage.get).mockImplementation(async () => {
+        interrupted = true;
+        return Buffer.from('encrypted-content');
+      });
+      const on_progress = vi.fn();
+
+      const result = await service.save_snapshot('test-tenant', 'owner-1', {
+        snapshot_id: 'od-snap-1',
+        output_path: '/tmp/interrupted.zip',
+        should_interrupt: () => interrupted,
+        on_progress,
+      });
+
+      expect(mock_context.storage.get).toHaveBeenCalledOnce();
+      expect(result.files_saved).toBe(1);
+      expect(result.interrupted).toBe(true);
+      expect(on_progress).toHaveBeenLastCalledWith(
+        expect.objectContaining({ operation: 'save', workload: 'onedrive', phase: 'interrupted' }),
+      );
+    });
   });
 });

--- a/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
+++ b/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
@@ -1,0 +1,132 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  OneDriveConnector,
+  OneDriveFileVersionIndexRepository,
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveRestoreService } from '@/services/onedrive-restore.service';
+import { OneDriveVerificationService } from '@/services/onedrive-verification.service';
+
+const CONTENT = Buffer.from('file-content');
+const CHECKSUM = createHash('sha256').update(CONTENT).digest('hex');
+
+function make_entry(file_id: string): OneDriveManifestEntry {
+  return {
+    file_id,
+    drive_id: 'drive-1',
+    file_name: `${file_id}.txt`,
+    parent_path: '/',
+    size_bytes: CONTENT.length,
+    change_type: 'updated',
+    backup_at: '2026-08-17T00:00:00.000Z',
+    storage_key: `onedrive/data/${file_id}`,
+    checksum: CHECKSUM,
+  };
+}
+
+function make_manifest(): OneDriveSnapshotManifest {
+  const entries = [make_entry('file-1'), make_entry('file-2')];
+  return {
+    id: 'manifest-1',
+    tenant_id: 'tenant-1',
+    snapshot_id: 'snap-1',
+    owner_id: 'owner-1',
+    created_at: new Date('2026-08-17T00:00:00.000Z'),
+    total_files: entries.length,
+    total_size_bytes: entries.reduce((sum, entry) => sum + entry.size_bytes, 0),
+    entries,
+  };
+}
+
+function make_context(storage: TenantContext['storage']): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage,
+    encrypt: vi.fn((data: Buffer) => data),
+    decrypt: vi.fn((data: Buffer) => data),
+    create_cipher: vi.fn(),
+    create_decipher: vi.fn(),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+function make_manifest_repository(manifest: OneDriveSnapshotManifest): OneDriveManifestRepository {
+  return {
+    find_by_snapshot: vi.fn().mockResolvedValue(manifest),
+  } as unknown as OneDriveManifestRepository;
+}
+
+describe('OneDrive operation cancellation', () => {
+  it('restore finishes the current file then stops with partial counts', async () => {
+    let interrupted = false;
+    const storage = {
+      get: vi.fn().mockImplementation(async () => {
+        interrupted = true;
+        return CONTENT;
+      }),
+    } as unknown as TenantContext['storage'];
+    const context = make_context(storage);
+    const factory = {
+      create: vi.fn().mockResolvedValue(context),
+    } as unknown as TenantContextFactory;
+    const connector = {
+      list_drives: vi.fn().mockResolvedValue([{ drive_id: 'drive-1', drive_name: 'Documents' }]),
+      upload_small_file: vi.fn().mockResolvedValue(undefined),
+    } as unknown as OneDriveConnector;
+    const on_progress = vi.fn();
+    const service = new OneDriveRestoreService(
+      factory,
+      connector,
+      make_manifest_repository(make_manifest()),
+    );
+
+    const result = await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+      should_interrupt: () => interrupted,
+      on_progress,
+    });
+
+    expect(connector.upload_small_file).toHaveBeenCalledOnce();
+    expect(result.files_restored).toBe(1);
+    expect(result.interrupted).toBe(true);
+    expect(on_progress).toHaveBeenLastCalledWith(
+      expect.objectContaining({ operation: 'restore', workload: 'onedrive', phase: 'interrupted' }),
+    );
+  });
+
+  it('verify does not start index or blob reads after cancellation', async () => {
+    const storage = {
+      exists: vi.fn(),
+      get: vi.fn(),
+    } as unknown as TenantContext['storage'];
+    const context = make_context(storage);
+    const factory = {
+      create: vi.fn().mockResolvedValue(context),
+    } as unknown as TenantContextFactory;
+    const indexes = { find_by_file_id: vi.fn() } as unknown as OneDriveFileVersionIndexRepository;
+    const on_progress = vi.fn();
+    const service = new OneDriveVerificationService(
+      factory,
+      make_manifest_repository(make_manifest()),
+      indexes,
+    );
+
+    const result = await service.verify_onedrive_snapshot('tenant-1', 'owner-1', 'snap-1', {
+      should_interrupt: () => true,
+      on_progress,
+    });
+
+    expect(indexes.find_by_file_id).not.toHaveBeenCalled();
+    expect(storage.exists).not.toHaveBeenCalled();
+    expect(result.total_checked).toBe(0);
+    expect(result.interrupted).toBe(true);
+    expect(on_progress).toHaveBeenLastCalledWith(
+      expect.objectContaining({ operation: 'verify', workload: 'onedrive', phase: 'interrupted' }),
+    );
+  });
+});

--- a/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
+++ b/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
@@ -9,7 +9,9 @@ import type {
   TenantContext,
   TenantContextFactory,
 } from '@wisecom/atlas-types';
+import { OneDriveBackupService } from '@/services/onedrive-backup.service';
 import { OneDriveRestoreService } from '@/services/onedrive-restore.service';
+import { OneDriveSaveService } from '@/services/onedrive-save.service';
 import { OneDriveVerificationService } from '@/services/onedrive-verification.service';
 
 const CONTENT = Buffer.from('file-content');
@@ -62,6 +64,53 @@ function make_manifest_repository(manifest: OneDriveSnapshotManifest): OneDriveM
 }
 
 describe('OneDrive operation cancellation', () => {
+  it('does no remote work when every operation starts interrupted', async () => {
+    const factory = { create: vi.fn() } as unknown as TenantContextFactory;
+    const callbacks = Array.from({ length: 4 }, () => vi.fn());
+    const should_interrupt = (): boolean => true;
+    const backup = new OneDriveBackupService(
+      factory,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+    const restore = new OneDriveRestoreService(factory, {} as never, {} as never);
+    const save = new OneDriveSaveService(factory, {} as never);
+    const verify = new OneDriveVerificationService(factory, {} as never, {} as never);
+
+    const results = await Promise.all([
+      backup.backup_onedrive('tenant-1', 'owner-1', {
+        should_interrupt,
+        on_progress: callbacks[0],
+      }),
+      restore.restore_onedrive('tenant-1', 'owner-1', {
+        snapshot_id: 'snap-1',
+        should_interrupt,
+        on_progress: callbacks[1],
+      }),
+      save.save_snapshot('tenant-1', 'owner-1', {
+        snapshot_id: 'snap-1',
+        should_interrupt,
+        on_progress: callbacks[2],
+      }),
+      verify.verify_onedrive_snapshot('tenant-1', 'owner-1', 'snap-1', {
+        should_interrupt,
+        on_progress: callbacks[3],
+      }),
+    ]);
+
+    expect(factory.create).not.toHaveBeenCalled();
+    expect(results.every((result) => result.interrupted)).toBe(true);
+    for (const callback of callbacks) {
+      expect(callback.mock.calls.map(([event]) => event.phase)).toEqual([
+        'discovering',
+        'finalizing',
+        'interrupted',
+      ]);
+    }
+  });
+
   it('restore finishes the current file then stops with partial counts', async () => {
     let interrupted = false;
     const storage = {
@@ -97,6 +146,13 @@ describe('OneDrive operation cancellation', () => {
     expect(on_progress).toHaveBeenLastCalledWith(
       expect.objectContaining({ operation: 'restore', workload: 'onedrive', phase: 'interrupted' }),
     );
+    expect(on_progress.mock.calls.map(([event]) => event.phase)).toEqual([
+      'discovering',
+      'processing',
+      'processing',
+      'finalizing',
+      'interrupted',
+    ]);
   });
 
   it('verify does not start index or blob reads after cancellation', async () => {
@@ -121,6 +177,7 @@ describe('OneDrive operation cancellation', () => {
       on_progress,
     });
 
+    expect(factory.create).not.toHaveBeenCalled();
     expect(indexes.find_by_file_id).not.toHaveBeenCalled();
     expect(storage.exists).not.toHaveBeenCalled();
     expect(result.total_checked).toBe(0);

--- a/packages/outlook/src/services/backup/folder-sync-executor.ts
+++ b/packages/outlook/src/services/backup/folder-sync-executor.ts
@@ -4,7 +4,11 @@ import type { MailboxConnector, MailMessage } from '@wisecom/atlas-types';
 import type { ManifestEntry } from '@wisecom/atlas-types';
 import { fetch_and_store_attachments } from '@/services/backup/attachment-storage-sync';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
-import type { BackupProgressReporter, ObjectLockPolicy } from '@wisecom/atlas-types';
+import type {
+  BackupProgressReporter,
+  ObjectLockPolicy,
+  OperationProgressCallback,
+} from '@wisecom/atlas-types';
 
 export interface FolderSyncResult {
   entries: ManifestEntry[];
@@ -31,6 +35,7 @@ export interface FolderSyncParams {
   progress: BackupProgressReporter;
   is_interrupted: () => boolean;
   is_hard_stopped: () => boolean;
+  on_progress?: OperationProgressCallback;
   prev_delta_link?: string;
   previous_manifest_entries?: number;
   page_size?: number;
@@ -117,6 +122,7 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
     progress,
     is_interrupted,
     is_hard_stopped,
+    on_progress,
     prev_delta_link,
     folder_total,
     page_size,
@@ -178,6 +184,15 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
       const msg_eta = rate > 0 ? (global_total - gp) / rate : 0;
       progress.update_total(gp, global_total, rate, msg_eta);
       progress.update_active(folder_index, folder_processed, rate, msg_eta);
+      on_progress?.({
+        operation: 'backup',
+        workload: 'outlook',
+        phase: 'processing',
+        processed: gp,
+        total: global_total,
+        current: message.subject ?? message.message_id,
+        rate,
+      });
     }
 
     await flush_pending_attachments(
@@ -243,6 +258,15 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
       const eta = rate > 0 ? (global_total - gp) / rate : 0;
       progress.update_total(gp, global_total, rate, eta);
       progress.update_active(folder_index, folder_processed, rate, eta);
+      on_progress?.({
+        operation: 'backup',
+        workload: 'outlook',
+        phase: 'processing',
+        processed: gp,
+        total: global_total,
+        current: message.subject ?? message.message_id,
+        rate,
+      });
     }
 
     await flush_pending_attachments(

--- a/packages/outlook/src/services/backup/folder-sync-executor.ts
+++ b/packages/outlook/src/services/backup/folder-sync-executor.ts
@@ -7,8 +7,9 @@ import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import type {
   BackupProgressReporter,
   ObjectLockPolicy,
-  OperationProgressCallback,
+  OperationControlOptions,
 } from '@wisecom/atlas-types';
+import { emit_operation_progress } from '@wisecom/atlas-core/services/shared/operation-progress';
 
 export interface FolderSyncResult {
   entries: ManifestEntry[];
@@ -35,7 +36,7 @@ export interface FolderSyncParams {
   progress: BackupProgressReporter;
   is_interrupted: () => boolean;
   is_hard_stopped: () => boolean;
-  on_progress?: OperationProgressCallback;
+  operation_control: OperationControlOptions;
   prev_delta_link?: string;
   previous_manifest_entries?: number;
   page_size?: number;
@@ -122,7 +123,7 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
     progress,
     is_interrupted,
     is_hard_stopped,
-    on_progress,
+    operation_control,
     prev_delta_link,
     folder_total,
     page_size,
@@ -184,7 +185,7 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
       const msg_eta = rate > 0 ? (global_total - gp) / rate : 0;
       progress.update_total(gp, global_total, rate, msg_eta);
       progress.update_active(folder_index, folder_processed, rate, msg_eta);
-      on_progress?.({
+      emit_operation_progress(operation_control, {
         operation: 'backup',
         workload: 'outlook',
         phase: 'processing',
@@ -258,7 +259,7 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
       const eta = rate > 0 ? (global_total - gp) / rate : 0;
       progress.update_total(gp, global_total, rate, eta);
       progress.update_active(folder_index, folder_processed, rate, eta);
-      on_progress?.({
+      emit_operation_progress(operation_control, {
         operation: 'backup',
         workload: 'outlook',
         phase: 'processing',

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -7,18 +7,18 @@ import type { ManifestEntry, ManifestObjectLockPolicy } from '@wisecom/atlas-typ
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { assert_mailbox_exists } from '@wisecom/atlas-core/services/shared/mailbox-assertions';
 import { sync_single_folder } from '@/services/backup/folder-sync-executor';
-import { folder_matches_selector } from '@/services/shared/folder-selector';
+import { apply_folder_filter } from '@/services/shared/folder-selector';
 import {
   build_manifest,
   create_pending_snapshot,
   mark_snapshot_completed,
+  resolve_sync_mode,
 } from '@/services/backup/snapshot-manifest-builder';
 import type {
   BackupProgressReporter,
   BackupUseCase,
   SyncOptions,
   SyncResult,
-  BackupSyncMode,
 } from '@wisecom/atlas-types';
 import {
   TENANT_CONTEXT_FACTORY_TOKEN,
@@ -67,6 +67,12 @@ export class MailboxSyncService implements BackupUseCase {
         owner_display_name: options.owner_display_name,
       });
       const sync_start = Date.now();
+      options.on_progress?.({
+        operation: 'backup',
+        workload: 'outlook',
+        phase: 'discovering',
+        processed: 0,
+      });
       const should_interrupt: () => boolean = options.should_interrupt ?? always_false;
       const should_force_stop: () => boolean = options.should_force_stop ?? always_false;
 
@@ -75,10 +81,10 @@ export class MailboxSyncService implements BackupUseCase {
         : await this._manifests.find_latest_by_owner(ctx, owner_id);
       const saved_links = previous?.delta_links ?? {};
       const previous_entry_count = previous?.total_objects ?? 0;
-      const mode = this.resolve_sync_mode(options, saved_links);
+      const mode = resolve_sync_mode(options.force_full, saved_links);
 
       const all_folders = await this._connector.list_mail_folders(tenant_id, owner_id);
-      const folder_selection = this.apply_folder_filter(all_folders, options.folder_filter);
+      const folder_selection = apply_folder_filter(all_folders, options.folder_filter);
       const folders = folder_selection.folders;
       const warnings = [...folder_selection.warnings];
       const progress =
@@ -88,6 +94,13 @@ export class MailboxSyncService implements BackupUseCase {
         ) ??
         NOOP_BACKUP_PROGRESS_REPORTER;
       const global_total = folders.reduce((sum, f) => sum + f.total_item_count, 0);
+      options.on_progress?.({
+        operation: 'backup',
+        workload: 'outlook',
+        phase: 'processing',
+        processed: 0,
+        total: global_total,
+      });
 
       const all_entries: ManifestEntry[] = [];
       const new_delta_links: Record<string, string> = {};
@@ -144,8 +157,16 @@ export class MailboxSyncService implements BackupUseCase {
         progress.mark_done(i, outcome.stored, outcome.deduplicated, outcome.attachments_stored);
       }
 
-      if (should_interrupt()) progress.mark_all_pending_interrupted();
+      const interrupted = should_interrupt();
+      if (interrupted) progress.mark_all_pending_interrupted();
       progress.finish(global_processed);
+      options.on_progress?.({
+        operation: 'backup',
+        workload: 'outlook',
+        phase: 'finalizing',
+        processed: global_processed,
+        total: global_total,
+      });
 
       const merged_links = { ...saved_links, ...new_delta_links };
       const manifest = build_manifest(
@@ -158,12 +179,20 @@ export class MailboxSyncService implements BackupUseCase {
         mailbox_purpose,
       );
       await this._manifests.save(ctx, manifest);
+      options.on_progress?.({
+        operation: 'backup',
+        workload: 'outlook',
+        phase: interrupted ? 'interrupted' : 'completed',
+        processed: global_processed,
+        total: global_total,
+      });
 
       const completed = mark_snapshot_completed(snapshot, all_entries.length);
       return {
         snapshot: completed,
         manifest,
         mode,
+        interrupted,
         summary: {
           stored,
           deduplicated,
@@ -171,7 +200,7 @@ export class MailboxSyncService implements BackupUseCase {
           processed: global_processed,
           folder_errors,
           warnings,
-          interrupted: should_interrupt(),
+          interrupted,
           completed_folder_count: Object.keys(new_delta_links).length,
           total_folder_count: folders.length,
           elapsed_ms: Date.now() - sync_start,
@@ -224,6 +253,7 @@ export class MailboxSyncService implements BackupUseCase {
         progress,
         is_interrupted: should_interrupt,
         is_hard_stopped: should_force_stop,
+        ...(options.on_progress ? { on_progress: options.on_progress } : {}),
         ...(prev_link !== undefined ? { prev_delta_link: prev_link } : {}),
         previous_manifest_entries: previous_entry_count,
         ...(options.page_size !== undefined ? { page_size: options.page_size } : {}),
@@ -268,41 +298,6 @@ export class MailboxSyncService implements BackupUseCase {
         retain_until: options.object_lock_policy.retain_until,
       },
     };
-  }
-
-  private resolve_sync_mode(
-    options: SyncOptions,
-    saved_links: Record<string, string>,
-  ): BackupSyncMode {
-    if (options.force_full) return 'full';
-    if (Object.keys(saved_links).length > 0) return 'incremental';
-    return 'initial';
-  }
-
-  /**
-   * Filters the folder list by user-supplied selectors. A selector matches a
-   * full path (`Inbox/Projects`) or a bare folder name at any depth
-   * (`Projects`), and always includes the matched folder's subtree.
-   * Returns all folders if no filter is specified.
-   */
-  private apply_folder_filter(
-    folders: MailFolder[],
-    filter?: string[],
-  ): { folders: MailFolder[]; warnings: string[] } {
-    if (!filter || filter.length === 0) return { folders, warnings: [] };
-
-    const matched = folders.filter((f) =>
-      filter.some((selector) => folder_matches_selector(f.folder_path, selector)),
-    );
-    const warnings: string[] = [];
-
-    for (const selector of filter) {
-      if (matched.some((f) => folder_matches_selector(f.folder_path, selector))) continue;
-      const available = folders.map((f) => f.folder_path).join(', ');
-      warnings.push(`Folder "${selector}" not found. Available: ${available}`);
-    }
-
-    return { folders: matched, warnings };
   }
 
   private async warn_if_replica(ctx: {

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -6,6 +6,11 @@ import type { ManifestRepository } from '@wisecom/atlas-types';
 import type { ManifestEntry, ManifestObjectLockPolicy } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { assert_mailbox_exists } from '@wisecom/atlas-core/services/shared/mailbox-assertions';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 import { sync_single_folder } from '@/services/backup/folder-sync-executor';
 import { apply_folder_filter } from '@/services/shared/folder-selector';
 import {
@@ -14,6 +19,10 @@ import {
   mark_snapshot_completed,
   resolve_sync_mode,
 } from '@/services/backup/snapshot-manifest-builder';
+import {
+  build_interrupted_result,
+  mark_progress_interrupted,
+} from '@/services/backup/outlook-interrupted-result';
 import type {
   BackupProgressReporter,
   BackupUseCase,
@@ -57,6 +66,10 @@ export class MailboxSyncService implements BackupUseCase {
     options: SyncOptions = {},
   ): Promise<SyncResult> {
     owner_id = normalize_owner_id(owner_id);
+    if (begin_operation_progress(options, 'backup', 'outlook')) {
+      finish_operation_progress(options, 'backup', 'outlook', 0, 0);
+      return build_interrupted_result(tenant_id, owner_id, options);
+    }
     await assert_mailbox_exists(this._connector, tenant_id, owner_id);
     const mailbox_purpose = await this._connector.get_mailbox_purpose?.(tenant_id, owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
@@ -67,12 +80,6 @@ export class MailboxSyncService implements BackupUseCase {
         owner_display_name: options.owner_display_name,
       });
       const sync_start = Date.now();
-      options.on_progress?.({
-        operation: 'backup',
-        workload: 'outlook',
-        phase: 'discovering',
-        processed: 0,
-      });
       const should_interrupt: () => boolean = options.should_interrupt ?? always_false;
       const should_force_stop: () => boolean = options.should_force_stop ?? always_false;
 
@@ -94,7 +101,7 @@ export class MailboxSyncService implements BackupUseCase {
         ) ??
         NOOP_BACKUP_PROGRESS_REPORTER;
       const global_total = folders.reduce((sum, f) => sum + f.total_item_count, 0);
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'backup',
         workload: 'outlook',
         phase: 'processing',
@@ -157,10 +164,9 @@ export class MailboxSyncService implements BackupUseCase {
         progress.mark_done(i, outcome.stored, outcome.deduplicated, outcome.attachments_stored);
       }
 
-      let interrupted = should_interrupt();
-      if (interrupted) progress.mark_all_pending_interrupted();
+      let interrupted = mark_progress_interrupted(progress, should_interrupt());
       progress.finish(global_processed);
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'backup',
         workload: 'outlook',
         phase: 'finalizing',
@@ -180,7 +186,7 @@ export class MailboxSyncService implements BackupUseCase {
       );
       await this._manifests.save(ctx, manifest);
       interrupted ||= should_interrupt();
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'backup',
         workload: 'outlook',
         phase: interrupted ? 'interrupted' : 'completed',
@@ -254,7 +260,7 @@ export class MailboxSyncService implements BackupUseCase {
         progress,
         is_interrupted: should_interrupt,
         is_hard_stopped: should_force_stop,
-        ...(options.on_progress ? { on_progress: options.on_progress } : {}),
+        operation_control: options,
         ...(prev_link !== undefined ? { prev_delta_link: prev_link } : {}),
         previous_manifest_entries: previous_entry_count,
         ...(options.page_size !== undefined ? { page_size: options.page_size } : {}),

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -157,7 +157,7 @@ export class MailboxSyncService implements BackupUseCase {
         progress.mark_done(i, outcome.stored, outcome.deduplicated, outcome.attachments_stored);
       }
 
-      const interrupted = should_interrupt();
+      let interrupted = should_interrupt();
       if (interrupted) progress.mark_all_pending_interrupted();
       progress.finish(global_processed);
       options.on_progress?.({
@@ -179,6 +179,7 @@ export class MailboxSyncService implements BackupUseCase {
         mailbox_purpose,
       );
       await this._manifests.save(ctx, manifest);
+      interrupted ||= should_interrupt();
       options.on_progress?.({
         operation: 'backup',
         workload: 'outlook',

--- a/packages/outlook/src/services/backup/outlook-interrupted-result.ts
+++ b/packages/outlook/src/services/backup/outlook-interrupted-result.ts
@@ -1,0 +1,47 @@
+import type { BackupProgressReporter, SyncOptions, SyncResult } from '@wisecom/atlas-types';
+import {
+  build_manifest,
+  create_pending_snapshot,
+  mark_snapshot_completed,
+  resolve_sync_mode,
+} from '@/services/backup/snapshot-manifest-builder';
+
+/** Builds a zero-work result when backup is cancelled before discovery. */
+export function build_interrupted_result(
+  tenant_id: string,
+  owner_id: string,
+  options: SyncOptions,
+): SyncResult {
+  const pending = create_pending_snapshot(tenant_id, owner_id, {
+    owner_email: options.owner_email,
+    owner_display_name: options.owner_display_name,
+  });
+  const snapshot = mark_snapshot_completed(pending, 0);
+  return {
+    snapshot,
+    manifest: build_manifest(owner_id, snapshot.id, [], {}, 0, undefined, undefined),
+    mode: resolve_sync_mode(options.force_full, {}),
+    interrupted: true,
+    summary: {
+      stored: 0,
+      deduplicated: 0,
+      attachments_stored: 0,
+      processed: 0,
+      folder_errors: [],
+      warnings: [],
+      interrupted: true,
+      completed_folder_count: 0,
+      total_folder_count: 0,
+      elapsed_ms: 0,
+    },
+  };
+}
+
+/** Marks pending dashboard rows and preserves the interruption state. */
+export function mark_progress_interrupted(
+  progress: BackupProgressReporter,
+  interrupted: boolean,
+): boolean {
+  if (interrupted) progress.mark_all_pending_interrupted();
+  return interrupted;
+}

--- a/packages/outlook/src/services/backup/snapshot-manifest-builder.ts
+++ b/packages/outlook/src/services/backup/snapshot-manifest-builder.ts
@@ -7,6 +7,7 @@ import type {
   ManifestEntry,
   ManifestObjectLockPolicy,
 } from '@wisecom/atlas-types';
+import type { BackupSyncMode } from '@wisecom/atlas-types';
 
 export interface OwnerIdentityHint {
   readonly owner_email?: string | undefined;
@@ -75,4 +76,13 @@ export function build_manifest(
     ...(mailbox_purpose ? { mailbox_purpose } : {}),
     entries,
   };
+}
+
+/** Resolves whether a mailbox run is full, incremental, or its initial backup. */
+export function resolve_sync_mode(
+  force_full: boolean | undefined,
+  saved_links: Record<string, string>,
+): BackupSyncMode {
+  if (force_full) return 'full';
+  return Object.keys(saved_links).length > 0 ? 'incremental' : 'initial';
 }

--- a/packages/outlook/src/services/restore/restore-execution-orchestrator.ts
+++ b/packages/outlook/src/services/restore/restore-execution-orchestrator.ts
@@ -14,7 +14,7 @@ import {
   create_restore_root,
   ensure_subfolder,
 } from '@/services/restore/folder-restore-planner';
-import type { TransferProgressReporter } from '@wisecom/atlas-types';
+import type { OperationProgressCallback, TransferProgressReporter } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -66,6 +66,7 @@ export async function restore_folder_entries(
   start: number,
   dashboard: TransferProgressReporter,
   is_interrupted: () => boolean,
+  on_progress?: OperationProgressCallback,
 ): Promise<{ restored: number; attachments: number; errors: string[] }> {
   let restored = 0;
   let attachments = 0;
@@ -100,6 +101,15 @@ export async function restore_folder_entries(
       eta_seconds: eta,
     });
     dashboard.update_total(gp, global_total, rate, eta);
+    on_progress?.({
+      operation: 'restore',
+      workload: 'outlook',
+      phase: 'processing',
+      processed: gp,
+      total: global_total,
+      current: entry.subject ?? entry.object_id,
+      rate,
+    });
   }
 
   return { restored, attachments, errors };
@@ -163,6 +173,7 @@ export async function restore_single_message(
     errors: [],
     verification_warnings: [],
     restore_folder_name: root.display_name,
+    interrupted: false,
   };
 }
 

--- a/packages/outlook/src/services/restore/restore-execution-orchestrator.ts
+++ b/packages/outlook/src/services/restore/restore-execution-orchestrator.ts
@@ -14,9 +14,10 @@ import {
   create_restore_root,
   ensure_subfolder,
 } from '@/services/restore/folder-restore-planner';
-import type { OperationProgressCallback, TransferProgressReporter } from '@wisecom/atlas-types';
+import type { OperationControlOptions, TransferProgressReporter } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { emit_operation_progress } from '@wisecom/atlas-core/services/shared/operation-progress';
 
 /** Decrypts, sanitizes, creates one message via Graph, then uploads attachments. */
 export async function restore_one_entry(
@@ -66,7 +67,7 @@ export async function restore_folder_entries(
   start: number,
   dashboard: TransferProgressReporter,
   is_interrupted: () => boolean,
-  on_progress?: OperationProgressCallback,
+  control: OperationControlOptions,
 ): Promise<{ restored: number; attachments: number; errors: string[] }> {
   let restored = 0;
   let attachments = 0;
@@ -101,7 +102,7 @@ export async function restore_folder_entries(
       eta_seconds: eta,
     });
     dashboard.update_total(gp, global_total, rate, eta);
-    on_progress?.({
+    emit_operation_progress(control, {
       operation: 'restore',
       workload: 'outlook',
       phase: 'processing',

--- a/packages/outlook/src/services/restore/restore-loop-executor.ts
+++ b/packages/outlook/src/services/restore/restore-loop-executor.ts
@@ -8,7 +8,7 @@ import {
   log_restore_summary,
   restore_folder_entries,
 } from '@/services/restore/restore-execution-orchestrator';
-import type { TransferProgressReporter } from '@wisecom/atlas-types';
+import type { OperationControlOptions, TransferProgressReporter } from '@wisecom/atlas-types';
 
 /** Iterates folder groups and restores messages with dashboard progress and SIGINT handling. */
 export async function execute_restore_loop(
@@ -22,6 +22,7 @@ export async function execute_restore_loop(
   folder_map: Map<string, string>,
   created_folders: Map<string, string>,
   dashboard: TransferProgressReporter,
+  control: OperationControlOptions = {},
 ): Promise<RestoreResult> {
   let global_restored = 0;
   let global_att = 0;
@@ -34,12 +35,20 @@ export async function execute_restore_loop(
   const on_sigint = (): void => {
     interrupted = true;
   };
+  const is_interrupted = (): boolean => interrupted || control.should_interrupt?.() === true;
   process.on('SIGINT', on_sigint);
 
   try {
+    control.on_progress?.({
+      operation: 'restore',
+      workload: 'outlook',
+      phase: 'processing',
+      processed: 0,
+      total: global_total,
+    });
     let folder_index = 0;
     for (const [fid, folder_items] of groups) {
-      if (interrupted) break;
+      if (is_interrupted()) break;
       dashboard.mark_active(folder_index);
 
       const target_fid = await ensure_subfolder(
@@ -64,7 +73,8 @@ export async function execute_restore_loop(
         global_total,
         start,
         dashboard,
-        () => interrupted,
+        is_interrupted,
+        control.on_progress,
       );
 
       global_restored += result.restored;
@@ -76,14 +86,22 @@ export async function execute_restore_loop(
       const eta = rate > 0 ? (global_total - global_restored) / rate : 0;
       dashboard.update_total(global_restored, global_total, rate, eta);
 
-      if (interrupted) break;
+      if (is_interrupted()) break;
       dashboard.mark_done(folder_index, result.restored, result.attachments);
       folder_index++;
     }
 
-    if (interrupted) dashboard.mark_all_pending_interrupted();
+    const was_interrupted = is_interrupted();
+    if (was_interrupted) dashboard.mark_all_pending_interrupted();
     dashboard.finish(global_restored);
     log_restore_summary(global_restored, global_att, global_errors, start);
+    control.on_progress?.({
+      operation: 'restore',
+      workload: 'outlook',
+      phase: was_interrupted ? 'interrupted' : 'completed',
+      processed: global_restored,
+      total: global_total,
+    });
 
     return {
       snapshot_id,
@@ -94,6 +112,7 @@ export async function execute_restore_loop(
       errors: all_errors,
       verification_warnings: [],
       restore_folder_name: root.display_name,
+      interrupted: was_interrupted,
     };
   } finally {
     process.removeListener('SIGINT', on_sigint);

--- a/packages/outlook/src/services/restore/restore-loop-executor.ts
+++ b/packages/outlook/src/services/restore/restore-loop-executor.ts
@@ -3,6 +3,10 @@ import type { ManifestEntry } from '@wisecom/atlas-types';
 import type { RestoreConnector } from '@wisecom/atlas-types';
 import type { RestoreResult } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
+import {
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 import { ensure_subfolder } from '@/services/restore/folder-restore-planner';
 import {
   log_restore_summary,
@@ -39,7 +43,7 @@ export async function execute_restore_loop(
   process.on('SIGINT', on_sigint);
 
   try {
-    control.on_progress?.({
+    emit_operation_progress(control, {
       operation: 'restore',
       workload: 'outlook',
       phase: 'processing',
@@ -74,7 +78,7 @@ export async function execute_restore_loop(
         start,
         dashboard,
         is_interrupted,
-        control.on_progress,
+        control,
       );
 
       global_restored += result.restored;
@@ -91,17 +95,18 @@ export async function execute_restore_loop(
       folder_index++;
     }
 
-    const was_interrupted = is_interrupted();
-    if (was_interrupted) dashboard.mark_all_pending_interrupted();
+    const interrupted_before_finalization = is_interrupted();
+    if (interrupted_before_finalization) dashboard.mark_all_pending_interrupted();
     dashboard.finish(global_restored);
     log_restore_summary(global_restored, global_att, global_errors, start);
-    control.on_progress?.({
-      operation: 'restore',
-      workload: 'outlook',
-      phase: was_interrupted ? 'interrupted' : 'completed',
-      processed: global_restored,
-      total: global_total,
-    });
+    const was_interrupted = finish_operation_progress(
+      control,
+      'restore',
+      'outlook',
+      global_restored,
+      global_total,
+      interrupted_before_finalization,
+    );
 
     return {
       snapshot_id,

--- a/packages/outlook/src/services/restore/restore.service.ts
+++ b/packages/outlook/src/services/restore/restore.service.ts
@@ -26,6 +26,11 @@ import {
   MAILBOX_CONNECTOR_TOKEN,
   RESTORE_CONNECTOR_TOKEN,
 } from '@wisecom/atlas-types';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 
 @injectable()
 export class RestoreService implements RestoreUseCase {
@@ -45,13 +50,10 @@ export class RestoreService implements RestoreUseCase {
     snapshot_id: string,
     options: RestoreOptions = {},
   ): Promise<RestoreResult> {
+    if (begin_operation_progress(options, 'restore', 'outlook')) {
+      return this.finish_empty_result(snapshot_id, options);
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'restore',
-      workload: 'outlook',
-      phase: 'discovering',
-      processed: 0,
-    });
     try {
       const manifest = await this.load_manifest(ctx, snapshot_id);
       const source_mailbox = manifest.owner_id;
@@ -62,13 +64,13 @@ export class RestoreService implements RestoreUseCase {
       const entries = await this.resolve_entries(ctx, manifest, source_mailbox, tenant_id, options);
       if (entries.length === 0) {
         logger.warn('No entries to restore');
-        return this.empty_result(snapshot_id);
+        return this.finish_empty_result(snapshot_id, options);
       }
 
       if (options.message_ref) {
         if (options.should_interrupt?.() === true) {
           const result = this.empty_result(snapshot_id, true);
-          options.on_progress?.({
+          emit_operation_progress(options, {
             operation: 'restore',
             workload: 'outlook',
             phase: 'interrupted',
@@ -77,7 +79,7 @@ export class RestoreService implements RestoreUseCase {
           });
           return result;
         }
-        options.on_progress?.({
+        emit_operation_progress(options, {
           operation: 'restore',
           workload: 'outlook',
           phase: 'processing',
@@ -95,14 +97,7 @@ export class RestoreService implements RestoreUseCase {
           snapshot_id,
           entries[0]!,
         );
-        const interrupted = options.should_interrupt?.() === true;
-        options.on_progress?.({
-          operation: 'restore',
-          workload: 'outlook',
-          phase: interrupted ? 'interrupted' : 'completed',
-          processed: 1,
-          total: 1,
-        });
+        const interrupted = finish_operation_progress(options, 'restore', 'outlook', 1, 1);
         return { ...result, interrupted };
       }
 
@@ -129,13 +124,10 @@ export class RestoreService implements RestoreUseCase {
     owner_id: string,
     options: RestoreOptions = {},
   ): Promise<RestoreResult> {
+    if (begin_operation_progress(options, 'restore', 'outlook')) {
+      return this.finish_empty_result('mailbox', options);
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'restore',
-      workload: 'outlook',
-      phase: 'discovering',
-      processed: 0,
-    });
     try {
       const target = options.target_mailbox?.toLowerCase() ?? owner_id;
 
@@ -144,7 +136,7 @@ export class RestoreService implements RestoreUseCase {
       const manifests = await this.load_mailbox_manifests(ctx, owner_id, options);
       if (manifests.length === 0) {
         logger.warn('No snapshots found for this mailbox in the given date range');
-        return this.empty_result('mailbox');
+        return this.finish_empty_result('mailbox', options);
       }
 
       const entries = merge_snapshot_entries(manifests);
@@ -157,7 +149,7 @@ export class RestoreService implements RestoreUseCase {
 
       if (filtered.length === 0) {
         logger.warn('No entries to restore after filtering');
-        return this.empty_result('mailbox');
+        return this.finish_empty_result('mailbox', options);
       }
 
       logger.info(`Aggregated ${manifests.length} snapshots -- ${filtered.length} unique messages`);
@@ -285,6 +277,11 @@ export class RestoreService implements RestoreUseCase {
           `Verify the email address and try again.`,
       );
     }
+  }
+
+  private finish_empty_result(snapshot_id: string, options: RestoreOptions): RestoreResult {
+    const interrupted = finish_operation_progress(options, 'restore', 'outlook', 0, 0);
+    return this.empty_result(snapshot_id, interrupted);
   }
 
   private empty_result(snapshot_id: string, interrupted = false): RestoreResult {

--- a/packages/outlook/src/services/restore/restore.service.ts
+++ b/packages/outlook/src/services/restore/restore.service.ts
@@ -46,6 +46,12 @@ export class RestoreService implements RestoreUseCase {
     options: RestoreOptions = {},
   ): Promise<RestoreResult> {
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'restore',
+      workload: 'outlook',
+      phase: 'discovering',
+      processed: 0,
+    });
     try {
       const manifest = await this.load_manifest(ctx, snapshot_id);
       const source_mailbox = manifest.owner_id;
@@ -60,7 +66,26 @@ export class RestoreService implements RestoreUseCase {
       }
 
       if (options.message_ref) {
-        return restore_single_message(
+        if (options.should_interrupt?.() === true) {
+          const result = this.empty_result(snapshot_id, true);
+          options.on_progress?.({
+            operation: 'restore',
+            workload: 'outlook',
+            phase: 'interrupted',
+            processed: 0,
+            total: 1,
+          });
+          return result;
+        }
+        options.on_progress?.({
+          operation: 'restore',
+          workload: 'outlook',
+          phase: 'processing',
+          processed: 0,
+          total: 1,
+          current: entries[0]!.subject ?? entries[0]!.object_id,
+        });
+        const result = await restore_single_message(
           ctx,
           this._connector,
           this._restore_connector,
@@ -70,6 +95,15 @@ export class RestoreService implements RestoreUseCase {
           snapshot_id,
           entries[0]!,
         );
+        const interrupted = options.should_interrupt?.() === true;
+        options.on_progress?.({
+          operation: 'restore',
+          workload: 'outlook',
+          phase: interrupted ? 'interrupted' : 'completed',
+          processed: 1,
+          total: 1,
+        });
+        return { ...result, interrupted };
       }
 
       return this.restore_batch(
@@ -96,6 +130,12 @@ export class RestoreService implements RestoreUseCase {
     options: RestoreOptions = {},
   ): Promise<RestoreResult> {
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'restore',
+      workload: 'outlook',
+      phase: 'discovering',
+      processed: 0,
+    });
     try {
       const target = options.target_mailbox?.toLowerCase() ?? owner_id;
 
@@ -232,6 +272,7 @@ export class RestoreService implements RestoreUseCase {
       folder_map,
       created_folders,
       dashboard,
+      options,
     );
   }
 
@@ -246,7 +287,7 @@ export class RestoreService implements RestoreUseCase {
     }
   }
 
-  private empty_result(snapshot_id: string): RestoreResult {
+  private empty_result(snapshot_id: string, interrupted = false): RestoreResult {
     return {
       snapshot_id,
       restored_count: 0,
@@ -256,6 +297,7 @@ export class RestoreService implements RestoreUseCase {
       errors: [],
       verification_warnings: [],
       restore_folder_name: '',
+      interrupted,
     };
   }
 }

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -8,9 +8,10 @@ import {
   add_eml_to_archive,
   finalize_archive,
 } from '@/services/save/save-zip-writer';
-import type { OperationProgressCallback, TransferProgressReporter } from '@wisecom/atlas-types';
+import type { OperationControlOptions, TransferProgressReporter } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { emit_operation_progress } from '@wisecom/atlas-core/services/shared/operation-progress';
 
 interface DecryptedAttachment {
   readonly name: string;
@@ -36,21 +37,27 @@ export async function save_entries_to_archive(
   folder_map: Map<string, string>,
   dashboard: TransferProgressReporter,
   is_interrupted: () => boolean,
-  on_progress?: OperationProgressCallback,
-): Promise<Omit<SaveResult, 'snapshot_id' | 'interrupted'>> {
+  control: OperationControlOptions,
+): Promise<Omit<SaveResult, 'snapshot_id'> & { processed: number }> {
   const { archive, promise } = create_save_archive(output_path);
 
   let global_saved = 0;
   let global_att = 0;
   let global_errors = 0;
+  let global_processed = 0;
   const all_errors: string[] = [];
   const integrity_failures: string[] = [];
+  let interrupted = false;
+  const should_interrupt = (): boolean => {
+    interrupted ||= is_interrupted();
+    return interrupted;
+  };
   const start = Date.now();
   const global_total = [...groups.values()].reduce((s, g) => s + g.length, 0);
 
   let folder_index = 0;
   for (const [fid, folder_items] of groups) {
-    if (is_interrupted()) break;
+    if (should_interrupt()) break;
     dashboard.mark_active(folder_index);
 
     const folder_name = folder_map.get(fid) ?? 'Unknown';
@@ -68,28 +75,28 @@ export async function save_entries_to_archive(
       global_total,
       start,
       dashboard,
-      is_interrupted,
+      should_interrupt,
       { all_errors, integrity_failures },
-      on_progress,
+      control,
     );
 
     global_errors += folder_result.error_count;
-
-    if (!is_interrupted()) {
+    if (!should_interrupt()) {
       dashboard.mark_done(folder_index, folder_result.folder_saved, folder_result.folder_att);
     }
 
     global_saved += folder_result.folder_saved;
     global_att += folder_result.folder_att;
+    global_processed += folder_result.folder_processed;
     folder_index++;
   }
 
   dashboard.show_finalizing();
-  on_progress?.({
+  emit_operation_progress(control, {
     operation: 'save',
     workload: 'outlook',
     phase: 'finalizing',
-    processed: global_saved,
+    processed: global_processed,
     total: global_total,
   });
   await finalize_archive(archive);
@@ -105,6 +112,8 @@ export async function save_entries_to_archive(
     output_path,
     total_bytes,
     integrity_failures,
+    processed: global_processed,
+    interrupted: should_interrupt(),
   };
 }
 
@@ -135,11 +144,12 @@ async function process_folder_entries(
   dashboard: TransferProgressReporter,
   is_interrupted: () => boolean,
   counters: FolderEntryCounters,
-  on_progress?: OperationProgressCallback,
+  control: OperationControlOptions,
 ): Promise<{
   folder_saved: number;
   folder_att: number;
   error_count: number;
+  folder_processed: number;
 }> {
   let folder_saved = 0;
   let folder_processed = 0;
@@ -186,7 +196,7 @@ async function process_folder_entries(
       eta_seconds: eta,
     });
     dashboard.update_total(gp, global_total, rate, eta);
-    on_progress?.({
+    emit_operation_progress(control, {
       operation: 'save',
       workload: 'outlook',
       phase: 'processing',
@@ -197,7 +207,7 @@ async function process_folder_entries(
     });
   }
 
-  return { folder_saved, folder_att, error_count };
+  return { folder_saved, folder_processed, folder_att, error_count };
 }
 
 async function process_single_entry(

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -8,7 +8,7 @@ import {
   add_eml_to_archive,
   finalize_archive,
 } from '@/services/save/save-zip-writer';
-import type { TransferProgressReporter } from '@wisecom/atlas-types';
+import type { OperationProgressCallback, TransferProgressReporter } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -36,7 +36,8 @@ export async function save_entries_to_archive(
   folder_map: Map<string, string>,
   dashboard: TransferProgressReporter,
   is_interrupted: () => boolean,
-): Promise<Omit<SaveResult, 'snapshot_id'>> {
+  on_progress?: OperationProgressCallback,
+): Promise<Omit<SaveResult, 'snapshot_id' | 'interrupted'>> {
   const { archive, promise } = create_save_archive(output_path);
 
   let global_saved = 0;
@@ -69,6 +70,7 @@ export async function save_entries_to_archive(
       dashboard,
       is_interrupted,
       { all_errors, integrity_failures },
+      on_progress,
     );
 
     global_errors += folder_result.error_count;
@@ -83,6 +85,13 @@ export async function save_entries_to_archive(
   }
 
   dashboard.show_finalizing();
+  on_progress?.({
+    operation: 'save',
+    workload: 'outlook',
+    phase: 'finalizing',
+    processed: global_saved,
+    total: global_total,
+  });
   await finalize_archive(archive);
   const total_bytes = await promise;
 
@@ -126,6 +135,7 @@ async function process_folder_entries(
   dashboard: TransferProgressReporter,
   is_interrupted: () => boolean,
   counters: FolderEntryCounters,
+  on_progress?: OperationProgressCallback,
 ): Promise<{
   folder_saved: number;
   folder_att: number;
@@ -176,6 +186,15 @@ async function process_folder_entries(
       eta_seconds: eta,
     });
     dashboard.update_total(gp, global_total, rate, eta);
+    on_progress?.({
+      operation: 'save',
+      workload: 'outlook',
+      phase: 'processing',
+      processed: gp,
+      total: global_total,
+      current: entry.subject ?? entry.object_id,
+      rate,
+    });
   }
 
   return { folder_saved, folder_att, error_count };

--- a/packages/outlook/src/services/save/save.service.ts
+++ b/packages/outlook/src/services/save/save.service.ts
@@ -24,6 +24,11 @@ import {
   MANIFEST_REPOSITORY_TOKEN,
   MAILBOX_CONNECTOR_TOKEN,
 } from '@wisecom/atlas-types';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 import { save_entries_to_archive } from '@/services/save/save-entry-processor';
 
 @injectable()
@@ -39,13 +44,10 @@ export class SaveService implements SaveUseCase {
     snapshot_id: string,
     options: SaveOptions = {},
   ): Promise<SaveResult> {
+    if (begin_operation_progress(options, 'save', 'outlook')) {
+      return this.finish_empty_result(snapshot_id, options);
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'save',
-      workload: 'outlook',
-      phase: 'discovering',
-      processed: 0,
-    });
     try {
       const manifest = await this.load_manifest(ctx, snapshot_id);
       const owner_id = manifest.owner_id;
@@ -53,11 +55,7 @@ export class SaveService implements SaveUseCase {
       const entries = await this.resolve_entries(ctx, manifest, owner_id, tenant_id, options);
       if (entries.length === 0) {
         logger.warn('No entries to save');
-        return this.empty_result(
-          snapshot_id,
-          options.output_path ?? '',
-          options.should_interrupt?.() === true,
-        );
+        return this.finish_empty_result(snapshot_id, options);
       }
 
       return this.save_batch(ctx, tenant_id, owner_id, snapshot_id, entries, options);
@@ -71,23 +69,16 @@ export class SaveService implements SaveUseCase {
     owner_id: string,
     options: SaveOptions = {},
   ): Promise<SaveResult> {
+    if (begin_operation_progress(options, 'save', 'outlook')) {
+      return this.finish_empty_result('mailbox', options);
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'save',
-      workload: 'outlook',
-      phase: 'discovering',
-      processed: 0,
-    });
     try {
       const manifests = await this.load_mailbox_manifests(ctx, owner_id, options);
 
       if (manifests.length === 0) {
         logger.warn('No snapshots found for this mailbox in the given date range');
-        return this.empty_result(
-          'mailbox',
-          options.output_path ?? '',
-          options.should_interrupt?.() === true,
-        );
+        return this.finish_empty_result('mailbox', options);
       }
 
       const entries = merge_snapshot_entries(manifests);
@@ -99,11 +90,7 @@ export class SaveService implements SaveUseCase {
       const filtered = await this.apply_entry_filters(entries, owner_id, tenant_id, options);
       if (filtered.length === 0) {
         logger.warn('No entries to save after filtering');
-        return this.empty_result(
-          'mailbox',
-          options.output_path ?? '',
-          options.should_interrupt?.() === true,
-        );
+        return this.finish_empty_result('mailbox', options);
       }
 
       logger.info(`Aggregated ${manifests.length} snapshots -- ${filtered.length} unique messages`);
@@ -242,24 +229,30 @@ export class SaveService implements SaveUseCase {
         folder_map,
         dashboard,
         is_interrupted,
-        options.on_progress,
+        options,
       );
 
-      const interrupted = is_interrupted();
+      const { processed, ...save_result } = result;
+      const interrupted = result.interrupted || is_interrupted();
       if (interrupted) dashboard.mark_all_pending_interrupted();
       dashboard.finish();
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'save',
         workload: 'outlook',
         phase: interrupted ? 'interrupted' : 'completed',
-        processed: result.saved_count,
+        processed,
         total: [...groups.values()].reduce((sum, entries) => sum + entries.length, 0),
       });
 
-      return { ...result, snapshot_id, interrupted };
+      return { ...save_result, snapshot_id, interrupted };
     } finally {
       process.removeListener('SIGINT', on_sigint);
     }
+  }
+
+  private finish_empty_result(snapshot_id: string, options: SaveOptions): SaveResult {
+    const interrupted = finish_operation_progress(options, 'save', 'outlook', 0, 0);
+    return this.empty_result(snapshot_id, options.output_path ?? '', interrupted);
   }
 
   private empty_result(snapshot_id: string, output_path: string, interrupted = false): SaveResult {

--- a/packages/outlook/src/services/save/save.service.ts
+++ b/packages/outlook/src/services/save/save.service.ts
@@ -28,8 +28,6 @@ import { save_entries_to_archive } from '@/services/save/save-entry-processor';
 
 @injectable()
 export class SaveService implements SaveUseCase {
-  private _interrupted = false;
-
   constructor(
     @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
     @inject(MANIFEST_REPOSITORY_TOKEN) private readonly _manifests: ManifestRepository,
@@ -42,6 +40,12 @@ export class SaveService implements SaveUseCase {
     options: SaveOptions = {},
   ): Promise<SaveResult> {
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'save',
+      workload: 'outlook',
+      phase: 'discovering',
+      processed: 0,
+    });
     try {
       const manifest = await this.load_manifest(ctx, snapshot_id);
       const owner_id = manifest.owner_id;
@@ -49,7 +53,11 @@ export class SaveService implements SaveUseCase {
       const entries = await this.resolve_entries(ctx, manifest, owner_id, tenant_id, options);
       if (entries.length === 0) {
         logger.warn('No entries to save');
-        return this.empty_result(snapshot_id, options.output_path ?? '');
+        return this.empty_result(
+          snapshot_id,
+          options.output_path ?? '',
+          options.should_interrupt?.() === true,
+        );
       }
 
       return this.save_batch(ctx, tenant_id, owner_id, snapshot_id, entries, options);
@@ -64,12 +72,22 @@ export class SaveService implements SaveUseCase {
     options: SaveOptions = {},
   ): Promise<SaveResult> {
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'save',
+      workload: 'outlook',
+      phase: 'discovering',
+      processed: 0,
+    });
     try {
       const manifests = await this.load_mailbox_manifests(ctx, owner_id, options);
 
       if (manifests.length === 0) {
         logger.warn('No snapshots found for this mailbox in the given date range');
-        return this.empty_result('mailbox', options.output_path ?? '');
+        return this.empty_result(
+          'mailbox',
+          options.output_path ?? '',
+          options.should_interrupt?.() === true,
+        );
       }
 
       const entries = merge_snapshot_entries(manifests);
@@ -81,7 +99,11 @@ export class SaveService implements SaveUseCase {
       const filtered = await this.apply_entry_filters(entries, owner_id, tenant_id, options);
       if (filtered.length === 0) {
         logger.warn('No entries to save after filtering');
-        return this.empty_result('mailbox', options.output_path ?? '');
+        return this.empty_result(
+          'mailbox',
+          options.output_path ?? '',
+          options.should_interrupt?.() === true,
+        );
       }
 
       logger.info(`Aggregated ${manifests.length} snapshots -- ${filtered.length} unique messages`);
@@ -189,6 +211,7 @@ export class SaveService implements SaveUseCase {
       groups,
       folder_map,
       dashboard,
+      options,
     );
   }
 
@@ -200,11 +223,14 @@ export class SaveService implements SaveUseCase {
     groups: Map<string, ManifestEntry[]>,
     folder_map: Map<string, string>,
     dashboard: TransferProgressReporter,
+    options: SaveOptions,
   ): Promise<SaveResult> {
-    this._interrupted = false;
+    let sigint_interrupted = false;
     const on_sigint = (): void => {
-      this._interrupted = true;
+      sigint_interrupted = true;
     };
+    const is_interrupted = (): boolean =>
+      sigint_interrupted || options.should_interrupt?.() === true;
     process.on('SIGINT', on_sigint);
 
     try {
@@ -215,19 +241,28 @@ export class SaveService implements SaveUseCase {
         groups,
         folder_map,
         dashboard,
-        () => this._interrupted,
+        is_interrupted,
+        options.on_progress,
       );
 
-      if (this._interrupted) dashboard.mark_all_pending_interrupted();
+      const interrupted = is_interrupted();
+      if (interrupted) dashboard.mark_all_pending_interrupted();
       dashboard.finish();
+      options.on_progress?.({
+        operation: 'save',
+        workload: 'outlook',
+        phase: interrupted ? 'interrupted' : 'completed',
+        processed: result.saved_count,
+        total: [...groups.values()].reduce((sum, entries) => sum + entries.length, 0),
+      });
 
-      return { ...result, snapshot_id };
+      return { ...result, snapshot_id, interrupted };
     } finally {
       process.removeListener('SIGINT', on_sigint);
     }
   }
 
-  private empty_result(snapshot_id: string, output_path: string): SaveResult {
+  private empty_result(snapshot_id: string, output_path: string, interrupted = false): SaveResult {
     return {
       snapshot_id,
       saved_count: 0,
@@ -237,6 +272,7 @@ export class SaveService implements SaveUseCase {
       output_path,
       total_bytes: 0,
       integrity_failures: [],
+      interrupted,
     };
   }
 }

--- a/packages/outlook/src/services/shared/folder-selector.ts
+++ b/packages/outlook/src/services/shared/folder-selector.ts
@@ -4,6 +4,7 @@
  */
 
 import { FOLDER_PATH_SEPARATOR } from '@/adapters/graph-folder-tree-enumerator';
+import type { MailFolder } from '@wisecom/atlas-types';
 
 /**
  * True when `selector` selects `folder_path`.
@@ -30,4 +31,31 @@ export function folder_matches_selector(folder_path: string, selector: string): 
   }
 
   return false;
+}
+
+/**
+ * Filters mailbox folders by user selectors and reports selectors that matched nothing.
+ */
+export function apply_folder_filter(
+  folders: MailFolder[],
+  filter?: string[],
+): { folders: MailFolder[]; warnings: string[] } {
+  if (!filter || filter.length === 0) return { folders, warnings: [] };
+
+  const matched = folders.filter((folder) =>
+    filter.some((selector) => folder_matches_selector(folder.folder_path, selector)),
+  );
+  const warnings = filter
+    .filter(
+      (selector) =>
+        !matched.some((folder) => folder_matches_selector(folder.folder_path, selector)),
+    )
+    .map(
+      (selector) =>
+        `Folder "${selector}" not found. Available: ${folders
+          .map((folder) => folder.folder_path)
+          .join(', ')}`,
+    );
+
+  return { folders: matched, warnings };
 }

--- a/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
@@ -175,13 +175,19 @@ describe('interrupt delta-link safeguard (issue #23)', () => {
       if (page === 1) interrupted = true;
     });
 
-    await service.sync_mailbox('t', 'user@test.com', {
+    const on_progress = vi.fn();
+    const result = await service.sync_mailbox('t', 'user@test.com', {
       should_interrupt: () => interrupted,
+      on_progress,
     });
 
     // page 1 was fully processed (2 unique bodies stored), pages 2-3 never were
     expect(vi.mocked(storage.put).mock.calls.length).toBe(2);
     expect(saved_delta_links()).toEqual({ 'folder-1': 'https://prev-delta' });
+    expect(result.interrupted).toBe(true);
+    expect(on_progress).toHaveBeenLastCalledWith(
+      expect.objectContaining({ operation: 'backup', workload: 'outlook', phase: 'interrupted' }),
+    );
   });
 
   it('does not persist a delta link captured on an interrupted final page', async () => {

--- a/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
@@ -216,4 +216,18 @@ describe('interrupt delta-link safeguard (issue #23)', () => {
 
     expect(saved_delta_links()).toEqual({ 'folder-1': 'https://new-delta' });
   });
+  it('honors cancellation requested by the finalizing progress event', async () => {
+    let interrupted = false;
+    connector.fetch_delta = make_streaming_fetch_delta([[make_message('m1')]], 'https://new-delta');
+
+    const result = await service.sync_mailbox('t', 'user@test.com', {
+      on_progress: (event) => {
+        if (event.phase === 'finalizing') interrupted = true;
+      },
+      should_interrupt: () => interrupted,
+    });
+
+    expect(result.interrupted).toBe(true);
+    expect(saved_delta_links()).toEqual({ 'folder-1': 'https://new-delta' });
+  });
 });

--- a/packages/outlook/tests/unit/operation-pre-abort.test.ts
+++ b/packages/outlook/tests/unit/operation-pre-abort.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TenantContextFactory } from '@wisecom/atlas-types';
+import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
+import { RestoreService } from '@/services/restore/restore.service';
+import { SaveService } from '@/services/save/save.service';
+
+describe('Outlook operation cancellation', () => {
+  it('does no remote work when every operation starts interrupted', async () => {
+    const factory = { create: vi.fn() } as unknown as TenantContextFactory;
+    const callbacks = Array.from({ length: 5 }, () => vi.fn());
+    const should_interrupt = (): boolean => true;
+    const backup = new MailboxSyncService(factory, {} as never, {} as never);
+    const restore = new RestoreService(factory, {} as never, {} as never, {} as never);
+    const save = new SaveService(factory, {} as never, {} as never);
+
+    const results = await Promise.all([
+      backup.sync_mailbox('tenant-1', 'owner-1', {
+        should_interrupt,
+        on_progress: callbacks[0],
+      }),
+      restore.restore_snapshot('tenant-1', 'snap-1', {
+        should_interrupt,
+        on_progress: callbacks[1],
+      }),
+      restore.restore_mailbox('tenant-1', 'owner-1', {
+        should_interrupt,
+        on_progress: callbacks[2],
+      }),
+      save.save_snapshot('tenant-1', 'snap-1', {
+        should_interrupt,
+        on_progress: callbacks[3],
+      }),
+      save.save_mailbox('tenant-1', 'owner-1', {
+        should_interrupt,
+        on_progress: callbacks[4],
+      }),
+    ]);
+
+    expect(factory.create).not.toHaveBeenCalled();
+    expect(results.every((result) => result.interrupted)).toBe(true);
+    for (const callback of callbacks) {
+      expect(callback.mock.calls.map(([event]) => event.phase)).toEqual([
+        'discovering',
+        'finalizing',
+        'interrupted',
+      ]);
+    }
+  });
+});

--- a/packages/outlook/tests/unit/restore-service-test-fixtures.ts
+++ b/packages/outlook/tests/unit/restore-service-test-fixtures.ts
@@ -1,0 +1,40 @@
+import type { Manifest, ManifestEntry } from '@wisecom/atlas-types';
+
+/** Builds a minimal Outlook manifest entry for restore service tests. */
+export function make_restore_entry(id: string, folder_id: string): ManifestEntry {
+  return {
+    object_id: id,
+    storage_key: `data/user/${id}`,
+    checksum: id,
+    size_bytes: 100,
+    subject: `Subject ${id}`,
+    folder_id,
+  };
+}
+
+/** Builds a minimal Outlook manifest for restore service tests. */
+export function make_restore_manifest(entries: ManifestEntry[]): Manifest {
+  return {
+    id: 'manifest-1',
+    tenant_id: 'test-tenant',
+    owner_id: 'user@test.com',
+    snapshot_id: 'snap-1',
+    created_at: new Date(),
+    total_objects: entries.length,
+    total_size_bytes: entries.reduce((sum, entry) => sum + entry.size_bytes, 0),
+    delta_links: {},
+    entries,
+  };
+}
+
+/** Builds the encrypted-message fixture consumed by the restore service tests. */
+export function make_stored_message(folder_id: string): Buffer {
+  const json = JSON.stringify({
+    subject: 'Hello',
+    body: { contentType: 'Text', content: 'Hello world' },
+    parentFolderId: folder_id,
+    receivedDateTime: '2026-01-01T00:00:00Z',
+    isRead: true,
+  });
+  return Buffer.concat([Buffer.from('E'), Buffer.from(json)]);
+}

--- a/packages/outlook/tests/unit/restore.service.test.ts
+++ b/packages/outlook/tests/unit/restore.service.test.ts
@@ -136,9 +136,15 @@ describe('RestoreService', () => {
     const manifest = make_manifest([]);
     (mock_manifests.find_by_snapshot as ReturnType<typeof vi.fn>).mockResolvedValue(manifest);
 
-    const result = await service.restore_snapshot('test-tenant', 'snap-1');
+    const on_progress = vi.fn();
+    const result = await service.restore_snapshot('test-tenant', 'snap-1', { on_progress });
     expect(result.restored_count).toBe(0);
     expect(mock_restore.create_mail_folder).not.toHaveBeenCalled();
+    expect(on_progress.mock.calls.map(([event]) => event.phase)).toEqual([
+      'discovering',
+      'finalizing',
+      'completed',
+    ]);
   });
 
   it('restores a single message by index', async () => {

--- a/packages/outlook/tests/unit/restore.service.test.ts
+++ b/packages/outlook/tests/unit/restore.service.test.ts
@@ -12,44 +12,13 @@ import type { MailboxConnector, MailFolder } from '@wisecom/atlas-types';
 import type { ManifestRepository } from '@wisecom/atlas-types';
 import type { TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
 import type { RestoreConnector } from '@wisecom/atlas-types';
-import type { Manifest, ManifestEntry } from '@wisecom/atlas-types';
+import type { ManifestEntry } from '@wisecom/atlas-types';
 import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
-
-function make_entry(id: string, folder_id: string): ManifestEntry {
-  return {
-    object_id: id,
-    storage_key: `data/user/${id}`,
-    checksum: id,
-    size_bytes: 100,
-    subject: `Subject ${id}`,
-    folder_id,
-  };
-}
-
-function make_manifest(entries: ManifestEntry[]): Manifest {
-  return {
-    id: 'manifest-1',
-    tenant_id: 'test-tenant',
-    owner_id: 'user@test.com',
-    snapshot_id: 'snap-1',
-    created_at: new Date(),
-    total_objects: entries.length,
-    total_size_bytes: entries.reduce((s, e) => s + e.size_bytes, 0),
-    delta_links: {},
-    entries,
-  };
-}
-
-function make_stored_message(folder_id: string): Buffer {
-  const json = JSON.stringify({
-    subject: 'Hello',
-    body: { contentType: 'Text', content: 'Hello world' },
-    parentFolderId: folder_id,
-    receivedDateTime: '2026-01-01T00:00:00Z',
-    isRead: true,
-  });
-  return Buffer.concat([Buffer.from('E'), Buffer.from(json)]);
-}
+import {
+  make_restore_entry as make_entry,
+  make_restore_manifest as make_manifest,
+  make_stored_message,
+} from '@/../tests/unit/restore-service-test-fixtures';
 
 describe('RestoreService', () => {
   let container: Container;
@@ -199,6 +168,33 @@ describe('RestoreService', () => {
     expect(result.restored_count).toBe(3);
     expect(mock_restore.create_message).toHaveBeenCalledTimes(3);
     expect(mock_restore.create_mail_folder).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns partial counts and stops before the next message when interrupted', async () => {
+    const manifest = make_manifest([
+      make_entry('msg-1', 'f1'),
+      make_entry('msg-2', 'f1'),
+      make_entry('msg-3', 'f1'),
+    ]);
+    (mock_manifests.find_by_snapshot as ReturnType<typeof vi.fn>).mockResolvedValue(manifest);
+    let interrupted = false;
+    vi.mocked(mock_restore.create_message).mockImplementation(async () => {
+      interrupted = true;
+      return 'new-msg-id';
+    });
+    const on_progress = vi.fn();
+
+    const result = await service.restore_snapshot('test-tenant', 'snap-1', {
+      should_interrupt: () => interrupted,
+      on_progress,
+    });
+
+    expect(mock_restore.create_message).toHaveBeenCalledOnce();
+    expect(result.restored_count).toBe(1);
+    expect(result.interrupted).toBe(true);
+    expect(on_progress).toHaveBeenLastCalledWith(
+      expect.objectContaining({ operation: 'restore', workload: 'outlook', phase: 'interrupted' }),
+    );
   });
 
   it('restores attachments alongside messages', async () => {

--- a/packages/outlook/tests/unit/save.service.test.ts
+++ b/packages/outlook/tests/unit/save.service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Container } from 'inversify';
 import 'reflect-metadata';
 import { SaveService } from '@/services/save/save.service';
+import { save_entries_to_archive } from '@/services/save/save-entry-processor';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
@@ -116,6 +117,40 @@ describe('SaveService', () => {
 
       expect(result.saved_count).toBe(2);
       expect(result.snapshot_id).toBe('snap-1');
+    });
+
+    it('returns partial counts when interrupted between entries', async () => {
+      const manifest = make_manifest([make_entry('msg-1', 'f1'), make_entry('msg-2', 'f1')]);
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(manifest);
+      let interrupted = false;
+      vi.mocked(save_entries_to_archive).mockImplementationOnce(async (...args) => {
+        const dashboard = args[5];
+        const is_interrupted = args[6];
+        dashboard.update_total(1, 2, 1, 1);
+        interrupted = true;
+        expect(is_interrupted()).toBe(true);
+        return {
+          saved_count: 1,
+          attachment_count: 0,
+          error_count: 0,
+          errors: [],
+          output_path: 'test.zip',
+          total_bytes: 512,
+          integrity_failures: [],
+        };
+      });
+      const on_progress = vi.fn();
+
+      const result = await service.save_snapshot('test-tenant', 'snap-1', {
+        should_interrupt: () => interrupted,
+        on_progress,
+      });
+
+      expect(result.saved_count).toBe(1);
+      expect(result.interrupted).toBe(true);
+      expect(on_progress).toHaveBeenLastCalledWith(
+        expect.objectContaining({ operation: 'save', workload: 'outlook', phase: 'interrupted' }),
+      );
     });
 
     it('returns empty result when no entries', async () => {

--- a/packages/outlook/tests/unit/save.service.test.ts
+++ b/packages/outlook/tests/unit/save.service.test.ts
@@ -22,6 +22,8 @@ vi.mock('@/services/save/save-entry-processor', () => ({
     output_path: 'test.zip',
     total_bytes: 1024,
     integrity_failures: [],
+    processed: 2,
+    interrupted: false,
   }),
 }));
 
@@ -137,6 +139,8 @@ describe('SaveService', () => {
           output_path: 'test.zip',
           total_bytes: 512,
           integrity_failures: [],
+          processed: 1,
+          interrupted: true,
         };
       });
       const on_progress = vi.fn();
@@ -150,6 +154,30 @@ describe('SaveService', () => {
       expect(result.interrupted).toBe(true);
       expect(on_progress).toHaveBeenLastCalledWith(
         expect.objectContaining({ operation: 'save', workload: 'outlook', phase: 'interrupted' }),
+      );
+    });
+
+    it('keeps terminal progress monotonic when an entry fails', async () => {
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
+        make_manifest([make_entry('msg-1', 'f1')]),
+      );
+      vi.mocked(save_entries_to_archive).mockResolvedValueOnce({
+        saved_count: 0,
+        attachment_count: 0,
+        error_count: 1,
+        errors: ['failed'],
+        output_path: 'test.zip',
+        total_bytes: 0,
+        integrity_failures: [],
+        processed: 1,
+        interrupted: false,
+      });
+      const on_progress = vi.fn();
+
+      await service.save_snapshot('test-tenant', 'snap-1', { on_progress });
+
+      expect(on_progress).toHaveBeenLastCalledWith(
+        expect.objectContaining({ phase: 'completed', processed: 1 }),
       );
     });
 

--- a/packages/sdk/src/onedrive-api.factory.ts
+++ b/packages/sdk/src/onedrive-api.factory.ts
@@ -42,12 +42,10 @@ export function create_onedrive_api(tenant_id: string, container: Container): On
       return await backup.backup_onedrive(tenant_id, owner_id, adapt_operation_options(options));
     },
     async verify(owner_id, snapshot_id, options) {
-      return await verification.verify_onedrive_snapshot(
-        tenant_id,
-        owner_id,
-        snapshot_id,
-        adapt_operation_options(options),
-      );
+      const adapted = adapt_operation_options(options);
+      return adapted === undefined
+        ? await verification.verify_onedrive_snapshot(tenant_id, owner_id, snapshot_id)
+        : await verification.verify_onedrive_snapshot(tenant_id, owner_id, snapshot_id, adapted);
     },
     async restore(owner_id, options) {
       return await restore.restore_onedrive(tenant_id, owner_id, adapt_operation_options(options)!);

--- a/packages/sdk/src/onedrive-api.factory.ts
+++ b/packages/sdk/src/onedrive-api.factory.ts
@@ -20,6 +20,7 @@ import {
   ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
   ONEDRIVE_STATUS_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
+import { adapt_operation_options } from '@/operation-options';
 
 /** Builds the OneDriveApi sub-namespace from the DI container. */
 export function create_onedrive_api(tenant_id: string, container: Container): OneDriveApi {
@@ -38,16 +39,21 @@ export function create_onedrive_api(tenant_id: string, container: Container): On
 
   return {
     async backup(owner_id, options) {
-      return await backup.backup_onedrive(tenant_id, owner_id, options);
+      return await backup.backup_onedrive(tenant_id, owner_id, adapt_operation_options(options));
     },
-    async verify(owner_id, snapshot_id) {
-      return await verification.verify_onedrive_snapshot(tenant_id, owner_id, snapshot_id);
+    async verify(owner_id, snapshot_id, options) {
+      return await verification.verify_onedrive_snapshot(
+        tenant_id,
+        owner_id,
+        snapshot_id,
+        adapt_operation_options(options),
+      );
     },
     async restore(owner_id, options) {
-      return await restore.restore_onedrive(tenant_id, owner_id, options);
+      return await restore.restore_onedrive(tenant_id, owner_id, adapt_operation_options(options)!);
     },
     async save(owner_id, options) {
-      return await save.save_snapshot(tenant_id, owner_id, options);
+      return await save.save_snapshot(tenant_id, owner_id, adapt_operation_options(options)!);
     },
     async listSnapshots(owner_id) {
       return await catalog.list_onedrive_snapshots(tenant_id, owner_id);

--- a/packages/sdk/src/operation-options.ts
+++ b/packages/sdk/src/operation-options.ts
@@ -1,4 +1,8 @@
-import type { OperationControlOptions, SdkOperationOptions } from '@wisecom/atlas-types';
+import type {
+  OperationControlOptions,
+  OperationProgressCallback,
+  SdkOperationOptions,
+} from '@wisecom/atlas-types';
 
 type AdaptedOperationOptions<T extends SdkOperationOptions> = Omit<T, 'onProgress' | 'signal'> &
   OperationControlOptions;
@@ -11,7 +15,18 @@ export function adapt_operation_options<T extends SdkOperationOptions>(
   const { onProgress: on_progress, signal, ...rest } = options;
   return {
     ...rest,
-    ...(on_progress ? { on_progress } : {}),
+    ...(on_progress ? { on_progress: isolate_progress_callback(on_progress) } : {}),
     ...(signal ? { should_interrupt: () => signal.aborted } : {}),
+  };
+}
+
+/** Prevents observer failures from changing operation state. */
+function isolate_progress_callback(callback: OperationProgressCallback): OperationProgressCallback {
+  return (event) => {
+    try {
+      callback(event);
+    } catch {
+      // Progress observers cannot participate in operation control.
+    }
   };
 }

--- a/packages/sdk/src/operation-options.ts
+++ b/packages/sdk/src/operation-options.ts
@@ -1,0 +1,17 @@
+import type { OperationControlOptions, SdkOperationOptions } from '@wisecom/atlas-types';
+
+type AdaptedOperationOptions<T extends SdkOperationOptions> = Omit<T, 'onProgress' | 'signal'> &
+  OperationControlOptions;
+
+/** Maps public SDK progress/cancellation options to internal service hooks. */
+export function adapt_operation_options<T extends SdkOperationOptions>(
+  options: T | undefined,
+): AdaptedOperationOptions<T> | undefined {
+  if (!options) return undefined;
+  const { onProgress: on_progress, signal, ...rest } = options;
+  return {
+    ...rest,
+    ...(on_progress ? { on_progress } : {}),
+    ...(signal ? { should_interrupt: () => signal.aborted } : {}),
+  };
+}

--- a/packages/sdk/src/outlook-api.factory.ts
+++ b/packages/sdk/src/outlook-api.factory.ts
@@ -23,6 +23,7 @@ import {
   MAILBOX_DISCOVERY_TOKEN,
 } from '@wisecom/atlas-types';
 import { run_with_cost_tracking } from '@wisecom/atlas-core/services/shared/graph-request-context';
+import { adapt_operation_options } from '@/operation-options';
 
 /** Builds the OutlookApi sub-namespace from the DI container. */
 export function create_outlook_api(tenant_id: string, container: Container): OutlookApi {
@@ -39,30 +40,34 @@ export function create_outlook_api(tenant_id: string, container: Container): Out
   return {
     async backup(mailbox_id, options) {
       const [result, cost_result] = await run_with_cost_tracking(() =>
-        backup.sync_mailbox(tenant_id, mailbox_id, options),
+        backup.sync_mailbox(tenant_id, mailbox_id, adapt_operation_options(options)),
       );
       return { ...result, graph_cost: cost_result };
     },
     async verify(snapshot_id, options) {
-      return await verification.verify_snapshot_integrity(tenant_id, snapshot_id, options);
+      return await verification.verify_snapshot_integrity(
+        tenant_id,
+        snapshot_id,
+        adapt_operation_options(options),
+      );
     },
     async restore(snapshot_id, options) {
       const [result, cost_result] = await run_with_cost_tracking(() =>
-        restore.restore_snapshot(tenant_id, snapshot_id, options),
+        restore.restore_snapshot(tenant_id, snapshot_id, adapt_operation_options(options)),
       );
       return { ...result, graph_cost: cost_result };
     },
     async restoreMailbox(mailbox_id, options) {
       const [result, cost_result] = await run_with_cost_tracking(() =>
-        restore.restore_mailbox(tenant_id, mailbox_id, options),
+        restore.restore_mailbox(tenant_id, mailbox_id, adapt_operation_options(options)),
       );
       return { ...result, graph_cost: cost_result };
     },
     async save(snapshot_id, options) {
-      return await save.save_snapshot(tenant_id, snapshot_id, options);
+      return await save.save_snapshot(tenant_id, snapshot_id, adapt_operation_options(options));
     },
     async saveMailbox(mailbox_id, options) {
-      return await save.save_mailbox(tenant_id, mailbox_id, options);
+      return await save.save_mailbox(tenant_id, mailbox_id, adapt_operation_options(options));
     },
     async listMailboxes() {
       return await catalog.list_mailboxes(tenant_id);

--- a/packages/sdk/src/sharepoint-api.factory.ts
+++ b/packages/sdk/src/sharepoint-api.factory.ts
@@ -45,12 +45,10 @@ export function create_sharepoint_api(tenant_id: string, container: Container): 
       return await backup.backup_site(tenant_id, site_id, adapt_operation_options(options));
     },
     async verify(site_id, snapshot_id, options) {
-      return await verification.verify_sharepoint_snapshot(
-        tenant_id,
-        site_id,
-        snapshot_id,
-        adapt_operation_options(options),
-      );
+      const adapted = adapt_operation_options(options);
+      return adapted === undefined
+        ? await verification.verify_sharepoint_snapshot(tenant_id, site_id, snapshot_id)
+        : await verification.verify_sharepoint_snapshot(tenant_id, site_id, snapshot_id, adapted);
     },
     async restore(site_id, options) {
       return await restore.restore_sharepoint(

--- a/packages/sdk/src/sharepoint-api.factory.ts
+++ b/packages/sdk/src/sharepoint-api.factory.ts
@@ -22,6 +22,7 @@ import {
   SHAREPOINT_STATUS_USE_CASE_TOKEN,
   SHAREPOINT_CONNECTOR_TOKEN,
 } from '@wisecom/atlas-types';
+import { adapt_operation_options } from '@/operation-options';
 
 /** Builds the SharePointApi sub-namespace from the DI container. */
 export function create_sharepoint_api(tenant_id: string, container: Container): SharePointApi {
@@ -41,16 +42,25 @@ export function create_sharepoint_api(tenant_id: string, container: Container): 
 
   return {
     async backup(site_id, options) {
-      return await backup.backup_site(tenant_id, site_id, options);
+      return await backup.backup_site(tenant_id, site_id, adapt_operation_options(options));
     },
-    async verify(site_id, snapshot_id) {
-      return await verification.verify_sharepoint_snapshot(tenant_id, site_id, snapshot_id);
+    async verify(site_id, snapshot_id, options) {
+      return await verification.verify_sharepoint_snapshot(
+        tenant_id,
+        site_id,
+        snapshot_id,
+        adapt_operation_options(options),
+      );
     },
     async restore(site_id, options) {
-      return await restore.restore_sharepoint(tenant_id, site_id, options);
+      return await restore.restore_sharepoint(
+        tenant_id,
+        site_id,
+        adapt_operation_options(options)!,
+      );
     },
     async save(site_id, options) {
-      return await save.save_snapshot(tenant_id, site_id, options);
+      return await save.save_snapshot(tenant_id, site_id, adapt_operation_options(options)!);
     },
     async listSnapshots(site_id) {
       return await catalog.list_sharepoint_snapshots(tenant_id, site_id);

--- a/packages/sdk/tests/unit/progress-and-cancellation.test.ts
+++ b/packages/sdk/tests/unit/progress-and-cancellation.test.ts
@@ -33,7 +33,13 @@ function expect_adapted_options(
   on_progress: unknown,
   controller: AbortController,
 ): void {
-  expect(options.on_progress).toBe(on_progress);
+  (options.on_progress as (event: object) => void)({
+    operation: 'backup',
+    workload: 'onedrive',
+    phase: 'processing',
+    processed: 1,
+  });
+  expect(on_progress).toHaveBeenCalledOnce();
   expect(options).not.toHaveProperty('onProgress');
   expect(options).not.toHaveProperty('signal');
   const should_interrupt = options.should_interrupt as () => boolean;
@@ -57,13 +63,7 @@ describe('SDK progress and cancellation option adaptation', () => {
       signal: controller.signal,
     });
 
-    const options = sync_mailbox.mock.calls[0]![2];
-    expect(options.on_progress).toBe(on_progress);
-    expect(options).not.toHaveProperty('onProgress');
-    expect(options).not.toHaveProperty('signal');
-    expect(options.should_interrupt()).toBe(false);
-    controller.abort();
-    expect(options.should_interrupt()).toBe(true);
+    expect_adapted_options(sync_mailbox.mock.calls[0]![2], on_progress, controller);
   });
 
   it('adapts OneDrive backup onProgress and signal to internal hooks', async () => {
@@ -80,13 +80,7 @@ describe('SDK progress and cancellation option adaptation', () => {
       signal: controller.signal,
     });
 
-    const options = backup_onedrive.mock.calls[0]![2];
-    expect(options.on_progress).toBe(on_progress);
-    expect(options).not.toHaveProperty('onProgress');
-    expect(options).not.toHaveProperty('signal');
-    expect(options.should_interrupt()).toBe(false);
-    controller.abort();
-    expect(options.should_interrupt()).toBe(true);
+    expect_adapted_options(backup_onedrive.mock.calls[0]![2], on_progress, controller);
   });
 
   it('adapts SharePoint backup onProgress and signal to internal hooks', async () => {
@@ -103,13 +97,7 @@ describe('SDK progress and cancellation option adaptation', () => {
       signal: controller.signal,
     });
 
-    const options = backup_site.mock.calls[0]![2];
-    expect(options.on_progress).toBe(on_progress);
-    expect(options).not.toHaveProperty('onProgress');
-    expect(options).not.toHaveProperty('signal');
-    expect(options.should_interrupt()).toBe(false);
-    controller.abort();
-    expect(options.should_interrupt()).toBe(true);
+    expect_adapted_options(backup_site.mock.calls[0]![2], on_progress, controller);
   });
 
   it('adapts Outlook verify, restore, and save options', async () => {
@@ -225,5 +213,28 @@ describe('SDK progress and cancellation option adaptation', () => {
     );
     expect_adapted_options(restore_sharepoint.mock.calls[0]![2], callbacks[1], controllers[1]);
     expect_adapted_options(save_snapshot.mock.calls[0]![2], callbacks[2], controllers[2]);
+  });
+  it('isolates operation results from consumer progress callback errors', async () => {
+    const backup_onedrive = vi.fn(async (_tenant_id, _owner_id, options) => {
+      options.on_progress({
+        operation: 'backup',
+        workload: 'onedrive',
+        phase: 'processing',
+        processed: 1,
+      });
+      return { interrupted: false };
+    });
+    const api = create_onedrive_api(
+      TENANT_ID,
+      container_with([ONEDRIVE_BACKUP_USE_CASE_TOKEN, { backup_onedrive }]),
+    );
+
+    await expect(
+      api.backup(OWNER_ID, {
+        onProgress: () => {
+          throw new Error('consumer failed');
+        },
+      }),
+    ).resolves.toEqual({ interrupted: false });
   });
 });

--- a/packages/sdk/tests/unit/progress-and-cancellation.test.ts
+++ b/packages/sdk/tests/unit/progress-and-cancellation.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Container } from 'inversify';
+import {
+  BACKUP_USE_CASE_TOKEN,
+  VERIFICATION_USE_CASE_TOKEN,
+  RESTORE_USE_CASE_TOKEN,
+  SAVE_USE_CASE_TOKEN,
+  ONEDRIVE_BACKUP_USE_CASE_TOKEN,
+  ONEDRIVE_VERIFICATION_USE_CASE_TOKEN,
+  ONEDRIVE_RESTORE_USE_CASE_TOKEN,
+  ONEDRIVE_SAVE_USE_CASE_TOKEN,
+  SHAREPOINT_BACKUP_USE_CASE_TOKEN,
+  SHAREPOINT_VERIFICATION_USE_CASE_TOKEN,
+  SHAREPOINT_RESTORE_USE_CASE_TOKEN,
+  SHAREPOINT_SAVE_USE_CASE_TOKEN,
+} from '@wisecom/atlas-types';
+import { create_outlook_api } from '@/outlook-api.factory';
+import { create_onedrive_api } from '@/onedrive-api.factory';
+import { create_sharepoint_api } from '@/sharepoint-api.factory';
+
+const TENANT_ID = 'tenant-1';
+const OWNER_ID = 'owner-1';
+
+function container_with(...entries: [symbol, unknown][]): Container {
+  const services = new Map(entries);
+  return {
+    get: vi.fn((requested: symbol) => services.get(requested) ?? {}),
+  } as unknown as Container;
+}
+
+function expect_adapted_options(
+  options: Record<string, unknown>,
+  on_progress: unknown,
+  controller: AbortController,
+): void {
+  expect(options.on_progress).toBe(on_progress);
+  expect(options).not.toHaveProperty('onProgress');
+  expect(options).not.toHaveProperty('signal');
+  const should_interrupt = options.should_interrupt as () => boolean;
+  expect(should_interrupt()).toBe(false);
+  controller.abort();
+  expect(should_interrupt()).toBe(true);
+}
+
+describe('SDK progress and cancellation option adaptation', () => {
+  it('adapts Outlook backup onProgress and signal to internal hooks', async () => {
+    const sync_mailbox = vi.fn().mockResolvedValue({ interrupted: false });
+    const api = create_outlook_api(
+      TENANT_ID,
+      container_with([BACKUP_USE_CASE_TOKEN, { sync_mailbox }]),
+    );
+    const controller = new AbortController();
+    const on_progress = vi.fn();
+
+    await api.backup(OWNER_ID, {
+      onProgress: on_progress,
+      signal: controller.signal,
+    });
+
+    const options = sync_mailbox.mock.calls[0]![2];
+    expect(options.on_progress).toBe(on_progress);
+    expect(options).not.toHaveProperty('onProgress');
+    expect(options).not.toHaveProperty('signal');
+    expect(options.should_interrupt()).toBe(false);
+    controller.abort();
+    expect(options.should_interrupt()).toBe(true);
+  });
+
+  it('adapts OneDrive backup onProgress and signal to internal hooks', async () => {
+    const backup_onedrive = vi.fn().mockResolvedValue({ interrupted: false });
+    const api = create_onedrive_api(
+      TENANT_ID,
+      container_with([ONEDRIVE_BACKUP_USE_CASE_TOKEN, { backup_onedrive }]),
+    );
+    const controller = new AbortController();
+    const on_progress = vi.fn();
+
+    await api.backup(OWNER_ID, {
+      onProgress: on_progress,
+      signal: controller.signal,
+    });
+
+    const options = backup_onedrive.mock.calls[0]![2];
+    expect(options.on_progress).toBe(on_progress);
+    expect(options).not.toHaveProperty('onProgress');
+    expect(options).not.toHaveProperty('signal');
+    expect(options.should_interrupt()).toBe(false);
+    controller.abort();
+    expect(options.should_interrupt()).toBe(true);
+  });
+
+  it('adapts SharePoint backup onProgress and signal to internal hooks', async () => {
+    const backup_site = vi.fn().mockResolvedValue({ interrupted: false });
+    const api = create_sharepoint_api(
+      TENANT_ID,
+      container_with([SHAREPOINT_BACKUP_USE_CASE_TOKEN, { backup_site }]),
+    );
+    const controller = new AbortController();
+    const on_progress = vi.fn();
+
+    await api.backup(OWNER_ID, {
+      onProgress: on_progress,
+      signal: controller.signal,
+    });
+
+    const options = backup_site.mock.calls[0]![2];
+    expect(options.on_progress).toBe(on_progress);
+    expect(options).not.toHaveProperty('onProgress');
+    expect(options).not.toHaveProperty('signal');
+    expect(options.should_interrupt()).toBe(false);
+    controller.abort();
+    expect(options.should_interrupt()).toBe(true);
+  });
+
+  it('adapts Outlook verify, restore, and save options', async () => {
+    const verify_snapshot_integrity = vi.fn().mockResolvedValue({ interrupted: false });
+    const restore_snapshot = vi.fn().mockResolvedValue({ interrupted: false });
+    const save_snapshot = vi.fn().mockResolvedValue({ interrupted: false });
+    const api = create_outlook_api(
+      TENANT_ID,
+      container_with(
+        [VERIFICATION_USE_CASE_TOKEN, { verify_snapshot_integrity }],
+        [RESTORE_USE_CASE_TOKEN, { restore_snapshot }],
+        [SAVE_USE_CASE_TOKEN, { save_snapshot }],
+      ),
+    );
+    const controllers = [new AbortController(), new AbortController(), new AbortController()];
+    const callbacks = [vi.fn(), vi.fn(), vi.fn()];
+
+    await api.verify('snap-1', {
+      onProgress: callbacks[0],
+      signal: controllers[0].signal,
+    });
+    await api.restore('snap-1', {
+      onProgress: callbacks[1],
+      signal: controllers[1].signal,
+    });
+    await api.save('snap-1', {
+      onProgress: callbacks[2],
+      signal: controllers[2].signal,
+    });
+
+    expect_adapted_options(
+      verify_snapshot_integrity.mock.calls[0]![2],
+      callbacks[0],
+      controllers[0],
+    );
+    expect_adapted_options(restore_snapshot.mock.calls[0]![2], callbacks[1], controllers[1]);
+    expect_adapted_options(save_snapshot.mock.calls[0]![2], callbacks[2], controllers[2]);
+  });
+
+  it('adapts OneDrive verify, restore, and save options', async () => {
+    const verify_onedrive_snapshot = vi.fn().mockResolvedValue({ interrupted: false });
+    const restore_onedrive = vi.fn().mockResolvedValue({ interrupted: false });
+    const save_snapshot = vi.fn().mockResolvedValue({ interrupted: false });
+    const api = create_onedrive_api(
+      TENANT_ID,
+      container_with(
+        [ONEDRIVE_VERIFICATION_USE_CASE_TOKEN, { verify_onedrive_snapshot }],
+        [ONEDRIVE_RESTORE_USE_CASE_TOKEN, { restore_onedrive }],
+        [ONEDRIVE_SAVE_USE_CASE_TOKEN, { save_snapshot }],
+      ),
+    );
+    const controllers = [new AbortController(), new AbortController(), new AbortController()];
+    const callbacks = [vi.fn(), vi.fn(), vi.fn()];
+
+    await api.verify(OWNER_ID, 'snap-1', {
+      onProgress: callbacks[0],
+      signal: controllers[0].signal,
+    });
+    await api.restore(OWNER_ID, {
+      snapshot_id: 'snap-1',
+      onProgress: callbacks[1],
+      signal: controllers[1].signal,
+    });
+    await api.save(OWNER_ID, {
+      snapshot_id: 'snap-1',
+      onProgress: callbacks[2],
+      signal: controllers[2].signal,
+    });
+
+    expect_adapted_options(
+      verify_onedrive_snapshot.mock.calls[0]![3],
+      callbacks[0],
+      controllers[0],
+    );
+    expect_adapted_options(restore_onedrive.mock.calls[0]![2], callbacks[1], controllers[1]);
+    expect_adapted_options(save_snapshot.mock.calls[0]![2], callbacks[2], controllers[2]);
+  });
+
+  it('adapts SharePoint verify, restore, and save options', async () => {
+    const verify_sharepoint_snapshot = vi.fn().mockResolvedValue({ interrupted: false });
+    const restore_sharepoint = vi.fn().mockResolvedValue({ interrupted: false });
+    const save_snapshot = vi.fn().mockResolvedValue({ interrupted: false });
+    const api = create_sharepoint_api(
+      TENANT_ID,
+      container_with(
+        [SHAREPOINT_VERIFICATION_USE_CASE_TOKEN, { verify_sharepoint_snapshot }],
+        [SHAREPOINT_RESTORE_USE_CASE_TOKEN, { restore_sharepoint }],
+        [SHAREPOINT_SAVE_USE_CASE_TOKEN, { save_snapshot }],
+      ),
+    );
+    const controllers = [new AbortController(), new AbortController(), new AbortController()];
+    const callbacks = [vi.fn(), vi.fn(), vi.fn()];
+
+    await api.verify(OWNER_ID, 'snap-1', {
+      onProgress: callbacks[0],
+      signal: controllers[0].signal,
+    });
+    await api.restore(OWNER_ID, {
+      snapshot_id: 'snap-1',
+      onProgress: callbacks[1],
+      signal: controllers[1].signal,
+    });
+    await api.save(OWNER_ID, {
+      snapshot_id: 'snap-1',
+      onProgress: callbacks[2],
+      signal: controllers[2].signal,
+    });
+
+    expect_adapted_options(
+      verify_sharepoint_snapshot.mock.calls[0]![3],
+      callbacks[0],
+      controllers[0],
+    );
+    expect_adapted_options(restore_sharepoint.mock.calls[0]![2], callbacks[1], controllers[1]);
+    expect_adapted_options(save_snapshot.mock.calls[0]![2], callbacks[2], controllers[2]);
+  });
+});

--- a/packages/sharepoint/src/services/sharepoint-backup-builders.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-builders.ts
@@ -103,10 +103,12 @@ export function build_empty_result(
   errors: string[],
   warnings: string[],
   healthy: boolean,
+  interrupted: boolean,
 ): SharePointBackupResult {
   return {
     site_id,
     snapshot: undefined,
+    interrupted,
     summary: {
       libraries_scanned,
       files_changed: 0,

--- a/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
@@ -30,6 +30,7 @@ export interface LibraryProcessingResult {
   delta_link?: string;
   /** Site-wide ledger after this library's retries and new failures. */
   failed_items: FailedItemLedger;
+  interrupted: boolean;
   package_report: PackageReport;
 }
 
@@ -66,6 +67,7 @@ export async function process_single_library(
   ctx: TenantContext,
   version_stats: VersionStatsState,
   failed_items: FailedItemLedger,
+  on_item_processed?: (file_name: string) => void,
 ): Promise<LibraryProcessingResult> {
   const prev_delta =
     options.force_full === true
@@ -92,7 +94,7 @@ export async function process_single_library(
     failed_item_ids: new Set<string>(),
   };
 
-  await retry_failed_items(
+  let interrupted = await retry_failed_items(
     connector,
     tenant_id,
     site_id,
@@ -103,9 +105,16 @@ export async function process_single_library(
     library_state,
     file_indexes,
     version_stats,
+    options.should_interrupt,
+    on_item_processed,
   );
 
+  let processed_delta_items = 0;
   for (const item of delta.items) {
+    if (options.should_interrupt?.() === true) {
+      interrupted = true;
+      break;
+    }
     await process_item_guarded(
       connector,
       item,
@@ -117,11 +126,18 @@ export async function process_single_library(
       file_indexes,
       version_stats,
     );
+    processed_delta_items++;
+    on_item_processed?.(item.file_name);
   }
 
-  const package_report = summarize_package_items(delta.items, library_state.failed_item_ids);
+  const incomplete_item_ids = new Set(library_state.failed_item_ids);
+  if (interrupted) {
+    for (const item of delta.items.slice(processed_delta_items))
+      incomplete_item_ids.add(item.item_id);
+  }
+  const package_report = summarize_package_items(delta.items, incomplete_item_ids);
 
-  delta_link_by_drive[library.drive_id] = delta.delta_link;
+  if (!interrupted) delta_link_by_drive[library.drive_id] = delta.delta_link;
   await cursors.save(ctx, {
     site_id,
     delta_link_by_drive,
@@ -135,7 +151,8 @@ export async function process_single_library(
     files_stored: library_state.library_files_stored,
     files_deduplicated: library_state.library_files_deduplicated,
     deleted_items: library_state.library_deleted_items,
-    delta_link: delta.delta_link,
+    ...(interrupted ? {} : { delta_link: delta.delta_link }),
+    interrupted,
     failed_items: library_state.failed_items,
     package_report,
   };

--- a/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
@@ -129,6 +129,7 @@ export async function process_single_library(
     processed_delta_items++;
     on_item_processed?.(item.file_name);
   }
+  interrupted ||= options.should_interrupt?.() === true;
 
   const incomplete_item_ids = new Set(library_state.failed_item_ids);
   if (interrupted) {

--- a/packages/sharepoint/src/services/sharepoint-backup-library-scan.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-library-scan.ts
@@ -1,6 +1,7 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import type { FailedItemLedger } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
 import type { PackageReport } from '@wisecom/atlas-core/services/shared/package-item-reporter';
+import { emit_operation_progress } from '@wisecom/atlas-core/services/shared/operation-progress';
 import type {
   SharePointBackupOptions,
   SharePointDeltaCursor,
@@ -27,6 +28,7 @@ export interface SharePointLibraryScanResult {
   version_stats: VersionStatsState;
   package_reports: PackageReport[];
   libraries_scanned: number;
+  items_processed: number;
   interrupted: boolean;
 }
 
@@ -76,9 +78,9 @@ export async function scan_all_libraries({
     },
     package_reports: [],
     libraries_scanned: 0,
+    items_processed: 0,
     interrupted: false,
   };
-  let processed = 0;
 
   for (const library of libraries) {
     if (options.should_interrupt?.() === true) {
@@ -103,12 +105,12 @@ export async function scan_all_libraries({
         result.version_stats,
         result.failed_items,
         (file_name) => {
-          processed++;
-          options.on_progress?.({
+          result.items_processed++;
+          emit_operation_progress(options, {
             operation: 'backup',
             workload: 'sharepoint',
             phase: 'processing',
-            processed,
+            processed: result.items_processed,
             current: file_name,
           });
         },

--- a/packages/sharepoint/src/services/sharepoint-backup-library-scan.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-library-scan.ts
@@ -1,0 +1,135 @@
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import type { FailedItemLedger } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
+import type { PackageReport } from '@wisecom/atlas-core/services/shared/package-item-reporter';
+import type {
+  SharePointBackupOptions,
+  SharePointDeltaCursor,
+  SharePointDeltaCursorRepository,
+  SharePointDocumentLibrary,
+  SharePointFileVersionIndexRepository,
+  SharePointManifestEntry,
+  SharePointSiteConnector,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { process_single_library } from '@/services/sharepoint-backup-library-processor';
+import type {
+  FileTrackingState,
+  VersionStatsState,
+} from '@/services/sharepoint-library-item-processor';
+
+export interface SharePointLibraryScanResult {
+  entries: SharePointManifestEntry[];
+  files_stored: number;
+  files_deduplicated: number;
+  deleted_items: number;
+  errors: string[];
+  failed_items: FailedItemLedger;
+  version_stats: VersionStatsState;
+  package_reports: PackageReport[];
+  libraries_scanned: number;
+  interrupted: boolean;
+}
+
+interface SharePointLibraryScanParams {
+  connector: SharePointSiteConnector;
+  cursors: SharePointDeltaCursorRepository;
+  file_indexes: SharePointFileVersionIndexRepository;
+  tenant_id: string;
+  site_id: string;
+  snapshot_id: string;
+  libraries: readonly SharePointDocumentLibrary[];
+  options: SharePointBackupOptions;
+  previous_cursor: SharePointDeltaCursor | undefined;
+  tracking: FileTrackingState;
+  delta_link_by_drive: Record<string, string>;
+  ctx: TenantContext;
+  initial_failed_items: FailedItemLedger;
+}
+
+/** Scans libraries sequentially and stops at a safe item boundary. */
+export async function scan_all_libraries({
+  connector,
+  cursors,
+  file_indexes,
+  tenant_id,
+  site_id,
+  snapshot_id,
+  libraries,
+  options,
+  previous_cursor,
+  tracking,
+  delta_link_by_drive,
+  ctx,
+  initial_failed_items,
+}: SharePointLibraryScanParams): Promise<SharePointLibraryScanResult> {
+  const result: SharePointLibraryScanResult = {
+    entries: [],
+    files_stored: 0,
+    files_deduplicated: 0,
+    deleted_items: 0,
+    errors: [],
+    failed_items: initial_failed_items,
+    version_stats: {
+      total_versions_stored: 0,
+      total_versions_unavailable: 0,
+      total_versions_failed: 0,
+    },
+    package_reports: [],
+    libraries_scanned: 0,
+    interrupted: false,
+  };
+  let processed = 0;
+
+  for (const library of libraries) {
+    if (options.should_interrupt?.() === true) {
+      result.interrupted = true;
+      break;
+    }
+    result.libraries_scanned++;
+    try {
+      const library_result = await process_single_library(
+        connector,
+        cursors,
+        file_indexes,
+        tenant_id,
+        site_id,
+        snapshot_id,
+        library,
+        options,
+        previous_cursor,
+        tracking,
+        delta_link_by_drive,
+        ctx,
+        result.version_stats,
+        result.failed_items,
+        (file_name) => {
+          processed++;
+          options.on_progress?.({
+            operation: 'backup',
+            workload: 'sharepoint',
+            phase: 'processing',
+            processed,
+            current: file_name,
+          });
+        },
+      );
+
+      result.failed_items = library_result.failed_items;
+      result.package_reports.push(library_result.package_report);
+      result.entries.push(...library_result.entries);
+      result.files_stored += library_result.files_stored;
+      result.files_deduplicated += library_result.files_deduplicated;
+      result.deleted_items += library_result.deleted_items;
+      if (library_result.interrupted) {
+        result.interrupted = true;
+        break;
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      logger.error(`Library ${library.drive_id} failed: ${reason}`);
+      result.errors.push(`Library ${library.drive_name} (${library.drive_id}): ${reason}`);
+    }
+  }
+
+  return result;
+}

--- a/packages/sharepoint/src/services/sharepoint-backup.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup.service.ts
@@ -9,7 +9,6 @@ import type {
   SharePointDeltaCursor,
   SharePointDeltaCursorRepository,
   SharePointFileVersionIndexRepository,
-  SharePointManifestEntry,
   SharePointManifestRepository,
   TenantContextFactory,
 } from '@wisecom/atlas-types';
@@ -20,23 +19,24 @@ import {
   SHAREPOINT_MANIFEST_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
 import {
   describe_failed_items,
   type FailedItemLedger,
 } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
-import type { PackageReport } from '@wisecom/atlas-core/services/shared/package-item-reporter';
 import {
   build_empty_result,
   build_package_warnings,
   build_snapshot_manifest,
 } from '@/services/sharepoint-backup-builders';
 import { ensure_libraries_discovered } from '@/services/sharepoint-backup-file-processor';
-import { process_single_library } from '@/services/sharepoint-backup-library-processor';
 import type {
   FileTrackingState,
   VersionStatsState,
 } from '@/services/sharepoint-library-item-processor';
+import {
+  scan_all_libraries,
+  type SharePointLibraryScanResult,
+} from '@/services/sharepoint-backup-library-scan';
 import { cleanup_stale_staging } from '@/services/sharepoint-large-file-pipeline';
 import { append_version_indexes } from '@/services/sharepoint-version-index-appender';
 
@@ -61,6 +61,12 @@ export class SharePointBackupService implements SharePointBackupUseCase {
   ): Promise<SharePointBackupResult> {
     site_id = normalize_owner_id(site_id);
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'backup',
+      workload: 'sharepoint',
+      phase: 'discovering',
+      processed: 0,
+    });
     if (options.object_lock_request?.retention_days) {
       // Bucket default retention: every new object version (files, versions,
       // manifests, cursors) inherits the lock - no write path can forget it.
@@ -74,6 +80,12 @@ export class SharePointBackupService implements SharePointBackupUseCase {
         options.force_full === true ? undefined : await this._cursors.load(ctx, site_id);
       const libraries = await this._connector.list_document_libraries(tenant_id, site_id);
       ensure_libraries_discovered(libraries.length);
+      options.on_progress?.({
+        operation: 'backup',
+        workload: 'sharepoint',
+        phase: 'processing',
+        processed: 0,
+      });
 
       const delta_link_by_drive: Record<string, string> = {
         ...(previous_cursor?.delta_link_by_drive ?? {}),
@@ -84,8 +96,11 @@ export class SharePointBackupService implements SharePointBackupUseCase {
 
       const manifest_created_at = new Date();
       const snapshot_id = `sp-snap-${manifest_created_at.getTime()}-${randomBytes(3).toString('hex')}`;
-      const scan = await this.scan_all_libraries(
-        previous_cursor?.failed_items ?? {},
+      const scan = await scan_all_libraries({
+        connector: this._connector,
+        cursors: this._cursors,
+        file_indexes: this._file_indexes,
+        initial_failed_items: previous_cursor?.failed_items ?? {},
         tenant_id,
         site_id,
         snapshot_id,
@@ -95,7 +110,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
         tracking,
         delta_link_by_drive,
         ctx,
-      );
+      });
 
       const cursor = this.build_cursor(site_id, delta_link_by_drive, tracking, scan.failed_items);
       const warnings = [
@@ -103,13 +118,17 @@ export class SharePointBackupService implements SharePointBackupUseCase {
         ...build_package_warnings(scan.package_reports),
         ...describe_failed_items(scan.failed_items),
       ];
-      const healthy = scan.errors.length === 0 && Object.keys(scan.failed_items).length === 0;
+      const healthy =
+        !scan.interrupted &&
+        scan.errors.length === 0 &&
+        Object.keys(scan.failed_items).length === 0;
 
+      let result: SharePointBackupResult;
       if (scan.entries.length === 0) {
         await this._cursors.save(ctx, cursor);
-        return build_empty_result(
+        result = build_empty_result(
           site_id,
-          libraries.length,
+          scan.libraries_scanned,
           scan.files_stored,
           scan.files_deduplicated,
           scan.deleted_items,
@@ -118,22 +137,30 @@ export class SharePointBackupService implements SharePointBackupUseCase {
           scan.errors,
           warnings,
           healthy,
+          scan.interrupted,
+        );
+      } else {
+        result = await this.finalize_snapshot(
+          ctx,
+          tenant_id,
+          site_id,
+          scan,
+          snapshot_id,
+          manifest_created_at,
+          scan.libraries_scanned,
+          options,
+          cursor,
+          warnings,
+          healthy,
         );
       }
-
-      return this.finalize_snapshot(
-        ctx,
-        tenant_id,
-        site_id,
-        scan,
-        snapshot_id,
-        manifest_created_at,
-        libraries.length,
-        options,
-        cursor,
-        warnings,
-        healthy,
-      );
+      options.on_progress?.({
+        operation: 'backup',
+        workload: 'sharepoint',
+        phase: scan.interrupted ? 'interrupted' : 'completed',
+        processed: scan.files_stored + scan.files_deduplicated + scan.deleted_items,
+      });
+      return result;
     } finally {
       ctx.destroy();
     }
@@ -147,84 +174,6 @@ export class SharePointBackupService implements SharePointBackupUseCase {
       previous_name_by_file_id: { ...(previous_cursor?.previous_name_by_file_id ?? {}) },
       previous_etag_by_file_id: { ...(previous_cursor?.previous_etag_by_file_id ?? {}) },
       previous_kind_by_file_id: { ...(previous_cursor?.previous_kind_by_file_id ?? {}) },
-    };
-  }
-
-  private async scan_all_libraries(
-    initial_failed_items: FailedItemLedger,
-    tenant_id: string,
-    site_id: string,
-    snapshot_id: string,
-    libraries: Awaited<ReturnType<SharePointSiteConnector['list_document_libraries']>>,
-    options: SharePointBackupOptions,
-    previous_cursor: SharePointDeltaCursor | undefined,
-    tracking: FileTrackingState,
-    delta_link_by_drive: Record<string, string>,
-    ctx: Awaited<ReturnType<TenantContextFactory['create']>>,
-  ): Promise<{
-    entries: SharePointManifestEntry[];
-    files_stored: number;
-    files_deduplicated: number;
-    deleted_items: number;
-    errors: string[];
-    failed_items: FailedItemLedger;
-    version_stats: VersionStatsState;
-    package_reports: PackageReport[];
-  }> {
-    const entries: SharePointManifestEntry[] = [];
-    let files_stored = 0;
-    let files_deduplicated = 0;
-    let deleted_items = 0;
-    const version_stats: VersionStatsState = {
-      total_versions_stored: 0,
-      total_versions_unavailable: 0,
-      total_versions_failed: 0,
-    };
-    const errors: string[] = [];
-    let failed_items = initial_failed_items;
-    const package_reports: PackageReport[] = [];
-
-    for (const library of libraries) {
-      try {
-        const library_result = await process_single_library(
-          this._connector,
-          this._cursors,
-          this._file_indexes,
-          tenant_id,
-          site_id,
-          snapshot_id,
-          library,
-          options,
-          previous_cursor,
-          tracking,
-          delta_link_by_drive,
-          ctx,
-          version_stats,
-          failed_items,
-        );
-
-        failed_items = library_result.failed_items;
-        package_reports.push(library_result.package_report);
-        entries.push(...library_result.entries);
-        files_stored += library_result.files_stored;
-        files_deduplicated += library_result.files_deduplicated;
-        deleted_items += library_result.deleted_items;
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        logger.error(`Library ${library.drive_id} failed: ${reason}`);
-        errors.push(`Library ${library.drive_name} (${library.drive_id}): ${reason}`);
-      }
-    }
-
-    return {
-      entries,
-      files_stored,
-      files_deduplicated,
-      deleted_items,
-      errors,
-      failed_items,
-      version_stats,
-      package_reports,
     };
   }
 
@@ -252,14 +201,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
     ctx: Awaited<ReturnType<TenantContextFactory['create']>>,
     tenant_id: string,
     site_id: string,
-    scan: {
-      entries: SharePointManifestEntry[];
-      files_stored: number;
-      files_deduplicated: number;
-      deleted_items: number;
-      errors: string[];
-      version_stats: VersionStatsState;
-    },
+    scan: SharePointLibraryScanResult,
     snapshot_id: string,
     manifest_created_at: Date,
     libraries_scanned: number,
@@ -291,6 +233,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
     return {
       site_id,
       snapshot,
+      interrupted: scan.interrupted,
       summary: {
         libraries_scanned,
         files_changed: scan.entries.length,

--- a/packages/sharepoint/src/services/sharepoint-backup.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup.service.ts
@@ -1,5 +1,10 @@
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { randomBytes } from 'node:crypto';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 import { inject, injectable } from 'inversify';
 import type {
   SharePointBackupOptions,
@@ -60,13 +65,11 @@ export class SharePointBackupService implements SharePointBackupUseCase {
     options: SharePointBackupOptions = {},
   ): Promise<SharePointBackupResult> {
     site_id = normalize_owner_id(site_id);
+    if (begin_operation_progress(options, 'backup', 'sharepoint')) {
+      finish_operation_progress(options, 'backup', 'sharepoint', 0, 0);
+      return build_empty_result(site_id, 0, 0, 0, 0, 0, 0, [], [], false, true);
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'backup',
-      workload: 'sharepoint',
-      phase: 'discovering',
-      processed: 0,
-    });
     if (options.object_lock_request?.retention_days) {
       // Bucket default retention: every new object version (files, versions,
       // manifests, cursors) inherits the lock - no write path can forget it.
@@ -80,7 +83,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
         options.force_full === true ? undefined : await this._cursors.load(ctx, site_id);
       const libraries = await this._connector.list_document_libraries(tenant_id, site_id);
       ensure_libraries_discovered(libraries.length);
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'backup',
         workload: 'sharepoint',
         phase: 'processing',
@@ -112,6 +115,13 @@ export class SharePointBackupService implements SharePointBackupUseCase {
         ctx,
       });
 
+      emit_operation_progress(options, {
+        operation: 'backup',
+        workload: 'sharepoint',
+        phase: 'finalizing',
+        processed: scan.items_processed,
+      });
+      scan.interrupted ||= options.should_interrupt?.() === true;
       const cursor = this.build_cursor(site_id, delta_link_by_drive, tracking, scan.failed_items);
       const warnings = [
         ...this.build_version_warnings(scan.version_stats),
@@ -154,11 +164,11 @@ export class SharePointBackupService implements SharePointBackupUseCase {
           healthy,
         );
       }
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'backup',
         workload: 'sharepoint',
         phase: scan.interrupted ? 'interrupted' : 'completed',
-        processed: scan.files_stored + scan.files_deduplicated + scan.deleted_items,
+        processed: scan.items_processed,
       });
       return result;
     } finally {

--- a/packages/sharepoint/src/services/sharepoint-entry-filter.ts
+++ b/packages/sharepoint/src/services/sharepoint-entry-filter.ts
@@ -1,0 +1,15 @@
+import type { SharePointManifestEntry } from '@wisecom/atlas-types';
+
+/** Filters manifest entries by file ID or full path, case-insensitively. */
+export function filter_sharepoint_entries(
+  entries: readonly SharePointManifestEntry[],
+  file_filter?: string[],
+): SharePointManifestEntry[] {
+  if (!file_filter || file_filter.length === 0) return [...entries];
+  const selected = new Set(file_filter.map((value) => value.toLowerCase()));
+  return entries.filter(
+    (entry) =>
+      selected.has(entry.file_id.toLowerCase()) ||
+      selected.has(`${entry.parent_path}/${entry.file_name}`.toLowerCase()),
+  );
+}

--- a/packages/sharepoint/src/services/sharepoint-library-item-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-library-item-processor.ts
@@ -188,13 +188,17 @@ export async function retry_failed_items(
   library_state: LibraryProcessingState,
   file_indexes: SharePointFileVersionIndexRepository,
   version_stats: VersionStatsState,
-): Promise<void> {
+  should_interrupt?: () => boolean,
+  on_item_processed?: (file_name: string) => void,
+): Promise<boolean> {
   for (const record of retryable_items(library_state.failed_items, drive_id)) {
+    if (should_interrupt?.() === true) return true;
     const item = await connector.fetch_item_by_id(tenant_id, site_id, drive_id, record.item_id);
 
     if (!item) {
       logger.info(`Failed item ${record.item_id} (${record.name}) no longer exists -- clearing`);
       library_state.failed_items = clear_item_failure(library_state.failed_items, record.item_id);
+      on_item_processed?.(record.name);
       continue;
     }
 
@@ -213,7 +217,9 @@ export async function retry_failed_items(
       file_indexes,
       version_stats,
     );
+    on_item_processed?.(item.file_name);
   }
+  return false;
 }
 
 /** Drops tracking state for one item so it is reprocessed as new content. */

--- a/packages/sharepoint/src/services/sharepoint-restore.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore.service.ts
@@ -25,6 +25,7 @@ import {
   describe_unresolved_destination,
   resolve_destination_library,
 } from '@/services/sharepoint-restore-target';
+import { filter_sharepoint_entries } from '@/services/sharepoint-entry-filter';
 
 const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
 
@@ -54,6 +55,12 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
   ): Promise<SharePointRestoreResult> {
     site_id = normalize_owner_id(site_id);
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'restore',
+      workload: 'sharepoint',
+      phase: 'discovering',
+      processed: 0,
+    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, site_id, options.snapshot_id);
       if (!manifest) {
@@ -62,7 +69,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
 
       const target_site = options.target_site_id ?? site_id;
       const conflict = options.conflict_behavior ?? 'rename';
-      const entries = this.filter_entries(manifest.entries, options.file_filter);
+      const entries = filter_sharepoint_entries(manifest.entries, options.file_filter);
 
       // Entry drive ids belong to the source site, so a cross-site restore has to
       // re-point every upload at a library of the target site.
@@ -93,29 +100,52 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
         destination_by_source_drive: new Map<string, string | undefined>(),
         single_source_library: new Set(restorable.map((e) => e.drive_id)).size === 1,
       };
+      options.on_progress?.({
+        operation: 'restore',
+        workload: 'sharepoint',
+        phase: 'processing',
+        processed: 0,
+        total: restorable.length,
+      });
 
       for (const entry of restorable) {
+        if (options.should_interrupt?.() === true) break;
         const destination_drive_id = this.resolve_entry_destination(entry, routing, errors);
         if (!destination_drive_id) {
           files_skipped++;
-          continue;
+        } else {
+          const outcome = await this.restore_single_entry(
+            tenant_id,
+            target_site,
+            destination_drive_id,
+            conflict,
+            ctx,
+            entry,
+            folder_ids,
+            errors,
+          );
+          if (outcome === 'restored') files_restored++;
+          else files_skipped++;
         }
-
-        const outcome = await this.restore_single_entry(
-          tenant_id,
-          target_site,
-          destination_drive_id,
-          conflict,
-          ctx,
-          entry,
-          folder_ids,
-          errors,
-        );
-        if (outcome === 'restored') files_restored++;
-        else files_skipped++;
+        options.on_progress?.({
+          operation: 'restore',
+          workload: 'sharepoint',
+          phase: 'processing',
+          processed: files_restored + files_skipped,
+          total: restorable.length,
+          current: entry.file_name,
+        });
       }
 
       const folders_created = folder_ids.size;
+      const interrupted = options.should_interrupt?.() === true;
+      options.on_progress?.({
+        operation: 'restore',
+        workload: 'sharepoint',
+        phase: interrupted ? 'interrupted' : 'completed',
+        processed: files_restored + files_skipped,
+        total: restorable.length,
+      });
 
       return {
         snapshot_id: options.snapshot_id,
@@ -123,6 +153,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
         folders_created,
         files_skipped,
         errors,
+        interrupted,
       };
     } finally {
       ctx.destroy();
@@ -239,19 +270,6 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
       logger.warn(`Skipped ${entry.file_name}: ${msg}`);
       return 'skipped';
     }
-  }
-
-  private filter_entries(
-    entries: readonly SharePointManifestEntry[],
-    file_filter?: string[],
-  ): SharePointManifestEntry[] {
-    if (!file_filter || file_filter.length === 0) return [...entries];
-    const filter_set = new Set(file_filter.map((f) => f.toLowerCase()));
-    return entries.filter(
-      (e) =>
-        filter_set.has(e.file_id.toLowerCase()) ||
-        filter_set.has(`${e.parent_path}/${e.file_name}`.toLowerCase()),
-    );
   }
 
   private async ensure_folder_path(

--- a/packages/sharepoint/src/services/sharepoint-restore.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore.service.ts
@@ -1,4 +1,9 @@
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 import { inject, injectable } from 'inversify';
 import type {
   SharePointDocumentLibrary,
@@ -54,13 +59,11 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
     options: SharePointRestoreOptions,
   ): Promise<SharePointRestoreResult> {
     site_id = normalize_owner_id(site_id);
+    if (begin_operation_progress(options, 'restore', 'sharepoint')) {
+      finish_operation_progress(options, 'restore', 'sharepoint', 0, 0);
+      return empty_restore_result(options.snapshot_id);
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'restore',
-      workload: 'sharepoint',
-      phase: 'discovering',
-      processed: 0,
-    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, site_id, options.snapshot_id);
       if (!manifest) {
@@ -100,7 +103,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
         destination_by_source_drive: new Map<string, string | undefined>(),
         single_source_library: new Set(restorable.map((e) => e.drive_id)).size === 1,
       };
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'restore',
         workload: 'sharepoint',
         phase: 'processing',
@@ -127,7 +130,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
           if (outcome === 'restored') files_restored++;
           else files_skipped++;
         }
-        options.on_progress?.({
+        emit_operation_progress(options, {
           operation: 'restore',
           workload: 'sharepoint',
           phase: 'processing',
@@ -138,14 +141,14 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
       }
 
       const folders_created = folder_ids.size;
-      const interrupted = options.should_interrupt?.() === true;
-      options.on_progress?.({
-        operation: 'restore',
-        workload: 'sharepoint',
-        phase: interrupted ? 'interrupted' : 'completed',
-        processed: files_restored + files_skipped,
-        total: restorable.length,
-      });
+      const interrupted = finish_operation_progress(
+        options,
+        'restore',
+        'sharepoint',
+        files_restored + files_skipped,
+        restorable.length,
+        files_restored + files_skipped < restorable.length,
+      );
 
       return {
         snapshot_id: options.snapshot_id,
@@ -321,4 +324,15 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
 
     return parent_id;
   }
+}
+
+function empty_restore_result(snapshot_id: string): SharePointRestoreResult {
+  return {
+    snapshot_id,
+    files_restored: 0,
+    folders_created: 0,
+    files_skipped: 0,
+    errors: [],
+    interrupted: true,
+  };
 }

--- a/packages/sharepoint/src/services/sharepoint-save.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-save.service.ts
@@ -25,6 +25,7 @@ import {
   stream_decrypt_from_storage,
   verify_streaming_checksum,
 } from '@/services/sharepoint-restore-streaming';
+import { filter_sharepoint_entries } from '@/services/sharepoint-entry-filter';
 
 @injectable()
 export class SharePointSaveService implements SharePointSaveUseCase {
@@ -42,17 +43,31 @@ export class SharePointSaveService implements SharePointSaveUseCase {
   ): Promise<FileSaveResult> {
     site_id = normalize_owner_id(site_id);
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'save',
+      workload: 'sharepoint',
+      phase: 'discovering',
+      processed: 0,
+    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, site_id, options.snapshot_id);
       if (!manifest) {
         throw new Error(`Snapshot ${options.snapshot_id} not found for site ${site_id}`);
       }
 
-      const entries = this.filter_entries(manifest.entries, options.file_filter);
+      const entries = filter_sharepoint_entries(manifest.entries, options.file_filter);
       const restorable = entries.filter((e) => e.change_type !== 'deleted' && e.storage_key);
 
       if (restorable.length === 0) {
-        return this.empty_result(options.snapshot_id, options.output_path ?? '');
+        const interrupted = options.should_interrupt?.() === true;
+        options.on_progress?.({
+          operation: 'save',
+          workload: 'sharepoint',
+          phase: interrupted ? 'interrupted' : 'completed',
+          processed: 0,
+          total: 0,
+        });
+        return this.empty_result(options.snapshot_id, options.output_path ?? '', interrupted);
       }
 
       const output_path =
@@ -60,35 +75,33 @@ export class SharePointSaveService implements SharePointSaveUseCase {
       const skip_integrity = options.skip_integrity_check ?? false;
       const { archive, promise } = create_file_archive(output_path);
 
-      let files_saved = 0;
-      let files_skipped = 0;
-      const errors: string[] = [];
       const integrity_failures: string[] = [];
+      const { files_saved, files_skipped, errors } = await this.save_restorable_entries_to_archive(
+        ctx,
+        archive,
+        restorable,
+        skip_integrity,
+        integrity_failures,
+        options,
+      );
 
-      for (const entry of restorable) {
-        try {
-          const content = await this.download_and_decrypt(
-            ctx,
-            entry,
-            skip_integrity,
-            integrity_failures,
-          );
-          if (!content) {
-            files_skipped++;
-            continue;
-          }
-          await add_file_to_archive(archive, entry.parent_path, entry.file_name, content);
-          files_saved++;
-          logger.info(`Saved: ${entry.parent_path}/${entry.file_name}`);
-        } catch (err) {
-          const msg = `${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`;
-          errors.push(msg);
-          files_skipped++;
-        }
-      }
-
+      options.on_progress?.({
+        operation: 'save',
+        workload: 'sharepoint',
+        phase: 'finalizing',
+        processed: files_saved + files_skipped,
+        total: restorable.length,
+      });
       await finalize_file_archive(archive);
       const total_bytes = await promise;
+      const interrupted = options.should_interrupt?.() === true;
+      options.on_progress?.({
+        operation: 'save',
+        workload: 'sharepoint',
+        phase: interrupted ? 'interrupted' : 'completed',
+        processed: files_saved + files_skipped,
+        total: restorable.length,
+      });
 
       return {
         snapshot_id: options.snapshot_id,
@@ -98,23 +111,64 @@ export class SharePointSaveService implements SharePointSaveUseCase {
         integrity_failures,
         output_path,
         total_bytes,
+        interrupted,
       };
     } finally {
       ctx.destroy();
     }
   }
 
-  private filter_entries(
-    entries: readonly SharePointManifestEntry[],
-    file_filter?: string[],
-  ): SharePointManifestEntry[] {
-    if (!file_filter || file_filter.length === 0) return [...entries];
-    const filter_set = new Set(file_filter.map((f) => f.toLowerCase()));
-    return entries.filter(
-      (e) =>
-        filter_set.has(e.file_id.toLowerCase()) ||
-        filter_set.has(`${e.parent_path}/${e.file_name}`.toLowerCase()),
-    );
+  /** Saves sequential entries until cancellation, reporting partial counts. */
+  private async save_restorable_entries_to_archive(
+    ctx: TenantContext,
+    archive: Parameters<typeof add_file_to_archive>[0],
+    entries: SharePointManifestEntry[],
+    skip_integrity: boolean,
+    integrity_failures: string[],
+    options: FileSaveOptions,
+  ): Promise<{ files_saved: number; files_skipped: number; errors: string[] }> {
+    let files_saved = 0;
+    let files_skipped = 0;
+    const errors: string[] = [];
+    options.on_progress?.({
+      operation: 'save',
+      workload: 'sharepoint',
+      phase: 'processing',
+      processed: 0,
+      total: entries.length,
+    });
+
+    for (const entry of entries) {
+      if (options.should_interrupt?.() === true) break;
+      try {
+        const content = await this.download_and_decrypt(
+          ctx,
+          entry,
+          skip_integrity,
+          integrity_failures,
+        );
+        if (!content) {
+          files_skipped++;
+        } else {
+          await add_file_to_archive(archive, entry.parent_path, entry.file_name, content);
+          files_saved++;
+          logger.info(`Saved: ${entry.parent_path}/${entry.file_name}`);
+        }
+      } catch (err) {
+        errors.push(`${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`);
+        files_skipped++;
+      }
+      options.on_progress?.({
+        operation: 'save',
+        workload: 'sharepoint',
+        phase: 'processing',
+        processed: files_saved + files_skipped,
+        total: entries.length,
+        current: entry.file_name,
+      });
+    }
+
+    return { files_saved, files_skipped, errors };
   }
 
   private async download_and_decrypt(
@@ -169,7 +223,11 @@ export class SharePointSaveService implements SharePointSaveUseCase {
     }
   }
 
-  private empty_result(snapshot_id: string, output_path: string): FileSaveResult {
+  private empty_result(
+    snapshot_id: string,
+    output_path: string,
+    interrupted = false,
+  ): FileSaveResult {
     return {
       snapshot_id,
       files_saved: 0,
@@ -178,6 +236,7 @@ export class SharePointSaveService implements SharePointSaveUseCase {
       integrity_failures: [],
       output_path,
       total_bytes: 0,
+      interrupted,
     };
   }
 }

--- a/packages/sharepoint/src/services/sharepoint-save.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-save.service.ts
@@ -1,4 +1,9 @@
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
@@ -42,13 +47,11 @@ export class SharePointSaveService implements SharePointSaveUseCase {
     options: FileSaveOptions,
   ): Promise<FileSaveResult> {
     site_id = normalize_owner_id(site_id);
+    if (begin_operation_progress(options, 'save', 'sharepoint')) {
+      finish_operation_progress(options, 'save', 'sharepoint', 0, 0);
+      return this.empty_result(options.snapshot_id, options.output_path ?? '', true);
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'save',
-      workload: 'sharepoint',
-      phase: 'discovering',
-      processed: 0,
-    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, site_id, options.snapshot_id);
       if (!manifest) {
@@ -59,14 +62,7 @@ export class SharePointSaveService implements SharePointSaveUseCase {
       const restorable = entries.filter((e) => e.change_type !== 'deleted' && e.storage_key);
 
       if (restorable.length === 0) {
-        const interrupted = options.should_interrupt?.() === true;
-        options.on_progress?.({
-          operation: 'save',
-          workload: 'sharepoint',
-          phase: interrupted ? 'interrupted' : 'completed',
-          processed: 0,
-          total: 0,
-        });
+        const interrupted = finish_operation_progress(options, 'save', 'sharepoint', 0, 0);
         return this.empty_result(options.snapshot_id, options.output_path ?? '', interrupted);
       }
 
@@ -85,7 +81,7 @@ export class SharePointSaveService implements SharePointSaveUseCase {
         options,
       );
 
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'save',
         workload: 'sharepoint',
         phase: 'finalizing',
@@ -94,8 +90,9 @@ export class SharePointSaveService implements SharePointSaveUseCase {
       });
       await finalize_file_archive(archive);
       const total_bytes = await promise;
-      const interrupted = options.should_interrupt?.() === true;
-      options.on_progress?.({
+      const interrupted =
+        files_saved + files_skipped < restorable.length || options.should_interrupt?.() === true;
+      emit_operation_progress(options, {
         operation: 'save',
         workload: 'sharepoint',
         phase: interrupted ? 'interrupted' : 'completed',
@@ -130,7 +127,7 @@ export class SharePointSaveService implements SharePointSaveUseCase {
     let files_saved = 0;
     let files_skipped = 0;
     const errors: string[] = [];
-    options.on_progress?.({
+    emit_operation_progress(options, {
       operation: 'save',
       workload: 'sharepoint',
       phase: 'processing',
@@ -158,7 +155,7 @@ export class SharePointSaveService implements SharePointSaveUseCase {
         errors.push(`${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`);
         files_skipped++;
       }
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'save',
         workload: 'sharepoint',
         phase: 'processing',

--- a/packages/sharepoint/src/services/sharepoint-site-tree-backup.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-site-tree-backup.service.ts
@@ -47,17 +47,18 @@ export class SharePointSiteTreeBackupService implements SharePointSiteTreeBackup
     const root_result = await this._backup.backup_site(tenant_id, root_site_id, options);
     const results = [with_extra_warnings(root_result, root_warnings)];
 
-    if (!include_subsites) return results;
+    if (!include_subsites || root_result.interrupted) return results;
 
     for (const subsite of tree.sites) {
+      if (options.should_interrupt?.() === true) break;
       logger.info(`Backing up subsite: ${subsite.display_name || subsite.site_url}`);
-      results.push(
-        await this._backup.backup_site(tenant_id, subsite.site_id, {
-          ...options,
-          site_url: subsite.site_url,
-          site_display_name: subsite.display_name,
-        }),
-      );
+      const subsite_result = await this._backup.backup_site(tenant_id, subsite.site_id, {
+        ...options,
+        site_url: subsite.site_url,
+        site_display_name: subsite.display_name,
+      });
+      results.push(subsite_result);
+      if (subsite_result.interrupted) break;
     }
 
     return results;

--- a/packages/sharepoint/src/services/sharepoint-verification.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-verification.service.ts
@@ -1,4 +1,9 @@
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 import type {
@@ -38,13 +43,18 @@ export class SharePointVerificationService implements SharePointVerificationUseC
     options: VerificationOptions = {},
   ): Promise<SharePointVerificationResult> {
     site_id = normalize_owner_id(site_id);
+    if (begin_operation_progress(options, 'verify', 'sharepoint')) {
+      finish_operation_progress(options, 'verify', 'sharepoint', 0, 0);
+      return {
+        snapshot_id,
+        total_checked: 0,
+        passed: 0,
+        failed_file_ids: [],
+        index_issues: [],
+        interrupted: true,
+      };
+    }
     const ctx = await this._tenant_factory.create(tenant_id);
-    options.on_progress?.({
-      operation: 'verify',
-      workload: 'sharepoint',
-      phase: 'discovering',
-      processed: 0,
-    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, site_id, snapshot_id);
       if (!manifest) {
@@ -55,7 +65,7 @@ export class SharePointVerificationService implements SharePointVerificationUseC
       const index_issues: string[] = [];
       let total_checked = 0;
       let processed = 0;
-      options.on_progress?.({
+      emit_operation_progress(options, {
         operation: 'verify',
         workload: 'sharepoint',
         phase: 'processing',
@@ -79,7 +89,7 @@ export class SharePointVerificationService implements SharePointVerificationUseC
           if (corrupt) failed_file_ids.push(entry.file_id);
         }
         processed++;
-        options.on_progress?.({
+        emit_operation_progress(options, {
           operation: 'verify',
           workload: 'sharepoint',
           phase: 'processing',
@@ -89,14 +99,14 @@ export class SharePointVerificationService implements SharePointVerificationUseC
         });
       }
 
-      const interrupted = options.should_interrupt?.() === true;
-      options.on_progress?.({
-        operation: 'verify',
-        workload: 'sharepoint',
-        phase: interrupted ? 'interrupted' : 'completed',
+      const interrupted = finish_operation_progress(
+        options,
+        'verify',
+        'sharepoint',
         processed,
-        total: manifest.entries.length,
-      });
+        manifest.entries.length,
+        processed < manifest.entries.length,
+      );
 
       return {
         snapshot_id,

--- a/packages/sharepoint/src/services/sharepoint-verification.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-verification.service.ts
@@ -9,6 +9,7 @@ import type {
   SharePointVerificationUseCase,
   TenantContext,
   TenantContextFactory,
+  VerificationOptions,
 } from '@wisecom/atlas-types';
 import {
   SHAREPOINT_FILE_VERSION_INDEX_REPOSITORY_TOKEN,
@@ -34,9 +35,16 @@ export class SharePointVerificationService implements SharePointVerificationUseC
     tenant_id: string,
     site_id: string,
     snapshot_id: string,
+    options: VerificationOptions = {},
   ): Promise<SharePointVerificationResult> {
     site_id = normalize_owner_id(site_id);
     const ctx = await this._tenant_factory.create(tenant_id);
+    options.on_progress?.({
+      operation: 'verify',
+      workload: 'sharepoint',
+      phase: 'discovering',
+      processed: 0,
+    });
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, site_id, snapshot_id);
       if (!manifest) {
@@ -46,8 +54,17 @@ export class SharePointVerificationService implements SharePointVerificationUseC
       const failed_file_ids: string[] = [];
       const index_issues: string[] = [];
       let total_checked = 0;
+      let processed = 0;
+      options.on_progress?.({
+        operation: 'verify',
+        workload: 'sharepoint',
+        phase: 'processing',
+        processed: 0,
+        total: manifest.entries.length,
+      });
 
       for (const entry of manifest.entries) {
+        if (options.should_interrupt?.() === true) break;
         const idx = await this._indexes.find_by_file_id(ctx, manifest.site_id, entry.file_id);
         const has_version = idx?.versions.some((v) => v.snapshot_id === snapshot_id);
         if (!has_version) {
@@ -56,12 +73,30 @@ export class SharePointVerificationService implements SharePointVerificationUseC
           );
         }
 
-        if (!this.entry_has_blob(entry)) continue;
-
-        total_checked++;
-        const corrupt = await this.is_blob_corrupt(ctx, entry);
-        if (corrupt) failed_file_ids.push(entry.file_id);
+        if (this.entry_has_blob(entry)) {
+          total_checked++;
+          const corrupt = await this.is_blob_corrupt(ctx, entry);
+          if (corrupt) failed_file_ids.push(entry.file_id);
+        }
+        processed++;
+        options.on_progress?.({
+          operation: 'verify',
+          workload: 'sharepoint',
+          phase: 'processing',
+          processed,
+          total: manifest.entries.length,
+          current: entry.file_name,
+        });
       }
+
+      const interrupted = options.should_interrupt?.() === true;
+      options.on_progress?.({
+        operation: 'verify',
+        workload: 'sharepoint',
+        phase: interrupted ? 'interrupted' : 'completed',
+        processed,
+        total: manifest.entries.length,
+      });
 
       return {
         snapshot_id,
@@ -69,6 +104,7 @@ export class SharePointVerificationService implements SharePointVerificationUseC
         passed: total_checked - failed_file_ids.length,
         failed_file_ids,
         index_issues,
+        interrupted,
       };
     } finally {
       ctx.destroy();

--- a/packages/sharepoint/tests/unit/services/sharepoint-backup-builders.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-backup-builders.test.ts
@@ -178,7 +178,7 @@ describe('build_snapshot_manifest', () => {
 
 describe('build_empty_result', () => {
   it('produces a result with snapshot undefined and given counters', () => {
-    const result = build_empty_result('site-1', 2, 5, 3, 1, 4, 2, [], [], true);
+    const result = build_empty_result('site-1', 2, 5, 3, 1, 4, 2, [], [], true, false);
 
     expect(result.site_id).toBe('site-1');
     expect(result.snapshot).toBeUndefined();
@@ -196,7 +196,7 @@ describe('build_empty_result', () => {
   });
 
   it('marks unhealthy when errors are present', () => {
-    const result = build_empty_result('site-1', 1, 0, 0, 0, 0, 0, ['timeout'], [], false);
+    const result = build_empty_result('site-1', 1, 0, 0, 0, 0, 0, ['timeout'], [], false, false);
 
     expect(result.summary.healthy).toBe(false);
     expect(result.summary.errors).toEqual(['timeout']);

--- a/packages/sharepoint/tests/unit/services/sharepoint-backup-failed-items.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-backup-failed-items.test.ts
@@ -244,4 +244,24 @@ describe('SharePoint backup — persistently failing items', () => {
     );
     expect(connector.download_file_content).toHaveBeenCalledTimes(1);
   });
+  it('keeps the prior delta link when the last item callback cancels', async () => {
+    let interrupted = false;
+    const cursors = make_cursors(make_previous_cursor({}));
+    const connector = make_connector({
+      fetch_delta: make_delta([make_file_item('f1')], 'https://next'),
+    });
+    const service = make_service({ connector, manifests, file_indexes, cursors });
+
+    const result = await service.backup_site('tenant-1', 'site-1', {
+      on_progress: (event) => {
+        if (event.phase === 'processing' && event.processed === 1) interrupted = true;
+      },
+      should_interrupt: () => interrupted,
+    });
+
+    expect(result.interrupted).toBe(true);
+    expect(last_saved_cursor(cursors).delta_link_by_drive['drive-1']).toBe(
+      'https://old-delta-link',
+    );
+  });
 });

--- a/packages/sharepoint/tests/unit/services/sharepoint-backup-failed-items.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-backup-failed-items.test.ts
@@ -221,4 +221,27 @@ describe('SharePoint backup — persistently failing items', () => {
     expect(result.summary.errors).toEqual([]);
     expect(last_saved_cursor(cursors).delta_link_by_drive['drive-1']).toBe('https://next');
   });
+  it('keeps the prior delta link when interrupted between items', async () => {
+    let interrupted = false;
+    const cursors = make_cursors(make_previous_cursor({}));
+    const connector = make_connector({
+      fetch_delta: make_delta([make_file_item('f1'), make_file_item('f2')], 'https://next'),
+    });
+    const on_progress = vi.fn((event: { phase: string; processed: number }) => {
+      if (event.phase === 'processing' && event.processed === 1) interrupted = true;
+    });
+
+    const service = make_service({ connector, manifests, file_indexes, cursors });
+    const result = await service.backup_site('tenant-1', 'site-1', {
+      on_progress,
+      should_interrupt: () => interrupted,
+    });
+
+    expect(result.interrupted).toBe(true);
+    expect(result.snapshot!.entries.map((entry) => entry.file_id)).toEqual(['f1']);
+    expect(last_saved_cursor(cursors).delta_link_by_drive['drive-1']).toBe(
+      'https://old-delta-link',
+    );
+    expect(connector.download_file_content).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/sharepoint/tests/unit/services/sharepoint-file-filter.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-file-filter.test.ts
@@ -6,10 +6,8 @@
  * before and 1 after.
  */
 import { describe, it, expect } from 'vitest';
-import 'reflect-metadata';
-import { SharePointRestoreService } from '@/services/sharepoint-restore.service';
-import { SharePointSaveService } from '@/services/sharepoint-save.service';
 import type { SharePointManifestEntry } from '@wisecom/atlas-types';
+import { filter_sharepoint_entries } from '@/services/sharepoint-entry-filter';
 
 const ITEM_ID = '01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3';
 
@@ -21,37 +19,24 @@ const ENTRY = {
   storage_key: 'sharepoint/data/o/abc',
 } as SharePointManifestEntry;
 
-interface Filterable {
-  filter_entries(
-    entries: readonly SharePointManifestEntry[],
-    file_filter?: string[],
-  ): SharePointManifestEntry[];
-}
-
-/** `filter_entries` is private; both services must answer the same way. */
-const services: [string, Filterable][] = [
-  ['restore', SharePointRestoreService.prototype as unknown as Filterable],
-  ['save', SharePointSaveService.prototype as unknown as Filterable],
-];
-
-describe.each(services)('%s file_filter', (_name, service) => {
+describe('SharePoint file_filter', () => {
   it('matches an item id pasted verbatim from a listing', () => {
-    expect(service.filter_entries([ENTRY], [ITEM_ID])).toHaveLength(1);
+    expect(filter_sharepoint_entries([ENTRY], [ITEM_ID])).toHaveLength(1);
   });
 
   it('matches an item id typed in any case', () => {
-    expect(service.filter_entries([ENTRY], [ITEM_ID.toLowerCase()])).toHaveLength(1);
+    expect(filter_sharepoint_entries([ENTRY], [ITEM_ID.toLowerCase()])).toHaveLength(1);
   });
 
   it('still matches by path', () => {
-    expect(service.filter_entries([ENTRY], ['/documents/report.docx'])).toHaveLength(1);
+    expect(filter_sharepoint_entries([ENTRY], ['/documents/report.docx'])).toHaveLength(1);
   });
 
   it('excludes what was not asked for', () => {
-    expect(service.filter_entries([ENTRY], ['/Documents/Other.docx'])).toHaveLength(0);
+    expect(filter_sharepoint_entries([ENTRY], ['/Documents/Other.docx'])).toHaveLength(0);
   });
 
   it('returns everything when no filter is given', () => {
-    expect(service.filter_entries([ENTRY], [])).toHaveLength(1);
+    expect(filter_sharepoint_entries([ENTRY], [])).toHaveLength(1);
   });
 });

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-cancellation.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-cancellation.test.ts
@@ -7,7 +7,10 @@ import type {
   TenantContext,
   TenantContextFactory,
 } from '@wisecom/atlas-types';
+import { SharePointBackupService } from '@/services/sharepoint-backup.service';
 import { SharePointRestoreService } from '@/services/sharepoint-restore.service';
+import { SharePointSaveService } from '@/services/sharepoint-save.service';
+import { SharePointVerificationService } from '@/services/sharepoint-verification.service';
 
 vi.mock('@/services/sharepoint-restore-streaming', () => ({
   should_stream_restore: vi.fn().mockReturnValue(false),
@@ -32,6 +35,53 @@ function make_entry(file_id: string): SharePointManifestEntry {
 }
 
 describe('SharePoint restore cancellation', () => {
+  it('does no remote work when every operation starts interrupted', async () => {
+    const factory = { create: vi.fn() } as unknown as TenantContextFactory;
+    const callbacks = Array.from({ length: 4 }, () => vi.fn());
+    const should_interrupt = (): boolean => true;
+    const backup = new SharePointBackupService(
+      factory,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+    const restore = new SharePointRestoreService(factory, {} as never, {} as never);
+    const save = new SharePointSaveService(factory, {} as never);
+    const verify = new SharePointVerificationService(factory, {} as never, {} as never);
+
+    const results = await Promise.all([
+      backup.backup_site('tenant-1', 'site-1', {
+        should_interrupt,
+        on_progress: callbacks[0],
+      }),
+      restore.restore_sharepoint('tenant-1', 'site-1', {
+        snapshot_id: 'snap-1',
+        should_interrupt,
+        on_progress: callbacks[1],
+      }),
+      save.save_snapshot('tenant-1', 'site-1', {
+        snapshot_id: 'snap-1',
+        should_interrupt,
+        on_progress: callbacks[2],
+      }),
+      verify.verify_sharepoint_snapshot('tenant-1', 'site-1', 'snap-1', {
+        should_interrupt,
+        on_progress: callbacks[3],
+      }),
+    ]);
+
+    expect(factory.create).not.toHaveBeenCalled();
+    expect(results.every((result) => result.interrupted)).toBe(true);
+    for (const callback of callbacks) {
+      expect(callback.mock.calls.map(([event]) => event.phase)).toEqual([
+        'discovering',
+        'finalizing',
+        'interrupted',
+      ]);
+    }
+  });
+
   it('finishes the current file then stops with partial counts', async () => {
     let interrupted = false;
     const context = {
@@ -70,5 +120,12 @@ describe('SharePoint restore cancellation', () => {
     expect(result).toMatchObject({ files_restored: 1, files_skipped: 0, interrupted: true });
     expect(connector.upload_small_file).toHaveBeenCalledTimes(1);
     expect(on_progress).toHaveBeenLastCalledWith(expect.objectContaining({ phase: 'interrupted' }));
+    expect(on_progress.mock.calls.map(([event]) => event.phase)).toEqual([
+      'discovering',
+      'processing',
+      'processing',
+      'finalizing',
+      'interrupted',
+    ]);
   });
 });

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-cancellation.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-cancellation.test.ts
@@ -1,0 +1,74 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  SharePointManifestEntry,
+  SharePointManifestRepository,
+  SharePointSiteConnector,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { SharePointRestoreService } from '@/services/sharepoint-restore.service';
+
+vi.mock('@/services/sharepoint-restore-streaming', () => ({
+  should_stream_restore: vi.fn().mockReturnValue(false),
+  stream_decrypt_from_storage: vi.fn(),
+  verify_streaming_checksum: vi.fn().mockReturnValue(true),
+}));
+
+const CONTENT = Buffer.from('restored-content');
+
+function make_entry(file_id: string): SharePointManifestEntry {
+  return {
+    file_id,
+    drive_id: 'drive-1',
+    file_name: `${file_id}.txt`,
+    parent_path: '/Documents',
+    size_bytes: CONTENT.length,
+    change_type: 'created',
+    backup_at: '2026-08-17T00:00:00.000Z',
+    storage_key: `sharepoint/data/site-1/${file_id}`,
+    checksum: createHash('sha256').update(CONTENT).digest('hex'),
+  };
+}
+
+describe('SharePoint restore cancellation', () => {
+  it('finishes the current file then stops with partial counts', async () => {
+    let interrupted = false;
+    const context = {
+      storage: { get: vi.fn().mockResolvedValue(CONTENT) },
+      decrypt: vi.fn((content: Buffer) => content),
+      destroy: vi.fn(),
+    } as unknown as TenantContext;
+    const factory = {
+      create: vi.fn().mockResolvedValue(context),
+    } as unknown as TenantContextFactory;
+    const connector = {
+      create_folder: vi.fn().mockResolvedValue('folder-id'),
+      upload_small_file: vi.fn().mockResolvedValue(undefined),
+      upload_large_file: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SharePointSiteConnector;
+    const manifests = {
+      find_by_snapshot: vi.fn().mockResolvedValue({
+        snapshot_id: 'snap-1',
+        site_id: 'site-1',
+        created_at: new Date('2026-08-17T00:00:00.000Z'),
+        total_files: 2,
+        entries: [make_entry('f1'), make_entry('f2')],
+      }),
+    } as unknown as SharePointManifestRepository;
+    const service = new SharePointRestoreService(factory, connector, manifests);
+    const on_progress = vi.fn((event: { phase: string; processed: number }) => {
+      if (event.phase === 'processing' && event.processed === 1) interrupted = true;
+    });
+
+    const result = await service.restore_sharepoint('tenant-1', 'site-1', {
+      snapshot_id: 'snap-1',
+      on_progress,
+      should_interrupt: () => interrupted,
+    });
+
+    expect(result).toMatchObject({ files_restored: 1, files_skipped: 0, interrupted: true });
+    expect(connector.upload_small_file).toHaveBeenCalledTimes(1);
+    expect(on_progress).toHaveBeenLastCalledWith(expect.objectContaining({ phase: 'interrupted' }));
+  });
+});

--- a/packages/sharepoint/tests/unit/services/sharepoint-save.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-save.service.test.ts
@@ -238,5 +238,30 @@ describe('SharePointSaveService', () => {
 
       expect(result.files_saved).toBe(1);
     });
+    it('stops between files and returns partial counts when interrupted', async () => {
+      let interrupted = false;
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
+        make_manifest([
+          make_entry({ file_id: 'f1', file_name: 'one.docx' }),
+          make_entry({ file_id: 'f2', file_name: 'two.docx' }),
+        ]),
+      );
+      const on_progress = vi.fn((event: { phase: string; processed: number }) => {
+        if (event.phase === 'processing' && event.processed === 1) interrupted = true;
+      });
+
+      const result = await service.save_snapshot('test-tenant', 'site-1', {
+        snapshot_id: 'sp-snap-1',
+        output_path: '/tmp/interrupted.zip',
+        on_progress,
+        should_interrupt: () => interrupted,
+      });
+
+      expect(result).toMatchObject({ files_saved: 1, files_skipped: 0, interrupted: true });
+      expect(mock_context.storage.get).toHaveBeenCalledTimes(1);
+      expect(on_progress).toHaveBeenLastCalledWith(
+        expect.objectContaining({ phase: 'interrupted' }),
+      );
+    });
   });
 });

--- a/packages/sharepoint/tests/unit/services/sharepoint-site-tree-backup.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-site-tree-backup.service.test.ts
@@ -12,10 +12,11 @@ function site(id: string): SharePointSite {
   return { site_id: id, site_url: `https://contoso.sharepoint.com/sites/${id}`, display_name: id };
 }
 
-function make_result(site_id: string): SharePointBackupResult {
+function make_result(site_id: string, interrupted = false): SharePointBackupResult {
   return {
     site_id,
     snapshot: undefined,
+    interrupted,
     summary: {
       libraries_scanned: 1,
       files_changed: 0,
@@ -111,5 +112,19 @@ describe('SharePointSiteTreeBackupService', () => {
     const results = await service.backup_site_tree('t', 'root', { include_subsites: true });
 
     expect(results[0]!.summary.warnings.join(' ')).toContain('locked');
+  });
+  it('does not start another subsite after an interrupted result', async () => {
+    vi.mocked(connector.list_subsites).mockResolvedValue({
+      sites: [site('projectx'), site('projecty')],
+      warnings: [],
+    });
+    vi.mocked(backup.backup_site).mockImplementation(async (_tenant, site_id) => {
+      return make_result(site_id, site_id === 'projectx');
+    });
+
+    const results = await service.backup_site_tree('t', 'root', { include_subsites: true });
+
+    expect(results.map((result) => result.site_id)).toEqual(['root', 'projectx']);
+    expect(backup.backup_site).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/sharepoint/tests/unit/services/sharepoint-verification.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-verification.service.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { createHash } from 'node:crypto';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type {
@@ -250,7 +249,7 @@ describe('SharePointVerificationService', () => {
       return undefined;
     });
 
-    vi.mocked(mocks.ctx.decrypt).mockImplementation((ciphertext: Buffer) => {
+    vi.mocked(mocks.ctx.decrypt).mockImplementation((_ciphertext: Buffer) => {
       return good_content;
     });
 
@@ -258,5 +257,26 @@ describe('SharePointVerificationService', () => {
 
     expect(result.total_checked).toBe(2);
     expect(result.index_issues.length).toBeGreaterThanOrEqual(1);
+  });
+  it('does not start another object read after interruption', async () => {
+    let interrupted = false;
+    vi.mocked(mocks.manifests.find_by_snapshot).mockResolvedValue(
+      make_manifest([make_entry({ file_id: 'f1' }), make_entry({ file_id: 'f2' })]),
+    );
+    vi.mocked(mocks.indexes.find_by_file_id).mockImplementation(async (_ctx, _site, file_id) => {
+      return make_index(file_id, true);
+    });
+    const on_progress = vi.fn((event: { phase: string; processed: number }) => {
+      if (event.phase === 'processing' && event.processed === 1) interrupted = true;
+    });
+
+    const result = await service.verify_sharepoint_snapshot(TENANT_ID, SITE_ID, SNAPSHOT_ID, {
+      on_progress,
+      should_interrupt: () => interrupted,
+    });
+
+    expect(result).toMatchObject({ total_checked: 1, passed: 1, interrupted: true });
+    expect(mocks.ctx.storage.get).toHaveBeenCalledTimes(1);
+    expect(on_progress).toHaveBeenLastCalledWith(expect.objectContaining({ phase: 'interrupted' }));
   });
 });

--- a/packages/types/src/ports/atlas/onedrive-api.port.ts
+++ b/packages/types/src/ports/atlas/onedrive-api.port.ts
@@ -13,12 +13,36 @@ import type { DeletionResult } from '@/ports/deletion/use-case.port';
 import type { ReplicationResult } from '@/domain/replication';
 import type { StorageTarget } from '@/ports/replication/storage-target.port';
 import type { OneDriveStatusResult } from '@/ports/onedrive/status.port';
+import type { VerificationOptions } from '@/ports/verification/use-case.port';
+import type { SdkOperationOptions } from '@/ports/atlas/progress-event.port';
+
+export type OneDriveSdkBackupOptions = Omit<
+  OneDriveBackupOptions,
+  'create_progress' | 'on_progress' | 'should_interrupt'
+> &
+  SdkOperationOptions;
+export type OneDriveSdkVerificationOptions = Omit<
+  VerificationOptions,
+  'on_progress' | 'should_interrupt'
+> &
+  SdkOperationOptions;
+export type OneDriveSdkRestoreOptions = Omit<
+  OneDriveRestoreOptions,
+  'on_progress' | 'should_interrupt'
+> &
+  SdkOperationOptions;
+export type OneDriveSdkSaveOptions = Omit<FileSaveOptions, 'on_progress' | 'should_interrupt'> &
+  SdkOperationOptions;
 
 export interface OneDriveApi {
-  backup(ownerId: string, options?: OneDriveBackupOptions): Promise<OneDriveBackupResult>;
-  verify(ownerId: string, snapshotId: string): Promise<OneDriveVerificationResult>;
-  restore(ownerId: string, options: OneDriveRestoreOptions): Promise<OneDriveRestoreResult>;
-  save(ownerId: string, options: FileSaveOptions): Promise<FileSaveResult>;
+  backup(ownerId: string, options?: OneDriveSdkBackupOptions): Promise<OneDriveBackupResult>;
+  verify(
+    ownerId: string,
+    snapshotId: string,
+    options?: OneDriveSdkVerificationOptions,
+  ): Promise<OneDriveVerificationResult>;
+  restore(ownerId: string, options: OneDriveSdkRestoreOptions): Promise<OneDriveRestoreResult>;
+  save(ownerId: string, options: OneDriveSdkSaveOptions): Promise<FileSaveResult>;
   listSnapshots(ownerId: string): Promise<OneDriveSnapshotManifest[]>;
   listFileVersions(ownerId: string, fileRef: string): Promise<OneDriveFileVersionRecord[]>;
   deleteOwnerData(ownerId: string): Promise<DeletionResult>;

--- a/packages/types/src/ports/atlas/outlook-api.port.ts
+++ b/packages/types/src/ports/atlas/outlook-api.port.ts
@@ -8,14 +8,36 @@ import type { DeletionResult } from '@/ports/deletion/use-case.port';
 import type { MailboxStats } from '@/domain/stats';
 import type { MailboxStatusResult } from '@/ports/status/use-case.port';
 import type { TenantMailbox, MailboxDiscoveryOptions } from '@/ports/mail/discovery.port';
+import type { SdkOperationOptions } from '@/ports/atlas/progress-event.port';
+
+export type OutlookBackupOptions = Omit<
+  SyncOptions,
+  'progress' | 'create_progress' | 'on_progress' | 'should_interrupt' | 'should_force_stop'
+> &
+  SdkOperationOptions;
+export type OutlookVerificationOptions = Omit<
+  VerificationOptions,
+  'on_progress' | 'should_interrupt'
+> &
+  SdkOperationOptions;
+export type OutlookRestoreOptions = Omit<
+  RestoreOptions,
+  'create_progress' | 'on_progress' | 'should_interrupt'
+> &
+  SdkOperationOptions;
+export type OutlookSaveOptions = Omit<
+  SaveOptions,
+  'create_progress' | 'on_progress' | 'should_interrupt'
+> &
+  SdkOperationOptions;
 
 export interface OutlookApi {
-  backup(mailboxId: string, options?: SyncOptions): Promise<SyncResult>;
-  verify(snapshotId: string, options?: VerificationOptions): Promise<VerificationResult>;
-  restore(snapshotId: string, options?: RestoreOptions): Promise<RestoreResult>;
-  restoreMailbox(mailboxId: string, options?: RestoreOptions): Promise<RestoreResult>;
-  save(snapshotId: string, options?: SaveOptions): Promise<SaveResult>;
-  saveMailbox(mailboxId: string, options?: SaveOptions): Promise<SaveResult>;
+  backup(mailboxId: string, options?: OutlookBackupOptions): Promise<SyncResult>;
+  verify(snapshotId: string, options?: OutlookVerificationOptions): Promise<VerificationResult>;
+  restore(snapshotId: string, options?: OutlookRestoreOptions): Promise<RestoreResult>;
+  restoreMailbox(mailboxId: string, options?: OutlookRestoreOptions): Promise<RestoreResult>;
+  save(snapshotId: string, options?: OutlookSaveOptions): Promise<SaveResult>;
+  saveMailbox(mailboxId: string, options?: OutlookSaveOptions): Promise<SaveResult>;
   listMailboxes(): Promise<MailboxSummary[]>;
   listSnapshots(mailboxId: string): Promise<Manifest[]>;
   getSnapshotDetail(snapshotId: string): Promise<Manifest | undefined>;

--- a/packages/types/src/ports/atlas/progress-event.port.ts
+++ b/packages/types/src/ports/atlas/progress-event.port.ts
@@ -1,0 +1,31 @@
+interface OperationProgressBase {
+  readonly operation: 'backup' | 'restore' | 'save' | 'verify';
+  readonly workload: 'outlook' | 'onedrive' | 'sharepoint';
+  readonly processed: number;
+  readonly total?: number;
+  readonly current?: string;
+  readonly rate?: number;
+}
+
+/** A typed lifecycle event emitted by long-running SDK operations. */
+export type OperationProgressEvent =
+  | (OperationProgressBase & { readonly phase: 'discovering' })
+  | (OperationProgressBase & { readonly phase: 'processing' })
+  | (OperationProgressBase & { readonly phase: 'finalizing' })
+  | (OperationProgressBase & { readonly phase: 'completed' })
+  | (OperationProgressBase & { readonly phase: 'interrupted' });
+
+export type OperationProgressPhase = OperationProgressEvent['phase'];
+export type OperationProgressCallback = (event: OperationProgressEvent) => void;
+
+/** Public options shared by long-running SDK operations. */
+export interface SdkOperationOptions {
+  readonly onProgress?: OperationProgressCallback;
+  readonly signal?: AbortSignal;
+}
+
+/** Internal hooks used by services without exposing AbortSignal or SDK naming. */
+export interface OperationControlOptions {
+  readonly on_progress?: OperationProgressCallback;
+  readonly should_interrupt?: () => boolean;
+}

--- a/packages/types/src/ports/atlas/sharepoint-api.port.ts
+++ b/packages/types/src/ports/atlas/sharepoint-api.port.ts
@@ -17,12 +17,36 @@ import type { FileSaveOptions, FileSaveResult } from '@/ports/save/file-save.por
 import type { DeletionResult } from '@/ports/deletion/use-case.port';
 import type { SharePointSite } from '@/ports/sharepoint/connector.port';
 import type { SharePointStatusResult } from '@/ports/sharepoint/status.port';
+import type { VerificationOptions } from '@/ports/verification/use-case.port';
+import type { SdkOperationOptions } from '@/ports/atlas/progress-event.port';
+
+export type SharePointSdkBackupOptions = Omit<
+  SharePointBackupOptions,
+  'create_progress' | 'on_progress' | 'should_interrupt'
+> &
+  SdkOperationOptions;
+export type SharePointSdkVerificationOptions = Omit<
+  VerificationOptions,
+  'on_progress' | 'should_interrupt'
+> &
+  SdkOperationOptions;
+export type SharePointSdkRestoreOptions = Omit<
+  SharePointRestoreOptions,
+  'on_progress' | 'should_interrupt'
+> &
+  SdkOperationOptions;
+export type SharePointSdkSaveOptions = Omit<FileSaveOptions, 'on_progress' | 'should_interrupt'> &
+  SdkOperationOptions;
 
 export interface SharePointApi {
-  backup(siteId: string, options?: SharePointBackupOptions): Promise<SharePointBackupResult>;
-  verify(siteId: string, snapshotId: string): Promise<SharePointVerificationResult>;
-  restore(siteId: string, options: SharePointRestoreOptions): Promise<SharePointRestoreResult>;
-  save(siteId: string, options: FileSaveOptions): Promise<FileSaveResult>;
+  backup(siteId: string, options?: SharePointSdkBackupOptions): Promise<SharePointBackupResult>;
+  verify(
+    siteId: string,
+    snapshotId: string,
+    options?: SharePointSdkVerificationOptions,
+  ): Promise<SharePointVerificationResult>;
+  restore(siteId: string, options: SharePointSdkRestoreOptions): Promise<SharePointRestoreResult>;
+  save(siteId: string, options: SharePointSdkSaveOptions): Promise<FileSaveResult>;
   listSnapshots(siteId: string): Promise<SharePointSnapshotManifest[]>;
   listFileVersions(siteId: string, fileRef: string): Promise<SharePointFileVersionRecord[]>;
   listSites(): Promise<SharePointSite[]>;

--- a/packages/types/src/ports/backup/use-case.port.ts
+++ b/packages/types/src/ports/backup/use-case.port.ts
@@ -70,6 +70,7 @@ export interface SyncResult {
   readonly manifest: Manifest;
   readonly mode: BackupSyncMode;
   readonly summary: BackupSyncSummary;
+  readonly interrupted: boolean;
   /** Graph API cost for this operation. Present when called via the SDK; absent via CLI. */
   readonly graph_cost?: OperationCost;
 }

--- a/packages/types/src/ports/backup/use-case.port.ts
+++ b/packages/types/src/ports/backup/use-case.port.ts
@@ -1,6 +1,7 @@
 import type { Manifest } from '@/domain/manifest';
 import type { Snapshot } from '@/domain/snapshot';
 import type { OperationCost } from '@/domain/graph-cost';
+import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
 
 export type BackupSyncMode = 'full' | 'incremental' | 'initial';
 export type ObjectLockMode = 'GOVERNANCE' | 'COMPLIANCE';
@@ -37,7 +38,7 @@ export interface BackupProgressReporter {
   finish(actual_total?: number): void;
 }
 
-export interface SyncOptions {
+export interface SyncOptions extends OperationControlOptions {
   readonly folder_filter?: string[] | undefined;
   readonly force_full?: boolean | undefined;
   readonly page_size?: number | undefined;
@@ -46,7 +47,6 @@ export interface SyncOptions {
   readonly progress?: BackupProgressReporter | undefined;
   readonly create_progress?:
     ((folders: { name: string; total_items: number }[]) => BackupProgressReporter) | undefined;
-  readonly should_interrupt?: (() => boolean) | undefined;
   readonly should_force_stop?: (() => boolean) | undefined;
   readonly owner_email?: string | undefined;
   readonly owner_display_name?: string | undefined;

--- a/packages/types/src/ports/index.ts
+++ b/packages/types/src/ports/index.ts
@@ -103,9 +103,34 @@ export type {
 export type { DekValidationFn } from './replication/dek-validation.port';
 
 export type { AtlasInstanceConfig, AtlasInstance } from './atlas/use-case.port';
-export type { OutlookApi } from './atlas/outlook-api.port';
-export type { OneDriveApi } from './atlas/onedrive-api.port';
-export type { SharePointApi } from './atlas/sharepoint-api.port';
+export type {
+  OutlookApi,
+  OutlookBackupOptions,
+  OutlookVerificationOptions,
+  OutlookRestoreOptions,
+  OutlookSaveOptions,
+} from './atlas/outlook-api.port';
+export type {
+  OneDriveApi,
+  OneDriveSdkBackupOptions,
+  OneDriveSdkVerificationOptions,
+  OneDriveSdkRestoreOptions,
+  OneDriveSdkSaveOptions,
+} from './atlas/onedrive-api.port';
+export type {
+  SharePointApi,
+  SharePointSdkBackupOptions,
+  SharePointSdkVerificationOptions,
+  SharePointSdkRestoreOptions,
+  SharePointSdkSaveOptions,
+} from './atlas/sharepoint-api.port';
+export type {
+  OperationProgressEvent,
+  OperationProgressPhase,
+  OperationProgressCallback,
+  SdkOperationOptions,
+  OperationControlOptions,
+} from './atlas/progress-event.port';
 
 export type {
   UserIdentityResolver,

--- a/packages/types/src/ports/onedrive/restore.port.ts
+++ b/packages/types/src/ports/onedrive/restore.port.ts
@@ -15,6 +15,7 @@ export interface OneDriveRestoreResult {
   readonly folders_created: number;
   readonly files_skipped: number;
   readonly errors: string[];
+  readonly interrupted: boolean;
 }
 
 export interface OneDriveRestoreUseCase {

--- a/packages/types/src/ports/onedrive/restore.port.ts
+++ b/packages/types/src/ports/onedrive/restore.port.ts
@@ -1,6 +1,8 @@
+import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
+
 export type OneDriveRestoreConflictBehavior = 'replace' | 'rename' | 'fail';
 
-export interface OneDriveRestoreOptions {
+export interface OneDriveRestoreOptions extends OperationControlOptions {
   readonly snapshot_id: string;
   readonly target_owner_id?: string;
   readonly file_filter?: string[];

--- a/packages/types/src/ports/onedrive/use-case.port.ts
+++ b/packages/types/src/ports/onedrive/use-case.port.ts
@@ -24,6 +24,7 @@ export interface OneDriveBackupSummary {
 export interface OneDriveBackupResult {
   readonly owner_id: string;
   readonly snapshot: OneDriveSnapshotManifest | undefined;
+  readonly interrupted: boolean;
   readonly summary: OneDriveBackupSummary;
 }
 
@@ -73,6 +74,7 @@ export interface OneDriveVerificationResult {
   readonly passed: number;
   readonly failed_file_ids: string[];
   readonly index_issues: string[];
+  readonly interrupted: boolean;
 }
 
 export interface OneDriveVerificationUseCase {

--- a/packages/types/src/ports/onedrive/use-case.port.ts
+++ b/packages/types/src/ports/onedrive/use-case.port.ts
@@ -3,6 +3,8 @@ import type {
   OneDriveSnapshotManifest,
 } from '../../domain/onedrive-manifest';
 import type { BackupProgressReporter, ObjectLockRequest } from '../backup/use-case.port';
+import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
+import type { VerificationOptions } from '@/ports/verification/use-case.port';
 
 export interface OneDriveBackupSummary {
   readonly drives_scanned: number;
@@ -25,7 +27,7 @@ export interface OneDriveBackupResult {
   readonly summary: OneDriveBackupSummary;
 }
 
-export interface OneDriveBackupOptions {
+export interface OneDriveBackupOptions extends OperationControlOptions {
   readonly force_full?: boolean | undefined;
   readonly owner_email?: string | undefined;
   readonly owner_display_name?: string | undefined;
@@ -79,5 +81,6 @@ export interface OneDriveVerificationUseCase {
     tenant_id: string,
     owner_id: string,
     snapshot_id: string,
+    options?: VerificationOptions,
   ): Promise<OneDriveVerificationResult>;
 }

--- a/packages/types/src/ports/restore/use-case.port.ts
+++ b/packages/types/src/ports/restore/use-case.port.ts
@@ -13,6 +13,7 @@ export interface RestoreResult {
   readonly restore_folder_name: string;
   /** Graph API cost for this operation. Present when called via the SDK; absent via CLI. */
   readonly graph_cost?: OperationCost;
+  readonly interrupted: boolean;
 }
 
 export interface RestoreOptions extends OperationControlOptions {

--- a/packages/types/src/ports/restore/use-case.port.ts
+++ b/packages/types/src/ports/restore/use-case.port.ts
@@ -1,5 +1,6 @@
 import type { OperationCost } from '@/domain/graph-cost';
 import type { TransferProgressReporter } from '@/ports/shared/transfer-progress.port';
+import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
 
 export interface RestoreResult {
   readonly snapshot_id: string;
@@ -14,7 +15,7 @@ export interface RestoreResult {
   readonly graph_cost?: OperationCost;
 }
 
-export interface RestoreOptions {
+export interface RestoreOptions extends OperationControlOptions {
   readonly folder_name?: string;
   readonly message_ref?: string;
   readonly target_mailbox?: string;

--- a/packages/types/src/ports/save/file-save.port.ts
+++ b/packages/types/src/ports/save/file-save.port.ts
@@ -1,4 +1,6 @@
-export interface FileSaveOptions {
+import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
+
+export interface FileSaveOptions extends OperationControlOptions {
   readonly snapshot_id: string;
   /** Only save specific files (by file ID or full path). */
   readonly file_filter?: string[];

--- a/packages/types/src/ports/save/file-save.port.ts
+++ b/packages/types/src/ports/save/file-save.port.ts
@@ -18,6 +18,7 @@ export interface FileSaveResult {
   readonly integrity_failures: string[];
   readonly output_path: string;
   readonly total_bytes: number;
+  readonly interrupted: boolean;
 }
 
 export interface OneDriveSaveUseCase {

--- a/packages/types/src/ports/save/use-case.port.ts
+++ b/packages/types/src/ports/save/use-case.port.ts
@@ -22,6 +22,7 @@ export interface SaveResult {
   readonly errors: string[];
   readonly output_path: string;
   readonly total_bytes: number;
+  readonly interrupted: boolean;
   readonly integrity_failures: string[];
 }
 

--- a/packages/types/src/ports/save/use-case.port.ts
+++ b/packages/types/src/ports/save/use-case.port.ts
@@ -1,6 +1,7 @@
 import type { TransferProgressReporter } from '@/ports/shared/transfer-progress.port';
+import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
 
-export interface SaveOptions {
+export interface SaveOptions extends OperationControlOptions {
   readonly folder_name?: string;
   readonly message_ref?: string;
   readonly start_date?: Date;

--- a/packages/types/src/ports/sharepoint/restore.port.ts
+++ b/packages/types/src/ports/sharepoint/restore.port.ts
@@ -1,6 +1,8 @@
+import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
+
 export type SharePointRestoreConflictBehavior = 'replace' | 'rename' | 'fail';
 
-export interface SharePointRestoreOptions {
+export interface SharePointRestoreOptions extends OperationControlOptions {
   readonly snapshot_id: string;
   /** Optional target site ID to restore to (defaults to original site). */
   readonly target_site_id?: string;

--- a/packages/types/src/ports/sharepoint/restore.port.ts
+++ b/packages/types/src/ports/sharepoint/restore.port.ts
@@ -17,6 +17,7 @@ export interface SharePointRestoreResult {
   readonly folders_created: number;
   readonly files_skipped: number;
   readonly errors: string[];
+  readonly interrupted: boolean;
 }
 
 export interface SharePointRestoreUseCase {

--- a/packages/types/src/ports/sharepoint/use-case.port.ts
+++ b/packages/types/src/ports/sharepoint/use-case.port.ts
@@ -24,6 +24,7 @@ export interface SharePointBackupSummary {
 export interface SharePointBackupResult {
   readonly site_id: string;
   readonly snapshot: SharePointSnapshotManifest | undefined;
+  readonly interrupted: boolean;
   readonly summary: SharePointBackupSummary;
 }
 
@@ -71,6 +72,7 @@ export interface SharePointVerificationResult {
   readonly total_checked: number;
   readonly passed: number;
   readonly failed_file_ids: string[];
+  readonly interrupted: boolean;
   readonly index_issues: string[];
 }
 

--- a/packages/types/src/ports/sharepoint/use-case.port.ts
+++ b/packages/types/src/ports/sharepoint/use-case.port.ts
@@ -3,6 +3,8 @@ import type {
   SharePointSnapshotManifest,
 } from '../../domain/sharepoint-manifest';
 import type { ObjectLockRequest } from '../backup/use-case.port';
+import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
+import type { VerificationOptions } from '@/ports/verification/use-case.port';
 
 export interface SharePointBackupSummary {
   readonly libraries_scanned: number;
@@ -25,7 +27,7 @@ export interface SharePointBackupResult {
   readonly summary: SharePointBackupSummary;
 }
 
-export interface SharePointBackupOptions {
+export interface SharePointBackupOptions extends OperationControlOptions {
   readonly force_full?: boolean | undefined;
   readonly site_url?: string | undefined;
   readonly site_display_name?: string | undefined;
@@ -78,6 +80,7 @@ export interface SharePointVerificationUseCase {
     tenant_id: string,
     site_id: string,
     snapshot_id: string,
+    options?: VerificationOptions,
   ): Promise<SharePointVerificationResult>;
 }
 

--- a/packages/types/src/ports/verification/use-case.port.ts
+++ b/packages/types/src/ports/verification/use-case.port.ts
@@ -1,4 +1,6 @@
-export interface VerificationOptions {
+import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
+
+export interface VerificationOptions extends OperationControlOptions {
   /**
    * Existence-only verification: batched HeadObject on every referenced key
    * instead of download + decrypt + hash. Catches deleted/missing objects at

--- a/packages/types/src/ports/verification/use-case.port.ts
+++ b/packages/types/src/ports/verification/use-case.port.ts
@@ -14,6 +14,7 @@ export interface VerificationResult {
   readonly total_checked: number;
   readonly passed: number;
   readonly failed: string[];
+  readonly interrupted: boolean;
   /**
    * Objects that can never be verified because no blob was stored for them
    * (e.g. attachments skipped by pre-fix backups with an empty storage_key).


### PR DESCRIPTION
Closes #39.

## Problem

The SDK (`@wisecom/atlas-sdk`) gave embedders no way to report progress or cancel a running backup, restore, save, or verify. The plumbing existed internally, but it was CLI-shaped and undocumented:

- `SyncOptions.progress` / `create_progress` expected a `BackupProgressReporter` — an imperative dashboard interface (`mark_active()`, `update_paging()`, `mark_all_pending_interrupted()`) built for the Ink renderer, impractical for SDK consumers.
- `should_interrupt` / `should_force_stop` were polling booleans, not the idiomatic `AbortSignal`, and were absent from `docs/reference/sdk.md`.
- OneDrive and SharePoint backup options exposed no progress or cancellation at all.

## Fix

- Public SDK options gain `onProgress(event)` and `signal`, across Outlook, OneDrive, and SharePoint `backup` / `restore` / `save` / `verify`.
- `signal` maps onto the existing interrupt mechanism; `BackupProgressReporter` and `TransferProgressReporter` stay internal CLI adapters, and the public wrappers omit them. Reporter-factory hooks were removed from the SDK reference accordingly.
- Typed lifecycle: `discovering → processing → finalizing → completed | interrupted`, exactly one terminal event per operation, `processed` nondecreasing, and `interrupted: true` on every graceful stop.
- Cancellation is a graceful stop, not an `AbortError`: operations finish the in-flight item, return their normal partial result, and never persist a delta/cursor for an incompletely enumerated drive, library, or folder (keeps the issue #23 safeguard intact).
- Pre-aborted calls short-circuit at each service entry: no tenant context, no Graph or S3 request, no bucket retention mutation, no archive creation — just the zero-work interrupted result plus its terminal events.
- Progress observers are invoked through a non-throwing emitter (`packages/core/src/services/shared/operation-progress.ts`), so a consumer callback that throws cannot corrupt backup outcomes or cursor state.
- Docs: new "Progress and Cancellation" section in `docs/reference/sdk.md`, `interrupted` added to result types.

## Verification

`pnpm run test` (all 10 packages), `typecheck`, `lint`, `format:check`, `build`, and `docs:build` pass on this branch. Focused regressions cover pre-aborted entry for every workload/operation, throwing observers preserving stored files and delta links, terminal-count monotonicity when an entry fails, and last-item cancellation not advancing cursors.