### PR TITLE
fix(restore): classify GCM tag failures on the exact Node message

### DIFF
--- a/packages/core/src/utils/gcm-auth.ts
+++ b/packages/core/src/utils/gcm-auth.ts
@@ -1,0 +1,22 @@
+/**
+ * Classification of AES-256-GCM authentication-tag failures.
+ *
+ * Node reports a failed tag check from `decipher.final()` with the exact
+ * message below and no error code, so the message is the only signal available.
+ * Matching it exactly -- instead of any error mentioning "auth" -- keeps
+ * storage authorization/authentication failures out of the tampering bucket:
+ * an expired S3 credential must not be reported to an incident responder as a
+ * wrong key or modified ciphertext.
+ */
+
+/** Node's OpenSSL GCM tag-verification failure message. */
+const GCM_AUTH_FAILURE_MESSAGE = 'Unsupported state or unable to authenticate data';
+
+/** Returns whether an error (or any of its causes) is an AES-GCM authentication-tag failure. */
+export function is_gcm_auth_failure(err: unknown): boolean {
+  for (let current = err, depth = 0; current instanceof Error && depth < 5; depth++) {
+    if (current.message === GCM_AUTH_FAILURE_MESSAGE) return true;
+    current = current.cause;
+  }
+  return false;
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -16,3 +16,4 @@ export type { SecureStoreOptions, KeyringBackend } from './secure-config-store';
 export { CONFIG_KEYS, find_config_key, mask_secret } from './config-keys';
 export type { ConfigKeySpec } from './config-keys';
 export { html_to_text } from './html-to-text';
+export { is_gcm_auth_failure } from './gcm-auth';

--- a/packages/onedrive/src/services/onedrive-restore-integrity.ts
+++ b/packages/onedrive/src/services/onedrive-restore-integrity.ts
@@ -8,12 +8,6 @@ export class OneDriveDecryptAuthError extends Error {
   }
 }
 
