### PR TITLE
fix(replication): rehydrate --all recovers every workload, not Outlook alone (#88)

### DIFF
--- a/docs/operations/replication.md
+++ b/docs/operations/replication.md
@@ -237,11 +237,13 @@ atlas rehydrate --site contoso.sharepoint.com,guid,guid --source-config ./offsit
 atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-123 --source-config ./offsite.json
 ```
 
-**Full tenant recovery:**
+**Full tenant recovery (all workloads):**
 
 ```bash
 atlas rehydrate --all --source-config ./offsite.json
 ```
+
+`--all` enumerates all three manifest roots -- `manifests/` (Outlook), `onedrive/manifests/` (OneDrive), and `sharepoint/manifests/` (SharePoint) -- and reports copied/skipped/failed counts per workload. Any workload that yielded no objects is named in a warning, so an incomplete DR drill cannot pass silently.
 
 Rehydration skips snapshots that already exist on primary. It does not merge, diff, or resolve conflicts.
 
@@ -262,8 +264,10 @@ await atlas.onedrive.rehydrateSnapshot('owner-id', 'od-snap-123', offsite);
 await atlas.sharepoint.rehydrateSite('site-id', offsite);
 await atlas.sharepoint.rehydrateSnapshot('site-id', 'sp-snap-123', offsite);
 
-// Full tenant DR
-await atlas.rehydrateTenant(offsite);
+// Full tenant DR: Outlook + OneDrive + SharePoint in one call.
+// `workloads` carries one entry per workload; `total` is their aggregate.
+const recovery = await atlas.rehydrateTenant(offsite);
+recovery.workloads.forEach((w) => console.log(w.workload, w.result.objects_copied));
 ```
 
 ## Object Lock

--- a/docs/reference/cli-recovery.md
+++ b/docs/reference/cli-recovery.md
@@ -198,6 +198,9 @@ atlas rehydrate --all --source-config ./offsite.json
 
 atlas rehydrate --site https://contoso.sharepoint.com/sites/Engineering --source-config ./offsite.json
 atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000-a1b2c3 --source-config ./offsite.json
+
+atlas rehydrate -o user@company.com --source-config ./offsite.json
+atlas rehydrate -o user@company.com -s od-snap-1735689600000-a1b2c3 --source-config ./offsite.json
 ```
 
 | Option                      | Description                                                  |
@@ -205,7 +208,8 @@ atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000
 | `-s, --snapshot <id>`       | Recover a specific snapshot from the replica                 |
 | `-m, --mailbox <email>`     | Recover all snapshots for a mailbox from the replica         |
 | `--site <url-or-id>`        | Recover all SharePoint snapshots for a site from the replica |
-| `--all`                     | Recover all mailboxes and snapshots (full tenant DR)         |
+| `-o, --owner <email-or-id>` | Recover all OneDrive snapshots for an owner from the replica |
+| `--all`                     | Recover every workload: Outlook, OneDrive, and SharePoint    |
 | `--source-endpoint <url>`   | Source replica S3 endpoint URL                               |
 | `--source-access-key <key>` | Source replica S3 access key                                 |
 | `--source-secret-key <key>` | Source replica S3 secret key                                 |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -671,7 +671,7 @@ atlas rehydrate -o user@company.com -s od-snap-1735689600000-a1b2c3 --source-con
 | `-m, --mailbox <email>`     | Recover all snapshots for a mailbox from the replica         |
 | `--site <url-or-id>`        | Recover all SharePoint snapshots for a site from the replica |
 | `-o, --owner <email-or-id>` | Recover all OneDrive snapshots for an owner from the replica |
-| `--all`                     | Recover all mailboxes and snapshots (full tenant DR)         |
+| `--all`                     | Recover every workload: Outlook, OneDrive, and SharePoint    |
 | `--source-endpoint <url>`   | Source replica S3 endpoint URL                               |
 | `--source-access-key <key>` | Source replica S3 access key                                 |
 | `--source-secret-key <key>` | Source replica S3 secret key                                 |
@@ -683,8 +683,17 @@ Scopes are matched in the order `--site`, `-o/--owner`, `-s/--snapshot`, `-m/--m
 
 `-o/--owner` accepts an email or a raw Entra ID object ID. Recovery resolves an email through Microsoft Graph only -- unlike `atlas onedrive` commands it does not write the resolved identity back to primary, because that write would bootstrap a fresh encryption key in the target bucket and block the replica's key from being copied (see _Encryption Key Safety_ below). Pass the object ID directly when Graph is unreachable or the user has been deleted from the directory.
 
-::: warning `--all` covers Outlook only
-Despite the `full tenant recovery` label it prints, `--all` enumerates Outlook manifests only -- OneDrive and SharePoint snapshots are not recovered by it. Recover those explicitly with `-o/--owner` per owner and `--site` per site. Tracked in [#88](https://github.com/wisecom-oy/atlas/issues/88).
+::: tip What `--all` covers
+`--all` recovers all three workloads -- every Outlook mailbox (`manifests/`), every OneDrive owner (`onedrive/manifests/`), and every SharePoint site (`sharepoint/manifests/`) present on the replica. The summary breaks the run down per workload, so a recovery that restored only part of the tenant is visible instead of hidden behind one aggregate status line:
+
+```
+Workload    Scope       Copied  Skipped  Failed  Size
+outlook     2-snapshots  35      0        0       433.3 KB
+onedrive    1-owners     12      1        0       2.7 MB
+sharepoint  1-sites      59      0        0       7.1 MB
+```
+
+A workload with no objects at all prints a warning naming it -- the replica held nothing for it. Verify that against the source before treating the drill as a pass.
 :::
 
 ::: danger Rehydration Is Not Sync

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -617,10 +617,14 @@ atlas replicate -m user@company.com --target-config ./offsite.json
 atlas replicate --site https://contoso.sharepoint.com/sites/Engineering --target-config ./offsite.json
 atlas replicate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000-a1b2c3 --target-config ./offsite.json
 
+atlas replicate -o user@company.com --target-config ./offsite.json
+atlas replicate -o user@company.com -s od-snap-1735689600000-a1b2c3 --target-config ./offsite.json
+
 atlas replicate --status
 atlas replicate --status -m user@company.com
 atlas replicate --status -s <snapshot-id>
 atlas replicate --status --site https://contoso.sharepoint.com/sites/Engineering
+atlas replicate --status -o user@company.com
 ```
 
 | Option                      | Description                                                |
@@ -628,6 +632,7 @@ atlas replicate --status --site https://contoso.sharepoint.com/sites/Engineering
 | `-s, --snapshot <id>`       | Replicate a specific snapshot                              |
 | `-m, --mailbox <email>`     | Replicate all unreplicated snapshots for a mailbox         |
 | `--site <url-or-id>`        | Replicate all unreplicated snapshots for a SharePoint site |
+| `-o, --owner <email-or-id>` | Replicate all unreplicated snapshots for a OneDrive owner  |
 | `--target-endpoint <url>`   | Target S3 endpoint URL                                     |
 | `--target-access-key <key>` | Target S3 access key                                       |
 | `--target-secret-key <key>` | Target S3 secret key                                       |
@@ -655,6 +660,9 @@ atlas rehydrate --all --source-config ./offsite.json
 
 atlas rehydrate --site https://contoso.sharepoint.com/sites/Engineering --source-config ./offsite.json
 atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000-a1b2c3 --source-config ./offsite.json
+
+atlas rehydrate -o user@company.com --source-config ./offsite.json
+atlas rehydrate -o user@company.com -s od-snap-1735689600000-a1b2c3 --source-config ./offsite.json
 ```
 
 | Option                      | Description                                                  |
@@ -662,6 +670,7 @@ atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000
 | `-s, --snapshot <id>`       | Recover a specific snapshot from the replica                 |
 | `-m, --mailbox <email>`     | Recover all snapshots for a mailbox from the replica         |
 | `--site <url-or-id>`        | Recover all SharePoint snapshots for a site from the replica |
+| `-o, --owner <email-or-id>` | Recover all OneDrive snapshots for an owner from the replica |
 | `--all`                     | Recover all mailboxes and snapshots (full tenant DR)         |
 | `--source-endpoint <url>`   | Source replica S3 endpoint URL                               |
 | `--source-access-key <key>` | Source replica S3 access key                                 |
@@ -669,6 +678,14 @@ atlas rehydrate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000
 | `--source-region <region>`  | Source replica S3 region (default: `us-east-1`)              |
 | `--source-config <path>`    | Path to JSON file with source S3 credentials                 |
 | `-t, --tenant <id>`         | Override tenant ID                                           |
+
+Scopes are matched in the order `--site`, `-o/--owner`, `-s/--snapshot`, `-m/--mailbox`, `--all`. Combining `--site` or `-o/--owner` with `-s/--snapshot` narrows the recovery to that single SharePoint or OneDrive snapshot; `-s` on its own resolves Outlook snapshots. Owner and site identifiers are lowercased before they become storage keys, so any casing addresses the same tree.
+
+`-o/--owner` accepts an email or a raw Entra ID object ID. Recovery resolves an email through Microsoft Graph only -- unlike `atlas onedrive` commands it does not write the resolved identity back to primary, because that write would bootstrap a fresh encryption key in the target bucket and block the replica's key from being copied (see _Encryption Key Safety_ below). Pass the object ID directly when Graph is unreachable or the user has been deleted from the directory.
+
+::: warning `--all` covers Outlook only
+Despite the `full tenant recovery` label it prints, `--all` enumerates Outlook manifests only -- OneDrive and SharePoint snapshots are not recovered by it. Recover those explicitly with `-o/--owner` per owner and `--site` per site. Tracked in [#88](https://github.com/wisecom-oy/atlas/issues/88).
+:::
 
 ::: danger Rehydration Is Not Sync
 Rehydration copies explicitly selected data from a designated replica to primary. It does not merge, diff, or resolve conflicts. After rehydration, primary resumes as the source of truth. Delta links in recovered manifests may be stale -- Atlas falls back to full sync on the next backup automatically.

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -281,7 +281,13 @@ const status = await atlas.getReplicationStatus('snapshot-id');
 // Disaster recovery: recover from a replica
 await atlas.rehydrateSnapshot('snapshot-id', offsite);
 await atlas.rehydrateMailbox('user@company.com', offsite);
-await atlas.rehydrateTenant(offsite);
+
+// Full tenant DR: every workload, reported per workload
+const recovery = await atlas.rehydrateTenant(offsite);
+for (const { workload, result } of recovery.workloads) {
+  console.log(workload, result.objects_copied, result.objects_failed);
+}
+console.log(recovery.total.status);
 ```
 
 `createStorageTarget` accepts a `StorageTargetConfig`:

--- a/packages/cli/src/commands/rehydrate.command.tsx
+++ b/packages/cli/src/commands/rehydrate.command.tsx
@@ -15,12 +15,14 @@ import {
 } from '@wisecom/atlas-types';
 import { create_storage_target } from '@wisecom/atlas-s3';
 import type { StorageTarget } from '@wisecom/atlas-types';
-import type { ReplicationResult } from '@wisecom/atlas-types';
+import type { ReplicationResult, TenantRehydrationResult } from '@wisecom/atlas-types';
 import { Box } from 'ink';
 import { Banner } from '@/ui/components/banner';
 import { KeyValueList } from '@/ui/components/key-value-list';
 import type { KeyValueItem } from '@/ui/components/key-value-list';
 import { ResultSummary } from '@/ui/components/result-summary';
+import { DataTable } from '@/ui/components/data-table';
+import type { TableColumn } from '@/ui/components/data-table';
 import { render_static_view } from '@/ui/render';
 import { format_bytes } from '@/command-formatters';
 import { logger, GRAPH_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-core';
@@ -160,7 +162,8 @@ async function execute_rehydrate(container: Container, options: RehydrateOptions
   } else if (options.mailbox) {
     result = await use_case.rehydrate_mailbox(tenant_id, options.mailbox, source);
   } else if (options.all) {
-    result = await use_case.rehydrate_tenant(tenant_id, source);
+    await report_tenant_result(await use_case.rehydrate_tenant(tenant_id, source));
+    return;
   } else {
     logger.error('One of --snapshot, --mailbox, --owner, --site, or --all is required');
     process.exitCode = 1;
@@ -244,4 +247,47 @@ async function report_result(result: ReplicationResult): Promise<void> {
   }
 
   if (result.objects_failed > 0) process.exitCode = 1;
+}
+
+interface WorkloadRow {
+  workload: string;
+  scope: string;
+  copied: number;
+  skipped: number;
+  failed: number;
+  size: string;
+}
+
+const WORKLOAD_COLUMNS: TableColumn<WorkloadRow>[] = [
+  { key: 'workload', header: 'Workload', color: () => 'cyan' },
+  { key: 'scope', header: 'Scope' },
+  { key: 'copied', header: 'Copied' },
+  { key: 'skipped', header: 'Skipped' },
+  { key: 'failed', header: 'Failed', color: (row) => (row.failed > 0 ? 'red' : undefined) },
+  { key: 'size', header: 'Size' },
+];
+
+/** Reports a full tenant recovery: one row per workload, so a partial recovery is visible. */
+async function report_tenant_result(result: TenantRehydrationResult): Promise<void> {
+  const rows: WorkloadRow[] = result.workloads.map((w) => ({
+    workload: w.workload,
+    scope: w.result.snapshot_id,
+    copied: w.result.objects_copied,
+    skipped: w.result.objects_skipped,
+    failed: w.result.objects_failed,
+    size: format_bytes(w.result.bytes_copied),
+  }));
+
+  await render_static_view(<DataTable columns={WORKLOAD_COLUMNS} rows={rows} />);
+  await report_result(result.total);
+
+  const empty = result.workloads.filter(
+    (w) => w.result.objects_copied === 0 && w.result.objects_skipped === 0,
+  );
+  if (empty.length > 0) {
+    logger.warn(
+      `No snapshots found on the replica for: ${empty.map((w) => w.workload).join(', ')}. ` +
+        'Confirm this matches the source before treating the recovery as complete.',
+    );
+  }
 }

--- a/packages/cli/src/commands/rehydrate.command.tsx
+++ b/packages/cli/src/commands/rehydrate.command.tsx
@@ -3,10 +3,15 @@ import type { Command } from 'commander';
 import type { Container } from 'inversify';
 import type { AtlasConfig } from '@wisecom/atlas-core';
 import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
-import type { ReplicationUseCase, SharePointReplicationUseCase } from '@wisecom/atlas-types';
+import type {
+  ReplicationUseCase,
+  SharePointReplicationUseCase,
+  OneDriveReplicationUseCase,
+} from '@wisecom/atlas-types';
 import {
   REPLICATION_USE_CASE_TOKEN,
   SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
+  ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
 import { create_storage_target } from '@wisecom/atlas-s3';
 import type { StorageTarget } from '@wisecom/atlas-types';
@@ -18,7 +23,28 @@ import type { KeyValueItem } from '@/ui/components/key-value-list';
 import { ResultSummary } from '@/ui/components/result-summary';
 import { render_static_view } from '@/ui/render';
 import { format_bytes } from '@/command-formatters';
-import { logger } from '@wisecom/atlas-core';
+import { logger, GRAPH_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-core';
+import type { UserIdentityResolver } from '@wisecom/atlas-types';
+
+/**
+ * Resolves an owner for recovery without touching primary storage.
+ *
+ * The shared `resolve_owner` helper persists the identity registry to primary, which would
+ * bootstrap a fresh DEK there and make the source key un-copyable (`DekOverwriteRefusedError`).
+ * Recovery therefore reads Graph directly, and passes a raw object ID through untouched so DR
+ * still works when Graph is unreachable.
+ */
+async function resolve_owner_for_recovery(
+  container: Container,
+  tenant_id: string,
+  owner_input: string,
+): Promise<string> {
+  if (!owner_input.includes('@')) return owner_input;
+  const graph = container.get<UserIdentityResolver>(GRAPH_IDENTITY_RESOLVER_TOKEN);
+  const identity = await graph.resolve_user(tenant_id, owner_input);
+  logger.info(`Resolved ${owner_input} -> ${identity.object_id} (${identity.display_name})`);
+  return identity.object_id;
+}
 
 type ContainerFactory = () => Container;
 
@@ -26,6 +52,7 @@ interface RehydrateOptions {
   snapshot?: string;
   mailbox?: string;
   site?: string;
+  owner?: string;
   all?: boolean;
   tenant?: string;
   sourceEndpoint?: string;
@@ -46,6 +73,7 @@ export function register_rehydrate_command(
     .option('-s, --snapshot <id>', 'recover a specific snapshot')
     .option('-m, --mailbox <id>', 'recover all snapshots for a mailbox')
     .option('--site <url-or-id>', 'recover all snapshots for a SharePoint site')
+    .option('-o, --owner <email-or-id>', 'recover all OneDrive snapshots for an owner')
     .option('--all', 'recover all mailboxes and snapshots (full tenant DR)')
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option('--source-endpoint <url>', 'source replica S3 endpoint URL')
@@ -67,6 +95,10 @@ function resolve_mode_text(options: RehydrateOptions): string | undefined {
     return `recover SharePoint snapshot ${options.snapshot} for site ${options.site}`;
   }
   if (options.site) return `recover SharePoint site ${options.site}`;
+  if (options.owner && options.snapshot) {
+    return `recover OneDrive snapshot ${options.snapshot} for owner ${options.owner}`;
+  }
+  if (options.owner) return `recover OneDrive owner ${options.owner}`;
   if (options.snapshot) return `recover snapshot ${options.snapshot}`;
   if (options.mailbox) return `recover mailbox ${options.mailbox}`;
   if (options.all) return 'full tenant recovery';
@@ -108,6 +140,21 @@ async function execute_rehydrate(container: Container, options: RehydrateOptions
     } else {
       result = await sharepoint_replication.rehydrate_site(tenant_id, options.site, source);
     }
+  } else if (options.owner) {
+    const onedrive_replication = container.get<OneDriveReplicationUseCase>(
+      ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
+    );
+    const owner_id = await resolve_owner_for_recovery(container, tenant_id, options.owner);
+    if (options.snapshot) {
+      result = await onedrive_replication.rehydrate_owner_snapshot(
+        tenant_id,
+        owner_id,
+        options.snapshot,
+        source,
+      );
+    } else {
+      result = await onedrive_replication.rehydrate_owner(tenant_id, owner_id, source);
+    }
   } else if (options.snapshot) {
     result = await use_case.rehydrate_snapshot(tenant_id, options.snapshot, source);
   } else if (options.mailbox) {
@@ -115,7 +162,7 @@ async function execute_rehydrate(container: Container, options: RehydrateOptions
   } else if (options.all) {
     result = await use_case.rehydrate_tenant(tenant_id, source);
   } else {
-    logger.error('One of --snapshot, --mailbox, or --all is required');
+    logger.error('One of --snapshot, --mailbox, --owner, --site, or --all is required');
     process.exitCode = 1;
     return;
   }

--- a/packages/cli/src/commands/replicate.command.tsx
+++ b/packages/cli/src/commands/replicate.command.tsx
@@ -3,10 +3,15 @@ import type { Command } from 'commander';
 import type { Container } from 'inversify';
 import type { AtlasConfig } from '@wisecom/atlas-core';
 import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
-import type { ReplicationUseCase, SharePointReplicationUseCase } from '@wisecom/atlas-types';
+import type {
+  ReplicationUseCase,
+  SharePointReplicationUseCase,
+  OneDriveReplicationUseCase,
+} from '@wisecom/atlas-types';
 import {
   REPLICATION_USE_CASE_TOKEN,
   SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
+  ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
 import { create_storage_target } from '@wisecom/atlas-s3';
 import type { StorageTarget } from '@wisecom/atlas-types';
@@ -19,6 +24,7 @@ import type { TableColumn } from '@/ui/components/data-table';
 import { render_static_view } from '@/ui/render';
 import { format_bytes } from '@/command-formatters';
 import { logger } from '@wisecom/atlas-core';
+import { resolve_owner } from '@/commands/onedrive-command.handlers';
 
 type ContainerFactory = () => Container;
 
@@ -26,6 +32,7 @@ interface ReplicateOptions {
   snapshot?: string;
   mailbox?: string;
   site?: string;
+  owner?: string;
   tenant?: string;
   targetEndpoint?: string;
   targetAccessKey?: string;
@@ -46,6 +53,10 @@ export function register_replicate_command(
     .option('-s, --snapshot <id>', 'replicate a specific snapshot')
     .option('-m, --mailbox <id>', 'replicate all unreplicated snapshots for a mailbox')
     .option('--site <url-or-id>', 'replicate all unreplicated snapshots for a SharePoint site')
+    .option(
+      '-o, --owner <email-or-id>',
+      'replicate all unreplicated snapshots for a OneDrive owner',
+    )
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option('--target-endpoint <url>', 'target S3 endpoint URL')
     .option('--target-access-key <key>', 'target S3 access key')
@@ -66,7 +77,11 @@ async function execute_replicate(container: Container, options: ReplicateOptions
   const use_case = container.get<ReplicationUseCase>(REPLICATION_USE_CASE_TOKEN);
 
   if (options.status) {
-    await show_status(use_case, tenant_id, options);
+    const owner_scope = options.owner
+      ? (await resolve_owner(container, tenant_id, options.owner)).object_id
+      : undefined;
+    const scope_id = options.mailbox ?? options.site ?? owner_scope;
+    await show_status(use_case, tenant_id, options.snapshot, scope_id);
     return;
   }
 
@@ -103,6 +118,27 @@ async function execute_replicate(container: Container, options: ReplicateOptions
       );
       await report_results(results);
     }
+  } else if (options.owner) {
+    const onedrive_replication = container.get<OneDriveReplicationUseCase>(
+      ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
+    );
+    const owner = await resolve_owner(container, tenant_id, options.owner);
+    if (options.snapshot) {
+      const results = await onedrive_replication.replicate_owner(
+        tenant_id,
+        owner.object_id,
+        options.snapshot,
+        [target],
+      );
+      await report_results(results);
+    } else {
+      const results = await onedrive_replication.replicate_all_owner_snapshots(
+        tenant_id,
+        owner.object_id,
+        [target],
+      );
+      await report_results(results);
+    }
   } else if (options.snapshot) {
     const results = await use_case.replicate_snapshot(tenant_id, options.snapshot, [target]);
     await report_results(results);
@@ -111,7 +147,7 @@ async function execute_replicate(container: Container, options: ReplicateOptions
     await report_results(results);
   } else {
     logger.error(
-      'Either --snapshot, --mailbox, or --site is required (or --status to view status)',
+      'Either --snapshot, --mailbox, --owner, or --site is required (or --status to view status)',
     );
     process.exitCode = 1;
   }
@@ -237,17 +273,16 @@ const STATUS_COLUMNS: TableColumn<StatusRow>[] = [
 async function show_status(
   use_case: ReplicationUseCase,
   tenant_id: string,
-  options: ReplicateOptions,
+  snapshot_id: string | undefined,
+  scope_id: string | undefined,
 ): Promise<void> {
   await render_static_view(<Banner title="Replication Status" />);
 
   let records: ReplicationStatusRecord[];
-  if (options.snapshot) {
-    records = await use_case.get_replication_status(tenant_id, options.snapshot);
-  } else if (options.mailbox) {
-    records = await use_case.get_replication_status_by_owner(tenant_id, options.mailbox);
-  } else if (options.site) {
-    records = await use_case.get_replication_status_by_owner(tenant_id, options.site);
+  if (snapshot_id) {
+    records = await use_case.get_replication_status(tenant_id, snapshot_id);
+  } else if (scope_id) {
+    records = await use_case.get_replication_status_by_owner(tenant_id, scope_id);
   } else {
     records = await use_case.get_replication_status(tenant_id);
   }

--- a/packages/cli/tests/unit/replication-owner-scope.test.ts
+++ b/packages/cli/tests/unit/replication-owner-scope.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { register_replicate_command } from '@/commands/replicate.command';
+import { register_rehydrate_command } from '@/commands/rehydrate.command';
+import {
+  REPLICATION_USE_CASE_TOKEN,
+  SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
+  ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
+  USER_IDENTITY_RESOLVER_TOKEN,
+} from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN, GRAPH_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-core';
+import type { ReplicationResult } from '@wisecom/atlas-types';
+
+const OWNER_EMAIL = 'user@example.com';
+const OWNER_OBJECT_ID = '75a21b57-4d82-4f42-9ccc-7c231c30f78c';
+
+const RESULT: ReplicationResult = {
+  snapshot_id: 'od-snap-1',
+  target_id: 'replica',
+  status: 'COMPLETED',
+  objects_copied: 3,
+  objects_skipped: 0,
+  objects_failed: 0,
+  bytes_copied: 1024,
+  elapsed_ms: 12,
+  errors: [],
+};
+
+interface OneDriveReplicationMock {
+  replicate_owner: Mock;
+  replicate_all_owner_snapshots: Mock;
+  rehydrate_owner_snapshot: Mock;
+  rehydrate_owner: Mock;
+}
+
+interface OutlookReplicationMock {
+  replicate_snapshot: Mock;
+  get_replication_status: Mock;
+  get_replication_status_by_owner: Mock;
+}
+
+function make_onedrive_mock(): OneDriveReplicationMock {
+  return {
+    replicate_owner: vi.fn().mockResolvedValue([RESULT]),
+    replicate_all_owner_snapshots: vi.fn().mockResolvedValue([RESULT]),
+    rehydrate_owner_snapshot: vi.fn().mockResolvedValue(RESULT),
+    rehydrate_owner: vi.fn().mockResolvedValue(RESULT),
+  };
+}
+
+const TARGET_ARGS = [
+  '--target-endpoint',
+  'http://replica:9000',
+  '--target-access-key',
+  'key',
+  '--target-secret-key',
+  'secret',
+];
+
+const SOURCE_ARGS = [
+  '--source-endpoint',
+  'http://replica:9000',
+  '--source-access-key',
+  'key',
+  '--source-secret-key',
+  'secret',
+];
+
+describe('replicate/rehydrate --owner OneDrive scope', () => {
+  let container: Container;
+  let onedrive: OneDriveReplicationMock;
+  let outlook: OutlookReplicationMock;
+  let program: Command;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    container = new Container();
+    onedrive = make_onedrive_mock();
+    outlook = {
+      replicate_snapshot: vi.fn().mockResolvedValue([RESULT]),
+      get_replication_status: vi.fn().mockResolvedValue([]),
+      get_replication_status_by_owner: vi.fn().mockResolvedValue([]),
+    };
+
+    container.bind(ONEDRIVE_REPLICATION_USE_CASE_TOKEN).toConstantValue(onedrive);
+    container.bind(REPLICATION_USE_CASE_TOKEN).toConstantValue(outlook);
+    container.bind(SHAREPOINT_REPLICATION_USE_CASE_TOKEN).toConstantValue({});
+    const identity = {
+      resolve_user: vi.fn().mockResolvedValue({
+        object_id: OWNER_OBJECT_ID,
+        email: OWNER_EMAIL,
+        display_name: 'Example User',
+      }),
+    };
+    container.bind(USER_IDENTITY_RESOLVER_TOKEN).toConstantValue(identity);
+    container.bind(GRAPH_IDENTITY_RESOLVER_TOKEN).toConstantValue(identity);
+    container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({
+      tenant_id: 'test-tenant',
+      encryption_passphrase: 'pass',
+    });
+
+    program = new Command();
+    program.exitOverride();
+    register_replicate_command(program, () => container);
+    register_rehydrate_command(program, () => container);
+  });
+
+  it('replicates every unreplicated snapshot under the owner object ID, not the raw email', async () => {
+    await program.parseAsync(['replicate', '-o', OWNER_EMAIL, ...TARGET_ARGS], { from: 'user' });
+
+    expect(onedrive.replicate_all_owner_snapshots).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+      [expect.objectContaining({ endpoint: 'http://replica:9000' })],
+    );
+    expect(onedrive.replicate_owner).not.toHaveBeenCalled();
+  });
+
+  it('routes replicate -o with -s to the single OneDrive snapshot, not the Outlook path', async () => {
+    await program.parseAsync(['replicate', '-o', OWNER_EMAIL, '-s', 'od-snap-1', ...TARGET_ARGS], {
+      from: 'user',
+    });
+
+    expect(onedrive.replicate_owner).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+      'od-snap-1',
+      expect.any(Array),
+    );
+    expect(outlook.replicate_snapshot).not.toHaveBeenCalled();
+  });
+
+  it('passes a raw object ID through untouched so DR works without Graph', async () => {
+    await program.parseAsync(['replicate', '-o', OWNER_OBJECT_ID, ...TARGET_ARGS], {
+      from: 'user',
+    });
+
+    expect(onedrive.replicate_all_owner_snapshots).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+      expect.any(Array),
+    );
+  });
+
+  it('scopes --status -o to the resolved owner object ID', async () => {
+    await program.parseAsync(['replicate', '--status', '-o', OWNER_EMAIL], { from: 'user' });
+
+    expect(outlook.get_replication_status_by_owner).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+    );
+  });
+
+  it('rehydrates the owner from the replica using the resolved object ID', async () => {
+    await program.parseAsync(['rehydrate', '-o', OWNER_EMAIL, ...SOURCE_ARGS], { from: 'user' });
+
+    expect(onedrive.rehydrate_owner).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+      expect.objectContaining({ endpoint: 'http://replica:9000' }),
+    );
+  });
+
+  it('routes rehydrate -o with -s to the single OneDrive snapshot', async () => {
+    await program.parseAsync(['rehydrate', '-o', OWNER_EMAIL, '-s', 'od-snap-1', ...SOURCE_ARGS], {
+      from: 'user',
+    });
+
+    expect(onedrive.rehydrate_owner_snapshot).toHaveBeenCalledWith(
+      'test-tenant',
+      OWNER_OBJECT_ID,
+      'od-snap-1',
+      expect.anything(),
+    );
+    expect(onedrive.rehydrate_owner).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/tests/unit/replication-owner-scope.test.ts
+++ b/packages/cli/tests/unit/replication-owner-scope.test.ts
@@ -39,6 +39,7 @@ interface OutlookReplicationMock {
   replicate_snapshot: Mock;
   get_replication_status: Mock;
   get_replication_status_by_owner: Mock;
+  rehydrate_tenant: Mock;
 }
 
 function make_onedrive_mock(): OneDriveReplicationMock {
@@ -82,6 +83,14 @@ describe('replicate/rehydrate --owner OneDrive scope', () => {
       replicate_snapshot: vi.fn().mockResolvedValue([RESULT]),
       get_replication_status: vi.fn().mockResolvedValue([]),
       get_replication_status_by_owner: vi.fn().mockResolvedValue([]),
+      rehydrate_tenant: vi.fn().mockResolvedValue({
+        total: RESULT,
+        workloads: [
+          { workload: 'outlook', result: RESULT },
+          { workload: 'onedrive', result: RESULT },
+          { workload: 'sharepoint', result: RESULT },
+        ],
+      }),
     };
 
     container.bind(ONEDRIVE_REPLICATION_USE_CASE_TOKEN).toConstantValue(onedrive);
@@ -175,5 +184,34 @@ describe('replicate/rehydrate --owner OneDrive scope', () => {
       expect.anything(),
     );
     expect(onedrive.rehydrate_owner).not.toHaveBeenCalled();
+  });
+
+  it('dispatches --all to full tenant recovery across every workload', async () => {
+    await program.parseAsync(['rehydrate', '--all', ...SOURCE_ARGS], { from: 'user' });
+
+    expect(outlook.rehydrate_tenant).toHaveBeenCalledWith(
+      'test-tenant',
+      expect.objectContaining({ endpoint: 'http://replica:9000' }),
+    );
+  });
+
+  it('warns naming each workload the replica held nothing for', async () => {
+    const warn_spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const empty = { ...RESULT, objects_copied: 0, objects_skipped: 0, objects_total: 0 };
+    vi.mocked(outlook.rehydrate_tenant).mockResolvedValue({
+      total: RESULT,
+      workloads: [
+        { workload: 'outlook', result: RESULT },
+        { workload: 'onedrive', result: empty },
+        { workload: 'sharepoint', result: empty },
+      ],
+    });
+
+    await program.parseAsync(['rehydrate', '--all', ...SOURCE_ARGS], { from: 'user' });
+
+    const warned = warn_spy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(warned).toContain('onedrive, sharepoint');
+    expect(warned).not.toContain('outlook,');
+    warn_spy.mockRestore();
   });
 });

--- a/packages/core/src/services/replication/onedrive-replication.service.ts
+++ b/packages/core/src/services/replication/onedrive-replication.service.ts
@@ -15,9 +15,11 @@ import {
 import { replicate_onedrive_snapshot } from '@/services/replication/onedrive-snapshot-replicator';
 import { save_replication_status } from '@/services/replication/replication-status-repository';
 import { ensure_source_dek_on_primary } from '@/services/replication/rehydration-dek-helper';
+import { rehydrate_od_manifests } from '@/services/replication/rehydration-od-manifests-runner';
 import {
   build_replication_result,
   build_skip_result,
+  merge_replication_results,
 } from '@/services/replication/replication-result-builder';
 import {
   OD_MANIFEST_PREFIX,
@@ -166,7 +168,7 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
       const manifests = await this._od_manifests.list_snapshots_by_owner(source_ctx, owner_id);
       const ancillary = await collect_od_ancillary_keys(source_ctx, owner_id);
 
-      return this.rehydrate_manifests(
+      return this.rehydrate_owner_manifests(
         source_ctx,
         primary_ctx,
         manifests,
@@ -174,6 +176,42 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
         source,
         tenant_id,
       );
+    } finally {
+      source_ctx.destroy();
+      primary_ctx.destroy();
+    }
+  }
+
+  /** DR: recover every OneDrive owner's snapshots from a replica. */
+  async rehydrate_all_owners(tenant_id: string, source: StorageTarget): Promise<ReplicationResult> {
+    await ensure_source_dek_on_primary(this.create_primary_target(), source, tenant_id);
+    const primary_ctx = await this._tenant_factory.create(tenant_id);
+    const source_ctx = await source.create_context(tenant_id);
+    try {
+      const all = await this._od_manifests.list_all_manifests(source_ctx);
+      const by_owner = new Map<string, OneDriveSnapshotManifest[]>();
+      for (const manifest of all) {
+        const bucket = by_owner.get(manifest.owner_id);
+        if (bucket) bucket.push(manifest);
+        else by_owner.set(manifest.owner_id, [manifest]);
+      }
+
+      const results: ReplicationResult[] = [];
+      for (const [owner_id, manifests] of by_owner) {
+        const ancillary = await collect_od_ancillary_keys(source_ctx, owner_id);
+        results.push(
+          await this.rehydrate_owner_manifests(
+            source_ctx,
+            primary_ctx,
+            manifests,
+            ancillary,
+            source,
+            tenant_id,
+          ),
+        );
+      }
+
+      return merge_replication_results(results, `${by_owner.size}-owners`, source.target_id);
     } finally {
       source_ctx.destroy();
       primary_ctx.destroy();
@@ -231,7 +269,8 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
     return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
   }
 
-  private async rehydrate_manifests(
+  /** Rehydrates one owner's manifests, supplying this service's DEK validator and passphrase. */
+  private rehydrate_owner_manifests(
     source_ctx: TenantContext,
     primary_ctx: TenantContext,
     manifests: OneDriveSnapshotManifest[],
@@ -239,53 +278,15 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
     source: StorageTarget,
     tenant_id: string,
   ): Promise<ReplicationResult> {
-    const start = Date.now();
-    await this._validate_dek(
-      source_ctx.storage,
-      primary_ctx.storage,
-      this._config.encryption_passphrase,
+    return rehydrate_od_manifests(
+      source_ctx,
+      primary_ctx,
+      manifests,
+      ancillary_keys,
+      source,
       tenant_id,
-    );
-
-    let total_copied = 0;
-    let total_skipped = 0;
-    let total_failed = 0;
-    let total_bytes = 0;
-    const all_errors: string[] = [];
-    let snapshot_count = 0;
-
-    for (const manifest of manifests) {
-      const key = `${OD_MANIFEST_PREFIX}/${manifest.owner_id}/${manifest.snapshot_id}.json`;
-      if (await primary_ctx.storage.exists(key)) {
-        total_skipped++;
-        continue;
-      }
-
-      const rep = await replicate_onedrive_snapshot(source_ctx, primary_ctx, manifest, key, {
-        skip_marker: true,
-        ancillary_keys,
-      });
-      total_copied += rep.objects_copied;
-      total_skipped += rep.objects_skipped;
-      total_failed += rep.objects_failed;
-      total_bytes += rep.bytes_copied;
-      all_errors.push(...rep.errors);
-      snapshot_count++;
-    }
-
-    const label =
-      manifests.length === 1 ? manifests[0]!.snapshot_id : `${snapshot_count}-snapshots`;
-    return build_replication_result(
-      {
-        objects_copied: total_copied,
-        objects_skipped: total_skipped,
-        objects_failed: total_failed,
-        bytes_copied: total_bytes,
-        errors: all_errors,
-      },
-      label,
-      source.target_id,
-      Date.now() - start,
+      this._validate_dek,
+      this._config.encryption_passphrase,
     );
   }
 

--- a/packages/core/src/services/replication/outlook-replication-helpers.ts
+++ b/packages/core/src/services/replication/outlook-replication-helpers.ts
@@ -1,0 +1,43 @@
+import type { Manifest, ManifestRepository, TenantContext } from '@wisecom/atlas-types';
+
+export const OUTLOOK_MANIFEST_PREFIX = 'manifests';
+
+/** Loads an Outlook manifest by snapshot ID, throwing a located error when it is absent. */
+export async function require_outlook_manifest(
+  repo: ManifestRepository,
+  ctx: TenantContext,
+  snapshot_id: string,
+  location?: 'source',
+): Promise<Manifest> {
+  const manifest = await repo.find_by_snapshot(ctx, snapshot_id);
+  if (!manifest) {
+    const where = location === 'source' ? ' on source' : '';
+    throw new Error(`No manifest found for snapshot ${snapshot_id}${where}`);
+  }
+  return manifest;
+}
+
+/** Lists a mailbox's manifests oldest-first, so replication replays snapshots in order. */
+export async function list_mailbox_manifests(
+  repo: ManifestRepository,
+  ctx: TenantContext,
+  owner_id: string,
+): Promise<Manifest[]> {
+  const all = await repo.list_all_manifests(ctx);
+  return all
+    .filter((m) => m.owner_id === owner_id)
+    .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+}
+
+/** Finds manifests present on the source but missing from the target. */
+export async function diff_outlook_manifests(
+  source_manifests: Manifest[],
+  target_ctx: TenantContext,
+  owner_id: string,
+): Promise<Manifest[]> {
+  const target_keys = await target_ctx.storage.list(`${OUTLOOK_MANIFEST_PREFIX}/${owner_id}/`);
+  const target_snapshot_ids = new Set(
+    target_keys.map((k) => k.split('/').pop()?.replace('.json', '')).filter(Boolean) as string[],
+  );
+  return source_manifests.filter((m) => !target_snapshot_ids.has(m.snapshot_id));
+}

--- a/packages/core/src/services/replication/rehydration-od-manifests-runner.ts
+++ b/packages/core/src/services/replication/rehydration-od-manifests-runner.ts
@@ -1,0 +1,66 @@
+import type { TenantContext } from '@wisecom/atlas-types';
+import type { OneDriveSnapshotManifest } from '@wisecom/atlas-types';
+import type { StorageTarget, DekValidationFn } from '@wisecom/atlas-types';
+import type { ReplicationResult } from '@wisecom/atlas-types';
+import { replicate_onedrive_snapshot } from '@/services/replication/onedrive-snapshot-replicator';
+import { build_replication_result } from '@/services/replication/replication-result-builder';
+
+const OD_MANIFEST_PREFIX = 'onedrive/manifests';
+
+/**
+ * Rehydrates multiple OneDrive manifests from a source target back to the primary,
+ * skipping manifests that already exist on the primary.
+ */
+export async function rehydrate_od_manifests(
+  source_ctx: TenantContext,
+  primary_ctx: TenantContext,
+  manifests: OneDriveSnapshotManifest[],
+  ancillary_keys: string[],
+  source: StorageTarget,
+  tenant_id: string,
+  validate_dek: DekValidationFn,
+  passphrase: string,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  await validate_dek(source_ctx.storage, primary_ctx.storage, passphrase, tenant_id);
+
+  let total_copied = 0;
+  let total_skipped = 0;
+  let total_failed = 0;
+  let total_bytes = 0;
+  const all_errors: string[] = [];
+  let snapshot_count = 0;
+
+  for (const manifest of manifests) {
+    const key = `${OD_MANIFEST_PREFIX}/${manifest.owner_id}/${manifest.snapshot_id}.json`;
+    if (await primary_ctx.storage.exists(key)) {
+      total_skipped++;
+      continue;
+    }
+
+    const rep = await replicate_onedrive_snapshot(source_ctx, primary_ctx, manifest, key, {
+      skip_marker: true,
+      ancillary_keys,
+    });
+    total_copied += rep.objects_copied;
+    total_skipped += rep.objects_skipped;
+    total_failed += rep.objects_failed;
+    total_bytes += rep.bytes_copied;
+    all_errors.push(...rep.errors);
+    snapshot_count++;
+  }
+
+  const label = manifests.length === 1 ? manifests[0]!.snapshot_id : `${snapshot_count}-snapshots`;
+  return build_replication_result(
+    {
+      objects_copied: total_copied,
+      objects_skipped: total_skipped,
+      objects_failed: total_failed,
+      bytes_copied: total_bytes,
+      errors: all_errors,
+    },
+    label,
+    source.target_id,
+    Date.now() - start,
+  );
+}

--- a/packages/core/src/services/replication/replication-result-builder.ts
+++ b/packages/core/src/services/replication/replication-result-builder.ts
@@ -64,6 +64,36 @@ export function build_skip_result(snapshot_id: string, target_id: string): Repli
   };
 }
 
+/** Aggregates several replication results into one, summing counts and concatenating errors. */
+export function merge_replication_results(
+  results: readonly ReplicationResult[],
+  snapshot_id: string,
+  target_id: string,
+): ReplicationResult {
+  let objects_copied = 0;
+  let objects_skipped = 0;
+  let objects_failed = 0;
+  let bytes_copied = 0;
+  let elapsed_ms = 0;
+  const errors: string[] = [];
+
+  for (const r of results) {
+    objects_copied += r.objects_copied;
+    objects_skipped += r.objects_skipped;
+    objects_failed += r.objects_failed;
+    bytes_copied += r.bytes_copied;
+    elapsed_ms += r.elapsed_ms;
+    errors.push(...r.errors);
+  }
+
+  return build_replication_result(
+    { objects_copied, objects_skipped, objects_failed, bytes_copied, errors },
+    snapshot_id,
+    target_id,
+    elapsed_ms,
+  );
+}
+
 export function to_status_record(
   result: ReplicationResult,
   target: StorageTarget,

--- a/packages/core/src/services/replication/replication.service.ts
+++ b/packages/core/src/services/replication/replication.service.ts
@@ -3,15 +3,26 @@ import { inject, injectable } from 'inversify';
 import type { TenantContextFactory, TenantContext } from '@wisecom/atlas-types';
 import type { ManifestRepository } from '@wisecom/atlas-types';
 import type { ReplicationUseCase } from '@wisecom/atlas-types';
+import type {
+  OneDriveReplicationUseCase,
+  SharePointReplicationUseCase,
+} from '@wisecom/atlas-types';
 import type { StorageTarget, StorageTargetFactory } from '@wisecom/atlas-types';
 import type { DekValidationFn } from '@wisecom/atlas-types';
-import type { ReplicationResult, ReplicationStatusRecord } from '@wisecom/atlas-types';
+import type {
+  ReplicationResult,
+  ReplicationStatusRecord,
+  TenantRehydrationResult,
+  WorkloadRehydrationResult,
+} from '@wisecom/atlas-types';
 import type { Manifest } from '@wisecom/atlas-types';
 import {
   TENANT_CONTEXT_FACTORY_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
   DEK_VALIDATION_FN_TOKEN,
   STORAGE_TARGET_FACTORY_TOKEN,
+  ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
+  SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
 import { replicate_snapshot_to_target } from '@/services/replication/snapshot-replicator';
 import { rehydrate_manifests } from '@/services/replication/rehydration-manifests-runner';
@@ -21,11 +32,17 @@ import {
   list_replication_status_by_owner,
   list_replication_status_by_snapshot,
 } from '@/services/replication/replication-status-repository';
+import {
+  require_outlook_manifest,
+  list_mailbox_manifests,
+  diff_outlook_manifests,
+} from '@/services/replication/outlook-replication-helpers';
 import { ensure_source_dek_on_primary } from '@/services/replication/rehydration-dek-helper';
 import {
   build_replication_result,
   build_skip_result,
   to_status_record,
+  merge_replication_results,
 } from '@/services/replication/replication-result-builder';
 import type { AtlasConfig } from '@/utils/config';
 import { ATLAS_CONFIG_TOKEN } from '@/utils/config';
@@ -38,6 +55,10 @@ export class ReplicationService implements ReplicationUseCase {
     @inject(ATLAS_CONFIG_TOKEN) private readonly _config: AtlasConfig,
     @inject(DEK_VALIDATION_FN_TOKEN) private readonly _validate_dek: DekValidationFn,
     @inject(STORAGE_TARGET_FACTORY_TOKEN) private readonly _target_factory: StorageTargetFactory,
+    @inject(ONEDRIVE_REPLICATION_USE_CASE_TOKEN)
+    private readonly _onedrive: OneDriveReplicationUseCase,
+    @inject(SHAREPOINT_REPLICATION_USE_CASE_TOKEN)
+    private readonly _sharepoint: SharePointReplicationUseCase,
   ) {}
 
   async replicate_snapshot(
@@ -47,7 +68,7 @@ export class ReplicationService implements ReplicationUseCase {
   ): Promise<ReplicationResult[]> {
     const source_ctx = await this._tenant_factory.create(tenant_id);
     try {
-      const manifest = await this.require_manifest(source_ctx, snapshot_id);
+      const manifest = await require_outlook_manifest(this._manifests, source_ctx, snapshot_id);
       const results: ReplicationResult[] = [];
 
       for (const target of targets) {
@@ -70,13 +91,13 @@ export class ReplicationService implements ReplicationUseCase {
     owner_id = normalize_owner_id(owner_id);
     const source_ctx = await this._tenant_factory.create(tenant_id);
     try {
-      const manifests = await this.list_mailbox_manifests(source_ctx, owner_id);
+      const manifests = await list_mailbox_manifests(this._manifests, source_ctx, owner_id);
       const results: ReplicationResult[] = [];
 
       for (const target of targets) {
         const target_ctx = await target.create_context(tenant_id);
         try {
-          const missing = await this.diff_manifests(manifests, target_ctx, owner_id);
+          const missing = await diff_outlook_manifests(manifests, target_ctx, owner_id);
 
           for (const manifest of missing) {
             const result = await this.copy_to_target(source_ctx, target, manifest, tenant_id);
@@ -103,7 +124,12 @@ export class ReplicationService implements ReplicationUseCase {
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);
     try {
-      const manifest = await this.require_manifest_from_ctx(source_ctx, snapshot_id);
+      const manifest = await require_outlook_manifest(
+        this._manifests,
+        source_ctx,
+        snapshot_id,
+        'source',
+      );
 
       const manifest_key = `manifests/${manifest.owner_id}/${snapshot_id}.json`;
       if (await primary_ctx.storage.exists(manifest_key)) {
@@ -134,7 +160,7 @@ export class ReplicationService implements ReplicationUseCase {
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);
     try {
-      const manifests = await this.list_mailbox_manifests(source_ctx, owner_id);
+      const manifests = await list_mailbox_manifests(this._manifests, source_ctx, owner_id);
       return await rehydrate_manifests(
         source_ctx,
         primary_ctx,
@@ -150,7 +176,41 @@ export class ReplicationService implements ReplicationUseCase {
     }
   }
 
-  async rehydrate_tenant(tenant_id: string, source: StorageTarget): Promise<ReplicationResult> {
+  /**
+   * DR: recover every workload from a replica.
+   *
+   * Outlook manifests live under `manifests/`, OneDrive under `onedrive/manifests/` and SharePoint
+   * under `sharepoint/manifests/`, so enumerating one prefix recovers one third of the tenant.
+   * Each workload's own tenant-wide recovery is invoked and reported separately.
+   */
+  async rehydrate_tenant(
+    tenant_id: string,
+    source: StorageTarget,
+  ): Promise<TenantRehydrationResult> {
+    const outlook = await this.rehydrate_outlook_tenant(tenant_id, source);
+    const onedrive = await this._onedrive.rehydrate_all_owners(tenant_id, source);
+    const sharepoint = await this._sharepoint.rehydrate_all_sites(tenant_id, source);
+
+    const workloads: WorkloadRehydrationResult[] = [
+      { workload: 'outlook', result: outlook },
+      { workload: 'onedrive', result: onedrive },
+      { workload: 'sharepoint', result: sharepoint },
+    ];
+
+    return {
+      total: merge_replication_results(
+        workloads.map((w) => w.result),
+        'full-tenant',
+        source.target_id,
+      ),
+      workloads,
+    };
+  }
+
+  private async rehydrate_outlook_tenant(
+    tenant_id: string,
+    source: StorageTarget,
+  ): Promise<ReplicationResult> {
     await ensure_source_dek_on_primary(this.create_primary_target(), source, tenant_id);
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);
@@ -243,40 +303,6 @@ export class ReplicationService implements ReplicationUseCase {
       skip_marker: is_rehydration,
     });
     return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
-  }
-
-  private async require_manifest(ctx: TenantContext, snapshot_id: string): Promise<Manifest> {
-    const manifest = await this._manifests.find_by_snapshot(ctx, snapshot_id);
-    if (!manifest) throw new Error(`No manifest found for snapshot ${snapshot_id}`);
-    return manifest;
-  }
-
-  private async require_manifest_from_ctx(
-    ctx: TenantContext,
-    snapshot_id: string,
-  ): Promise<Manifest> {
-    const manifest = await this._manifests.find_by_snapshot(ctx, snapshot_id);
-    if (!manifest) throw new Error(`No manifest found for snapshot ${snapshot_id} on source`);
-    return manifest;
-  }
-
-  private async list_mailbox_manifests(ctx: TenantContext, owner_id: string): Promise<Manifest[]> {
-    const all = await this._manifests.list_all_manifests(ctx);
-    return all
-      .filter((m) => m.owner_id === owner_id)
-      .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
-  }
-
-  private async diff_manifests(
-    source_manifests: Manifest[],
-    target_ctx: TenantContext,
-    owner_id: string,
-  ): Promise<Manifest[]> {
-    const target_keys = await target_ctx.storage.list(`manifests/${owner_id}/`);
-    const target_snapshot_ids = new Set(
-      target_keys.map((k) => k.split('/').pop()?.replace('.json', '')).filter(Boolean) as string[],
-    );
-    return source_manifests.filter((m) => !target_snapshot_ids.has(m.snapshot_id));
   }
 
   private create_primary_target(): StorageTarget {

--- a/packages/core/src/services/replication/replication.service.ts
+++ b/packages/core/src/services/replication/replication.service.ts
@@ -188,6 +188,7 @@ export class ReplicationService implements ReplicationUseCase {
     tenant_id: string,
     owner_id: string,
   ): Promise<ReplicationStatusRecord[]> {
+    owner_id = normalize_owner_id(owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
       return await list_replication_status_by_owner(ctx, owner_id);

--- a/packages/core/src/services/replication/sharepoint-replication.service.ts
+++ b/packages/core/src/services/replication/sharepoint-replication.service.ts
@@ -22,6 +22,7 @@ import { rehydrate_sp_manifests } from '@/services/replication/rehydration-sp-ma
 import {
   build_replication_result,
   build_skip_result,
+  merge_replication_results,
 } from '@/services/replication/replication-result-builder';
 import type { AtlasConfig } from '@/utils/config';
 import { ATLAS_CONFIG_TOKEN } from '@/utils/config';
@@ -181,6 +182,44 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
         this._validate_dek,
         this._config.encryption_passphrase,
       );
+    } finally {
+      source_ctx.destroy();
+      primary_ctx.destroy();
+    }
+  }
+
+  /** DR: recover every SharePoint site's snapshots from a replica. */
+  async rehydrate_all_sites(tenant_id: string, source: StorageTarget): Promise<ReplicationResult> {
+    await ensure_source_dek_on_primary(this.create_primary_target(), source, tenant_id);
+    const primary_ctx = await this._tenant_factory.create(tenant_id);
+    const source_ctx = await source.create_context(tenant_id);
+    try {
+      const all = await this._sp_manifests.list_all_manifests(source_ctx);
+      const by_site = new Map<string, SharePointSnapshotManifest[]>();
+      for (const manifest of all) {
+        const bucket = by_site.get(manifest.site_id);
+        if (bucket) bucket.push(manifest);
+        else by_site.set(manifest.site_id, [manifest]);
+      }
+
+      const results: ReplicationResult[] = [];
+      for (const [site_id, manifests] of by_site) {
+        const ancillary = await collect_sp_ancillary_keys(source_ctx, site_id);
+        results.push(
+          await rehydrate_sp_manifests(
+            source_ctx,
+            primary_ctx,
+            manifests,
+            ancillary,
+            source,
+            tenant_id,
+            this._validate_dek,
+            this._config.encryption_passphrase,
+          ),
+        );
+      }
+
+      return merge_replication_results(results, `${by_site.size}-sites`, source.target_id);
     } finally {
       source_ctx.destroy();
       primary_ctx.destroy();

--- a/packages/core/tests/unit/services/replication/replication.service.test.ts
+++ b/packages/core/tests/unit/services/replication/replication.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ReplicationService } from '@/services/replication/replication.service';
-import { ReplicationStatus } from '@wisecom/atlas-types';
+import { ReplicationStatus, ReplicationVerificationStatus } from '@wisecom/atlas-types';
 import type {
   TenantContext,
   TenantContextFactory,
@@ -11,6 +11,9 @@ import type {
   StorageTarget,
   StorageTargetFactory,
   DekValidationFn,
+  ReplicationResult,
+  OneDriveReplicationUseCase,
+  SharePointReplicationUseCase,
 } from '@wisecom/atlas-types';
 import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
 import type { AtlasConfig } from '@/utils/config';
@@ -66,6 +69,27 @@ function make_manifest(
   };
 }
 
+/** Builds a workload-level result as returned by the OneDrive/SharePoint tenant scopes. */
+function make_workload_result(
+  snapshot_id: string,
+  objects_copied: number,
+  bytes_copied = 100,
+): ReplicationResult {
+  return {
+    snapshot_id,
+    target_id: 'offsite',
+    status: ReplicationStatus.COMPLETED,
+    objects_total: objects_copied,
+    objects_copied,
+    objects_skipped: 0,
+    objects_failed: 0,
+    bytes_copied,
+    elapsed_ms: 5,
+    errors: [],
+    verification_status: ReplicationVerificationStatus.SKIPPED,
+  };
+}
+
 describe('ReplicationService', () => {
   let source_storage: ObjectStorage;
   let target_storage: ObjectStorage;
@@ -77,6 +101,8 @@ describe('ReplicationService', () => {
   let target: StorageTarget;
   let validate_dek: DekValidationFn;
   let target_factory: StorageTargetFactory;
+  let onedrive_replication: OneDriveReplicationUseCase;
+  let sharepoint_replication: SharePointReplicationUseCase;
   let service: ReplicationService;
 
   beforeEach(() => {
@@ -129,12 +155,28 @@ describe('ReplicationService', () => {
 
     validate_dek = vi.fn().mockResolvedValue(undefined) as unknown as DekValidationFn;
     target_factory = vi.fn().mockReturnValue(target) as unknown as StorageTargetFactory;
+    onedrive_replication = {
+      replicate_owner: vi.fn(),
+      replicate_all_owner_snapshots: vi.fn(),
+      rehydrate_owner_snapshot: vi.fn(),
+      rehydrate_owner: vi.fn(),
+      rehydrate_all_owners: vi.fn().mockResolvedValue(make_workload_result('0-owners', 0, 0)),
+    };
+    sharepoint_replication = {
+      replicate_site: vi.fn(),
+      replicate_all_site_snapshots: vi.fn(),
+      rehydrate_site_snapshot: vi.fn(),
+      rehydrate_site: vi.fn(),
+      rehydrate_all_sites: vi.fn().mockResolvedValue(make_workload_result('0-sites', 0, 0)),
+    };
     service = new ReplicationService(
       tenant_factory,
       manifests,
       config,
       validate_dek,
       target_factory,
+      onedrive_replication,
+      sharepoint_replication,
     );
   });
 
@@ -200,7 +242,7 @@ describe('ReplicationService', () => {
     expect(result.objects_copied).toBe(0);
   });
 
-  it('rehydrate_tenant copies all missing snapshots from source', async () => {
+  it('rehydrate_tenant recovers Outlook, OneDrive, and SharePoint, not Outlook alone', async () => {
     const m1 = make_manifest('snap-1', 'mbx-1', []);
     const m2 = make_manifest('snap-2', 'mbx-2', []);
 
@@ -212,6 +254,12 @@ describe('ReplicationService', () => {
     vi.mocked(target_storage.exists).mockResolvedValue(false);
     vi.mocked(source_storage.get).mockResolvedValue(Buffer.from('data'));
     vi.mocked(target_storage.get).mockResolvedValue(Buffer.from('data'));
+    vi.mocked(onedrive_replication.rehydrate_all_owners).mockResolvedValue(
+      make_workload_result('2-owners', 7, 700),
+    );
+    vi.mocked(sharepoint_replication.rehydrate_all_sites).mockResolvedValue(
+      make_workload_result('1-sites', 59, 5900),
+    );
 
     const source_target: StorageTarget = {
       target_id: 'offsite',
@@ -221,7 +269,44 @@ describe('ReplicationService', () => {
 
     const result = await service.rehydrate_tenant('tenant-1', source_target);
 
-    expect(result.status).toBe(ReplicationStatus.COMPLETED);
+    expect(onedrive_replication.rehydrate_all_owners).toHaveBeenCalledWith(
+      'tenant-1',
+      source_target,
+    );
+    expect(sharepoint_replication.rehydrate_all_sites).toHaveBeenCalledWith(
+      'tenant-1',
+      source_target,
+    );
+    expect(result.workloads.map((w) => w.workload)).toEqual(['outlook', 'onedrive', 'sharepoint']);
+    expect(result.total.status).toBe(ReplicationStatus.COMPLETED);
+    const by_workload = new Map(result.workloads.map((w) => [w.workload, w.result]));
+    expect(by_workload.get('onedrive')?.objects_copied).toBe(7);
+    expect(by_workload.get('sharepoint')?.objects_copied).toBe(59);
+    expect(result.total.objects_copied).toBe(by_workload.get('outlook')!.objects_copied + 7 + 59);
+    expect(result.total.bytes_copied).toBe(by_workload.get('outlook')!.bytes_copied + 700 + 5900);
+  });
+
+  it('rehydrate_tenant reports a workload that failed without hiding it in the aggregate', async () => {
+    vi.mocked(manifests.list_all_manifests).mockResolvedValue([]);
+    vi.mocked(onedrive_replication.rehydrate_all_owners).mockResolvedValue({
+      ...make_workload_result('1-owners', 0, 0),
+      status: ReplicationStatus.FAILED,
+      objects_failed: 3,
+      objects_total: 3,
+      errors: ['onedrive/data/owner/abc: access denied'],
+    });
+
+    const source_target: StorageTarget = {
+      target_id: 'offsite',
+      endpoint: 'http://offsite:9000',
+      create_context: vi.fn().mockResolvedValue(target_ctx),
+    };
+
+    const result = await service.rehydrate_tenant('tenant-1', source_target);
+
+    expect(result.total.status).not.toBe(ReplicationStatus.COMPLETED);
+    expect(result.total.objects_failed).toBe(3);
+    expect(result.total.errors).toContain('onedrive/data/owner/abc: access denied');
   });
 
   it('get_replication_status returns empty when no sidecars exist', async () => {

--- a/packages/core/tests/unit/services/replication/replication.service.test.ts
+++ b/packages/core/tests/unit/services/replication/replication.service.test.ts
@@ -231,4 +231,12 @@ describe('ReplicationService', () => {
 
     expect(results).toEqual([]);
   });
+
+  it('get_replication_status_by_owner lowercases the owner id used as the sidecar prefix', async () => {
+    vi.mocked(source_storage.list).mockResolvedValue([]);
+
+    await service.get_replication_status_by_owner('tenant-1', 'User@Company.COM');
+
+    expect(source_storage.list).toHaveBeenCalledWith('_meta/replication/user@company.com/');
+  });
 });

--- a/packages/core/tests/unit/services/replication/workload-tenant-rehydration.test.ts
+++ b/packages/core/tests/unit/services/replication/workload-tenant-rehydration.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OneDriveReplicationService } from '@/services/replication/onedrive-replication.service';
+import { SharePointReplicationService } from '@/services/replication/sharepoint-replication.service';
+import { ReplicationStatus } from '@wisecom/atlas-types';
+import type {
+  TenantContext,
+  TenantContextFactory,
+  ObjectStorage,
+  StorageTarget,
+  StorageTargetFactory,
+  DekValidationFn,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  SharePointManifestRepository,
+  SharePointSnapshotManifest,
+} from '@wisecom/atlas-types';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+import type { AtlasConfig } from '@/utils/config';
+
+import { replicate_onedrive_snapshot } from '@/services/replication/onedrive-snapshot-replicator';
+import { rehydrate_sp_manifests } from '@/services/replication/rehydration-sp-manifests-runner';
+vi.mock('@/services/replication/rehydration-dek-helper', () => ({
+  ensure_source_dek_on_primary: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/services/replication/onedrive-snapshot-replicator', () => ({
+  replicate_onedrive_snapshot: vi.fn().mockResolvedValue({
+    objects_copied: 4,
+    objects_skipped: 0,
+    objects_failed: 0,
+    bytes_copied: 400,
+    errors: [],
+  }),
+}));
+
+vi.mock('@/services/replication/rehydration-sp-manifests-runner', () => ({
+  rehydrate_sp_manifests: vi.fn(),
+}));
+
+const CONFIG: AtlasConfig = {
+  tenant_id: 'tenant-1',
+  client_id: 'c',
+  client_secret: 's',
+  s3_endpoint: 'http://primary:9000',
+  s3_access_key: 'k',
+  s3_secret_key: 's',
+  s3_region: 'us-east-1',
+  encryption_passphrase: 'pass',
+};
+
+function make_storage(): ObjectStorage {
+  return {
+    put: vi.fn(),
+    get: vi.fn().mockResolvedValue(Buffer.from('blob')),
+    delete: vi.fn(),
+    delete_version: vi.fn(),
+    exists: vi.fn().mockResolvedValue(false),
+    list: vi.fn().mockResolvedValue([]),
+    list_versions: vi.fn(),
+    begin_multipart_upload: vi.fn(),
+    copy: vi.fn(),
+    abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+    probe_immutability: vi.fn(),
+  };
+}
+
+function make_ctx(storage: ObjectStorage): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage,
+    encrypt: vi.fn((d: Buffer) => d),
+    decrypt: vi.fn((d: Buffer) => d),
+    create_cipher: stub_tenant_create_cipher,
+    destroy: vi.fn(),
+  };
+}
+
+function od_manifest(owner_id: string, snapshot_id: string): OneDriveSnapshotManifest {
+  return {
+    id: `m-${snapshot_id}`,
+    tenant_id: 'tenant-1',
+    owner_id,
+    snapshot_id,
+    created_at: new Date('2026-01-01'),
+    total_files: 1,
+    total_size_bytes: 100,
+    entries: [{ file_id: 'f1', path: '/a.txt', storage_key: `onedrive/data/${owner_id}/aaa` }],
+  } as unknown as OneDriveSnapshotManifest;
+}
+
+function sp_manifest(site_id: string, snapshot_id: string): SharePointSnapshotManifest {
+  return {
+    id: `m-${snapshot_id}`,
+    tenant_id: 'tenant-1',
+    site_id,
+    snapshot_id,
+    created_at: new Date('2026-01-01'),
+    total_files: 1,
+    total_size_bytes: 100,
+    entries: [],
+  } as unknown as SharePointSnapshotManifest;
+}
+
+describe('tenant-wide workload rehydration', () => {
+  let source_storage: ObjectStorage;
+  let primary_storage: ObjectStorage;
+  let source_ctx: TenantContext;
+  let primary_ctx: TenantContext;
+  let tenant_factory: TenantContextFactory;
+  let validate_dek: DekValidationFn;
+  let target_factory: StorageTargetFactory;
+  let source: StorageTarget;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    source_storage = make_storage();
+    primary_storage = make_storage();
+    source_ctx = make_ctx(source_storage);
+    primary_ctx = make_ctx(primary_storage);
+    tenant_factory = { create: vi.fn().mockResolvedValue(primary_ctx) };
+    validate_dek = vi.fn().mockResolvedValue(undefined) as unknown as DekValidationFn;
+    target_factory = vi.fn().mockReturnValue({
+      target_id: 'primary',
+      endpoint: 'http://primary:9000',
+      create_context: vi.fn().mockResolvedValue(primary_ctx),
+    }) as unknown as StorageTargetFactory;
+    source = {
+      target_id: 'replica',
+      endpoint: 'http://replica:9000',
+      create_context: vi.fn().mockResolvedValue(source_ctx),
+    };
+  });
+
+  it('rehydrate_all_owners recovers every owner found on the replica', async () => {
+    const manifests: OneDriveManifestRepository = {
+      save: vi.fn(),
+      find_by_snapshot: vi.fn(),
+      find_latest_by_owner: vi.fn(),
+      list_snapshots_by_owner: vi.fn(),
+      list_all_manifests: vi
+        .fn()
+        .mockResolvedValue([
+          od_manifest('owner-a', 'od-1'),
+          od_manifest('owner-a', 'od-2'),
+          od_manifest('owner-b', 'od-3'),
+        ]),
+    };
+    const service = new OneDriveReplicationService(
+      tenant_factory,
+      manifests,
+      CONFIG,
+      validate_dek,
+      target_factory,
+    );
+
+    const result = await service.rehydrate_all_owners('tenant-1', source);
+
+    expect(replicate_onedrive_snapshot).toHaveBeenCalledTimes(3);
+    expect(result.snapshot_id).toBe('2-owners');
+    expect(result.objects_copied).toBe(12);
+    expect(result.bytes_copied).toBe(1200);
+    expect(result.status).toBe(ReplicationStatus.COMPLETED);
+  });
+
+  it('rehydrate_all_owners collects ancillary keys per owner, never one owner for all', async () => {
+    vi.mocked(source_storage.list).mockImplementation(async (prefix: string) => {
+      if (prefix.includes('owner-a')) return ['onedrive/index/owner-a/files/1'];
+      if (prefix.includes('owner-b')) return ['onedrive/index/owner-b/files/2'];
+      return [];
+    });
+    const manifests: OneDriveManifestRepository = {
+      save: vi.fn(),
+      find_by_snapshot: vi.fn(),
+      find_latest_by_owner: vi.fn(),
+      list_snapshots_by_owner: vi.fn(),
+      list_all_manifests: vi
+        .fn()
+        .mockResolvedValue([od_manifest('owner-a', 'od-1'), od_manifest('owner-b', 'od-2')]),
+    };
+    const service = new OneDriveReplicationService(
+      tenant_factory,
+      manifests,
+      CONFIG,
+      validate_dek,
+      target_factory,
+    );
+
+    await service.rehydrate_all_owners('tenant-1', source);
+
+    const calls = vi.mocked(replicate_onedrive_snapshot).mock.calls;
+    const ancillary_by_snapshot = new Map(
+      calls.map((c) => [c[2].snapshot_id, c[4]?.ancillary_keys]),
+    );
+    expect(ancillary_by_snapshot.get('od-1')).toEqual(['onedrive/index/owner-a/files/1']);
+    expect(ancillary_by_snapshot.get('od-2')).toEqual(['onedrive/index/owner-b/files/2']);
+  });
+
+  it('rehydrate_all_owners returns an empty result when the replica holds no OneDrive data', async () => {
+    const manifests: OneDriveManifestRepository = {
+      save: vi.fn(),
+      find_by_snapshot: vi.fn(),
+      find_latest_by_owner: vi.fn(),
+      list_snapshots_by_owner: vi.fn(),
+      list_all_manifests: vi.fn().mockResolvedValue([]),
+    };
+    const service = new OneDriveReplicationService(
+      tenant_factory,
+      manifests,
+      CONFIG,
+      validate_dek,
+      target_factory,
+    );
+
+    const result = await service.rehydrate_all_owners('tenant-1', source);
+
+    expect(replicate_onedrive_snapshot).not.toHaveBeenCalled();
+    expect(result.objects_copied).toBe(0);
+    expect(result.snapshot_id).toBe('0-owners');
+  });
+
+  it('rehydrate_all_sites recovers every site found on the replica', async () => {
+    vi.mocked(rehydrate_sp_manifests).mockResolvedValue({
+      snapshot_id: 'sp',
+      target_id: 'replica',
+      status: ReplicationStatus.COMPLETED,
+      objects_total: 30,
+      objects_copied: 30,
+      objects_skipped: 0,
+      objects_failed: 0,
+      bytes_copied: 3000,
+      elapsed_ms: 4,
+      errors: [],
+      verification_status: 'SKIPPED',
+    } as never);
+
+    const manifests: SharePointManifestRepository = {
+      save: vi.fn(),
+      find_by_snapshot: vi.fn(),
+      find_latest_by_site: vi.fn(),
+      list_snapshots_by_site: vi.fn(),
+      list_all_manifests: vi
+        .fn()
+        .mockResolvedValue([sp_manifest('site-a', 'sp-1'), sp_manifest('site-b', 'sp-2')]),
+    };
+    const service = new SharePointReplicationService(
+      tenant_factory,
+      manifests,
+      CONFIG,
+      validate_dek,
+      target_factory,
+    );
+
+    const result = await service.rehydrate_all_sites('tenant-1', source);
+
+    expect(rehydrate_sp_manifests).toHaveBeenCalledTimes(2);
+    expect(result.snapshot_id).toBe('2-sites');
+    expect(result.objects_copied).toBe(60);
+    expect(result.bytes_copied).toBe(6000);
+  });
+});

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -6,7 +6,13 @@ export type {
   MonthlyBreakdown,
 } from '@wisecom/atlas-types';
 export type { MailboxStatusResult, FolderStatus } from '@wisecom/atlas-types';
-export type { ReplicationResult, ReplicationStatusRecord } from '@wisecom/atlas-types';
+export type {
+  ReplicationResult,
+  ReplicationStatusRecord,
+  TenantRehydrationResult,
+  WorkloadRehydrationResult,
+  RehydrationWorkload,
+} from '@wisecom/atlas-types';
 export type { StorageTarget, StorageTargetConfig } from '@wisecom/atlas-types';
 export type { StorageTargetSdkConfig } from '@wisecom/atlas-s3';
 export type { SyncResult } from '@wisecom/atlas-types';

--- a/packages/types/src/domain/index.ts
+++ b/packages/types/src/domain/index.ts
@@ -28,6 +28,9 @@ export type {
   ReplicationResult,
   ReplicationObjectResult,
   ReplicationStatusRecord,
+  RehydrationWorkload,
+  WorkloadRehydrationResult,
+  TenantRehydrationResult,
 } from './replication';
 export { ReplicationStatus, ReplicationVerificationStatus } from './replication';
 export type {

--- a/packages/types/src/domain/replication.ts
+++ b/packages/types/src/domain/replication.ts
@@ -33,6 +33,25 @@ export interface ReplicationResult {
   readonly replicated_manifest_checksum?: string;
 }
 
+/** Workloads covered by full tenant recovery. */
+export type RehydrationWorkload = 'outlook' | 'onedrive' | 'sharepoint';
+
+export interface WorkloadRehydrationResult {
+  readonly workload: RehydrationWorkload;
+  readonly result: ReplicationResult;
+}
+
+/**
+ * Result of a full tenant recovery: one entry per workload plus their aggregate.
+ *
+ * Every workload is always present, so a caller can tell "recovered nothing because the replica
+ * held nothing" apart from "never looked".
+ */
+export interface TenantRehydrationResult {
+  readonly total: ReplicationResult;
+  readonly workloads: readonly WorkloadRehydrationResult[];
+}
+
 /** Durable sidecar record persisted at `_meta/replication/{owner_id}/{snapshot}/{target}.json`. */
 export interface ReplicationStatusRecord {
   readonly target_id: string;

--- a/packages/types/src/ports/atlas/use-case.port.ts
+++ b/packages/types/src/ports/atlas/use-case.port.ts
@@ -1,6 +1,10 @@
 import type { StorageCheckRequest, StorageCheckResult } from '@/ports/storage-check/use-case.port';
 import type { BucketStats } from '@/domain/stats';
-import type { ReplicationResult, ReplicationStatusRecord } from '@/domain/replication';
+import type {
+  ReplicationResult,
+  ReplicationStatusRecord,
+  TenantRehydrationResult,
+} from '@/domain/replication';
 import type { StorageTarget } from '@/ports/replication/storage-target.port';
 import type { OutlookApi } from '@/ports/atlas/outlook-api.port';
 import type { OneDriveApi } from '@/ports/atlas/onedrive-api.port';
@@ -32,7 +36,8 @@ export interface AtlasInstance {
   replicateMailbox(mailboxId: string, targets: StorageTarget[]): Promise<ReplicationResult[]>;
   rehydrateSnapshot(snapshotId: string, source: StorageTarget): Promise<ReplicationResult>;
   rehydrateMailbox(mailboxId: string, source: StorageTarget): Promise<ReplicationResult>;
-  rehydrateTenant(source: StorageTarget): Promise<ReplicationResult>;
+  /** Full tenant recovery across Outlook, OneDrive, and SharePoint, reported per workload. */
+  rehydrateTenant(source: StorageTarget): Promise<TenantRehydrationResult>;
   getReplicationStatus(snapshotId?: string): Promise<ReplicationStatusRecord[]>;
   getReplicationStatusByMailbox(mailboxId: string): Promise<ReplicationStatusRecord[]>;
 }

--- a/packages/types/src/ports/replication/onedrive-replication.port.ts
+++ b/packages/types/src/ports/replication/onedrive-replication.port.ts
@@ -31,4 +31,7 @@ export interface OneDriveReplicationUseCase {
     owner_id: string,
     source: StorageTarget,
   ): Promise<ReplicationResult>;
+
+  /** DR: recover every OneDrive owner's snapshots from a replica. */
+  rehydrate_all_owners(tenant_id: string, source: StorageTarget): Promise<ReplicationResult>;
 }

--- a/packages/types/src/ports/replication/sharepoint-replication.port.ts
+++ b/packages/types/src/ports/replication/sharepoint-replication.port.ts
@@ -31,4 +31,7 @@ export interface SharePointReplicationUseCase {
     site_id: string,
     source: StorageTarget,
   ): Promise<ReplicationResult>;
+
+  /** DR: recover every SharePoint site's snapshots from a replica. */
+  rehydrate_all_sites(tenant_id: string, source: StorageTarget): Promise<ReplicationResult>;
 }

--- a/packages/types/src/ports/replication/use-case.port.ts
+++ b/packages/types/src/ports/replication/use-case.port.ts
@@ -1,4 +1,8 @@
-import type { ReplicationResult, ReplicationStatusRecord } from '@/domain/replication';
+import type {
+  ReplicationResult,
+  ReplicationStatusRecord,
+  TenantRehydrationResult,
+} from '@/domain/replication';
 import type { StorageTarget } from '@/ports/replication/storage-target.port';
 
 export interface ReplicationUseCase {
@@ -30,8 +34,13 @@ export interface ReplicationUseCase {
     source: StorageTarget,
   ): Promise<ReplicationResult>;
 
-  /** DR: recover all mailboxes and snapshots from a designated replica. */
-  rehydrate_tenant(tenant_id: string, source: StorageTarget): Promise<ReplicationResult>;
+  /**
+   * DR: recover every workload (Outlook, OneDrive, SharePoint) from a designated replica.
+   *
+   * Returns a per-workload breakdown so an operator can audit what a "full tenant recovery"
+   * actually restored instead of trusting a single aggregate status line.
+   */
+  rehydrate_tenant(tenant_id: string, source: StorageTarget): Promise<TenantRehydrationResult>;
 
   /** Queries durable replication status records, optionally filtered by snapshot. */
   get_replication_status(


### PR DESCRIPTION
Closes #88. Follows #96 (`-o/--owner` scope), which documented this gap as a warning; that warning is now replaced by working behavior.

## Problem

`rehydrate_tenant` enumerated the Outlook `manifests/` prefix only. A run documented and printed as **"full tenant recovery"** restored one workload of three and still reported `COMPLETED` with a green exit code — OneDrive (`onedrive/manifests/`) and SharePoint (`sharepoint/manifests/`) were never looked at. A DR drill could pass while two thirds of the tenant stayed unrecovered, discoverable only by manually reconciling `stats` against the replica.

## Changes

- **`rehydrate_all_owners` / `rehydrate_all_sites`** added to the OneDrive and SharePoint replication ports. Both repositories already exposed `list_all_manifests`, so this is aggregation, not new crawling. Manifests are grouped per owner/site so each keeps **its own** ancillary keys (version indexes, delta cursors) — using one owner's keys for all would silently mis-copy.
- **`rehydrate_tenant` runs all three workloads** and returns `TenantRehydrationResult`: one entry per workload plus their aggregate. Reporting per workload is what makes "full tenant recovery" auditable; a single status line is exactly what hid this bug.
- **`rehydrate --all` prints a per-workload table** and warns naming any workload the replica held nothing for, so an incomplete drill cannot pass silently.
- **SDK** `rehydrateTenant` returns the same breakdown; `TenantRehydrationResult` / `WorkloadRehydrationResult` / `RehydrationWorkload` exported from the SDK entry point. Breaking, but the previous return value described one workload while claiming to describe the tenant.
- Extracted `rehydration-od-manifests-runner.ts` (mirrors the existing `rehydration-sp-manifests-runner.ts`) and `outlook-replication-helpers.ts` to keep the touched services inside the 300-line rule.
- Docs: `cli.md`, `cli-recovery.md`, `operations/replication.md`, `reference/sdk.md`. `cli-recovery.md` had also missed `-o/--owner` from #96 — added there too.

I did **not** add a tenant-wide `replicate` scope (proposed-fix item 4 in the issue, not in its acceptance criteria). Say the word and it's a small follow-up.

## Verification

Live drill against the Wisecom tenant. Replica seeded with one workload's manifests each — 4 Outlook, 1 OneDrive, 3 SharePoint — recovering into a **fresh empty** primary:

```
$ atlas rehydrate --all --source-config replica.json
Mode:   full tenant recovery
Workload    Scope        Copied  Skipped  Failed  Size
outlook     4-snapshots  35      35       0       433.3 KB
onedrive    1-owners     12      1        0       2.7 MB
sharepoint  1-sites      59      90       0       7.1 MB
Result: COMPLETED
106 copied | 126 skipped | 0 failed — 10.2 MB, 1586ms
```

Before this change the same command reported `35 copied — 433.3 KB` and `COMPLETED`.

Recovered primary matches the replica exactly (4 Outlook snapshots, 1 OneDrive, 3 SharePoint — replica manifest counts confirmed with `mc`), and integrity verification passed for every workload:

```
outlook:     [+] All 35 objects passed integrity check
onedrive:    [+] All 6 entries passed verification
sharepoint:  [+] All 29 entries passed verification
```

Re-running `--all` copied 0 and skipped all 8 manifests, so recovery stays idempotent.

Tests: `workload-tenant-rehydration.test.ts` (4 tests — per-owner/site enumeration, per-owner ancillary keys, empty replica, per-site aggregation); `replication.service.test.ts` replaces the Outlook-only tenant test with one asserting all three workloads dispatch and that a failed workload is not hidden in the aggregate; CLI test covers `--all` dispatch and the empty-workload warning. Full suite 912 tests, lint, typecheck, `docs:build` all pass.

## Acceptance criteria

- [x] `rehydrate --all` into an empty primary restores Outlook, OneDrive, and SharePoint snapshots present in the source
- [x] Summary output breaks the result down per workload
- [x] Regression test seeding one manifest per workload (the old test at `replication.service.test.ts:203` seeded Outlook only and passed on the broken code)
- [x] `docs/reference/cli.md` states exactly which workloads `--all` covers