### PR TITLE
fix(backup): report version download failures with a reason and fail the run (#92)

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -300,9 +300,11 @@ Once the underlying problem clears, the next run picks the file up automatically
 Every backup prints a health status at the end:
 
 - **HEALTHY** -- all primary file content was backed up successfully. The snapshot and delta cursor are safe to rely on.
-- **UNHEALTHY** -- one or more critical errors occurred (file download failure, drive-level crash, encryption error). The affected drive's entries are excluded from the manifest and its delta cursor is not advanced. `process.exitCode` is set to `1` so CI/monitoring pipelines detect the failure.
+- **UNHEALTHY** -- one or more critical errors occurred (file download failure, drive-level crash, encryption error, or an unexpected version download failure). The affected drive's entries are excluded from the manifest and its delta cursor is not advanced. `process.exitCode` is set to `2` (partial run) so CI/monitoring pipelines detect the failure; a hard failure that aborts the run exits `1`.
 
-Non-critical issues such as historical version download failures or expired version URLs are reported as **warnings** in the output but do not affect the health status. Warnings appear as `[!]` lines above the status; errors appear indented under `UNHEALTHY`.
+A version download that fails for an unexpected reason -- throttling, `403 accessDenied`, a transient Graph fault -- means the file's history is missing from the snapshot, so it counts as an error and holds the run **UNHEALTHY** (issue #92). Each failure logs its own line with the Graph status and error code, e.g. `Version 2.0 of report.docx: HTTP 403 -- accessDenied`, and the run summary repeats the count.
+
+Versions the service reports as gone (`404`/`410`, content purged by the site's retention policy) are expected, counted as `unavailable`, and do not affect health. OneNote package accounting and other advisory notes remain **warnings**: they appear as `[!]` lines above the status and leave the exit code at `0`.
 
 ## Azure AD Permissions
 

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -333,9 +333,11 @@ Once the underlying problem clears, the next run picks the file up automatically
 Every backup prints a health status at the end:
 
 - **HEALTHY** -- all primary file content was backed up successfully across all document libraries. The snapshot and delta cursors are safe to rely on.
-- **UNHEALTHY** -- one or more critical errors occurred (file download failure, library-level crash, encryption error). The affected library's entries are excluded from the manifest and its delta cursor is not advanced. `process.exitCode` is set to `1` so CI/monitoring pipelines detect the failure.
+- **UNHEALTHY** -- one or more critical errors occurred (file download failure, library-level crash, encryption error, or an unexpected version download failure). The affected library's entries are excluded from the manifest and its delta cursor is not advanced. `process.exitCode` is set to `2` (partial run) so CI/monitoring pipelines detect the failure; a hard failure that aborts the run exits `1`.
 
-Non-critical issues such as historical version download failures or expired version URLs are reported as **warnings** in the output but do not affect the health status. Warnings appear as `[!]` lines above the status; errors appear indented under `UNHEALTHY`.
+A version download that fails for an unexpected reason -- throttling, `403 accessDenied`, a transient Graph fault -- means the file's history is missing from the snapshot, so it counts as an error and holds the run **UNHEALTHY** (issue #92). Each failure logs its own line with the Graph status and error code, e.g. `Version 2.0 of proposal.docx: HTTP 403 -- accessDenied`, and the run summary repeats the count.
+
+Versions the service reports as gone (`404`/`410`, content purged by the site's retention policy) are expected, counted as `unavailable`, and do not affect health. OneNote package accounting and other advisory notes remain **warnings**: they appear as `[!]` lines above the status and leave the exit code at `0`.
 
 ## Azure AD Permissions
 

--- a/packages/m365-graph/src/graph-error-helpers.ts
+++ b/packages/m365-graph/src/graph-error-helpers.ts
@@ -169,7 +169,7 @@ export async function with_graph_retry<T>(
       const jitter = Math.random() * BASE_DELAY_MS;
       const delay = Math.min(base + jitter, MAX_DELAY_MS);
 
-      const reason = describe_error(err);
+      const reason = describe_graph_error(err);
       logger.debug(
         `Retry ${attempt + 1}/${MAX_RETRIES} in ${(delay / 1000).toFixed(1)}s -- ${reason}`,
       );
@@ -200,11 +200,41 @@ function extract_retry_after(err: unknown): number | undefined {
   return undefined;
 }
 
-function describe_error(err: unknown): string {
+/**
+ * Renders any Graph/network error as a non-empty, actionable one-liner.
+ * Graph SDK errors routinely carry an empty `message` with the useful part in
+ * `statusCode`/`code`/`body`, so every available facet is joined rather than
+ * picking the first one present (issue #92).
+ */
+export function describe_graph_error(err: unknown): string {
+  if (err === null || err === undefined) return 'unknown error';
+  if (typeof err !== 'object') return String(err);
+
   const graph_err = err as Record<string, unknown>;
-  if (graph_err.statusCode) return `HTTP ${graph_err.statusCode}`;
-  if (graph_err.code) return String(graph_err.code);
-  return err instanceof Error ? err.message.slice(0, 80) : 'unknown';
+  const status = graph_err.statusCode ?? graph_err.status;
+  const message = err instanceof Error ? err.message.trim() : '';
+  const parts = [
+    typeof status === 'number' || typeof status === 'string' ? `HTTP ${status}` : '',
+    typeof graph_err.code === 'string' ? graph_err.code.trim() : '',
+    message.slice(0, 200),
+    message === '' && typeof graph_err.body === 'string' ? graph_err.body.slice(0, 200) : '',
+  ].filter((part) => part !== '');
+
+  return parts.length > 0 ? parts.join(' -- ') : `unknown error (${err.constructor.name})`;
+}
+
+/**
+ * HTTP 404/410: the content is gone for good (version purged by retention,
+ * item hard-deleted). Distinct from a transient failure -- callers count these
+ * as expected, not as backup errors.
+ */
+export function is_content_gone_error(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const graph_err = err as Record<string, unknown>;
+  const status = graph_err.statusCode ?? graph_err.status;
+  if (status === 404 || status === 410) return true;
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes('404') || message.includes('Not Found') || message.includes('410');
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/m365-graph/src/index.ts
+++ b/packages/m365-graph/src/index.ts
@@ -6,6 +6,8 @@ export {
   is_transient_error,
   is_network_error,
   is_retryable_error,
+  describe_graph_error,
+  is_content_gone_error,
   with_graph_retry,
 } from './graph-error-helpers';
 export { RateLimitedGraphConnector } from './rate-limited-graph-connector.adapter';

--- a/packages/m365-graph/tests/unit/graph-error-description.test.ts
+++ b/packages/m365-graph/tests/unit/graph-error-description.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { describe_graph_error, is_content_gone_error } from '@/graph-error-helpers';
+
+// Issue #92: Graph SDK errors routinely carry an empty `message` with the
+// actionable part in `statusCode`/`code`, which produced blank log lines like
+// "Version 1.0 of report.docx: ".
+
+describe('describe_graph_error', () => {
+  it('describes a Graph error whose message is empty', () => {
+    const reason = describe_graph_error({ statusCode: 403, code: 'accessDenied', message: '' });
+
+    expect(reason).toBe('HTTP 403 -- accessDenied');
+  });
+
+  it('joins status, code, and message when all are present', () => {
+    const err = Object.assign(new Error('Access denied'), {
+      statusCode: 403,
+      code: 'accessDenied',
+    });
+
+    expect(describe_graph_error(err)).toBe('HTTP 403 -- accessDenied -- Access denied');
+  });
+
+  it('falls back to the response body when there is no message', () => {
+    const reason = describe_graph_error({ body: '{"error":{"code":"resourceLocked"}}' });
+
+    expect(reason).toContain('resourceLocked');
+  });
+
+  it('never returns an empty string for an error carrying nothing useful', () => {
+    expect(describe_graph_error({})).not.toBe('');
+    expect(describe_graph_error(new Error(''))).not.toBe('');
+    expect(describe_graph_error(undefined)).toBe('unknown error');
+  });
+
+  it('caps long messages so one failure cannot flood the log', () => {
+    const err = new Error('x'.repeat(500));
+
+    expect(describe_graph_error(err).length).toBeLessThanOrEqual(200);
+  });
+});
+
+describe('is_content_gone_error', () => {
+  it.each([404, 410])('treats HTTP %i as gone', (status) => {
+    expect(is_content_gone_error({ statusCode: status })).toBe(true);
+    expect(is_content_gone_error({ status })).toBe(true);
+  });
+
+  it('does not treat a permission failure as gone', () => {
+    expect(is_content_gone_error({ statusCode: 403, code: 'accessDenied', message: '' })).toBe(
+      false,
+    );
+  });
+
+  it('does not treat a throttle as gone', () => {
+    expect(is_content_gone_error({ statusCode: 429 })).toBe(false);
+  });
+
+  it('ignores non-object errors', () => {
+    expect(is_content_gone_error('boom')).toBe(false);
+    expect(is_content_gone_error(undefined)).toBe(false);
+  });
+});

--- a/packages/onedrive/src/services/onedrive-backup.service.ts
+++ b/packages/onedrive/src/services/onedrive-backup.service.ts
@@ -156,8 +156,15 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
         updated_at: new Date().toISOString(),
       };
 
+      // Version downloads that failed for an unexpected reason leave history out
+      // of the snapshot: an error, not a warning, so the run exits EXIT_PARTIAL
+      // like every other incomplete backup (issue #92).
+      const errors = [...scan_result.errors];
       if (total_versions_failed > 0) {
-        warnings.push(`${total_versions_failed} version download(s) failed unexpectedly`);
+        errors.push(
+          `${total_versions_failed} version download(s) failed unexpectedly ` +
+            `-- see the per-version reasons above; those versions are not in this snapshot`,
+        );
       }
       warnings.push(...build_package_warnings(scan_result.package_report));
       // Files left un-backed-up are the run's headline problem: warn per item and
@@ -165,7 +172,7 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
       warnings.push(...describe_failed_items(scan_result.failed_items));
       const healthy =
         !scan_result.interrupted &&
-        scan_result.errors.length === 0 &&
+        errors.length === 0 &&
         Object.keys(scan_result.failed_items).length === 0;
 
       let result: OneDriveBackupResult;
@@ -179,7 +186,7 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
           scan_result.deleted_items,
           total_versions_stored,
           total_versions_unavailable,
-          scan_result.errors,
+          errors,
           warnings,
           scan_result.interrupted,
           healthy,
@@ -213,7 +220,7 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
           scan_result.deleted_items,
           total_versions_stored,
           total_versions_unavailable,
-          scan_result.errors,
+          errors,
           warnings,
           scan_result.interrupted,
           healthy,

--- a/packages/onedrive/src/services/onedrive-version-sync.ts
+++ b/packages/onedrive/src/services/onedrive-version-sync.ts
@@ -8,6 +8,7 @@ import type {
   TenantContext,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { describe_graph_error, is_content_gone_error } from '@wisecom/atlas-m365-graph';
 import { onedrive_data_key } from '@/services/onedrive-storage-keys';
 
 export interface VersionSyncResult {
@@ -124,23 +125,12 @@ async function download_version_classified(
     );
     return { status: 'ok', content };
   } catch (err) {
-    if (is_version_unavailable(err)) {
+    if (is_content_gone_error(err)) {
       logger.debug(
         `Version ${version.version_id} of ${item.file_name} no longer available (expired)`,
       );
       return { status: 'unavailable' };
     }
-    const reason = err instanceof Error ? err.message : String(err);
-    return { status: 'failed', reason };
+    return { status: 'failed', reason: describe_graph_error(err) };
   }
-}
-
-/** HTTP 404/410 indicate the version content has been purged by retention policy. */
-function is_version_unavailable(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false;
-  const status =
-    (err as Record<string, unknown>).statusCode ?? (err as Record<string, unknown>).status;
-  if (status === 404 || status === 410) return true;
-  const message = err instanceof Error ? err.message : String(err);
-  return message.includes('404') || message.includes('Not Found') || message.includes('410');
 }

--- a/packages/onedrive/tests/unit/services/onedrive-backup-version-failures.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-backup-version-failures.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  OneDriveBackupResult,
+  OneDriveDeltaItem,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveBackupService } from '@/services/onedrive-backup.service';
+
+// Issue #92: version downloads that fail for an unexpected reason left history
+// out of the snapshot while the run reported HEALTHY and exited 0.
+
+const FILE: OneDriveDeltaItem = {
+  item_id: 'f1',
+  drive_id: 'd1',
+  kind: 'file',
+  file_name: 'report.docx',
+  parent_path: '/Documents',
+  size_bytes: 64,
+  etag: 'etag-f1',
+  deleted: false,
+  download_url: 'https://example.invalid/f1',
+};
+
+function run_backup(version_error: unknown): Promise<OneDriveBackupResult> {
+  const context = {
+    tenant_id: 't',
+    storage: {
+      list: vi.fn().mockResolvedValue([]),
+      abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+      exists: vi.fn().mockResolvedValue(false),
+      put: vi.fn().mockResolvedValue(undefined),
+    },
+    encrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+  const factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(context),
+    create_storage_only: vi.fn(),
+  };
+  const connector = {
+    list_drives: vi.fn().mockResolvedValue([{ drive_id: 'd1', drive_name: 'OneDrive' }]),
+    fetch_delta: vi.fn().mockResolvedValue({
+      drive_id: 'd1',
+      delta_link: 'link-1',
+      items: [FILE],
+      reset_detected: false,
+    }),
+    download_file_content: vi.fn().mockResolvedValue(Buffer.from('content')),
+    list_file_versions: vi
+      .fn()
+      .mockResolvedValue([{ version_id: '1.0', last_modified_at: '2026-01-01', size_bytes: 10 }]),
+    download_file_version: vi.fn().mockRejectedValue(version_error),
+  };
+
+  const service = new OneDriveBackupService(
+    factory,
+    connector as never,
+    { save: vi.fn().mockResolvedValue(undefined) } as never,
+    {
+      find_by_file_id: vi.fn().mockResolvedValue(undefined),
+      append_version: vi.fn().mockResolvedValue(undefined),
+    } as never,
+    {
+      load: vi.fn().mockResolvedValue(undefined),
+      save: vi.fn().mockResolvedValue(undefined),
+    } as never,
+  );
+  return service.backup_onedrive('t', 'owner-1', {});
+}
+
+describe('OneDrive backup — version download failures (issue #92)', () => {
+  it('reports an unexpected version failure as an error and marks the run unhealthy', async () => {
+    const result = await run_backup({ statusCode: 403, code: 'accessDenied', message: '' });
+
+    expect(result.summary.errors).toHaveLength(1);
+    expect(result.summary.errors[0]).toContain('1 version download(s) failed unexpectedly');
+    expect(result.summary.healthy).toBe(false);
+  });
+
+  it('keeps an expired version (410) out of the error bucket and stays healthy', async () => {
+    const result = await run_backup({ statusCode: 410 });
+
+    expect(result.summary.errors).toEqual([]);
+    expect(result.summary.versions_unavailable).toBe(1);
+    expect(result.summary.healthy).toBe(true);
+  });
+});

--- a/packages/sharepoint/src/services/sharepoint-backup.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup.service.ts
@@ -124,14 +124,15 @@ export class SharePointBackupService implements SharePointBackupUseCase {
       scan.interrupted ||= options.should_interrupt?.() === true;
       const cursor = this.build_cursor(site_id, delta_link_by_drive, tracking, scan.failed_items);
       const warnings = [
-        ...this.build_version_warnings(scan.version_stats),
         ...build_package_warnings(scan.package_reports),
         ...describe_failed_items(scan.failed_items),
       ];
+      // Version downloads that failed for an unexpected reason leave history out
+      // of the snapshot: an error, not a warning, so the run exits EXIT_PARTIAL
+      // like every other incomplete backup (issue #92).
+      const errors = [...scan.errors, ...this.build_version_errors(scan.version_stats)];
       const healthy =
-        !scan.interrupted &&
-        scan.errors.length === 0 &&
-        Object.keys(scan.failed_items).length === 0;
+        !scan.interrupted && errors.length === 0 && Object.keys(scan.failed_items).length === 0;
 
       let result: SharePointBackupResult;
       if (scan.entries.length === 0) {
@@ -144,7 +145,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
           scan.deleted_items,
           scan.version_stats.total_versions_stored,
           scan.version_stats.total_versions_unavailable,
-          scan.errors,
+          errors,
           warnings,
           healthy,
           scan.interrupted,
@@ -160,6 +161,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
           scan.libraries_scanned,
           options,
           cursor,
+          errors,
           warnings,
           healthy,
         );
@@ -202,9 +204,12 @@ export class SharePointBackupService implements SharePointBackupUseCase {
     };
   }
 
-  private build_version_warnings(version_stats: VersionStatsState): string[] {
+  private build_version_errors(version_stats: VersionStatsState): string[] {
     if (version_stats.total_versions_failed === 0) return [];
-    return [`${version_stats.total_versions_failed} version download(s) failed unexpectedly`];
+    return [
+      `${version_stats.total_versions_failed} version download(s) failed unexpectedly ` +
+        `-- see the per-version reasons above; those versions are not in this snapshot`,
+    ];
   }
 
   private async finalize_snapshot(
@@ -217,6 +222,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
     libraries_scanned: number,
     options: SharePointBackupOptions,
     cursor: SharePointDeltaCursor,
+    errors: string[],
     warnings: string[],
     healthy: boolean,
   ): Promise<SharePointBackupResult> {
@@ -254,7 +260,7 @@ export class SharePointBackupService implements SharePointBackupUseCase {
         snapshot_created: true,
         versions_stored: scan.version_stats.total_versions_stored,
         versions_unavailable: scan.version_stats.total_versions_unavailable,
-        errors: scan.errors,
+        errors,
         warnings,
         healthy,
       },

--- a/packages/sharepoint/src/services/sharepoint-version-sync.ts
+++ b/packages/sharepoint/src/services/sharepoint-version-sync.ts
@@ -8,6 +8,7 @@ import type {
   TenantContext,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { describe_graph_error, is_content_gone_error } from '@wisecom/atlas-m365-graph';
 import { sharepoint_data_key } from '@/services/sharepoint-storage-keys';
 
 export interface VersionSyncResult {
@@ -119,23 +120,12 @@ async function download_version_classified(
     );
     return { status: 'ok', content };
   } catch (err) {
-    if (is_version_unavailable(err)) {
+    if (is_content_gone_error(err)) {
       logger.debug(
         `Version ${version.version_id} of ${item.file_name} no longer available (expired)`,
       );
       return { status: 'unavailable' };
     }
-    const reason = err instanceof Error ? err.message : String(err);
-    return { status: 'failed', reason };
+    return { status: 'failed', reason: describe_graph_error(err) };
   }
-}
-
-/** HTTP 404/410 indicate the version content has been purged by retention policy. */
-function is_version_unavailable(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false;
-  const status =
-    (err as Record<string, unknown>).statusCode ?? (err as Record<string, unknown>).status;
-  if (status === 404 || status === 410) return true;
-  const message = err instanceof Error ? err.message : String(err);
-  return message.includes('404') || message.includes('Not Found') || message.includes('410');
 }

--- a/packages/sharepoint/tests/unit/services/sharepoint-backup-version-failures.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-backup-version-failures.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SharePointDeltaItem } from '@wisecom/atlas-types';
+import {
+  make_connector,
+  make_cursors,
+  make_file_indexes,
+  make_file_item,
+  make_manifests,
+  make_service,
+} from './sharepoint-backup-determinism.fixtures';
+
+// Issue #92: version downloads that fail for an unexpected reason left history
+// out of the snapshot while the run reported HEALTHY and exited 0.
+
+function make_delta(items: SharePointDeltaItem[]) {
+  return vi.fn().mockResolvedValue({
+    drive_id: 'drive-1',
+    delta_link: 'https://delta-link',
+    items,
+    reset_detected: false,
+  });
+}
+
+function run_backup(version_error: unknown) {
+  const connector = make_connector({
+    fetch_delta: make_delta([make_file_item('f1')]),
+    list_file_versions: vi
+      .fn()
+      .mockResolvedValue([{ version_id: '1.0', last_modified_at: '2026-01-01', size_bytes: 10 }]),
+    download_file_version: vi.fn().mockRejectedValue(version_error),
+  });
+
+  return make_service({
+    connector,
+    manifests: make_manifests(),
+    file_indexes: make_file_indexes(),
+    cursors: make_cursors(),
+  }).backup_site('tenant-1', 'site-1', {});
+}
+
+describe('SharePoint backup — version download failures (issue #92)', () => {
+  it('reports an unexpected version failure as an error and marks the run unhealthy', async () => {
+    const result = await run_backup({ statusCode: 403, code: 'accessDenied', message: '' });
+
+    expect(result.summary.errors).toHaveLength(1);
+    expect(result.summary.errors[0]).toContain('1 version download(s) failed unexpectedly');
+    expect(result.summary.healthy).toBe(false);
+  });
+
+  it('keeps an expired version (410) out of the error bucket and stays healthy', async () => {
+    const result = await run_backup({ statusCode: 410 });
+
+    expect(result.summary.errors).toEqual([]);
+    expect(result.summary.versions_unavailable).toBe(1);
+    expect(result.summary.healthy).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #92.

## What was wrong

Two independent defects in the SharePoint/OneDrive version pipeline:

1. **Blank reasons.** `download_version_classified` built its reason from `err.message` alone. Graph SDK errors routinely arrive with an empty message and the useful part in `statusCode`/`code`, producing log lines like `[!] Version 1.0 of report.docx:` — nothing to act on.
2. **Failures could not affect the verdict.** The aggregate count was pushed into `warnings`, and `report_run_outcome()` only escalates `errors`/`interrupted`. A snapshot missing most of its version history printed `Status: HEALTHY` and exited 0, so a scheduled run could not detect it.

## Change

- `packages/m365-graph/src/graph-error-helpers.ts`: the private `describe_error` becomes exported `describe_graph_error`, now joining `HTTP <status>`, Graph `code`, message, and `body` (last resort) instead of returning the first facet present. Never returns an empty string. `is_content_gone_error` moves here too — the 404/410 check was copy-pasted identically in both version-sync modules.
- Both `*-version-sync.ts` use the shared helpers; the local `is_version_unavailable` copies are gone.
- `sharepoint-backup.service.ts` / `onedrive-backup.service.ts`: unexpected version failures now land in `errors`, are included in the `healthy` computation, and therefore reach `EXIT_PARTIAL` (2) through the existing `report_run_outcome()` path — the contract #32 established for Outlook. Expired versions (404/410) remain `unavailable` and keep the run healthy.

Deliberately out of scope: recording per-item version-failure reasons in the manifest (proposal item 4 in the issue). That is the same record-keeping #53 needs and belongs with it, not bolted on here.

## Verification

New tests fail on the unfixed code (confirmed by stashing the two service files: `1 failed | 1 passed` in each package) and pass after:

- `packages/m365-graph/tests/unit/graph-error-description.test.ts` — empty-message + `statusCode: 403` yields `HTTP 403 -- accessDenied`; never empty; message capped at 200 chars; 404/410 classified gone, 403/429 not.
- `packages/{sharepoint,onedrive}/tests/unit/services/*-backup-version-failures.test.ts` — a 403 version failure produces one error and `healthy: false`; a 410 leaves `errors` empty, counts one `unavailable`, and stays healthy.

Suites for the three touched packages: 302 tests passed (82 + 75 + 145). `pnpm run build`, `pnpm run lint` (two pre-existing warnings in untouched files), and `pnpm run docs:build` all clean.

Live smoke test against the Wisecom tenant with local MinIO, using the rebuilt CLI:

```
atlas sharepoint backup --site <intranet>          -> No changes detected, HEALTHY, exit 0
atlas sharepoint backup --site <intranet> --full   -> sp-snap-... created, 29 changed | 29 dedup, HEALTHY, exit 0
atlas onedrive backup -o <user>                    -> Versions: 2 stored, 0 unavailable, HEALTHY, exit 0
```

The healthy path is unchanged (OneNote package accounting stays a warning and does not touch the exit code). The 403 path is not reproducible on demand against a live tenant — that branch is covered by the unit tests above.

## Docs

`docs/sharepoint-backup.md` and `docs/onedrive-backup.md` said version failures "are reported as warnings ... but do not affect the health status", which is now the opposite of the behaviour. Both Snapshot Health Status sections were rewritten to state the new rule, show the new log shape, and correct the partial-run exit code (the paragraphs claimed `1`; `report_run_outcome` sets `2`).
