### PR TITLE
feat(replication): add tenant-wide replicate --all across every workload

### DIFF
--- a/docs/operations/replication.md
+++ b/docs/operations/replication.md
@@ -150,6 +150,14 @@ atlas replicate --site contoso.sharepoint.com,guid,guid -s sp-snap-123 --target-
 
 SharePoint replication copies data blobs, file version index files, delta cursors, and manifests. Ancillary objects (indexes + cursors) are replicated alongside data so that incremental sync resumes correctly after rehydration.
 
+### Replicate the Whole Tenant
+
+```bash
+atlas replicate --all --target-config ./offsite.json
+```
+
+`--all` walks all three manifest roots -- `manifests/` (Outlook), `onedrive/manifests/`, and `sharepoint/manifests/` -- and pushes every snapshot the target is missing, reporting copied/skipped/failed counts per workload. This is the outbound mirror of `atlas rehydrate --all`, and the invocation to schedule for an "everything offsite" job; per-scope flags remain for targeted pushes. Runs are idempotent: a target that is already current reports all zeroes.
+
 ### Using a Target Config File
 
 ```bash
@@ -198,6 +206,10 @@ const odSingle = await atlas.onedrive.replicateSnapshot('owner-id', 'od-snap-123
 // Replicate SharePoint site snapshots
 const spResults = await atlas.sharepoint.replicateAll('site-id', [offsite]);
 const spSingle = await atlas.sharepoint.replicateSnapshot('site-id', 'sp-snap-123', [offsite]);
+
+// Replicate every workload; `workloads` carries one entry per workload, `total` their aggregate
+const tenant = await atlas.replicateTenant([offsite]);
+tenant.workloads.forEach((w) => console.log(w.workload, w.result.objects_copied));
 
 // Query replication status
 const status = await atlas.getReplicationStatus('snapshot-id');

--- a/docs/reference/cli-recovery.md
+++ b/docs/reference/cli-recovery.md
@@ -160,24 +160,32 @@ atlas replicate -m user@company.com --target-config ./offsite.json
 atlas replicate --site https://contoso.sharepoint.com/sites/Engineering --target-config ./offsite.json
 atlas replicate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000-a1b2c3 --target-config ./offsite.json
 
+atlas replicate -o user@company.com --target-config ./offsite.json
+atlas replicate -o user@company.com -s od-snap-1735689600000-a1b2c3 --target-config ./offsite.json
+
+atlas replicate --all --target-config ./offsite.json
+
 atlas replicate --status
 atlas replicate --status -m user@company.com
 atlas replicate --status -s <snapshot-id>
 atlas replicate --status --site https://contoso.sharepoint.com/sites/Engineering
+atlas replicate --status -o user@company.com
 ```
 
-| Option                      | Description                                                |
-| --------------------------- | ---------------------------------------------------------- |
-| `-s, --snapshot <id>`       | Replicate a specific snapshot                              |
-| `-m, --mailbox <email>`     | Replicate all unreplicated snapshots for a mailbox         |
-| `--site <url-or-id>`        | Replicate all unreplicated snapshots for a SharePoint site |
-| `--target-endpoint <url>`   | Target S3 endpoint URL                                     |
-| `--target-access-key <key>` | Target S3 access key                                       |
-| `--target-secret-key <key>` | Target S3 secret key                                       |
-| `--target-region <region>`  | Target S3 region (default: `us-east-1`)                    |
-| `--target-config <path>`    | Path to JSON file with target S3 credentials               |
-| `--status`                  | Show replication status instead of replicating             |
-| `-t, --tenant <id>`         | Override tenant ID                                         |
+| Option                      | Description                                                 |
+| --------------------------- | ----------------------------------------------------------- |
+| `-s, --snapshot <id>`       | Replicate a specific snapshot                               |
+| `-m, --mailbox <email>`     | Replicate all unreplicated snapshots for a mailbox          |
+| `--site <url-or-id>`        | Replicate all unreplicated snapshots for a SharePoint site  |
+| `-o, --owner <email-or-id>` | Replicate all unreplicated snapshots for a OneDrive owner   |
+| `--all`                     | Replicate every workload: Outlook, OneDrive, and SharePoint |
+| `--target-endpoint <url>`   | Target S3 endpoint URL                                      |
+| `--target-access-key <key>` | Target S3 access key                                        |
+| `--target-secret-key <key>` | Target S3 secret key                                        |
+| `--target-region <region>`  | Target S3 region (default: `us-east-1`)                     |
+| `--target-config <path>`    | Path to JSON file with target S3 credentials                |
+| `--status`                  | Show replication status instead of replicating              |
+| `-t, --tenant <id>`         | Override tenant ID                                          |
 
 ::: tip Target Config File
 The target config file is a JSON object with `s3_endpoint`, `s3_access_key`, `s3_secret_key`, and optionally `s3_region` and `target_id`. The encryption passphrase is shared from the main Atlas configuration.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -620,6 +620,8 @@ atlas replicate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000
 atlas replicate -o user@company.com --target-config ./offsite.json
 atlas replicate -o user@company.com -s od-snap-1735689600000-a1b2c3 --target-config ./offsite.json
 
+atlas replicate --all --target-config ./offsite.json
+
 atlas replicate --status
 atlas replicate --status -m user@company.com
 atlas replicate --status -s <snapshot-id>
