### PR TITLE
fix(types): TenantBackupOptions accepts explicit undefined; gate CI on typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Typecheck
+        run: pnpm run typecheck
+
       - name: Lint
         run: pnpm run lint
 

--- a/packages/cli/src/commands/outlook-backup.handler.tsx
+++ b/packages/cli/src/commands/outlook-backup.handler.tsx
@@ -119,8 +119,8 @@ async function backup_all_mailboxes(
     concurrency,
     force_full: options.full ?? false,
     page_size,
-    ...(object_lock_request !== undefined && { object_lock_request }),
-    ...(object_lock_policy !== undefined && { object_lock_policy }),
+    object_lock_request,
+    object_lock_policy,
   });
 
   const mailbox_errors = result.outcomes

--- a/packages/types/src/ports/backup/orchestrator.port.ts
+++ b/packages/types/src/ports/backup/orchestrator.port.ts
@@ -2,15 +2,15 @@ import type { ObjectLockPolicy, ObjectLockRequest, SyncResult } from '@/ports/ba
 import type { TenantProgressReporter } from '@/ports/backup/tenant-progress.port';
 
 export interface TenantBackupOptions {
-  concurrency?: number;
-  force_full?: boolean;
-  page_size?: number;
+  concurrency?: number | undefined;
+  force_full?: boolean | undefined;
+  page_size?: number | undefined;
   /** Object Lock retention request applied to every mailbox in the run. */
-  object_lock_request?: ObjectLockRequest;
-  object_lock_policy?: ObjectLockPolicy;
-  progress?: TenantProgressReporter;
-  should_interrupt?: () => boolean;
-  should_force_stop?: () => boolean;
+  object_lock_request?: ObjectLockRequest | undefined;
+  object_lock_policy?: ObjectLockPolicy | undefined;
+  progress?: TenantProgressReporter | undefined;
+  should_interrupt?: (() => boolean) | undefined;
+  should_force_stop?: (() => boolean) | undefined;
 }
 
 export interface MailboxBackupOutcome {


### PR DESCRIPTION
Closes #83.

## State on arrival

The TS2379 error itself is gone: `packages/cli/src/commands/outlook-backup.handler.tsx` had since been worked around at the callsite with conditional spreads (`...(object_lock_request !== undefined && { object_lock_request })`). Both root causes named in the issue were still present:

1. `TenantBackupOptions` still declared its optional members without `| undefined`, unlike the three sibling ports (`ports/backup/use-case.port.ts`, `ports/onedrive/use-case.port.ts`, `ports/sharepoint/use-case.port.ts`).
2. CI still had no `typecheck` step, so the compiler was not a gate — the reason the original error reached the release branch and looked like a cache-triggered regression.

## Change

- `packages/types/src/ports/backup/orchestrator.port.ts`: every optional member takes `| undefined`, matching the siblings (`should_interrupt`/`should_force_stop` as `(() => boolean) | undefined`).
- `packages/cli/src/commands/outlook-backup.handler.tsx`: conditional spreads replaced by plain `object_lock_request` / `object_lock_policy` properties. Same runtime semantics — the orchestrator reads the property either way — with the workaround removed now that the type is honest.
- `.github/workflows/ci.yml`: `Typecheck` step (`pnpm run typecheck`) after `Build`, before `Lint`.

## Verification

Cache-bypassing run, so no stale replay:

```
$ pnpm exec turbo run typecheck --force
Tasks:    17 successful, 17 total   Cached: 0 cached, 17 total

$ pnpm exec turbo run test lint format:check
Tasks:    33 successful, 33 total
```

`pnpm run build` exits 0. No test added: the change is a type declaration plus a workflow step, and `tsc` — now a CI gate — is the check.

---

skipped: converting the interface to `readonly` members like its siblings; add when something actually mutates an options object.