### PR TITLE
fix(cli): add -o/--owner OneDrive scope to replicate and rehydrate (#89)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -617,10 +617,14 @@ atlas replicate -m user@company.com --target-config ./offsite.json
 atlas replicate --site https://contoso.sharepoint.com/sites/Engineering --target-config ./offsite.json
 atlas replicate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000-a1b2c3 --target-config ./offsite.json
 
+atlas replicate -o user@company.com --target-config ./offsite.json
+atlas replicate -o user@company.com -s od-snap-1735689600000-a1b2c3 --target-config ./offsite.json
+
 atlas replicate --status
 atlas replicate --status -m user@company.com
 atlas replicate --status -s <snapshot-id>
 atlas replicate --status --site https://contoso.sharepoint.com/sites/Engineering
+atlas replicate --status -o user@company.com
 ```
 
 | Option                      | Description                                                |
@@ -628,6 +632,7 @@ atlas replicate --status --site https://contoso.sharepoint.com/sites/Engineering
 | `-s, --snapshot <id>`       | Replicate a specific snapshot                              |
 | `-m, --mailbox <email>`     | Replicate all unreplicated snapshots for a mailbox         |
 | `--site <url-or-id>`        | Replicate all unreplicated snapshots for a SharePoint site |
+| `-o, --owner <email-or-id>` | Replicate all unreplicated snapshots for a OneDrive owner  |
 | `--target-endpoint <url>`   | Target S3 endpoint URL                                     |
 | `--target-access-key <key>` | Target S3 access key                                       |
 | `--target-secret-key <key>` | Target S3 secret key                                       |
@@ -655,6 +660,9 @@ atlas rehydrate --all --source-config ./offsite.json
 
 atlas rehydrate --site https://contoso.sharepoint.com/sites/Engineering --source-config ./offsite.json
 atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000-a1b2c3 --source-config ./offsite.json
+
+atlas rehydrate -o user@company.com --source-config ./offsite.json
+atlas rehydrate -o user@company.com -s od-snap-1735689600000-a1b2c3 --source-config ./offsite.json
 ```
 
 | Option                      | Description                                                  |
@@ -662,6 +670,7 @@ atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000
 | `-s, --snapshot <id>`       | Recover a specific snapshot from the replica                 |
 | `-m, --mailbox <email>`     | Recover all snapshots for a mailbox from the replica         |
 | `--site <url-or-id>`        | Recover all SharePoint snapshots for a site from the replica |
+| `-o, --owner <email-or-id>` | Recover all OneDrive snapshots for an owner from the replica |
 | `--all`                     | Recover all mailboxes and snapshots (full tenant DR)         |
 | `--source-endpoint <url>`   | Source replica S3 endpoint URL                               |
 | `--source-access-key <key>` | Source replica S3 access key                                 |
@@ -669,6 +678,14 @@ atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000
 | `--source-region <region>`  | Source replica S3 region (default: `us-east-1`)              |
 | `--source-config <path>`    | Path to JSON file with source S3 credentials                 |
 | `-t, --tenant <id>`         | Override tenant ID                                           |
+
+Scopes are matched in the order `--site`, `-o/--owner`, `-s/--snapshot`, `-m/--mailbox`, `--all`. Combining `--site` or `-o/--owner` with `-s/--snapshot` narrows the recovery to that single SharePoint or OneDrive snapshot; `-s` on its own resolves Outlook snapshots. Owner and site identifiers are lowercased before they become storage keys, so any casing addresses the same tree.
+
+`-o/--owner` accepts an email or a raw Entra ID object ID. Recovery resolves an email through Microsoft Graph only -- unlike `atlas onedrive` commands it does not write the resolved identity back to primary, because that write would bootstrap a fresh encryption key in the target bucket and block the replica's key from being copied (see _Encryption Key Safety_ below). Pass the object ID directly when Graph is unreachable or the user has been deleted from the directory.
+
+::: warning `--all` covers Outlook only
+Despite the `full tenant recovery` label it prints, `--all` enumerates Outlook manifests only -- OneDrive and SharePoint snapshots are not recovered by it. Recover those explicitly with `-o/--owner` per owner and `--site` per site. Tracked in [#88](https://github.com/wisecom-oy/atlas/issues/88).
+:::
 
 ::: danger Rehydration Is Not Sync
 Rehydration copies explicitly selected data from a designated replica to primary. It does not merge, diff, or resolve conflicts. After rehydration, primary resumes as the source of truth. Delta links in recovered manifests may be stale -- Atlas falls back to full sync on the next backup automatically.

--- a/packages/cli/src/commands/rehydrate.command.tsx
+++ b/packages/cli/src/commands/rehydrate.command.tsx
@@ -3,10 +3,15 @@ import type { Command } from 'commander';
 import type { Container } from 'inversify';
 import type { AtlasConfig } from '@wisecom/atlas-core';
 import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
-import type { ReplicationUseCase, SharePointReplicationUseCase } from '@wisecom/atlas-types';
+import type {
+  ReplicationUseCase,
+  SharePointReplicationUseCase,
+  OneDriveReplicationUseCase,
+} from '@wisecom/atlas-types';
 import {
   REPLICATION_USE_CASE_TOKEN,
   SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
+  ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
 import { create_storage_target } from '@wisecom/atlas-s3';
 import type { StorageTarget } from '@wisecom/atlas-types';
@@ -18,7 +23,28 @@ import type { KeyValueItem } from '@/ui/components/key-value-list';
 import { ResultSummary } from '@/ui/components/result-summary';
 import { render_static_view } from '@/ui/render';
 import { format_bytes } from '@/command-formatters';
-import { logger } from '@wisecom/atlas-core';
+import { logger, GRAPH_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-core';
+import type { UserIdentityResolver } from '@wisecom/atlas-types';
+
+/**
+ * Resolves an owner for recovery without touching primary storage.
+ *
+ * The shared `resolve_owner` helper persists the identity registry to primary, which would
+ * bootstrap a fresh DEK there and make the source key un-copyable (`DekOverwriteRefusedError`).
+ * Recovery therefore reads Graph directly, and passes a raw object ID through untouched so DR
+ * still works when Graph is unreachable.
+ */
+async function resolve_owner_for_recovery(
+  container: Container,
+  tenant_id: string,
+  owner_input: string,
+): Promise<string> {
+  if (!owner_input.includes('@')) return owner_input;
+  const graph = container.get<UserIdentityResolver>(GRAPH_IDENTITY_RESOLVER_TOKEN);
+  const identity = await graph.resolve_user(tenant_id, owner_input);
+  logger.info(`Resolved ${owner_input} -> ${identity.object_id} (${identity.display_name})`);
+  return identity.object_id;
+}
 
 type ContainerFactory = () => Container;
 
@@ -26,6 +52,7 @@ interface RehydrateOptions {
   snapshot?: string;
   mailbox?: string;
   site?: string;
+  owner?: string;
   all?: boolean;
   tenant?: string;
   sourceEndpoint?: string;
@@ -46,6 +73,7 @@ export function register_rehydrate_command(
     .option('-s, --snapshot <id>', 'recover a specific snapshot')
     .option('-m, --mailbox <id>', 'recover all snapshots for a mailbox')
     .option('--site <url-or-id>', 'recover all snapshots for a SharePoint site')
+    .option('-o, --owner <email-or-id>', 'recover all OneDrive snapshots for an owner')
     .option('--all', 'recover all mailboxes and snapshots (full tenant DR)')
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option('--source-endpoint <url>', 'source replica S3 endpoint URL')
@@ -67,6 +95,10 @@ function resolve_mode_text(options: RehydrateOptions): string | undefined {
     return `recover SharePoint snapshot ${options.snapshot} for site ${options.site}`;
   }
   if (options.site) return `recover SharePoint site ${options.site}`;
+  if (options.owner && options.snapshot) {
+    return `recover OneDrive snapshot ${options.snapshot} for owner ${options.owner}`;
+  }
+  if (options.owner) return `recover OneDrive owner ${options.owner}`;
   if (options.snapshot) return `recover snapshot ${options.snapshot}`;
   if (options.mailbox) return `recover mailbox ${options.mailbox}`;
   if (options.all) return 'full tenant recovery';
@@ -108,6 +140,21 @@ async function execute_rehydrate(container: Container, options: RehydrateOptions
     } else {
       result = await sharepoint_replication.rehydrate_site(tenant_id, options.site, source);
     }
+  } else if (options.owner) {
+    const onedrive_replication = container.get<OneDriveReplicationUseCase>(
+      ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
+    );
+    const owner_id = await resolve_owner_for_recovery(container, tenant_id, options.owner);
+    if (options.snapshot) {
+      result = await onedrive_replication.rehydrate_owner_snapshot(
+        tenant_id,
+        owner_id,
+        options.snapshot,
+        source,
+      );
+    } else {
+      result = await onedrive_replication.rehydrate_owner(tenant_id, owner_id, source);
+    }
   } else if (options.snapshot) {
     result = await use_case.rehydrate_snapshot(tenant_id, options.snapshot, source);
   } else if (options.mailbox) {
@@ -115,7 +162,7 @@ async function execute_rehydrate(container: Container, options: RehydrateOptions
   } else if (options.all) {
     result = await use_case.rehydrate_tenant(tenant_id, source);
   } else {
-    logger.error('One of --snapshot, --mailbox, or --all is required');
+    logger.error('One of --snapshot, --mailbox, --owner, --site, or --all is required');
     process.exitCode = 1;
     return;
   }

--- a/packages/cli/src/commands/replicate.command.tsx
+++ b/packages/cli/src/commands/replicate.command.tsx
@@ -3,10 +3,15 @@ import type { Command } from 'commander';
 import type { Container } from 'inversify';
 import type { AtlasConfig } from '@wisecom/atlas-core';
 import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
-import type { ReplicationUseCase, SharePointReplicationUseCase } from '@wisecom/atlas-types';
+import type {
+  ReplicationUseCase,
+  SharePointReplicationUseCase,
+  OneDriveReplicationUseCase,
+} from '@wisecom/atlas-types';
 import {
   REPLICATION_USE_CASE_TOKEN,
   SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
+  ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
 import { create_storage_target } from '@wisecom/atlas-s3';
 import type { StorageTarget } from '@wisecom/atlas-types';
@@ -19,6 +24,7 @@ import type { TableColumn } from '@/ui/components/data-table';
 import { render_static_view } from '@/ui/render';
 import { format_bytes } from '@/command-formatters';
 import { logger } from '@wisecom/atlas-core';
+import { resolve_owner } from '@/commands/onedrive-command.handlers';
 
 type ContainerFactory = () => Container;
 
@@ -26,6 +32,7 @@ interface ReplicateOptions {
   snapshot?: string;
   mailbox?: string;
   site?: string;
+  owner?: string;
   tenant?: string;
   targetEndpoint?: string;
   targetAccessKey?: string;
@@ -46,6 +53,10 @@ export function register_replicate_command(
     .option('-s, --snapshot <id>', 'replicate a specific snapshot')
     .option('-m, --mailbox <id>', 'replicate all unreplicated snapshots for a mailbox')
     .option('--site <url-or-id>', 'replicate all unreplicated snapshots for a SharePoint site')
+    .option(
+      '-o, --owner <email-or-id>',
+      'replicate all unreplicated snapshots for a OneDrive owner',
+    )
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option('--target-endpoint <url>', 'target S3 endpoint URL')
     .option('--target-access-key <key>', 'target S3 access key')
@@ -66,7 +77,11 @@ async function execute_replicate(container: Container, options: ReplicateOptions
   const use_case = container.get<ReplicationUseCase>(REPLICATION_USE_CASE_TOKEN);
 
   if (options.status) {
-    await show_status(use_case, tenant_id, options);
+    const owner_scope = options.owner
+      ? (await resolve_owner(container, tenant_id, options.owner)).object_id
+      : undefined;
+    const scope_id = options.mailbox ?? options.site ?? owner_scope;
+    await show_status(use_case, tenant_id, options.snapshot, scope_id);
     return;
   }
 
@@ -103,6 +118,27 @@ async function execute_replicate(container: Container, options: ReplicateOptions
       );
       await report_results(results);
     }
+  } else if (options.owner) {
+    const onedrive_replication = container.get<OneDriveReplicationUseCase>(
+      ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
+    );
+    const owner = await resolve_owner(container, tenant_id, options.owner);
+    if (options.snapshot) {
+      const results = await onedrive_replication.replicate_owner(
+        tenant_id,
+        owner.object_id,
+        options.snapshot,
+        [target],
+      );
+      await report_results(results);
+    } else {
+      const results = await onedrive_replication.replicate_all_owner_snapshots(
+        tenant_id,
+        owner.object_id,
+        [target],
+      );
+      await report_results(results);
+    }
   } else if (options.snapshot) {
     const results = await use_case.replicate_snapshot(tenant_id, options.snapshot, [target]);
     await report_results(results);
@@ -111,7 +147,7 @@ async function execute_replicate(container: Container, options: ReplicateOptions
     await report_results(results);
   } else {
     logger.error(
-      'Either --snapshot, --mailbox, or --site is required (or --status to view status)',
+      'Either --snapshot, --mailbox, --owner, or --site is required (or --status to view status)',
     );
     process.exitCode = 1;
   }
@@ -237,17 +273,16 @@ const STATUS_COLUMNS: TableColumn<StatusRow>[] = [
 async function show_status(
   use_case: ReplicationUseCase,
   tenant_id: string,
-  options: ReplicateOptions,
+  snapshot_id: string | undefined,
+  scope_id: string | undefined,
 ): Promise<void> {
   await render_static_view(<Banner title="Replication Status" />);
 
   let records: ReplicationStatusRecord[];
-  if (options.snapshot) {
-    records = await use_case.get_replication_status(tenant_id, options.snapshot);
-  } else if (options.mailbox) {
-    records = await use_case.get_replication_status_by_owner(tenant_id, options.mailbox);
-  } else if (options.site) {
-    records = await use_case.get_replication_status_by_owner(tenant_id, options.site);
+  if (snapshot_id) {
+    records = await use_case.get_replication_status(tenant_id, snapshot_id);
+  } else if (scope_id) {
+    records = await use_case.get_replication_status_by_owner(tenant_id, scope_id);
   } else {
     records = await use_case.get_replication_status(tenant_id);
   }

--- a/packages/cli/tests/unit/replication-owner-scope.test.ts
+++ b/packages/cli/tests/unit/replication-owner-scope.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { register_replicate_command } from '@/commands/replicate.command';
+import { register_rehydrate_command } from '@/commands/rehydrate.command';
+import {
+  REPLICATION_USE_CASE_TOKEN,
+  SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
+  ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
+  USER_IDENTITY_RESOLVER_TOKEN,
+} from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN, GRAPH_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-core';
+import type { ReplicationResult } from '@wisecom/atlas-types';
+
+const OWNER_EMAIL = 'user@example.com';
+const OWNER_OBJECT_ID = '75a21b57-4d82-4f42-9ccc-7c231c30f78c';
+
+const RESULT: ReplicationResult = {
+  snapshot_id: 'od-snap-1',
+  target_id: 'replica',
+  status: 'COMPLETED',
+  objects_copied: 3,
+  objects_skipped: 0,
+  objects_failed: 0,
+  bytes_copied: 1024,
+  elapsed_ms: 12,
+  errors: [],
+};
+
+interface OneDriveReplicationMock {
+  replicate_owner: Mock;
+  replicate_all_owner_snapshots: Mock;
+  rehydrate_owner_snapshot: Mock;
+  rehydrate_owner: Mock;
+}
+
+interface OutlookReplicationMock {
+  replicate_snapshot: Mock;
+  get_replication_status: Mock;
+  get_replication_status_by_owner: Mock;
+}
+
+function make_onedrive_mock(): OneDriveReplicationMock {
+  return {
+    replicate_owner: vi.fn().mockResolvedValue([RESULT]),
+    replicate_all_owner_snapshots: vi.fn().mockResolvedValue([RESULT]),
+    rehydrate_owner_snapshot: vi.fn().mockResolvedValue(RESULT),
+    rehydrate_owner: vi.fn().mockResolvedValue(RESULT),
+  };
+}
+
+const TARGET_ARGS = [
+  '--target-endpoint',
+  'http://replica:9000',
+  '--target-access-key',
+  'key',
+  '--target-secret-key',
+  'secret',
+];
+
+const SOURCE_ARGS = [
+  '--source-endpoint',
+  'http://replica:9000',
+  '--source-access-key',
+  'key',
+  '--source-secret-key',
+  'secret',
+];
+
+describe('replicate/rehydrate --owner OneDrive scope', () => {
+  let container: Container;
+  let onedrive: OneDriveReplicationMock;
+  let outlook: OutlookReplicationMock;
+  let program: Command;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    container = new Container();
+    onedrive = make_onedrive_mock();
+    outlook = {
+      replicate_snapshot: vi.fn().mockResolvedValue([RESULT]),
+      get_replication_status: vi.fn().mockResolvedValue([]),
+      get_replication_status_by_owner: vi.fn().mockResolvedValue([]),
+    };
+
+    container.bind(ONEDRIVE_REPLICATION_USE_CASE_TOKEN).toConstantValue(onedrive);
+    container.bind(REPLICATION_USE_CASE_TOKEN).toConstantValue(outlook);
+    container.bind(SHAREPOINT_REPLICATION_USE_CASE_TOKEN).toConstantValue({});
+    const identity = {
+      resolve_user: vi.fn().mockResolvedValue({
+        object_id: OWNER_OBJECT_ID,
+        email: OWNER_EMAIL,
+        display_name: 'Example User',
+      }),
+    };
+    container.bind(USER_IDENTITY_RESOLVER_TOKEN).toConstantValue(identity);
+    container.bind(GRAPH_IDENTITY_RESOLVER_TOKEN).toConstantValue(identity);
+    container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({
+      tenant_id: 'test-tenant',
+      encryption_passphrase: 'pass',
+    });
+
+    program = new Command();
+    program.exitOverride();
+    register_replicate_command(program, () => container);
+    register_rehydrate_command(program, () => container);
+  });
+
+  it('replicates every unreplicated snapshot under the owner object ID, not the raw email', async () => {
+    await program.parseAsync(['replicate', '-o', OWNER_EMAIL, ...TARGET_ARGS], { from: 'user' });
+
+    expect(onedrive.replicate_all_owner_snapshots).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+      [expect.objectContaining({ endpoint: 'http://replica:9000' })],
+    );
+    expect(onedrive.replicate_owner).not.toHaveBeenCalled();
+  });
+
+  it('routes replicate -o with -s to the single OneDrive snapshot, not the Outlook path', async () => {
+    await program.parseAsync(['replicate', '-o', OWNER_EMAIL, '-s', 'od-snap-1', ...TARGET_ARGS], {
+      from: 'user',
+    });
+
+    expect(onedrive.replicate_owner).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+      'od-snap-1',
+      expect.any(Array),
+    );
+    expect(outlook.replicate_snapshot).not.toHaveBeenCalled();
+  });
+
+  it('passes a raw object ID through untouched so DR works without Graph', async () => {
+    await program.parseAsync(['replicate', '-o', OWNER_OBJECT_ID, ...TARGET_ARGS], {
+      from: 'user',
+    });
+
+    expect(onedrive.replicate_all_owner_snapshots).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+      expect.any(Array),
+    );
+  });
+
+  it('scopes --status -o to the resolved owner object ID', async () => {
+    await program.parseAsync(['replicate', '--status', '-o', OWNER_EMAIL], { from: 'user' });
+
+    expect(outlook.get_replication_status_by_owner).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+    );
+  });
+
+  it('rehydrates the owner from the replica using the resolved object ID', async () => {
+    await program.parseAsync(['rehydrate', '-o', OWNER_EMAIL, ...SOURCE_ARGS], { from: 'user' });
+
+    expect(onedrive.rehydrate_owner).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+      expect.objectContaining({ endpoint: 'http://replica:9000' }),
+    );
+  });
+
+  it('routes rehydrate -o with -s to the single OneDrive snapshot', async () => {
+    await program.parseAsync(['rehydrate', '-o', OWNER_EMAIL, '-s', 'od-snap-1', ...SOURCE_ARGS], {
+      from: 'user',
+    });
+
+    expect(onedrive.rehydrate_owner_snapshot).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+      'od-snap-1',
+      expect.anything(),
+    );
+    expect(onedrive.rehydrate_owner).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/services/replication/replication.service.ts
+++ b/packages/core/src/services/replication/replication.service.ts
@@ -188,6 +188,7 @@ export class ReplicationService implements ReplicationUseCase {
     tenant_id: string,
     owner_id: string,
   ): Promise<ReplicationStatusRecord[]> {
+    owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       return await list_replication_status_by_owner(ctx, owner_id);

--- a/packages/core/tests/unit/services/replication/replication.service.test.ts
+++ b/packages/core/tests/unit/services/replication/replication.service.test.ts
@@ -231,4 +231,12 @@ describe('ReplicationService', () => {
 
     expect(results).toEqual([]);
   });
+
+  it('get_replication_status_by_owner lowercases the owner id used as the sidecar prefix', async () => {
+    vi.mocked(source_storage.list).mockResolvedValue([]);
+
+    await service.get_replication_status_by_owner('tenant-1', 'User@Company.COM');
+
+    expect(source_storage.list).toHaveBeenCalledWith('_meta/replication/user@company.com/');
+  });
 });


### PR DESCRIPTION
Closes #89.

## Problem

`OneDriveReplicationUseCase` was fully implemented and DI-registered, but no CLI flag reached it. `replicate` and `rehydrate` exposed `-s`, `-m`, `--site` (plus `--all`), so no flag combination could replicate or recover a OneDrive snapshot -- OneDrive was the only workload with zero DR coverage.

## Changes

- **`-o, --owner <email-or-id>` on both commands**, dispatching to `replicate_owner` / `replicate_all_owner_snapshots` and `rehydrate_owner_snapshot` / `rehydrate_owner`, mirroring the existing `--site` branch shape.
- **Owner email is resolved to its Entra object ID.** Wiring the flag alone was not enough: OneDrive manifests live under `onedrive/manifests/<object_id>/`, so passing the raw email matched nothing and the command reported success with an empty result table. `replicate` reuses the shared `resolve_owner` helper that every other `atlas onedrive` command uses.
- **`rehydrate` resolves via Graph only.** The shared `resolve_owner` persists the identity registry to *primary*; during recovery into an empty bucket that write bootstrapped a fresh DEK, after which `ensure_source_dek_on_primary` correctly refused to replace it (`DekOverwriteRefusedError`) and recovery was impossible. Recovery now reads Graph without writing back, and passes a raw object ID through untouched so DR still works when Graph is unreachable.
- **`get_replication_status_by_owner` normalizes the owner id** (root-cause fix, one line in the shared method). Every writer normalizes via `normalize_owner_id`, but the status lookup built its `_meta/replication/<owner>/` prefix from the raw argument, so `--status -m User@Company.com` silently returned nothing. This also fixed `--status --site` and the new `--status -o`.
- Docs: `-o/--owner` documented for both commands, scope precedence spelled out, DR resolution behavior explained, and an explicit warning that `--all` covers Outlook only (#88).

## Verification

Live run against the Wisecom tenant with primary + replica MinIO:

```
$ atlas replicate -o miika@wisecom.fi --target-config replica.json
[*] Resolved miika@wisecom.fi -> 75a21b57-... (Miika Oja-Kaukola)
od-snap-1786966034931-efe34a  replica  COMPLETED  12 copied  1 skipped  0 failed  2.7 MB

$ ATLAS_S3_ENDPOINT=<empty primary> atlas rehydrate -o miika@wisecom.fi --source-config replica.json
Result: COMPLETED
12 copied | 1 skipped | 0 failed - 2.7 MB, 93ms

$ ATLAS_S3_ENDPOINT=<recovered primary> atlas onedrive verify -o miika@wisecom.fi -s od-snap-1786966034931-efe34a
[+] All 6 entries passed verification

$ atlas replicate --status
75a21b57-...  od-snap-1786966034931-efe34a  replica  COMPLETED  12/13  2.7 MB
```

Before the object-ID resolution fix the first command printed an empty result table and exited 0. `--status -m` and `--status -s` re-checked for regressions after the `show_status` refactor.

Added `packages/cli/tests/unit/replication-owner-scope.test.ts` (6 tests) pinning the dispatch matrix, the resolved object ID, raw-object-ID passthrough, and `--status -o` scoping; plus a core test asserting the status sidecar prefix is lowercased. Full suite (905 tests), lint, typecheck, and `docs:build` pass.

## Acceptance criteria

- [x] `atlas replicate -o <email> --target-config <file>` replicates every unreplicated OneDrive snapshot for that owner
- [x] `atlas rehydrate -o <email> --source-config <file>` restores them into an empty primary; `atlas onedrive verify` passes afterwards
- [x] `atlas replicate --status` lists OneDrive snapshots alongside Outlook/SharePoint
- [x] CLI reference documents `-o/--owner` for both commands

Not in scope: including OneDrive/SharePoint in the `--all` dispatch (#88) -- documented as a warning here instead.