@@ -627,19 +629,31 @@ atlas replicate --status --site https://contoso.sharepoint.com/sites/Engineering
 atlas replicate --status -o user@company.com
 ```
 
-| Option                      | Description                                                |
-| --------------------------- | ---------------------------------------------------------- |
-| `-s, --snapshot <id>`       | Replicate a specific snapshot                              |
-| `-m, --mailbox <email>`     | Replicate all unreplicated snapshots for a mailbox         |
-| `--site <url-or-id>`        | Replicate all unreplicated snapshots for a SharePoint site |
-| `-o, --owner <email-or-id>` | Replicate all unreplicated snapshots for a OneDrive owner  |
-| `--target-endpoint <url>`   | Target S3 endpoint URL                                     |
-| `--target-access-key <key>` | Target S3 access key                                       |
-| `--target-secret-key <key>` | Target S3 secret key                                       |
-| `--target-region <region>`  | Target S3 region (default: `us-east-1`)                    |
-| `--target-config <path>`    | Path to JSON file with target S3 credentials               |
-| `--status`                  | Show replication status instead of replicating             |
-| `-t, --tenant <id>`         | Override tenant ID                                         |
+| Option                      | Description                                                 |
+| --------------------------- | ----------------------------------------------------------- |
+| `-s, --snapshot <id>`       | Replicate a specific snapshot                               |
+| `-m, --mailbox <email>`     | Replicate all unreplicated snapshots for a mailbox          |
+| `--site <url-or-id>`        | Replicate all unreplicated snapshots for a SharePoint site  |
+| `-o, --owner <email-or-id>` | Replicate all unreplicated snapshots for a OneDrive owner   |
+| `--all`                     | Replicate every workload: Outlook, OneDrive, and SharePoint |
+| `--target-endpoint <url>`   | Target S3 endpoint URL                                      |
+| `--target-access-key <key>` | Target S3 access key                                        |
+| `--target-secret-key <key>` | Target S3 secret key                                        |
+| `--target-region <region>`  | Target S3 region (default: `us-east-1`)                     |
+| `--target-config <path>`    | Path to JSON file with target S3 credentials                |
+| `--status`                  | Show replication status instead of replicating              |
+| `-t, --tenant <id>`         | Override tenant ID                                          |
+
+`--all` is the outbound mirror of `atlas rehydrate --all`: it walks all three manifest roots and pushes every snapshot the target is missing, then reports copied/skipped/failed counts per workload. Use it for a scheduled "everything offsite" job instead of scripting one invocation per mailbox, owner, and site:
+
+```
+Workload    Scope       Copied  Skipped  Failed  Size
+outlook     outlook     35      0        0       433.3 KB
+onedrive    onedrive    12      0        0       2.7 MB
+sharepoint  sharepoint  59      0        0       7.1 MB
+```
+
+Re-running is cheap and idempotent: snapshots already on the target are diffed out per scope, so a steady-state run reports all zeroes and moves nothing. Unlike `rehydrate --all`, zero counts are therefore **not** warned about here -- outbound they mean "target already current", which is the normal outcome of a scheduled job. Use `atlas replicate --status` to confirm which snapshots exist on which target.
 
 ::: tip Target Config File
 The target config file is a JSON object with `s3_endpoint`, `s3_access_key`, `s3_secret_key`, and optionally `s3_region` and `target_id`. The encryption passphrase is shared from the main Atlas configuration.

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -275,6 +275,10 @@ const results = await atlas.replicateSnapshot('snapshot-id', [offsite]);
 // Replicate all unreplicated snapshots for a mailbox
 const mailboxResults = await atlas.replicateMailbox('user@company.com', [offsite]);
 
+// Replicate every workload (Outlook + OneDrive + SharePoint), reported per workload
+const tenant = await atlas.replicateTenant([offsite]);
+console.log(tenant.total.objects_copied);
+
 // Query replication status
 const status = await atlas.getReplicationStatus('snapshot-id');
 

--- a/packages/cli/src/commands/rehydrate.command.tsx
+++ b/packages/cli/src/commands/rehydrate.command.tsx
@@ -15,16 +15,16 @@ import {
 } from '@wisecom/atlas-types';
 import { create_storage_target } from '@wisecom/atlas-s3';
 import type { StorageTarget } from '@wisecom/atlas-types';
-import type { ReplicationResult, TenantRehydrationResult } from '@wisecom/atlas-types';
+import type { ReplicationResult } from '@wisecom/atlas-types';
 import { Box } from 'ink';
 import { Banner } from '@/ui/components/banner';
 import { KeyValueList } from '@/ui/components/key-value-list';
 import type { KeyValueItem } from '@/ui/components/key-value-list';
-import { ResultSummary } from '@/ui/components/result-summary';
-import { DataTable } from '@/ui/components/data-table';
-import type { TableColumn } from '@/ui/components/data-table';
 import { render_static_view } from '@/ui/render';
-import { format_bytes } from '@/command-formatters';
+import {
+  report_replication_result,
+  report_tenant_workloads,
+} from '@/commands/tenant-workload-report';
 import { logger, GRAPH_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-core';
 import type { UserIdentityResolver } from '@wisecom/atlas-types';
 
@@ -162,7 +162,7 @@ async function execute_rehydrate(container: Container, options: RehydrateOptions
   } else if (options.mailbox) {
     result = await use_case.rehydrate_mailbox(tenant_id, options.mailbox, source);
   } else if (options.all) {
-    await report_tenant_result(await use_case.rehydrate_tenant(tenant_id, source));
+    await report_tenant_workloads(await use_case.rehydrate_tenant(tenant_id, source), 'replica');
     return;
   } else {
     logger.error('One of --snapshot, --mailbox, --owner, --site, or --all is required');
@@ -170,7 +170,7 @@ async function execute_rehydrate(container: Container, options: RehydrateOptions
     return;
   }
 
-  await report_result(result);
+  await report_replication_result(result);
 }
 
 function build_source(container: Container, options: RehydrateOptions): StorageTarget {
@@ -217,77 +217,4 @@ function build_source(container: Container, options: RehydrateOptions): StorageT
     ...(options.sourceRegion !== undefined ? { s3_region: options.sourceRegion } : {}),
     encryption_passphrase: config.encryption_passphrase,
   });
-}
-
-async function report_result(result: ReplicationResult): Promise<void> {
-  await render_static_view(
-    <Box flexDirection="column">
-      <KeyValueList
-        items={[
-          {
-            label: 'Result',
-            value: result.status,
-            color: result.status === 'COMPLETED' ? 'green' : 'red',
-          },
-        ]}
-      />
-      <ResultSummary
-        entries={[
-          { label: 'copied', value: result.objects_copied, color: 'green' },
-          { label: 'skipped', value: result.objects_skipped, color: 'yellow' },
-          { label: 'failed', value: result.objects_failed, color: 'red' },
-        ]}
-        suffix={`${format_bytes(result.bytes_copied)}, ${result.elapsed_ms}ms`}
-      />
-    </Box>,
-  );
-
-  for (const err of result.errors) {
-    logger.error(`  ${err}`);
-  }
-
-  if (result.objects_failed > 0) process.exitCode = 1;
-}
-
-interface WorkloadRow {
-  workload: string;
-  scope: string;
-  copied: number;
-  skipped: number;
-  failed: number;
-  size: string;
-}
-
-const WORKLOAD_COLUMNS: TableColumn<WorkloadRow>[] = [
-  { key: 'workload', header: 'Workload', color: () => 'cyan' },
-  { key: 'scope', header: 'Scope' },
-  { key: 'copied', header: 'Copied' },
-  { key: 'skipped', header: 'Skipped' },
-  { key: 'failed', header: 'Failed', color: (row) => (row.failed > 0 ? 'red' : undefined) },
-  { key: 'size', header: 'Size' },
-];
-
-/** Reports a full tenant recovery: one row per workload, so a partial recovery is visible. */
-async function report_tenant_result(result: TenantRehydrationResult): Promise<void> {
-  const rows: WorkloadRow[] = result.workloads.map((w) => ({
-    workload: w.workload,
-    scope: w.result.snapshot_id,
-    copied: w.result.objects_copied,
-    skipped: w.result.objects_skipped,
-    failed: w.result.objects_failed,
-    size: format_bytes(w.result.bytes_copied),
-  }));
-
-  await render_static_view(<DataTable columns={WORKLOAD_COLUMNS} rows={rows} />);
-  await report_result(result.total);
-
-  const empty = result.workloads.filter(
-    (w) => w.result.objects_copied === 0 && w.result.objects_skipped === 0,
-  );
-  if (empty.length > 0) {
-    logger.warn(
-      `No snapshots found on the replica for: ${empty.map((w) => w.workload).join(', ')}. ` +
-        'Confirm this matches the source before treating the recovery as complete.',
-    );
-  }
 }

--- a/packages/cli/src/commands/replicate.command.tsx
+++ b/packages/cli/src/commands/replicate.command.tsx
@@ -25,6 +25,7 @@ import { render_static_view } from '@/ui/render';
 import { format_bytes } from '@/command-formatters';
 import { logger } from '@wisecom/atlas-core';
 import { resolve_owner } from '@/commands/onedrive-command.handlers';
+import { report_tenant_workloads } from '@/commands/tenant-workload-report';
 
 type ContainerFactory = () => Container;
 
@@ -40,6 +41,7 @@ interface ReplicateOptions {
   targetRegion?: string;
   targetConfig?: string;
   status?: boolean;
+  all?: boolean;
 }
 
 /** Registers the `atlas replicate` subcommand. */
@@ -64,6 +66,7 @@ export function register_replicate_command(
     .option('--target-region <region>', 'target S3 region')
     .option('--target-config <path>', 'path to JSON file with target S3 credentials')
     .option('--status', 'show replication status instead of replicating')
+    .option('--all', 'replicate every unreplicated snapshot of every workload')
     .action((options: ReplicateOptions) => execute_replicate(get_container(), options));
 }
 
@@ -145,9 +148,12 @@ async function execute_replicate(container: Container, options: ReplicateOptions
   } else if (options.mailbox) {
     const results = await use_case.replicate_mailbox(tenant_id, options.mailbox, [target]);
     await report_results(results);
+  } else if (options.all) {
+    await report_tenant_workloads(await use_case.replicate_tenant(tenant_id, [target]));
   } else {
     logger.error(
-      'Either --snapshot, --mailbox, --owner, or --site is required (or --status to view status)',
+      'Either --snapshot, --mailbox, --owner, --site, or --all is required ' +
+        '(or --status to view status)',
     );
     process.exitCode = 1;
   }

--- a/packages/cli/src/commands/tenant-workload-report.tsx
+++ b/packages/cli/src/commands/tenant-workload-report.tsx
@@ -1,0 +1,97 @@
+import { Box } from 'ink';
+import type { ReplicationResult, TenantReplicationResult } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core';
+import { KeyValueList } from '@/ui/components/key-value-list';
+import { ResultSummary } from '@/ui/components/result-summary';
+import { DataTable } from '@/ui/components/data-table';
+import type { TableColumn } from '@/ui/components/data-table';
+import { render_static_view } from '@/ui/render';
+import { format_bytes } from '@/command-formatters';
+
+/** Renders one replication or recovery result, and fails the process when objects failed. */
+export async function report_replication_result(result: ReplicationResult): Promise<void> {
+  await render_static_view(
+    <Box flexDirection="column">
+      <KeyValueList
+        items={[
+          {
+            label: 'Result',
+            value: result.status,
+            color: result.status === 'COMPLETED' ? 'green' : 'red',
+          },
+        ]}
+      />
+      <ResultSummary
+        entries={[
+          { label: 'copied', value: result.objects_copied, color: 'green' },
+          { label: 'skipped', value: result.objects_skipped, color: 'yellow' },
+          { label: 'failed', value: result.objects_failed, color: 'red' },
+        ]}
+        suffix={`${format_bytes(result.bytes_copied)}, ${result.elapsed_ms}ms`}
+      />
+    </Box>,
+  );
+
+  for (const err of result.errors) {
+    logger.error(`  ${err}`);
+  }
+
+  if (result.objects_failed > 0) process.exitCode = 1;
+}
+
+interface WorkloadRow {
+  workload: string;
+  scope: string;
+  copied: number;
+  skipped: number;
+  failed: number;
+  size: string;
+}
+
+const WORKLOAD_COLUMNS: TableColumn<WorkloadRow>[] = [
+  { key: 'workload', header: 'Workload', color: () => 'cyan' },
+  { key: 'scope', header: 'Scope' },
+  { key: 'copied', header: 'Copied' },
+  { key: 'skipped', header: 'Skipped' },
+  { key: 'failed', header: 'Failed', color: (row) => (row.failed > 0 ? 'red' : undefined) },
+  { key: 'size', header: 'Size' },
+];
+
+/**
+ * Reports a tenant-wide run: one row per workload, so covering only part of the tenant is visible.
+ *
+ * `empty_workload_source` enables the "nothing found" warning and names where nothing was found.
+ * Only recovery passes it: recovery counts a skip per manifest already on primary, so zero copied
+ * AND zero skipped really means the replica held nothing. Replication diffs snapshots out against
+ * the target before producing any result, so an up-to-date target legitimately reports zeroes --
+ * warning there would fire on every scheduled run and train operators to ignore it.
+ */
+export async function report_tenant_workloads(
+  result: TenantReplicationResult,
+  empty_workload_source?: string,
+): Promise<void> {
+  const rows: WorkloadRow[] = result.workloads.map((w) => ({
+    workload: w.workload,
+    scope: w.result.snapshot_id,
+    copied: w.result.objects_copied,
+    skipped: w.result.objects_skipped,
+    failed: w.result.objects_failed,
+    size: format_bytes(w.result.bytes_copied),
+  }));
+
+  await render_static_view(<DataTable columns={WORKLOAD_COLUMNS} rows={rows} />);
+  await report_replication_result(result.total);
+
+  if (empty_workload_source === undefined) return;
+
+  const empty = result.workloads.filter(
+    (w) => w.result.objects_copied === 0 && w.result.objects_skipped === 0,
+  );
+  if (empty.length > 0) {
+    logger.warn(
+      `No snapshots found on the ${empty_workload_source} for: ` +
+        `${empty.map((w) => w.workload).join(', ')}. ` +
+        'Confirm this matches the source before treating the recovery as complete.',
+    );
+  }
+}

--- a/packages/cli/tests/unit/replication-owner-scope.test.ts
+++ b/packages/cli/tests/unit/replication-owner-scope.test.ts
@@ -39,6 +39,7 @@ interface OutlookReplicationMock {
   replicate_snapshot: Mock;
   get_replication_status: Mock;
   get_replication_status_by_owner: Mock;
+  replicate_tenant: Mock;
   rehydrate_tenant: Mock;
 }
 
@@ -84,6 +85,14 @@ describe('replicate/rehydrate --owner OneDrive scope', () => {
       get_replication_status: vi.fn().mockResolvedValue([]),
       get_replication_status_by_owner: vi.fn().mockResolvedValue([]),
       rehydrate_tenant: vi.fn().mockResolvedValue({
+        total: RESULT,
+        workloads: [
+          { workload: 'outlook', result: RESULT },
+          { workload: 'onedrive', result: RESULT },
+          { workload: 'sharepoint', result: RESULT },
+        ],
+      }),
+      replicate_tenant: vi.fn().mockResolvedValue({
         total: RESULT,
         workloads: [
           { workload: 'outlook', result: RESULT },
@@ -195,6 +204,15 @@ describe('replicate/rehydrate --owner OneDrive scope', () => {
     );
   });
 
+  it('dispatches replicate --all to tenant-wide replication', async () => {
+    await program.parseAsync(['replicate', '--all', ...TARGET_ARGS], { from: 'user' });
+
+    expect(outlook.replicate_tenant).toHaveBeenCalledWith('test-tenant', [
+      expect.objectContaining({ endpoint: 'http://replica:9000' }),
+    ]);
+    expect(outlook.replicate_snapshot).not.toHaveBeenCalled();
+  });
+
   it('warns naming each workload the replica held nothing for', async () => {
     const warn_spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const empty = { ...RESULT, objects_copied: 0, objects_skipped: 0, objects_total: 0 };
@@ -212,6 +230,25 @@ describe('replicate/rehydrate --owner OneDrive scope', () => {
     const warned = warn_spy.mock.calls.map((c) => c.join(' ')).join('\n');
     expect(warned).toContain('onedrive, sharepoint');
     expect(warned).not.toContain('outlook,');
+    warn_spy.mockRestore();
+  });
+
+  it('does not warn when replicate --all finds the target already current', async () => {
+    const warn_spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const nothing = { ...RESULT, objects_copied: 0, objects_skipped: 0, objects_total: 0 };
+    vi.mocked(outlook.replicate_tenant).mockResolvedValue({
+      total: nothing,
+      workloads: [
+        { workload: 'outlook', result: nothing },
+        { workload: 'onedrive', result: nothing },
+        { workload: 'sharepoint', result: nothing },
+      ],
+    });
+
+    await program.parseAsync(['replicate', '--all', ...TARGET_ARGS], { from: 'user' });
+
+    // Outbound zeroes mean "target already current" -- warning here would fire every run.
+    expect(warn_spy).not.toHaveBeenCalled();
     warn_spy.mockRestore();
   });
 });

--- a/packages/core/src/services/replication/manifest-grouping.ts
+++ b/packages/core/src/services/replication/manifest-grouping.ts
@@ -1,0 +1,20 @@
+/**
+ * Groups manifests by their owning scope (mailbox owner, OneDrive owner, SharePoint site).
+ *
+ * Tenant-wide replication and recovery must work per scope, not per manifest: ancillary objects
+ * (version indexes, delta cursors) and target diffs are addressed by scope prefix, so processing a
+ * flat manifest list would apply one scope's sidecars to another's snapshots.
+ */
+export function group_manifests_by_scope<T>(
+  manifests: readonly T[],
+  scope_of: (manifest: T) => string,
+): Map<string, T[]> {
+  const by_scope = new Map<string, T[]>();
+  for (const manifest of manifests) {
+    const scope = scope_of(manifest);
+    const bucket = by_scope.get(scope);
+    if (bucket) bucket.push(manifest);
+    else by_scope.set(scope, [manifest]);
+  }
+  return by_scope;
+}

--- a/packages/core/src/services/replication/onedrive-replication.service.ts
+++ b/packages/core/src/services/replication/onedrive-replication.service.ts
@@ -16,10 +16,14 @@ import { replicate_onedrive_snapshot } from '@/services/replication/onedrive-sna
 import { save_replication_status } from '@/services/replication/replication-status-repository';
 import { ensure_source_dek_on_primary } from '@/services/replication/rehydration-dek-helper';
 import { rehydrate_od_manifests } from '@/services/replication/rehydration-od-manifests-runner';
+import { group_manifests_by_scope } from '@/services/replication/manifest-grouping';
+import {
+  replicate_every_scope,
+  rehydrate_every_scope,
+} from '@/services/replication/tenant-scope-fanout';
 import {
   build_replication_result,
   build_skip_result,
-  merge_replication_results,
 } from '@/services/replication/replication-result-builder';
 import {
   OD_MANIFEST_PREFIX,
@@ -189,33 +193,38 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
     const source_ctx = await source.create_context(tenant_id);
     try {
       const all = await this._od_manifests.list_all_manifests(source_ctx);
-      const by_owner = new Map<string, OneDriveSnapshotManifest[]>();
-      for (const manifest of all) {
-        const bucket = by_owner.get(manifest.owner_id);
-        if (bucket) bucket.push(manifest);
-        else by_owner.set(manifest.owner_id, [manifest]);
-      }
-
-      const results: ReplicationResult[] = [];
-      for (const [owner_id, manifests] of by_owner) {
-        const ancillary = await collect_od_ancillary_keys(source_ctx, owner_id);
-        results.push(
-          await this.rehydrate_owner_manifests(
+      return await rehydrate_every_scope(
+        group_manifests_by_scope(all, (m) => m.owner_id),
+        'owners',
+        source.target_id,
+        async (owner_id, manifests) =>
+          this.rehydrate_owner_manifests(
             source_ctx,
             primary_ctx,
             manifests,
-            ancillary,
+            await collect_od_ancillary_keys(source_ctx, owner_id),
             source,
             tenant_id,
           ),
-        );
-      }
-
-      return merge_replication_results(results, `${by_owner.size}-owners`, source.target_id);
+      );
     } finally {
       source_ctx.destroy();
       primary_ctx.destroy();
     }
+  }
+
+  /** Replicates every unreplicated OneDrive snapshot for every owner in the tenant. */
+  async replicate_all_owners(
+    tenant_id: string,
+    targets: StorageTarget[],
+  ): Promise<ReplicationResult[]> {
+    return replicate_every_scope(
+      this._tenant_factory,
+      tenant_id,
+      (ctx) => this._od_manifests.list_all_manifests(ctx),
+      (m) => m.owner_id,
+      (owner_id) => this.replicate_all_owner_snapshots(tenant_id, owner_id, targets),
+    );
   }
 
   private async copy_to_target(

--- a/packages/core/src/services/replication/outlook-snapshot-copier.ts
+++ b/packages/core/src/services/replication/outlook-snapshot-copier.ts
@@ -1,0 +1,58 @@
+import type {
+  DekValidationFn,
+  Manifest,
+  ReplicationResult,
+  StorageTarget,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { replicate_snapshot_to_target } from '@/services/replication/snapshot-replicator';
+import { build_replication_result } from '@/services/replication/replication-result-builder';
+
+/** Copies one Outlook snapshot to a target, opening and releasing that target's context. */
+export async function copy_outlook_snapshot_to_target(
+  source_ctx: TenantContext,
+  target: StorageTarget,
+  manifest: Manifest,
+  tenant_id: string,
+  validate_dek: DekValidationFn,
+  passphrase: string,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  const target_ctx = await target.create_context(tenant_id);
+  try {
+    await validate_dek(source_ctx.storage, target_ctx.storage, passphrase, tenant_id);
+    const rep = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest);
+    return build_replication_result(
+      rep,
+      manifest.snapshot_id,
+      target.target_id,
+      Date.now() - start,
+    );
+  } finally {
+    target_ctx.destroy();
+  }
+}
+
+/**
+ * Copies one Outlook snapshot between two open contexts.
+ *
+ * `is_rehydration` suppresses the replica marker: the primary must not be stamped as a replica of
+ * the replica it was recovered from.
+ */
+export async function copy_outlook_snapshot_between(
+  source_ctx: TenantContext,
+  target_ctx: TenantContext,
+  manifest: Manifest,
+  target_id: string,
+  tenant_id: string,
+  validate_dek: DekValidationFn,
+  passphrase: string,
+  is_rehydration = false,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  await validate_dek(source_ctx.storage, target_ctx.storage, passphrase, tenant_id);
+  const rep = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest, {
+    skip_marker: is_rehydration,
+  });
+  return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
+}

--- a/packages/core/src/services/replication/replication.service.ts
+++ b/packages/core/src/services/replication/replication.service.ts
@@ -12,8 +12,7 @@ import type { DekValidationFn } from '@wisecom/atlas-types';
 import type {
   ReplicationResult,
   ReplicationStatusRecord,
-  TenantRehydrationResult,
-  WorkloadRehydrationResult,
+  TenantReplicationResult,
 } from '@wisecom/atlas-types';
 import type { Manifest } from '@wisecom/atlas-types';
 import {
@@ -24,7 +23,6 @@ import {
   ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
   SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
-import { replicate_snapshot_to_target } from '@/services/replication/snapshot-replicator';
 import { rehydrate_manifests } from '@/services/replication/rehydration-manifests-runner';
 import {
   save_replication_status,
@@ -39,10 +37,17 @@ import {
 } from '@/services/replication/outlook-replication-helpers';
 import { ensure_source_dek_on_primary } from '@/services/replication/rehydration-dek-helper';
 import {
-  build_replication_result,
+  copy_outlook_snapshot_to_target,
+  copy_outlook_snapshot_between,
+} from '@/services/replication/outlook-snapshot-copier';
+import {
+  replicate_every_scope,
+  build_tenant_result,
+  as_workload_result,
+} from '@/services/replication/tenant-scope-fanout';
+import {
   build_skip_result,
   to_status_record,
-  merge_replication_results,
 } from '@/services/replication/replication-result-builder';
 import type { AtlasConfig } from '@/utils/config';
 import { ATLAS_CONFIG_TOKEN } from '@/utils/config';
@@ -72,7 +77,7 @@ export class ReplicationService implements ReplicationUseCase {
       const results: ReplicationResult[] = [];
 
       for (const target of targets) {
-        const result = await this.copy_to_target(source_ctx, target, manifest, tenant_id);
+        const result = await this.copy_snapshot_to_target(source_ctx, target, manifest, tenant_id);
         await save_replication_status(source_ctx, to_status_record(result, target, manifest));
         results.push(result);
       }
@@ -100,7 +105,12 @@ export class ReplicationService implements ReplicationUseCase {
           const missing = await diff_outlook_manifests(manifests, target_ctx, owner_id);
 
           for (const manifest of missing) {
-            const result = await this.copy_to_target(source_ctx, target, manifest, tenant_id);
+            const result = await this.copy_snapshot_to_target(
+              source_ctx,
+              target,
+              manifest,
+              tenant_id,
+            );
             await save_replication_status(source_ctx, to_status_record(result, target, manifest));
             results.push(result);
           }
@@ -113,6 +123,43 @@ export class ReplicationService implements ReplicationUseCase {
     } finally {
       source_ctx.destroy();
     }
+  }
+
+  /**
+   * Replicates every unreplicated snapshot of every workload to the given targets.
+   *
+   * Each workload owns its own manifest root, so a tenant-wide push has to fan out per workload;
+   * enumerating one prefix would replicate a third of the tenant while reporting success.
+   */
+  async replicate_tenant(
+    tenant_id: string,
+    targets: StorageTarget[],
+  ): Promise<TenantReplicationResult> {
+    const target_id = targets.map((t) => t.target_id).join(', ');
+    const outlook = await replicate_every_scope(
+      this._tenant_factory,
+      tenant_id,
+      (ctx) => this._manifests.list_all_manifests(ctx),
+      (m) => m.owner_id,
+      (owner_id) => this.replicate_mailbox(tenant_id, owner_id, targets),
+    );
+
+    return build_tenant_result(
+      [
+        as_workload_result('outlook', outlook, target_id),
+        as_workload_result(
+          'onedrive',
+          await this._onedrive.replicate_all_owners(tenant_id, targets),
+          target_id,
+        ),
+        as_workload_result(
+          'sharepoint',
+          await this._sharepoint.replicate_all_sites(tenant_id, targets),
+          target_id,
+        ),
+      ],
+      target_id,
+    );
   }
 
   async rehydrate_snapshot(
@@ -136,12 +183,14 @@ export class ReplicationService implements ReplicationUseCase {
         return build_skip_result(snapshot_id, source.target_id);
       }
 
-      return await this.copy_between(
+      return await copy_outlook_snapshot_between(
         source_ctx,
         primary_ctx,
         manifest,
         source.target_id,
         tenant_id,
+        this._validate_dek,
+        this._config.encryption_passphrase,
         true,
       );
     } finally {
@@ -186,25 +235,21 @@ export class ReplicationService implements ReplicationUseCase {
   async rehydrate_tenant(
     tenant_id: string,
     source: StorageTarget,
-  ): Promise<TenantRehydrationResult> {
-    const outlook = await this.rehydrate_outlook_tenant(tenant_id, source);
-    const onedrive = await this._onedrive.rehydrate_all_owners(tenant_id, source);
-    const sharepoint = await this._sharepoint.rehydrate_all_sites(tenant_id, source);
-
-    const workloads: WorkloadRehydrationResult[] = [
-      { workload: 'outlook', result: outlook },
-      { workload: 'onedrive', result: onedrive },
-      { workload: 'sharepoint', result: sharepoint },
-    ];
-
-    return {
-      total: merge_replication_results(
-        workloads.map((w) => w.result),
-        'full-tenant',
-        source.target_id,
-      ),
-      workloads,
-    };
+  ): Promise<TenantReplicationResult> {
+    return build_tenant_result(
+      [
+        { workload: 'outlook', result: await this.rehydrate_outlook_tenant(tenant_id, source) },
+        {
+          workload: 'onedrive',
+          result: await this._onedrive.rehydrate_all_owners(tenant_id, source),
+        },
+        {
+          workload: 'sharepoint',
+          result: await this._sharepoint.rehydrate_all_sites(tenant_id, source),
+        },
+      ],
+      source.target_id,
+    );
   }
 
   private async rehydrate_outlook_tenant(
@@ -257,52 +302,21 @@ export class ReplicationService implements ReplicationUseCase {
     }
   }
 
-  private async copy_to_target(
+  /** Copies one snapshot outbound, binding this service's DEK validator and passphrase. */
+  private copy_snapshot_to_target(
     source_ctx: TenantContext,
     target: StorageTarget,
     manifest: Manifest,
     tenant_id: string,
   ): Promise<ReplicationResult> {
-    const start = Date.now();
-    const target_ctx = await target.create_context(tenant_id);
-    try {
-      await this._validate_dek(
-        source_ctx.storage,
-        target_ctx.storage,
-        this._config.encryption_passphrase,
-        tenant_id,
-      );
-      const rep = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest);
-      return build_replication_result(
-        rep,
-        manifest.snapshot_id,
-        target.target_id,
-        Date.now() - start,
-      );
-    } finally {
-      target_ctx.destroy();
-    }
-  }
-
-  private async copy_between(
-    source_ctx: TenantContext,
-    target_ctx: TenantContext,
-    manifest: Manifest,
-    target_id: string,
-    tenant_id: string,
-    is_rehydration = false,
-  ): Promise<ReplicationResult> {
-    const start = Date.now();
-    await this._validate_dek(
-      source_ctx.storage,
-      target_ctx.storage,
-      this._config.encryption_passphrase,
+    return copy_outlook_snapshot_to_target(
+      source_ctx,
+      target,
+      manifest,
       tenant_id,
+      this._validate_dek,
+      this._config.encryption_passphrase,
     );
-    const rep = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest, {
-      skip_marker: is_rehydration,
-    });
-    return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
   }
 
   private create_primary_target(): StorageTarget {

--- a/packages/core/src/services/replication/sharepoint-replication.service.ts
+++ b/packages/core/src/services/replication/sharepoint-replication.service.ts
@@ -15,15 +15,19 @@ import {
   DEK_VALIDATION_FN_TOKEN,
   STORAGE_TARGET_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
-import { replicate_sharepoint_snapshot } from '@/services/replication/sharepoint-snapshot-replicator';
 import { save_replication_status } from '@/services/replication/replication-status-repository';
 import { ensure_source_dek_on_primary } from '@/services/replication/rehydration-dek-helper';
 import { rehydrate_sp_manifests } from '@/services/replication/rehydration-sp-manifests-runner';
+import { group_manifests_by_scope } from '@/services/replication/manifest-grouping';
 import {
-  build_replication_result,
-  build_skip_result,
-  merge_replication_results,
-} from '@/services/replication/replication-result-builder';
+  replicate_every_scope,
+  rehydrate_every_scope,
+} from '@/services/replication/tenant-scope-fanout';
+import {
+  copy_sharepoint_snapshot_to_target,
+  copy_sharepoint_snapshot_between,
+} from '@/services/replication/sharepoint-snapshot-copier';
+import { build_skip_result } from '@/services/replication/replication-result-builder';
 import type { AtlasConfig } from '@/utils/config';
 import { ATLAS_CONFIG_TOKEN } from '@/utils/config';
 
@@ -143,13 +147,15 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
       }
 
       const ancillary = await collect_sp_ancillary_keys(source_ctx, site_id);
-      return this.copy_sp_between(
+      return copy_sharepoint_snapshot_between(
         source_ctx,
         primary_ctx,
         manifest,
         ancillary,
         source.target_id,
         tenant_id,
+        this._validate_dek,
+        this._config.encryption_passphrase,
         true,
       );
     } finally {
@@ -195,98 +201,59 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
     const source_ctx = await source.create_context(tenant_id);
     try {
       const all = await this._sp_manifests.list_all_manifests(source_ctx);
-      const by_site = new Map<string, SharePointSnapshotManifest[]>();
-      for (const manifest of all) {
-        const bucket = by_site.get(manifest.site_id);
-        if (bucket) bucket.push(manifest);
-        else by_site.set(manifest.site_id, [manifest]);
-      }
-
-      const results: ReplicationResult[] = [];
-      for (const [site_id, manifests] of by_site) {
-        const ancillary = await collect_sp_ancillary_keys(source_ctx, site_id);
-        results.push(
-          await rehydrate_sp_manifests(
+      return await rehydrate_every_scope(
+        group_manifests_by_scope(all, (m) => m.site_id),
+        'sites',
+        source.target_id,
+        async (site_id, manifests) =>
+          rehydrate_sp_manifests(
             source_ctx,
             primary_ctx,
             manifests,
-            ancillary,
+            await collect_sp_ancillary_keys(source_ctx, site_id),
             source,
             tenant_id,
             this._validate_dek,
             this._config.encryption_passphrase,
           ),
-        );
-      }
-
-      return merge_replication_results(results, `${by_site.size}-sites`, source.target_id);
+      );
     } finally {
       source_ctx.destroy();
       primary_ctx.destroy();
     }
   }
 
-  private async copy_sp_to_target(
+  /** Replicates every unreplicated SharePoint snapshot for every site in the tenant. */
+  async replicate_all_sites(
+    tenant_id: string,
+    targets: StorageTarget[],
+  ): Promise<ReplicationResult[]> {
+    return replicate_every_scope(
+      this._tenant_factory,
+      tenant_id,
+      (ctx) => this._sp_manifests.list_all_manifests(ctx),
+      (m) => m.site_id,
+      (site_id) => this.replicate_all_site_snapshots(tenant_id, site_id, targets),
+    );
+  }
+
+  /** Copies one snapshot outbound, binding this service's DEK validator and passphrase. */
+  private copy_sp_to_target(
     source_ctx: TenantContext,
     target: StorageTarget,
     manifest: SharePointSnapshotManifest,
     ancillary_keys: string[],
     tenant_id: string,
   ): Promise<ReplicationResult> {
-    const start = Date.now();
-    const target_ctx = await target.create_context(tenant_id);
-    await this._validate_dek(
-      source_ctx.storage,
-      target_ctx.storage,
-      this._config.encryption_passphrase,
-      tenant_id,
-    );
-    const manifest_key = `${SP_MANIFEST_PREFIX}/${manifest.site_id}/${manifest.snapshot_id}.json`;
-    const rep = await replicate_sharepoint_snapshot(
+    return copy_sharepoint_snapshot_to_target(
       source_ctx,
-      target_ctx,
+      target,
       manifest,
-      manifest_key,
-      {
-        ancillary_keys,
-      },
-    );
-    return build_replication_result(
-      rep,
-      manifest.snapshot_id,
-      target.target_id,
-      Date.now() - start,
-    );
-  }
-
-  private async copy_sp_between(
-    source_ctx: TenantContext,
-    target_ctx: TenantContext,
-    manifest: SharePointSnapshotManifest,
-    ancillary_keys: string[],
-    target_id: string,
-    tenant_id: string,
-    is_rehydration = false,
-  ): Promise<ReplicationResult> {
-    const start = Date.now();
-    await this._validate_dek(
-      source_ctx.storage,
-      target_ctx.storage,
-      this._config.encryption_passphrase,
+      ancillary_keys,
       tenant_id,
+      this._validate_dek,
+      this._config.encryption_passphrase,
     );
-    const manifest_key = `${SP_MANIFEST_PREFIX}/${manifest.site_id}/${manifest.snapshot_id}.json`;
-    const rep = await replicate_sharepoint_snapshot(
-      source_ctx,
-      target_ctx,
-      manifest,
-      manifest_key,
-      {
-        skip_marker: is_rehydration,
-        ancillary_keys,
-      },
-    );
-    return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
   }
 
   private async require_sp_manifest(

--- a/packages/core/src/services/replication/sharepoint-snapshot-copier.ts
+++ b/packages/core/src/services/replication/sharepoint-snapshot-copier.ts
@@ -1,0 +1,66 @@
+import type {
+  DekValidationFn,
+  ReplicationResult,
+  SharePointSnapshotManifest,
+  StorageTarget,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { replicate_sharepoint_snapshot } from '@/services/replication/sharepoint-snapshot-replicator';
+import { build_replication_result } from '@/services/replication/replication-result-builder';
+import { SP_MANIFEST_PREFIX } from '@/services/replication/sharepoint-replication-helpers';
+
+function manifest_key_of(manifest: SharePointSnapshotManifest): string {
+  return `${SP_MANIFEST_PREFIX}/${manifest.site_id}/${manifest.snapshot_id}.json`;
+}
+
+/** Copies one SharePoint snapshot to a target, opening and releasing that target's context. */
+export async function copy_sharepoint_snapshot_to_target(
+  source_ctx: TenantContext,
+  target: StorageTarget,
+  manifest: SharePointSnapshotManifest,
+  ancillary_keys: string[],
+  tenant_id: string,
+  validate_dek: DekValidationFn,
+  passphrase: string,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  const target_ctx = await target.create_context(tenant_id);
+  await validate_dek(source_ctx.storage, target_ctx.storage, passphrase, tenant_id);
+  const rep = await replicate_sharepoint_snapshot(
+    source_ctx,
+    target_ctx,
+    manifest,
+    manifest_key_of(manifest),
+    { ancillary_keys },
+  );
+  return build_replication_result(rep, manifest.snapshot_id, target.target_id, Date.now() - start);
+}
+
+/**
+ * Copies one SharePoint snapshot between two open contexts.
+ *
+ * `is_rehydration` suppresses the replica marker: the primary must not be stamped as a replica of
+ * the replica it was recovered from.
+ */
+export async function copy_sharepoint_snapshot_between(
+  source_ctx: TenantContext,
+  target_ctx: TenantContext,
+  manifest: SharePointSnapshotManifest,
+  ancillary_keys: string[],
+  target_id: string,
+  tenant_id: string,
+  validate_dek: DekValidationFn,
+  passphrase: string,
+  is_rehydration = false,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  await validate_dek(source_ctx.storage, target_ctx.storage, passphrase, tenant_id);
+  const rep = await replicate_sharepoint_snapshot(
+    source_ctx,
+    target_ctx,
+    manifest,
+    manifest_key_of(manifest),
+    { skip_marker: is_rehydration, ancillary_keys },
+  );
+  return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
+}

--- a/packages/core/src/services/replication/tenant-scope-fanout.ts
+++ b/packages/core/src/services/replication/tenant-scope-fanout.ts
@@ -1,0 +1,82 @@
+import type {
+  ReplicationResult,
+  ReplicationWorkload,
+  TenantContext,
+  TenantContextFactory,
+  TenantReplicationResult,
+  WorkloadReplicationResult,
+} from '@wisecom/atlas-types';
+import { merge_replication_results } from '@/services/replication/replication-result-builder';
+import { group_manifests_by_scope } from '@/services/replication/manifest-grouping';
+
+/**
+ * Runs an outbound replication for every scope (mailbox, OneDrive owner, SharePoint site) that has
+ * at least one manifest, and concatenates the per-snapshot results.
+ *
+ * The scope list is read once and the source context released before fanning out, so a long push
+ * does not hold a tenant context open for the whole run.
+ */
+export async function replicate_every_scope<M>(
+  tenant_factory: TenantContextFactory,
+  tenant_id: string,
+  list_all: (ctx: TenantContext) => Promise<M[]>,
+  scope_of: (manifest: M) => string,
+  replicate_scope: (scope_id: string) => Promise<ReplicationResult[]>,
+): Promise<ReplicationResult[]> {
+  const ctx = await tenant_factory.create(tenant_id);
+  let scope_ids: string[];
+  try {
+    scope_ids = [...group_manifests_by_scope(await list_all(ctx), scope_of).keys()];
+  } finally {
+    ctx.destroy();
+  }
+
+  const results: ReplicationResult[] = [];
+  for (const scope_id of scope_ids) {
+    results.push(...(await replicate_scope(scope_id)));
+  }
+  return results;
+}
+
+/**
+ * Recovers every scope present in a grouped manifest set, merging the per-scope results into one.
+ *
+ * The label reports how many scopes were covered (`3-owners`, `2-sites`), which is what makes an
+ * "everything" recovery auditable against the source.
+ */
+export async function rehydrate_every_scope<M>(
+  by_scope: Map<string, M[]>,
+  scope_label: string,
+  target_id: string,
+  rehydrate_scope: (scope_id: string, manifests: M[]) => Promise<ReplicationResult>,
+): Promise<ReplicationResult> {
+  const results: ReplicationResult[] = [];
+  for (const [scope_id, manifests] of by_scope) {
+    results.push(await rehydrate_scope(scope_id, manifests));
+  }
+  return merge_replication_results(results, `${by_scope.size}-${scope_label}`, target_id);
+}
+
+/** Assembles per-workload results into a tenant-level result carrying their aggregate. */
+export function build_tenant_result(
+  workloads: readonly WorkloadReplicationResult[],
+  target_id: string,
+): TenantReplicationResult {
+  return {
+    total: merge_replication_results(
+      workloads.map((w) => w.result),
+      'full-tenant',
+      target_id,
+    ),
+    workloads,
+  };
+}
+
+/** Labels a workload's per-snapshot results as a single workload-level result. */
+export function as_workload_result(
+  workload: ReplicationWorkload,
+  results: readonly ReplicationResult[],
+  target_id: string,
+): WorkloadReplicationResult {
+  return { workload, result: merge_replication_results(results, workload, target_id) };
+}

--- a/packages/core/tests/unit/services/replication/replication-fixtures.ts
+++ b/packages/core/tests/unit/services/replication/replication-fixtures.ts
@@ -1,0 +1,149 @@
+import { vi } from 'vitest';
+import { ReplicationStatus, ReplicationVerificationStatus } from '@wisecom/atlas-types';
+import type {
+  DekValidationFn,
+  Manifest,
+  ManifestEntry,
+  ManifestRepository,
+  ObjectStorage,
+  OneDriveReplicationUseCase,
+  ReplicationResult,
+  SharePointReplicationUseCase,
+  StorageTarget,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+import type { AtlasConfig } from '@/utils/config';
+
+export const TEST_CONFIG: AtlasConfig = {
+  tenant_id: 'tenant-1',
+  client_id: 'c',
+  client_secret: 's',
+  s3_endpoint: 'http://primary:9000',
+  s3_access_key: 'k',
+  s3_secret_key: 's',
+  s3_region: 'us-east-1',
+  encryption_passphrase: 'pass',
+};
+
+export function make_storage(): ObjectStorage {
+  return {
+    put: vi.fn(),
+    get: vi.fn().mockResolvedValue(Buffer.from('encrypted-blob')),
+    delete: vi.fn(),
+    delete_version: vi.fn(),
+    exists: vi.fn().mockResolvedValue(false),
+    list: vi.fn().mockResolvedValue([]),
+    list_versions: vi.fn(),
+    begin_multipart_upload: vi.fn().mockResolvedValue({
+      upload_part: vi.fn(),
+      complete: vi.fn(),
+      abort: vi.fn(),
+    }),
+    copy: vi.fn(),
+    abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+    probe_immutability: vi.fn(),
+  };
+}
+
+export function make_ctx(storage: ObjectStorage): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage,
+    encrypt: vi.fn((d: Buffer) => d),
+    decrypt: vi.fn((d: Buffer) => d),
+    create_cipher: stub_tenant_create_cipher,
+    destroy: vi.fn(),
+  };
+}
+
+export function make_entry(key: string): ManifestEntry {
+  return {
+    object_id: `obj-${key}`,
+    storage_key: `data/mbx/${key}`,
+    checksum: 'abc',
+    size_bytes: 100,
+  };
+}
+
+export function make_manifest(
+  snapshot_id: string,
+  owner_id = 'mbx-1',
+  entries: ManifestEntry[] = [],
+): Manifest {
+  return {
+    id: `manifest-${snapshot_id}`,
+    tenant_id: 'tenant-1',
+    owner_id,
+    snapshot_id,
+    created_at: new Date('2026-01-01'),
+    total_objects: entries.length,
+    total_size_bytes: entries.reduce((s, e) => s + e.size_bytes, 0),
+    delta_links: {},
+    entries,
+  };
+}
+
+/** Builds a workload-level result as returned by the OneDrive/SharePoint tenant scopes. */
+export function make_workload_result(
+  snapshot_id: string,
+  objects_copied: number,
+  bytes_copied = 100,
+): ReplicationResult {
+  return {
+    snapshot_id,
+    target_id: 'offsite',
+    status: ReplicationStatus.COMPLETED,
+    objects_total: objects_copied,
+    objects_copied,
+    objects_skipped: 0,
+    objects_failed: 0,
+    bytes_copied,
+    elapsed_ms: 5,
+    errors: [],
+    verification_status: ReplicationVerificationStatus.SKIPPED,
+  };
+}
+
+export function make_manifest_repository(): ManifestRepository {
+  return {
+    save: vi.fn(),
+    find_by_snapshot: vi.fn(),
+    find_latest_by_owner: vi.fn(),
+    list_all_manifests: vi.fn().mockResolvedValue([]),
+  };
+}
+
+export function make_onedrive_replication_mock(): OneDriveReplicationUseCase {
+  return {
+    replicate_owner: vi.fn(),
+    replicate_all_owner_snapshots: vi.fn(),
+    replicate_all_owners: vi.fn().mockResolvedValue([]),
+    rehydrate_owner_snapshot: vi.fn(),
+    rehydrate_owner: vi.fn(),
+    rehydrate_all_owners: vi.fn().mockResolvedValue(make_workload_result('0-owners', 0, 0)),
+  };
+}
+
+export function make_sharepoint_replication_mock(): SharePointReplicationUseCase {
+  return {
+    replicate_site: vi.fn(),
+    replicate_all_site_snapshots: vi.fn(),
+    replicate_all_sites: vi.fn().mockResolvedValue([]),
+    rehydrate_site_snapshot: vi.fn(),
+    rehydrate_site: vi.fn(),
+    rehydrate_all_sites: vi.fn().mockResolvedValue(make_workload_result('0-sites', 0, 0)),
+  };
+}
+
+export function make_storage_target(
+  target_id: string,
+  ctx: TenantContext,
+  endpoint = 'http://offsite:9000',
+): StorageTarget {
+  return { target_id, endpoint, create_context: vi.fn().mockResolvedValue(ctx) };
+}
+
+export function make_dek_validator(): DekValidationFn {
+  return vi.fn().mockResolvedValue(undefined) as unknown as DekValidationFn;
+}

--- a/packages/core/tests/unit/services/replication/replication.service.test.ts
+++ b/packages/core/tests/unit/services/replication/replication.service.test.ts
@@ -1,94 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ReplicationService } from '@/services/replication/replication.service';
-import { ReplicationStatus, ReplicationVerificationStatus } from '@wisecom/atlas-types';
+import { ReplicationStatus } from '@wisecom/atlas-types';
 import type {
   TenantContext,
   TenantContextFactory,
   ManifestRepository,
   ObjectStorage,
-  Manifest,
-  ManifestEntry,
   StorageTarget,
   StorageTargetFactory,
   DekValidationFn,
-  ReplicationResult,
   OneDriveReplicationUseCase,
   SharePointReplicationUseCase,
 } from '@wisecom/atlas-types';
-import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
-import type { AtlasConfig } from '@/utils/config';
+import {
+  TEST_CONFIG,
+  make_ctx,
+  make_dek_validator,
+  make_entry,
+  make_manifest,
+  make_manifest_repository,
+  make_onedrive_replication_mock,
+  make_sharepoint_replication_mock,
+  make_storage,
+  make_storage_target,
+} from './replication-fixtures';
 
 vi.mock('@/services/replication/rehydration-dek-helper', () => ({
   ensure_source_dek_on_primary: vi.fn().mockResolvedValue(undefined),
 }));
-
-function make_storage(): ObjectStorage {
-  return {
-    put: vi.fn(),
-    get: vi.fn().mockResolvedValue(Buffer.from('encrypted-blob')),
-    delete: vi.fn(),
-    delete_version: vi.fn(),
-    exists: vi.fn().mockResolvedValue(false),
-    list: vi.fn().mockResolvedValue([]),
-    list_versions: vi.fn(),
-    begin_multipart_upload: vi.fn().mockResolvedValue({
-      upload_part: vi.fn(),
-      complete: vi.fn(),
-      abort: vi.fn(),
-    }),
-    copy: vi.fn(),
-    abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
-    probe_immutability: vi.fn(),
-  };
-}
-
-function make_entry(key: string): ManifestEntry {
-  return {
-    object_id: `obj-${key}`,
-    storage_key: `data/mbx/${key}`,
-    checksum: 'abc',
-    size_bytes: 100,
-  };
-}
-
-function make_manifest(
-  snapshot_id: string,
-  owner_id = 'mbx-1',
-  entries: ManifestEntry[] = [],
-): Manifest {
-  return {
-    id: `manifest-${snapshot_id}`,
-    tenant_id: 'tenant-1',
-    owner_id,
-    snapshot_id,
-    created_at: new Date('2026-01-01'),
-    total_objects: entries.length,
-    total_size_bytes: entries.reduce((s, e) => s + e.size_bytes, 0),
-    delta_links: {},
-    entries,
-  };
-}
-
-/** Builds a workload-level result as returned by the OneDrive/SharePoint tenant scopes. */
-function make_workload_result(
-  snapshot_id: string,
-  objects_copied: number,
-  bytes_copied = 100,
-): ReplicationResult {
-  return {
-    snapshot_id,
-    target_id: 'offsite',
-    status: ReplicationStatus.COMPLETED,
-    objects_total: objects_copied,
-    objects_copied,
-    objects_skipped: 0,
-    objects_failed: 0,
-    bytes_copied,
-    elapsed_ms: 5,
-    errors: [],
-    verification_status: ReplicationVerificationStatus.SKIPPED,
-  };
-}
 
 describe('ReplicationService', () => {
   let source_storage: ObjectStorage;
@@ -97,7 +36,6 @@ describe('ReplicationService', () => {
   let target_ctx: TenantContext;
   let tenant_factory: TenantContextFactory;
   let manifests: ManifestRepository;
-  let config: AtlasConfig;
   let target: StorageTarget;
   let validate_dek: DekValidationFn;
   let target_factory: StorageTargetFactory;
@@ -108,71 +46,19 @@ describe('ReplicationService', () => {
   beforeEach(() => {
     source_storage = make_storage();
     target_storage = make_storage();
-
-    source_ctx = {
-      tenant_id: 'tenant-1',
-      storage: source_storage,
-      encrypt: vi.fn((d: Buffer) => d),
-      decrypt: vi.fn((d: Buffer) => d),
-      create_cipher: stub_tenant_create_cipher,
-      destroy: vi.fn(),
-    };
-
-    target_ctx = {
-      tenant_id: 'tenant-1',
-      storage: target_storage,
-      encrypt: vi.fn((d: Buffer) => d),
-      decrypt: vi.fn((d: Buffer) => d),
-      create_cipher: stub_tenant_create_cipher,
-      destroy: vi.fn(),
-    };
-
+    source_ctx = make_ctx(source_storage);
+    target_ctx = make_ctx(target_storage);
     tenant_factory = { create: vi.fn().mockResolvedValue(source_ctx) };
-
-    manifests = {
-      save: vi.fn(),
-      find_by_snapshot: vi.fn(),
-      find_latest_by_owner: vi.fn(),
-      list_all_manifests: vi.fn().mockResolvedValue([]),
-    };
-
-    config = {
-      tenant_id: 'tenant-1',
-      client_id: 'c',
-      client_secret: 's',
-      s3_endpoint: 'http://primary:9000',
-      s3_access_key: 'k',
-      s3_secret_key: 's',
-      s3_region: 'us-east-1',
-      encryption_passphrase: 'pass',
-    };
-
-    target = {
-      target_id: 'offsite',
-      endpoint: 'http://offsite:9000',
-      create_context: vi.fn().mockResolvedValue(target_ctx),
-    };
-
-    validate_dek = vi.fn().mockResolvedValue(undefined) as unknown as DekValidationFn;
+    manifests = make_manifest_repository();
+    target = make_storage_target('offsite', target_ctx);
+    validate_dek = make_dek_validator();
     target_factory = vi.fn().mockReturnValue(target) as unknown as StorageTargetFactory;
-    onedrive_replication = {
-      replicate_owner: vi.fn(),
-      replicate_all_owner_snapshots: vi.fn(),
-      rehydrate_owner_snapshot: vi.fn(),
-      rehydrate_owner: vi.fn(),
-      rehydrate_all_owners: vi.fn().mockResolvedValue(make_workload_result('0-owners', 0, 0)),
-    };
-    sharepoint_replication = {
-      replicate_site: vi.fn(),
-      replicate_all_site_snapshots: vi.fn(),
-      rehydrate_site_snapshot: vi.fn(),
-      rehydrate_site: vi.fn(),
-      rehydrate_all_sites: vi.fn().mockResolvedValue(make_workload_result('0-sites', 0, 0)),
-    };
+    onedrive_replication = make_onedrive_replication_mock();
+    sharepoint_replication = make_sharepoint_replication_mock();
     service = new ReplicationService(
       tenant_factory,
       manifests,
-      config,
+      TEST_CONFIG,
       validate_dek,
       target_factory,
       onedrive_replication,
@@ -240,73 +126,6 @@ describe('ReplicationService', () => {
 
     expect(result.status).toBe(ReplicationStatus.COMPLETED);
     expect(result.objects_copied).toBe(0);
-  });
-
-  it('rehydrate_tenant recovers Outlook, OneDrive, and SharePoint, not Outlook alone', async () => {
-    const m1 = make_manifest('snap-1', 'mbx-1', []);
-    const m2 = make_manifest('snap-2', 'mbx-2', []);
-
-    vi.mocked(manifests.list_all_manifests).mockImplementation(async (ctx) => {
-      if (ctx === target_ctx) return [m1, m2];
-      return [];
-    });
-    vi.mocked(source_storage.exists).mockResolvedValue(false);
-    vi.mocked(target_storage.exists).mockResolvedValue(false);
-    vi.mocked(source_storage.get).mockResolvedValue(Buffer.from('data'));
-    vi.mocked(target_storage.get).mockResolvedValue(Buffer.from('data'));
-    vi.mocked(onedrive_replication.rehydrate_all_owners).mockResolvedValue(
-      make_workload_result('2-owners', 7, 700),
-    );
-    vi.mocked(sharepoint_replication.rehydrate_all_sites).mockResolvedValue(
-      make_workload_result('1-sites', 59, 5900),
-    );
-
-    const source_target: StorageTarget = {
-      target_id: 'offsite',
-      endpoint: 'http://offsite:9000',
-      create_context: vi.fn().mockResolvedValue(target_ctx),
-    };
-
-    const result = await service.rehydrate_tenant('tenant-1', source_target);
-
-    expect(onedrive_replication.rehydrate_all_owners).toHaveBeenCalledWith(
-      'tenant-1',
-      source_target,
-    );
-    expect(sharepoint_replication.rehydrate_all_sites).toHaveBeenCalledWith(
-      'tenant-1',
-      source_target,
-    );
-    expect(result.workloads.map((w) => w.workload)).toEqual(['outlook', 'onedrive', 'sharepoint']);
-    expect(result.total.status).toBe(ReplicationStatus.COMPLETED);
-    const by_workload = new Map(result.workloads.map((w) => [w.workload, w.result]));
-    expect(by_workload.get('onedrive')?.objects_copied).toBe(7);
-    expect(by_workload.get('sharepoint')?.objects_copied).toBe(59);
-    expect(result.total.objects_copied).toBe(by_workload.get('outlook')!.objects_copied + 7 + 59);
-    expect(result.total.bytes_copied).toBe(by_workload.get('outlook')!.bytes_copied + 700 + 5900);
-  });
-
-  it('rehydrate_tenant reports a workload that failed without hiding it in the aggregate', async () => {
-    vi.mocked(manifests.list_all_manifests).mockResolvedValue([]);
-    vi.mocked(onedrive_replication.rehydrate_all_owners).mockResolvedValue({
-      ...make_workload_result('1-owners', 0, 0),
-      status: ReplicationStatus.FAILED,
-      objects_failed: 3,
-      objects_total: 3,
-      errors: ['onedrive/data/owner/abc: access denied'],
-    });
-
-    const source_target: StorageTarget = {
-      target_id: 'offsite',
-      endpoint: 'http://offsite:9000',
-      create_context: vi.fn().mockResolvedValue(target_ctx),
-    };
-
-    const result = await service.rehydrate_tenant('tenant-1', source_target);
-
-    expect(result.total.status).not.toBe(ReplicationStatus.COMPLETED);
-    expect(result.total.objects_failed).toBe(3);
-    expect(result.total.errors).toContain('onedrive/data/owner/abc: access denied');
   });
 
   it('get_replication_status returns empty when no sidecars exist', async () => {

--- a/packages/core/tests/unit/services/replication/tenant-replication.service.test.ts
+++ b/packages/core/tests/unit/services/replication/tenant-replication.service.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ReplicationService } from '@/services/replication/replication.service';
+import { ReplicationStatus } from '@wisecom/atlas-types';
+import type {
+  DekValidationFn,
+  ManifestRepository,
+  ObjectStorage,
+  OneDriveReplicationUseCase,
+  SharePointReplicationUseCase,
+  StorageTarget,
+  StorageTargetFactory,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import {
+  TEST_CONFIG,
+  make_ctx,
+  make_dek_validator,
+  make_entry,
+  make_manifest,
+  make_manifest_repository,
+  make_onedrive_replication_mock,
+  make_sharepoint_replication_mock,
+  make_storage,
+  make_storage_target,
+  make_workload_result,
+} from './replication-fixtures';
+
+vi.mock('@/services/replication/rehydration-dek-helper', () => ({
+  ensure_source_dek_on_primary: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('ReplicationService tenant scope', () => {
+  let primary_storage: ObjectStorage;
+  let remote_storage: ObjectStorage;
+  let primary_ctx: TenantContext;
+  let remote_ctx: TenantContext;
+  let tenant_factory: TenantContextFactory;
+  let manifests: ManifestRepository;
+  let validate_dek: DekValidationFn;
+  let target_factory: StorageTargetFactory;
+  let onedrive: OneDriveReplicationUseCase;
+  let sharepoint: SharePointReplicationUseCase;
+  let remote: StorageTarget;
+  let service: ReplicationService;
+
+  beforeEach(() => {
+    primary_storage = make_storage();
+    remote_storage = make_storage();
+    primary_ctx = make_ctx(primary_storage);
+    remote_ctx = make_ctx(remote_storage);
+    tenant_factory = { create: vi.fn().mockResolvedValue(primary_ctx) };
+    manifests = make_manifest_repository();
+    validate_dek = make_dek_validator();
+    remote = make_storage_target('offsite', remote_ctx);
+    target_factory = vi.fn().mockReturnValue(remote) as unknown as StorageTargetFactory;
+    onedrive = make_onedrive_replication_mock();
+    sharepoint = make_sharepoint_replication_mock();
+    service = new ReplicationService(
+      tenant_factory,
+      manifests,
+      TEST_CONFIG,
+      validate_dek,
+      target_factory,
+      onedrive,
+      sharepoint,
+    );
+  });
+
+  it('replicate_tenant pushes every mailbox plus OneDrive and SharePoint', async () => {
+    const m1 = make_manifest('snap-1', 'mbx-1', [make_entry('a')]);
+    const m2 = make_manifest('snap-2', 'mbx-2', [make_entry('b')]);
+
+    vi.mocked(manifests.list_all_manifests).mockResolvedValue([m1, m2]);
+    vi.mocked(remote_storage.list).mockResolvedValue([]);
+    vi.mocked(primary_storage.get).mockResolvedValue(Buffer.from('data'));
+    vi.mocked(remote_storage.get).mockResolvedValue(Buffer.from('data'));
+    vi.mocked(onedrive.replicate_all_owners).mockResolvedValue([
+      make_workload_result('od-snap-1', 5, 500),
+    ]);
+    vi.mocked(sharepoint.replicate_all_sites).mockResolvedValue([
+      make_workload_result('sp-snap-1', 9, 900),
+      make_workload_result('sp-snap-2', 4, 400),
+    ]);
+
+    const result = await service.replicate_tenant('tenant-1', [remote]);
+
+    expect(onedrive.replicate_all_owners).toHaveBeenCalledWith('tenant-1', [remote]);
+    expect(sharepoint.replicate_all_sites).toHaveBeenCalledWith('tenant-1', [remote]);
+    const by_workload = new Map(result.workloads.map((w) => [w.workload, w.result]));
+    // Both mailboxes are enumerated from the manifest root, not just the first.
+    expect(by_workload.get('outlook')?.objects_copied).toBe(2);
+    expect(by_workload.get('onedrive')?.objects_copied).toBe(5);
+    expect(by_workload.get('sharepoint')?.objects_copied).toBe(13);
+    expect(result.total.objects_copied).toBe(20);
+    expect(result.total.status).toBe(ReplicationStatus.COMPLETED);
+  });
+
+  it('replicate_tenant reports every workload even when nothing is replicated', async () => {
+    vi.mocked(manifests.list_all_manifests).mockResolvedValue([]);
+
+    const result = await service.replicate_tenant('tenant-1', [remote]);
+
+    expect(result.workloads.map((w) => w.workload)).toEqual(['outlook', 'onedrive', 'sharepoint']);
+    expect(result.total.objects_copied).toBe(0);
+  });
+
+  it('rehydrate_tenant recovers Outlook, OneDrive, and SharePoint, not Outlook alone', async () => {
+    const m1 = make_manifest('snap-1', 'mbx-1', []);
+    const m2 = make_manifest('snap-2', 'mbx-2', []);
+
+    vi.mocked(manifests.list_all_manifests).mockImplementation(async (ctx) => {
+      if (ctx === remote_ctx) return [m1, m2];
+      return [];
+    });
+    vi.mocked(primary_storage.get).mockResolvedValue(Buffer.from('data'));
+    vi.mocked(remote_storage.get).mockResolvedValue(Buffer.from('data'));
+    vi.mocked(onedrive.rehydrate_all_owners).mockResolvedValue(
+      make_workload_result('2-owners', 7, 700),
+    );
+    vi.mocked(sharepoint.rehydrate_all_sites).mockResolvedValue(
+      make_workload_result('1-sites', 59, 5900),
+    );
+
+    const result = await service.rehydrate_tenant('tenant-1', remote);
+
+    expect(onedrive.rehydrate_all_owners).toHaveBeenCalledWith('tenant-1', remote);
+    expect(sharepoint.rehydrate_all_sites).toHaveBeenCalledWith('tenant-1', remote);
+    expect(result.workloads.map((w) => w.workload)).toEqual(['outlook', 'onedrive', 'sharepoint']);
+    expect(result.total.status).toBe(ReplicationStatus.COMPLETED);
+    const by_workload = new Map(result.workloads.map((w) => [w.workload, w.result]));
+    expect(by_workload.get('onedrive')?.objects_copied).toBe(7);
+    expect(by_workload.get('sharepoint')?.objects_copied).toBe(59);
+    expect(result.total.objects_copied).toBe(by_workload.get('outlook')!.objects_copied + 7 + 59);
+    expect(result.total.bytes_copied).toBe(by_workload.get('outlook')!.bytes_copied + 700 + 5900);
+  });
+
+  it('rehydrate_tenant reports a workload that failed without hiding it in the aggregate', async () => {
+    vi.mocked(manifests.list_all_manifests).mockResolvedValue([]);
+    vi.mocked(onedrive.rehydrate_all_owners).mockResolvedValue({
+      ...make_workload_result('1-owners', 0, 0),
+      status: ReplicationStatus.FAILED,
+      objects_failed: 3,
+      objects_total: 3,
+      errors: ['onedrive/data/owner/abc: access denied'],
+    });
+
+    const result = await service.rehydrate_tenant('tenant-1', remote);
+
+    expect(result.total.status).not.toBe(ReplicationStatus.COMPLETED);
+    expect(result.total.objects_failed).toBe(3);
+    expect(result.total.errors).toContain('onedrive/data/owner/abc: access denied');
+  });
+});

--- a/packages/core/tests/unit/services/replication/workload-tenant-scope.test.ts
+++ b/packages/core/tests/unit/services/replication/workload-tenant-scope.test.ts
@@ -101,7 +101,7 @@ function sp_manifest(site_id: string, snapshot_id: string): SharePointSnapshotMa
   } as unknown as SharePointSnapshotManifest;
 }
 
-describe('tenant-wide workload rehydration', () => {
+describe('tenant-wide workload replication and recovery', () => {
   let source_storage: ObjectStorage;
   let primary_storage: ObjectStorage;
   let source_ctx: TenantContext;
@@ -256,5 +256,57 @@ describe('tenant-wide workload rehydration', () => {
     expect(result.snapshot_id).toBe('2-sites');
     expect(result.objects_copied).toBe(60);
     expect(result.bytes_copied).toBe(6000);
+  });
+
+  it('replicate_all_owners pushes every owner, not just the first', async () => {
+    const manifests: OneDriveManifestRepository = {
+      save: vi.fn(),
+      find_by_snapshot: vi.fn(),
+      find_latest_by_owner: vi.fn(),
+      list_snapshots_by_owner: vi.fn().mockResolvedValue([]),
+      list_all_manifests: vi
+        .fn()
+        .mockResolvedValue([
+          od_manifest('owner-a', 'od-1'),
+          od_manifest('owner-b', 'od-2'),
+          od_manifest('owner-a', 'od-3'),
+        ]),
+    };
+    const service = new OneDriveReplicationService(
+      tenant_factory,
+      manifests,
+      CONFIG,
+      validate_dek,
+      target_factory,
+    );
+    const spy = vi.spyOn(service, 'replicate_all_owner_snapshots').mockResolvedValue([]);
+
+    await service.replicate_all_owners('tenant-1', [source]);
+
+    expect(spy.mock.calls.map((c) => c[1])).toEqual(['owner-a', 'owner-b']);
+  });
+
+  it('replicate_all_sites pushes every site, not just the first', async () => {
+    const manifests: SharePointManifestRepository = {
+      save: vi.fn(),
+      find_by_snapshot: vi.fn(),
+      find_latest_by_site: vi.fn(),
+      list_snapshots_by_site: vi.fn().mockResolvedValue([]),
+      list_all_manifests: vi
+        .fn()
+        .mockResolvedValue([sp_manifest('site-a', 'sp-1'), sp_manifest('site-b', 'sp-2')]),
+    };
+    const service = new SharePointReplicationService(
+      tenant_factory,
+      manifests,
+      CONFIG,
+      validate_dek,
+      target_factory,
+    );
+    const spy = vi.spyOn(service, 'replicate_all_site_snapshots').mockResolvedValue([]);
+
+    await service.replicate_all_sites('tenant-1', [source]);
+
+    expect(spy.mock.calls.map((c) => c[1])).toEqual(['site-a', 'site-b']);
   });
 });

--- a/packages/sdk/src/atlas-instance.adapter.ts
+++ b/packages/sdk/src/atlas-instance.adapter.ts
@@ -65,6 +65,9 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     async replicateMailbox(mailbox_id, targets) {
       return await replication.replicate_mailbox(tenant_id, mailbox_id, targets);
     },
+    async replicateTenant(targets) {
+      return await replication.replicate_tenant(tenant_id, targets);
+    },
     async rehydrateSnapshot(snapshot_id, source) {
       return await replication.rehydrate_snapshot(tenant_id, snapshot_id, source);
     },

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -9,9 +9,9 @@ export type { MailboxStatusResult, FolderStatus } from '@wisecom/atlas-types';
 export type {
   ReplicationResult,
   ReplicationStatusRecord,
-  TenantRehydrationResult,
-  WorkloadRehydrationResult,
-  RehydrationWorkload,
+  TenantReplicationResult,
+  WorkloadReplicationResult,
+  ReplicationWorkload,
 } from '@wisecom/atlas-types';
 export type { StorageTarget, StorageTargetConfig } from '@wisecom/atlas-types';
 export type { StorageTargetSdkConfig } from '@wisecom/atlas-s3';

--- a/packages/types/src/domain/index.ts
+++ b/packages/types/src/domain/index.ts
@@ -28,9 +28,9 @@ export type {
   ReplicationResult,
   ReplicationObjectResult,
   ReplicationStatusRecord,
-  RehydrationWorkload,
-  WorkloadRehydrationResult,
-  TenantRehydrationResult,
+  ReplicationWorkload,
+  WorkloadReplicationResult,
+  TenantReplicationResult,
 } from './replication';
 export { ReplicationStatus, ReplicationVerificationStatus } from './replication';
 export type {

--- a/packages/types/src/domain/replication.ts
+++ b/packages/types/src/domain/replication.ts
@@ -33,23 +33,23 @@ export interface ReplicationResult {
   readonly replicated_manifest_checksum?: string;
 }
 
-/** Workloads covered by full tenant recovery. */
-export type RehydrationWorkload = 'outlook' | 'onedrive' | 'sharepoint';
+/** Workloads covered by tenant-wide replication and recovery. */
+export type ReplicationWorkload = 'outlook' | 'onedrive' | 'sharepoint';
 
-export interface WorkloadRehydrationResult {
-  readonly workload: RehydrationWorkload;
+export interface WorkloadReplicationResult {
+  readonly workload: ReplicationWorkload;
   readonly result: ReplicationResult;
 }
 
 /**
- * Result of a full tenant recovery: one entry per workload plus their aggregate.
+ * Result of a tenant-wide replication or recovery: one entry per workload plus their aggregate.
  *
- * Every workload is always present, so a caller can tell "recovered nothing because the replica
- * held nothing" apart from "never looked".
+ * Every workload is always present, so a caller can tell "copied nothing because the source held
+ * nothing" apart from "never looked" -- the distinction that made a full-tenant run unauditable.
  */
-export interface TenantRehydrationResult {
+export interface TenantReplicationResult {
   readonly total: ReplicationResult;
-  readonly workloads: readonly WorkloadRehydrationResult[];
+  readonly workloads: readonly WorkloadReplicationResult[];
 }
 
 /** Durable sidecar record persisted at `_meta/replication/{owner_id}/{snapshot}/{target}.json`. */

--- a/packages/types/src/ports/atlas/use-case.port.ts
+++ b/packages/types/src/ports/atlas/use-case.port.ts
@@ -3,7 +3,7 @@ import type { BucketStats } from '@/domain/stats';
 import type {
   ReplicationResult,
   ReplicationStatusRecord,
-  TenantRehydrationResult,
+  TenantReplicationResult,
 } from '@/domain/replication';
 import type { StorageTarget } from '@/ports/replication/storage-target.port';
 import type { OutlookApi } from '@/ports/atlas/outlook-api.port';
@@ -34,10 +34,12 @@ export interface AtlasInstance {
   listUsers(): Promise<IdentityRegistry | undefined>;
   replicateSnapshot(snapshotId: string, targets: StorageTarget[]): Promise<ReplicationResult[]>;
   replicateMailbox(mailboxId: string, targets: StorageTarget[]): Promise<ReplicationResult[]>;
+  /** Replicates every unreplicated snapshot of every workload, reported per workload. */
+  replicateTenant(targets: StorageTarget[]): Promise<TenantReplicationResult>;
   rehydrateSnapshot(snapshotId: string, source: StorageTarget): Promise<ReplicationResult>;
   rehydrateMailbox(mailboxId: string, source: StorageTarget): Promise<ReplicationResult>;
   /** Full tenant recovery across Outlook, OneDrive, and SharePoint, reported per workload. */
-  rehydrateTenant(source: StorageTarget): Promise<TenantRehydrationResult>;
+  rehydrateTenant(source: StorageTarget): Promise<TenantReplicationResult>;
   getReplicationStatus(snapshotId?: string): Promise<ReplicationStatusRecord[]>;
   getReplicationStatusByMailbox(mailboxId: string): Promise<ReplicationStatusRecord[]>;
 }

--- a/packages/types/src/ports/replication/onedrive-replication.port.ts
+++ b/packages/types/src/ports/replication/onedrive-replication.port.ts
@@ -34,4 +34,7 @@ export interface OneDriveReplicationUseCase {
 
   /** DR: recover every OneDrive owner's snapshots from a replica. */
   rehydrate_all_owners(tenant_id: string, source: StorageTarget): Promise<ReplicationResult>;
+
+  /** Replicates every unreplicated OneDrive snapshot for every owner in the tenant. */
+  replicate_all_owners(tenant_id: string, targets: StorageTarget[]): Promise<ReplicationResult[]>;
 }

--- a/packages/types/src/ports/replication/sharepoint-replication.port.ts
+++ b/packages/types/src/ports/replication/sharepoint-replication.port.ts
@@ -34,4 +34,7 @@ export interface SharePointReplicationUseCase {
 
   /** DR: recover every SharePoint site's snapshots from a replica. */
   rehydrate_all_sites(tenant_id: string, source: StorageTarget): Promise<ReplicationResult>;
+
+  /** Replicates every unreplicated SharePoint snapshot for every site in the tenant. */
+  replicate_all_sites(tenant_id: string, targets: StorageTarget[]): Promise<ReplicationResult[]>;
 }

--- a/packages/types/src/ports/replication/use-case.port.ts
+++ b/packages/types/src/ports/replication/use-case.port.ts
@@ -1,7 +1,7 @@
 import type {
   ReplicationResult,
   ReplicationStatusRecord,
-  TenantRehydrationResult,
+  TenantReplicationResult,
 } from '@/domain/replication';
 import type { StorageTarget } from '@/ports/replication/storage-target.port';
 
@@ -19,6 +19,14 @@ export interface ReplicationUseCase {
     owner_id: string,
     targets: StorageTarget[],
   ): Promise<ReplicationResult[]>;
+
+  /**
+   * Replicates every unreplicated snapshot of every workload to one or more targets.
+   *
+   * Returns a per-workload breakdown, so "replicate everything" can be audited instead of
+   * reporting one aggregate that hides a workload nothing was copied for.
+   */
+  replicate_tenant(tenant_id: string, targets: StorageTarget[]): Promise<TenantReplicationResult>;
 
   /** DR: recover a specific snapshot from a designated replica to primary. */
   rehydrate_snapshot(
@@ -40,7 +48,7 @@ export interface ReplicationUseCase {
    * Returns a per-workload breakdown so an operator can audit what a "full tenant recovery"
    * actually restored instead of trusting a single aggregate status line.
    */
-  rehydrate_tenant(tenant_id: string, source: StorageTarget): Promise<TenantRehydrationResult>;
+  rehydrate_tenant(tenant_id: string, source: StorageTarget): Promise<TenantReplicationResult>;
 
   /** Queries durable replication status records, optionally filtered by snapshot. */
   get_replication_status(


### PR DESCRIPTION
Follow-up requested on #97. Refs #88 (proposed-fix item 4, which was outside that issue's acceptance criteria).

> **Stacked PR** — based on `fix/88-rehydrate-all-workloads` (#97), not on the release branch. Review #97 first; merging it retargets this diff automatically.

## Problem

`rehydrate` gained a tenant scope in #97, but `replicate` had none. "Push everything offsite" meant scripting one invocation per mailbox, per OneDrive owner, and per SharePoint site — and any scope the script forgot silently never left primary. That is the same class of gap as #88, just in the outbound direction.

## Changes

- **`replicate_tenant`** on `ReplicationUseCase`, plus **`replicate_all_owners` / `replicate_all_sites`** on the OneDrive and SharePoint ports. Each enumerates its own manifest root and delegates to the existing per-scope replication, so the target diff, ancillary-key handling, and status sidecars are unchanged code paths.
- **`replicate --all`** in the CLI, printing the same per-workload table as `rehydrate --all`; **`replicateTenant`** on the SDK returning that breakdown.
- **The "nothing found" warning is now recovery-only.** The live drill caught this: outbound, snapshots are diffed out against the target *before* any result object exists, so an up-to-date target legitimately reports `0 copied / 0 skipped`. The warning fired on every steady-state run — a nightly false alarm trains operators to ignore the one run that matters. Recovery counts a skip per manifest already on primary, so zero-and-zero there really does mean the replica held nothing, and the warning stays.
- **Type rename:** `TenantRehydrationResult` → `TenantReplicationResult`, `WorkloadRehydrationResult` → `WorkloadReplicationResult`, `RehydrationWorkload` → `ReplicationWorkload`. Both directions now return the shape, so the rehydration-specific names introduced in #97 would have been wrong here. Renamed in this stack rather than left as a duplicate type.
- **Extractions** to stay inside the 300-line rule: `tenant-scope-fanout.ts` (the per-scope fan-out repeated in all three services), `manifest-grouping.ts`, `outlook-snapshot-copier.ts`, `sharepoint-snapshot-copier.ts`, a shared CLI `tenant-workload-report.tsx` (the table was about to be duplicated across two commands), and `replication-fixtures.ts` with the tenant-scope tests split into their own file.

## Verification

Live against the Wisecom tenant, pushing the real primary to an empty replica:

```
$ atlas replicate --all --target-config fresh-replica.json
Workload    Scope       Copied  Skipped  Failed  Size
outlook     outlook     118     35       0       1.5 MB
onedrive    onedrive    12      1        0       2.7 MB
sharepoint  sharepoint  59      149      0       7.1 MB
Result: COMPLETED
189 copied | 185 skipped | 0 failed — 11.3 MB