-/** Returns whether an error represents an AES-GCM authentication failure. */
-export function is_gcm_auth_failure(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err);
-  return message.includes('Unsupported state') || message.toLowerCase().includes('auth');
-}
-
 /** Compares a plaintext buffer with its expected SHA-256 checksum. */
 export function plaintext_sha256_equals_expected(content: Buffer, expected_hex: string): boolean {
   const actual_hex = createHash('sha256').update(content).digest('hex');

--- a/packages/onedrive/src/services/onedrive-restore.service.ts
+++ b/packages/onedrive/src/services/onedrive-restore.service.ts
@@ -26,8 +26,8 @@ import {
   stream_decrypt_from_storage,
   verify_streaming_checksum,
 } from '@/services/onedrive-restore-streaming';
+import { is_gcm_auth_failure } from '@wisecom/atlas-core/utils/gcm-auth';
 import {
-  is_gcm_auth_failure,
   OneDriveDecryptAuthError,
   plaintext_sha256_equals_expected,
 } from '@/services/onedrive-restore-integrity';

--- a/packages/sharepoint/src/services/sharepoint-restore-content.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore-content.ts
@@ -13,6 +13,7 @@
 import { createHash, timingSafeEqual } from 'node:crypto';
 import type { SharePointManifestEntry, TenantContext } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { is_gcm_auth_failure } from '@wisecom/atlas-core/utils/gcm-auth';
 import {
   should_stream_restore,
   stream_decrypt_from_storage,
@@ -97,12 +98,6 @@ async function buffered_download_and_decrypt(
     );
     return undefined;
   }
-}
-
-function is_gcm_auth_failure(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  const lower = msg.toLowerCase();
-  return msg.includes('Unsupported state') || lower.includes('auth');
 }
 
 function plaintext_sha256_equals_expected(content: Buffer, expected_hex: string): boolean {

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-auth-classification.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-auth-classification.test.ts
@@ -1,0 +1,76 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type { SharePointManifestEntry, TenantContext } from '@wisecom/atlas-types';
+import {
+  download_and_decrypt,
+  SharePointDecryptAuthError,
+} from '@/services/sharepoint-restore-content';
+
+vi.mock('@wisecom/atlas-core/utils/logger', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const CONTENT = Buffer.from('quarterly-report');
+const DEK = randomBytes(32);
+
+/** Produces the stored envelope: [IV (12)] [auth tag (16)] [ciphertext]. */
+function encrypt(plaintext: Buffer): Buffer {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', DEK, iv, { authTagLength: 16 });
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return Buffer.concat([iv, cipher.getAuthTag(), ciphertext]);
+}
+
+function decrypt(blob: Buffer): Buffer {
+  const decipher = createDecipheriv('aes-256-gcm', DEK, blob.subarray(0, 12), {
+    authTagLength: 16,
+  });
+  decipher.setAuthTag(blob.subarray(12, 28));
+  return Buffer.concat([decipher.update(blob.subarray(28)), decipher.final()]);
+}
+
+const ENTRY: SharePointManifestEntry = {
+  file_id: 'file-1',
+  drive_id: 'drive-1',
+  file_name: 'report.docx',
+  parent_path: '/Documents',
+  size_bytes: CONTENT.length,
+  change_type: 'created',
+  backup_at: '2026-08-17T00:00:00.000Z',
+  storage_key: 'sharepoint/data/site-1/file-1',
+  checksum: createHash('sha256').update(CONTENT).digest('hex'),
+};
+
+function make_ctx(get: () => Promise<Buffer>): TenantContext {
+  return { storage: { get }, decrypt } as unknown as TenantContext;
+}
+
+describe('SharePoint restore error classification', () => {
+  it('reports a tampered blob as an AES-GCM authentication failure', async () => {
+    const blob = encrypt(CONTENT);
+    blob[blob.length - 1] ^= 0xff;
+    await expect(
+      download_and_decrypt(
+        make_ctx(async () => blob),
+        ENTRY,
+      ),
+    ).rejects.toThrow(SharePointDecryptAuthError);
+  });
+
+  it('reports a storage authorization failure as a storage error, not tampering', async () => {
+    const ctx = make_ctx(() =>
+      Promise.reject(new Error('AccessDenied: the request authorization has expired')),
+    );
+    await expect(download_and_decrypt(ctx, ENTRY)).resolves.toBeUndefined();
+  });
+
+  it('does not treat a decrypt-stage error mentioning auth as tampering', async () => {
+    const ctx = {
+      storage: { get: async () => encrypt(CONTENT) },
+      decrypt: () => {
+        throw new Error('Authentication token for the KMS proxy expired');
+      },
+    } as unknown as TenantContext;
+    await expect(download_and_decrypt(ctx, ENTRY)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #76.

## Problem

`is_gcm_auth_failure` matched any error whose message contained the substring `auth`, so an expired S3 credential surfaced as `AES-GCM authentication failed for report.docx` — a diagnosis that points an incident responder at key compromise or tampered ciphertext. Both restore paths carried their own copy of the helper (`packages/sharepoint/src/services/sharepoint-restore-content.ts`, `packages/onedrive/src/services/onedrive-restore-integrity.ts`).

## Change

- New shared classifier `packages/core/src/utils/gcm-auth.ts`, exported from core utils. It matches Node's exact tag-verification message (`Unsupported state or unable to authenticate data`) and walks the `cause` chain (bounded at 5) so a wrapped failure still classifies.
- Both SharePoint and OneDrive restore paths import it; the two local copies are deleted.
- Node gives no error `code` for a GCM tag failure (verified on v24: `code` is `undefined`, message exact), so the exact message is the only available signal — hence message equality rather than `ERR_OSSL_BAD_DECRYPT`.
- Storage errors now fall through to the generic handlers and are reported as what they are: `Missing or unreadable blob for …` (buffered) or `Streaming decrypt failed for …` (streaming).

## Verification

New `packages/sharepoint/tests/unit/services/sharepoint-restore-auth-classification.test.ts` (real AES-256-GCM, no crypto mocks):

- flipping a byte of a stored blob still raises `SharePointDecryptAuthError`;
- a storage `get` rejecting with `AccessDenied: the request authorization has expired` resolves to `undefined` instead of raising a tampering error;
- a decrypt-stage error mentioning `Authentication token …` is no longer misclassified.

```
core/sharepoint/onedrive: tsc --noEmit clean; 502 tests pass (33+19+14 files)
```

No docs reference the classifier (`grep 'AES-GCM authentication' docs README.md` → empty), so no docs change is due.

---

skipped: a typed error taxonomy for storage vs crypto failures (#40 covers it); add when the SDK error classes land.