$ atlas replicate --all --target-config fresh-replica.json   # second run
0 copied | 0 skipped | 0 failed — 0 B          (and no warning)
```

Round trip — the replica `replicate --all` produced is a usable DR source:

```
$ ATLAS_S3_ENDPOINT=<empty primary> atlas rehydrate --all --source-config fresh-replica.json
outlook     6-snapshots  118  35   0  1.5 MB
onedrive    1-owners     12   1    0  2.7 MB
sharepoint  1-sites      59   149  0  7.1 MB
189 copied | 185 skipped | 0 failed — 11.3 MB

stats: 2 mailboxes / 6 snapshots, 1 OneDrive owner / 6 files, 1 site / 4 snapshots / 88 files
onedrive verify:    [+] All 6 entries passed verification
sharepoint verify:  [+] All 29 entries passed verification
outlook verify:     [+] All 35 objects passed integrity check
```

Tests: `tenant-replication.service.test.ts` covers tenant-wide push (every mailbox enumerated, OneDrive and SharePoint dispatched, aggregate summed) and all-workloads-present-when-empty; `workload-tenant-scope.test.ts` adds per-owner/per-site enumeration for the outbound scopes; CLI tests cover `replicate --all` dispatch and assert the steady-state run stays silent. Full suite 918 tests, lint, typecheck, `docs:build` pass.

Docs: `cli.md`, `cli-recovery.md` (which was still missing `-o/--owner` for `replicate` from #96), `operations/replication.md`, `reference/sdk.md`.