### PR TITLE
fix(read-paths): browsing a tenant no longer creates its bucket or a DEK

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -182,6 +182,19 @@ Atlas writes a marker file (`_meta/replica.marker`) on each target during first 
 
 Replication status sidecar files stored under `_meta/replication/` in the primary bucket are encrypted with the tenant DEK. Target endpoints, checksums, and error messages are not exposed at rest in S3.
 
+## S3 Permissions by Command Class
+
+Atlas splits its storage access in two, so a browsing operator never needs write credentials:
+
+| Command class                                                                                                 | S3 actions required                                                                                        | Provisioning |
+| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------ |
+| Read-only: `outlook list`, `outlook read`, `outlook status`, `outlook verify`, `onedrive list`, `sharepoint list`, `stats`, `list-users` | `s3:GetObject`, `s3:ListBucket`                                                                             | None         |
+| Write: `backup`, `restore`, `save`, `replicate`, `rehydrate`, `delete`                                          | the above plus `s3:CreateBucket`, `s3:PutObject`, `s3:DeleteObject`, `s3:DeleteObjectVersion`, lifecycle/lock configuration | Yes          |
+
+Read-only commands load the tenant context without provisioning: the bucket is never created and a missing `_meta/dek.enc` is never generated. Browsing a tenant that has never been backed up — a mistyped `-t`, or a tenant id from another environment — fails with `No backups found for tenant <id>` instead of leaving behind a lifecycle-configured bucket containing nothing but key material. That matters for two reasons: a wrapped DEK written on a read path is an audit-log surprise in a compliance-facing product, and buckets born from typos are indistinguishable from real tenants when reviewing storage.
+
+Grant a monitoring or audit principal the read-only row only. If it holds `s3:CreateBucket`, that is a leftover from Atlas versions before 2.1.0-beta and can be revoked.
+
 ## Configuration File Security
 
 ### Filesystem Permission Check

--- a/docs/self-hosting/storage.md
+++ b/docs/self-hosting/storage.md
@@ -8,6 +8,8 @@ Atlas creates each tenant's bucket automatically on first backup (`atlas-{tenant
 
 New buckets also receive housekeeping lifecycle rules: incomplete multipart uploads are aborted after 7 days, orphaned delete markers are removed, and noncurrent object versions expire after 30 days (versioning means overwritten delta cursors and indexes leave stale versions behind; Atlas never reads them -- its file version history is stored as first-class objects, not S3 versions).
 
+Provisioning happens on write paths only. Read-only commands (`list`, `read`, `status`, `verify`, `stats`, `list-users`) never issue `CreateBucket` and never bootstrap a DEK -- they fail with `No backups found for tenant <id>` when the tenant has no stored key, so a mistyped `-t` cannot leave an empty billable bucket behind. See [Security](../security.md) for the per-command-class IAM split.
+
 Backends that reject `ObjectLockEnabledForBucket` get a plain bucket and a loud warning at creation time; immutability will not work there.
 
 Run `atlas storage-check` to see which class a tenant's bucket is: `lock-capable`, `versioned-only (legacy)`, or `unversioned (legacy)`.

--- a/packages/cli/src/commands/list-users.command.tsx
+++ b/packages/cli/src/commands/list-users.command.tsx
@@ -62,7 +62,7 @@ async function execute_list_users(container: Container, options: ListUsersOption
     IDENTITY_REGISTRY_REPOSITORY_TOKEN,
   );
 
-  const ctx = await ctx_factory.create(tenant_id);
+  const ctx = await ctx_factory.create_readonly(tenant_id);
   const registry = await registry_repo.load(ctx);
 
   if (!registry || registry.entries.length === 0) {

--- a/packages/core/src/services/catalog/catalog.service.ts
+++ b/packages/core/src/services/catalog/catalog.service.ts
@@ -18,7 +18,7 @@ export class CatalogService implements CatalogUseCase {
    * for summary stats (object count, size, last backup time).
    */
   async list_mailboxes(tenant_id: string): Promise<MailboxSummary[]> {
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const all = await this._manifests.list_all_manifests(ctx);
       const by_mailbox = group_by_mailbox(all);
@@ -31,7 +31,7 @@ export class CatalogService implements CatalogUseCase {
   /** Returns every manifest for a given mailbox owner, sorted newest-first. */
   async list_snapshots(tenant_id: string, owner_id: string): Promise<Manifest[]> {
     owner_id = normalize_owner_id(owner_id);
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const all = await this._manifests.list_all_manifests(ctx);
       return all
@@ -44,7 +44,7 @@ export class CatalogService implements CatalogUseCase {
 
   /** Loads and returns one manifest by snapshot ID. */
   async get_snapshot_detail(tenant_id: string, snapshot_id: string): Promise<Manifest | undefined> {
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       return await this._manifests.find_by_snapshot(ctx, snapshot_id);
     } finally {
@@ -65,7 +65,7 @@ export class CatalogService implements CatalogUseCase {
     snapshot_id: string,
     message_ref: string,
   ): Promise<ReadMessageResult | undefined> {
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, snapshot_id);
       if (!manifest) return undefined;

--- a/packages/core/src/services/stats/stats.service.ts
+++ b/packages/core/src/services/stats/stats.service.ts
@@ -66,7 +66,7 @@ export class StatsService implements StatsUseCase {
 
   /** Loads all manifests and computes bucket-wide statistics. */
   async get_bucket_stats(tenant_id: string): Promise<BucketStats> {
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const all = await this._manifests.list_all_manifests(ctx);
       return timed(() => aggregate_bucket_stats(tenant_id, all));
@@ -78,7 +78,7 @@ export class StatsService implements StatsUseCase {
   /** Loads manifests for a single mailbox and computes its statistics. */
   async get_mailbox_stats(tenant_id: string, owner_id: string): Promise<MailboxStats> {
     owner_id = normalize_owner_id(owner_id);
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const all = await this._manifests.list_all_manifests(ctx);
       const filtered = all.filter((m) => m.owner_id === owner_id);
@@ -90,7 +90,7 @@ export class StatsService implements StatsUseCase {
 
   /** Loads OneDrive manifests (all owners or one) and computes drive statistics. */
   async get_onedrive_stats(tenant_id: string, owner_id?: string): Promise<DriveStats> {
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const manifests = owner_id
         ? await this._od_manifests.list_snapshots_by_owner(ctx, owner_id)
@@ -104,7 +104,7 @@ export class StatsService implements StatsUseCase {
 
   /** Loads SharePoint manifests (all sites or one) and computes drive statistics. */
   async get_sharepoint_stats(tenant_id: string, site_id?: string): Promise<DriveStats> {
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const manifests = site_id
         ? await this._sp_manifests.list_snapshots_by_site(ctx, site_id)

--- a/packages/core/src/services/verification/verification.service.ts
+++ b/packages/core/src/services/verification/verification.service.ts
@@ -62,7 +62,7 @@ export class VerificationService implements VerificationUseCase {
         manifests_in_chain: 0,
       };
     }
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const chain = await this.load_manifest_chain(ctx, snapshot_id);
       const entries = merge_snapshot_entries(chain);

--- a/packages/core/tests/unit/adapters/identity/caching-identity-resolver.test.ts
+++ b/packages/core/tests/unit/adapters/identity/caching-identity-resolver.test.ts
@@ -29,6 +29,7 @@ function make_registry_repo(initial_registry?: IdentityRegistry): IdentityRegist
 function make_ctx_factory(): TenantContextFactory {
   return {
     create: vi.fn().mockResolvedValue({ destroy: vi.fn() } as TenantContext),
+    create_readonly: vi.fn().mockResolvedValue({ destroy: vi.fn() } as TenantContext),
   };
 }
 

--- a/packages/core/tests/unit/services/catalog.service.test.ts
+++ b/packages/core/tests/unit/services/catalog.service.test.ts
@@ -83,6 +83,7 @@ describe('CatalogService', () => {
 
     const mock_factory: TenantContextFactory = {
       create: vi.fn().mockResolvedValue(mock_context),
+      create_readonly: vi.fn().mockResolvedValue(mock_context),
     };
 
     container = new Container();

--- a/packages/core/tests/unit/services/deletion/deletion.service.test.ts
+++ b/packages/core/tests/unit/services/deletion/deletion.service.test.ts
@@ -84,6 +84,7 @@ describe('DeletionService', () => {
 
     mock_factory = {
       create: vi.fn().mockResolvedValue(mock_context),
+      create_readonly: vi.fn().mockResolvedValue(mock_context),
       create_storage_only: vi.fn().mockResolvedValue({
         tenant_id: mock_context.tenant_id,
         storage: mock_context.storage,

--- a/packages/core/tests/unit/services/deletion/identifier-case.test.ts
+++ b/packages/core/tests/unit/services/deletion/identifier-case.test.ts
@@ -39,6 +39,7 @@ describe('deletion prefixes ignore identifier case', () => {
     storage = make_storage();
     const factory = {
       create: vi.fn(),
+      create_readonly: vi.fn(),
       create_storage_only: vi.fn().mockResolvedValue({ storage }),
     } as unknown as TenantContextFactory;
 

--- a/packages/core/tests/unit/services/deletion/workload-deletion.test.ts
+++ b/packages/core/tests/unit/services/deletion/workload-deletion.test.ts
@@ -32,6 +32,7 @@ describe('workload deletion', () => {
     storage = make_storage();
     factory = {
       create: vi.fn(),
+      create_readonly: vi.fn(),
       create_storage_only: vi.fn().mockResolvedValue({ tenant_id: 't', storage }),
     };
 

--- a/packages/core/tests/unit/services/mailbox-sync-object-lock.test.ts
+++ b/packages/core/tests/unit/services/mailbox-sync-object-lock.test.ts
@@ -90,6 +90,7 @@ describe('MailboxSyncService object lock', () => {
 
     const factory: TenantContextFactory = {
       create: vi.fn().mockResolvedValue(mock_context),
+      create_readonly: vi.fn().mockResolvedValue(mock_context),
     };
 
     const container = new Container();

--- a/packages/core/tests/unit/services/stats/stats.service.test.ts
+++ b/packages/core/tests/unit/services/stats/stats.service.test.ts
@@ -99,6 +99,7 @@ describe('StatsService', () => {
 
     const mock_factory: TenantContextFactory = {
       create: vi.fn().mockResolvedValue(mock_context),
+      create_readonly: vi.fn().mockResolvedValue(mock_context),
     };
 
     const container = new Container();

--- a/packages/core/tests/unit/services/verification.service.test.ts
+++ b/packages/core/tests/unit/services/verification.service.test.ts
@@ -77,6 +77,7 @@ describe('VerificationService', () => {
 
     tenant_factory = {
       create: vi.fn().mockResolvedValue(context),
+      create_readonly: vi.fn().mockResolvedValue(context),
     };
 
     manifests = {

--- a/packages/onedrive/src/services/onedrive-catalog.service.ts
+++ b/packages/onedrive/src/services/onedrive-catalog.service.ts
@@ -32,7 +32,7 @@ export class OneDriveCatalogService implements OneDriveCatalogUseCase {
     owner_id: string,
   ): Promise<OneDriveSnapshotManifest[]> {
     owner_id = normalize_owner_id(owner_id);
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       return this._manifests.list_snapshots_by_owner(ctx, owner_id);
     } finally {
@@ -47,7 +47,7 @@ export class OneDriveCatalogService implements OneDriveCatalogUseCase {
     file_ref: string,
   ): Promise<OneDriveFileVersionRecord[]> {
     owner_id = normalize_owner_id(owner_id);
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const file_id = await this.resolve_file_id(ctx, owner_id, file_ref);
       if (!file_id) return [];

--- a/packages/onedrive/src/services/onedrive-verification.service.ts
+++ b/packages/onedrive/src/services/onedrive-verification.service.ts
@@ -54,7 +54,7 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
         interrupted: true,
       };
     }
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, snapshot_id);
       if (!manifest) {

--- a/packages/onedrive/src/services/status/onedrive-status.service.ts
+++ b/packages/onedrive/src/services/status/onedrive-status.service.ts
@@ -33,7 +33,7 @@ export class OneDriveStatusService implements OneDriveStatusUseCase {
   async check_onedrive_status(tenant_id: string, owner_id: string): Promise<OneDriveStatusResult> {
     owner_id = normalize_owner_id(owner_id);
 
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const saved_cursor = await this._cursors.load(ctx, owner_id);
       const saved_links = saved_cursor?.delta_link_by_drive ?? {};

--- a/packages/onedrive/tests/unit/services/onedrive-backup-retention.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-backup-retention.test.ts
@@ -18,6 +18,7 @@ function make_harness(): {
   } as unknown as TenantContext;
   const factory: TenantContextFactory = {
     create: vi.fn().mockResolvedValue(context),
+    create_readonly: vi.fn().mockResolvedValue(context),
     create_storage_only: vi.fn(),
   };
   const connector = { list_drives: vi.fn().mockResolvedValue([]) };

--- a/packages/onedrive/tests/unit/services/onedrive-backup-version-failures.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-backup-version-failures.test.ts
@@ -36,6 +36,7 @@ function run_backup(version_error: unknown): Promise<OneDriveBackupResult> {
   } as unknown as TenantContext;
   const factory: TenantContextFactory = {
     create: vi.fn().mockResolvedValue(context),
+    create_readonly: vi.fn().mockResolvedValue(context),
     create_storage_only: vi.fn(),
   };
   const connector = {

--- a/packages/onedrive/tests/unit/services/onedrive-failed-item-ledger.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-failed-item-ledger.test.ts
@@ -117,6 +117,7 @@ function make_harness(options: {
 
   const factory: TenantContextFactory = {
     create: vi.fn().mockResolvedValue(context),
+    create_readonly: vi.fn().mockResolvedValue(context),
     create_storage_only: vi.fn(),
   };
 

--- a/packages/onedrive/tests/unit/services/onedrive-package-accounting.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-package-accounting.test.ts
@@ -54,6 +54,7 @@ function run_backup(
   } as unknown as TenantContext;
   const factory: TenantContextFactory = {
     create: vi.fn().mockResolvedValue(context),
+    create_readonly: vi.fn().mockResolvedValue(context),
     create_storage_only: vi.fn(),
   };
   const connector = {

--- a/packages/onedrive/tests/unit/services/onedrive-save.service.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-save.service.test.ts
@@ -88,6 +88,7 @@ describe('OneDriveSaveService', () => {
 
     const mock_factory: TenantContextFactory = {
       create: vi.fn().mockResolvedValue(mock_context),
+      create_readonly: vi.fn().mockResolvedValue(mock_context),
     };
 
     mock_manifests = {

--- a/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
+++ b/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
@@ -122,6 +122,7 @@ describe('OneDrive operation cancellation', () => {
     const context = make_context(storage);
     const factory = {
       create: vi.fn().mockResolvedValue(context),
+      create_readonly: vi.fn().mockResolvedValue(context),
     } as unknown as TenantContextFactory;
     const connector = {
       list_drives: vi.fn().mockResolvedValue([{ drive_id: 'drive-1', drive_name: 'Documents' }]),
@@ -163,6 +164,7 @@ describe('OneDrive operation cancellation', () => {
     const context = make_context(storage);
     const factory = {
       create: vi.fn().mockResolvedValue(context),
+      create_readonly: vi.fn().mockResolvedValue(context),
     } as unknown as TenantContextFactory;
     const indexes = { find_by_file_id: vi.fn() } as unknown as OneDriveFileVersionIndexRepository;
     const on_progress = vi.fn();

--- a/packages/outlook/src/services/status/mailbox-status.service.ts
+++ b/packages/outlook/src/services/status/mailbox-status.service.ts
@@ -25,7 +25,7 @@ export class MailboxStatusService implements StatusUseCase {
     owner_id = normalize_owner_id(owner_id);
     await assert_mailbox_exists(this._connector, tenant_id, owner_id);
 
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const previous = await this._manifests.find_latest_by_owner(ctx, owner_id);
       const saved_links = previous?.delta_links ?? {};

--- a/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
@@ -133,6 +133,7 @@ describe('interrupt delta-link safeguard (issue #23)', () => {
     };
     const factory: TenantContextFactory = {
       create: vi.fn().mockResolvedValue(context),
+      create_readonly: vi.fn().mockResolvedValue(context),
       create_storage_only: vi.fn(),
     };
     manifests = {

--- a/packages/outlook/tests/unit/mailbox-status.service.test.ts
+++ b/packages/outlook/tests/unit/mailbox-status.service.test.ts
@@ -94,6 +94,7 @@ describe('MailboxStatusService', () => {
 
     const mock_factory: TenantContextFactory = {
       create: vi.fn().mockResolvedValue(mock_context),
+      create_readonly: vi.fn().mockResolvedValue(mock_context),
     };
 
     const container = new Container();

--- a/packages/outlook/tests/unit/mailbox-sync-nested-folders.test.ts
+++ b/packages/outlook/tests/unit/mailbox-sync-nested-folders.test.ts
@@ -75,6 +75,7 @@ describe('MailboxSyncService - nested folders', () => {
     };
     const mock_factory = {
       create: vi.fn().mockResolvedValue(make_mock_context()),
+      create_readonly: vi.fn().mockResolvedValue(make_mock_context()),
     } as unknown as TenantContextFactory;
 
     const container = new Container();

--- a/packages/outlook/tests/unit/mailbox-sync-test-fixtures.ts
+++ b/packages/outlook/tests/unit/mailbox-sync-test-fixtures.ts
@@ -104,6 +104,7 @@ export function create_mailbox_sync_harness(): MailboxSyncHarness {
 
   const mock_factory: TenantContextFactory = {
     create: vi.fn().mockResolvedValue(mock_context),
+    create_readonly: vi.fn().mockResolvedValue(mock_context),
   };
 
   const container = new Container();

--- a/packages/outlook/tests/unit/mailbox-sync.service.test.ts
+++ b/packages/outlook/tests/unit/mailbox-sync.service.test.ts
@@ -112,6 +112,7 @@ describe('MailboxSyncService', () => {
 
     mock_factory = {
       create: vi.fn().mockResolvedValue(mock_context),
+      create_readonly: vi.fn().mockResolvedValue(mock_context),
     };
 
     container = new Container();

--- a/packages/outlook/tests/unit/restore.service.test.ts
+++ b/packages/outlook/tests/unit/restore.service.test.ts
@@ -93,6 +93,7 @@ describe('RestoreService', () => {
     container = new Container();
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue({
       create: vi.fn().mockResolvedValue(mock_context),
+      create_readonly: vi.fn().mockResolvedValue(mock_context),
     } as unknown as TenantContextFactory);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);

--- a/packages/outlook/tests/unit/save.service.test.ts
+++ b/packages/outlook/tests/unit/save.service.test.ts
@@ -79,6 +79,7 @@ describe('SaveService', () => {
 
     const mock_factory: TenantContextFactory = {
       create: vi.fn().mockResolvedValue(mock_context),
+      create_readonly: vi.fn().mockResolvedValue(mock_context),
     };
 
     mock_manifests = {

--- a/packages/s3/src/adapters/tenant-context.factory.ts
+++ b/packages/s3/src/adapters/tenant-context.factory.ts
@@ -38,16 +38,35 @@ export class DefaultTenantContextFactory implements TenantContextFactory {
     const key_service = new EnvelopeKeyService(this._config.encryption_passphrase);
     const dek = await this.load_or_create_dek(storage, key_service, tenant_id);
 
-    return {
+    return build_context(tenant_id, storage, key_service, dek);
+  }
+
+  /**
+   * Loads a tenant context without provisioning: the bucket is never created
+   * and a missing DEK is never generated, so browsing an unknown tenant (a
+   * mistyped `-t`) cannot leave a lifecycle-configured bucket and wrapped key
+   * material behind, and read-only credentials need no `s3:CreateBucket` or
+   * `_meta/` write permission (issue #93).
+   */
+  async create_readonly(tenant_id: string): Promise<TenantContext> {
+    const storage = new S3ObjectStorage(this._s3, tenant_bucket_name(tenant_id));
+    const key_service = new EnvelopeKeyService(this._config.encryption_passphrase);
+
+    let wrapped: Buffer;
+    try {
+      wrapped = await storage.get(DEK_META_KEY);
+    } catch (err) {
+      key_service.destroy();
+      if (is_absent(err)) throw new Error(`No backups found for tenant ${tenant_id}`);
+      throw err;
+    }
+
+    return build_context(
       tenant_id,
       storage,
-      encrypt: (data: Buffer): Buffer => key_service.encrypt(data, dek),
-      decrypt: (data: Buffer): Buffer => key_service.decrypt(data, dek),
-      create_cipher: () => key_service.create_encrypt_cipher(dek),
-      create_decipher: (iv: Buffer, auth_tag: Buffer) =>
-        key_service.create_decrypt_decipher(dek, iv, auth_tag),
-      destroy: (): void => key_service.destroy(),
-    };
+      key_service,
+      key_service.unwrap_dek(wrapped, tenant_id),
+    );
   }
 
   /** Loads an existing DEK or creates one with a race-safe conditional write. */
@@ -101,4 +120,29 @@ export class DefaultTenantContextFactory implements TenantContextFactory {
     }
     return stored_dek;
   }
+}
+
+/** Binds storage and DEK-backed crypto operations into a tenant context. */
+function build_context(
+  tenant_id: string,
+  storage: S3ObjectStorage,
+  key_service: EnvelopeKeyService,
+  dek: Buffer,
+): TenantContext {
+  return {
+    tenant_id,
+    storage,
+    encrypt: (data: Buffer): Buffer => key_service.encrypt(data, dek),
+    decrypt: (data: Buffer): Buffer => key_service.decrypt(data, dek),
+    create_cipher: () => key_service.create_encrypt_cipher(dek),
+    create_decipher: (iv: Buffer, auth_tag: Buffer) =>
+      key_service.create_decrypt_decipher(dek, iv, auth_tag),
+    destroy: (): void => key_service.destroy(),
+  };
+}
+
+/** Returns whether a storage error means "no such object or bucket" rather than a real failure. */
+function is_absent(err: unknown): boolean {
+  const name = (err as { name?: string } | null)?.name;
+  return name === 'NoSuchKey' || name === 'NoSuchBucket' || name === 'NotFound';
 }

--- a/packages/s3/tests/unit/tenant-context-readonly.test.ts
+++ b/packages/s3/tests/unit/tenant-context-readonly.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DefaultTenantContextFactory } from '@/adapters/tenant-context.factory';
+import { reset_bucket_cache } from '@/adapters/s3-bucket-manager';
+import { EnvelopeKeyService } from '@wisecom/atlas-core';
+import type { AtlasConfig } from '@wisecom/atlas-core';
+
+// Regression tests for issue #93: browsing a tenant must not provision it.
+// A read-only context issues no CreateBucket and no PutObject, so a mistyped
+// -t leaves no bucket and no key material behind, and read-only credentials
+// need neither s3:CreateBucket nor write access to _meta/.
+
+const TENANT_ID = '11111111-2222-3333-4444-555555555555';
+const CONFIG = { encryption_passphrase: 'unit-test-passphrase-long' } as AtlasConfig;
+
+interface CommandLike {
+  input: { Key?: string; Bucket?: string };
+}
+
+function make_s3(objects: Map<string, Buffer>) {
+  const send = vi.fn(async (cmd: CommandLike) => {
+    const name = cmd.constructor.name;
+    const key = cmd.input.Key ?? '';
+
+    if (name === 'GetObjectCommand') {
+      const data = objects.get(key);
+      if (!data) {
+        throw Object.assign(new Error('NoSuchKey'), {
+          name: 'NoSuchKey',
+          $metadata: { httpStatusCode: 404 },
+        });
+      }
+      return { Body: { transformToByteArray: async () => new Uint8Array(data) } };
+    }
+    throw new Error(`Unexpected command in read-only path: ${name}`);
+  });
+
+  return { send };
+}
+
+function stored_dek(): { objects: Map<string, Buffer>; plaintext: Buffer } {
+  const key_service = new EnvelopeKeyService(CONFIG.encryption_passphrase);
+  const dek = key_service.generate_dek();
+  const objects = new Map([['_meta/dek.enc', key_service.wrap_dek(dek, TENANT_ID)]]);
+  key_service.destroy();
+  return { objects, plaintext: dek };
+}
+
+describe('read-only tenant context (issue #93)', () => {
+  beforeEach(() => {
+    reset_bucket_cache();
+  });
+
+  it('loads an existing tenant without CreateBucket, HeadBucket, or PutObject', async () => {
+    const { objects } = stored_dek();
+    const s3 = make_s3(objects);
+    const ctx = await new DefaultTenantContextFactory(s3 as never, CONFIG).create_readonly(
+      TENANT_ID,
+    );
+
+    const commands = s3.send.mock.calls.map(([cmd]) => cmd.constructor.name);
+    expect(commands).toEqual(['GetObjectCommand']);
+    ctx.destroy();
+  });
+
+  it('decrypts data encrypted with the tenant DEK', async () => {
+    const { objects } = stored_dek();
+    const factory = new DefaultTenantContextFactory(make_s3(objects) as never, CONFIG);
+    const ctx = await factory.create_readonly(TENANT_ID);
+
+    expect(ctx.decrypt(ctx.encrypt(Buffer.from('payload'))).toString()).toBe('payload');
+    ctx.destroy();
+  });
+
+  it('reports that no backups exist instead of generating a DEK', async () => {
+    const s3 = make_s3(new Map());
+    const factory = new DefaultTenantContextFactory(s3 as never, CONFIG);
+
+    await expect(factory.create_readonly(TENANT_ID)).rejects.toThrow(
+      `No backups found for tenant ${TENANT_ID}`,
+    );
+    const commands = s3.send.mock.calls.map(([cmd]) => cmd.constructor.name);
+    expect(commands).toEqual(['GetObjectCommand']);
+  });
+
+  it('reports that no backups exist when the bucket itself is absent', async () => {
+    const s3 = {
+      send: vi.fn(async () => {
+        throw Object.assign(new Error('NoSuchBucket'), {
+          name: 'NoSuchBucket',
+          $metadata: { httpStatusCode: 404 },
+        });
+      }),
+    };
+    const factory = new DefaultTenantContextFactory(s3 as never, CONFIG);
+
+    await expect(factory.create_readonly(TENANT_ID)).rejects.toThrow(
+      `No backups found for tenant ${TENANT_ID}`,
+    );
+  });
+
+  it('surfaces a credential failure as itself, not as "no backups"', async () => {
+    const s3 = {
+      send: vi.fn(async () => {
+        throw Object.assign(new Error('The request signature we calculated does not match'), {
+          name: 'SignatureDoesNotMatch',
+          $metadata: { httpStatusCode: 403 },
+        });
+      }),
+    };
+    const factory = new DefaultTenantContextFactory(s3 as never, CONFIG);
+
+    await expect(factory.create_readonly(TENANT_ID)).rejects.toThrow('signature');
+  });
+});

--- a/packages/sharepoint/src/services/sharepoint-catalog.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-catalog.service.ts
@@ -32,7 +32,7 @@ export class SharePointCatalogService implements SharePointCatalogUseCase {
     site_id: string,
   ): Promise<SharePointSnapshotManifest[]> {
     site_id = normalize_owner_id(site_id);
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       return await this._manifests.list_snapshots_by_site(ctx, site_id);
     } finally {
@@ -47,7 +47,7 @@ export class SharePointCatalogService implements SharePointCatalogUseCase {
     file_ref: string,
   ): Promise<SharePointFileVersionRecord[]> {
     site_id = normalize_owner_id(site_id);
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const file_id = await this.resolve_file_id(ctx, site_id, file_ref);
       if (!file_id) return [];

--- a/packages/sharepoint/src/services/sharepoint-verification.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-verification.service.ts
@@ -54,7 +54,7 @@ export class SharePointVerificationService implements SharePointVerificationUseC
         interrupted: true,
       };
     }
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const manifest = await this._manifests.find_by_snapshot(ctx, site_id, snapshot_id);
       if (!manifest) {

--- a/packages/sharepoint/src/services/status/sharepoint-status.service.ts
+++ b/packages/sharepoint/src/services/status/sharepoint-status.service.ts
@@ -35,7 +35,7 @@ export class SharePointStatusService implements SharePointStatusUseCase {
     site_id: string,
   ): Promise<SharePointStatusResult> {
     site_id = normalize_owner_id(site_id);
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const previous_cursor = await this._cursors.load(ctx, site_id);
       const saved_links = previous_cursor?.delta_link_by_drive ?? {};

--- a/packages/sharepoint/tests/unit/services/sharepoint-backup-retention.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-backup-retention.test.ts
@@ -18,6 +18,7 @@ function make_harness(): {
   } as unknown as TenantContext;
   const factory: TenantContextFactory = {
     create: vi.fn().mockResolvedValue(context),
+    create_readonly: vi.fn().mockResolvedValue(context),
     create_storage_only: vi.fn(),
   };
   const connector = { list_document_libraries: vi.fn().mockResolvedValue([]) };

--- a/packages/sharepoint/tests/unit/services/sharepoint-catalog.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-catalog.service.test.ts
@@ -59,6 +59,7 @@ function make_index(
 function create_mocks() {
   const tenant_factory: TenantContextFactory = {
     create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
   };
 
   const manifests: SharePointManifestRepository = {
@@ -95,7 +96,7 @@ describe('SharePointCatalogService', () => {
       const result = await service.list_sharepoint_snapshots(TENANT_ID, SITE_ID);
 
       expect(result).toEqual([]);
-      expect(mocks.tenant_factory.create).toHaveBeenCalledWith(TENANT_ID);
+      expect(mocks.tenant_factory.create_readonly).toHaveBeenCalledWith(TENANT_ID);
       expect(mocks.manifests.list_snapshots_by_site).toHaveBeenCalledWith(ctx, SITE_ID);
     });
 

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-cancellation.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-cancellation.test.ts
@@ -91,6 +91,7 @@ describe('SharePoint restore cancellation', () => {
     } as unknown as TenantContext;
     const factory = {
       create: vi.fn().mockResolvedValue(context),
+      create_readonly: vi.fn().mockResolvedValue(context),
     } as unknown as TenantContextFactory;
     const connector = {
       create_folder: vi.fn().mockResolvedValue('folder-id'),

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-cross-site.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-cross-site.test.ts
@@ -60,6 +60,7 @@ describe('SharePointRestoreService cross-site routing', () => {
 
     const factory: TenantContextFactory = {
       create: vi.fn().mockResolvedValue(ctx),
+      create_readonly: vi.fn().mockResolvedValue(ctx),
       create_storage_only: vi.fn(),
     };
 

--- a/packages/sharepoint/tests/unit/services/sharepoint-save.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-save.service.test.ts
@@ -88,6 +88,7 @@ describe('SharePointSaveService', () => {
 
     const mock_factory: TenantContextFactory = {
       create: vi.fn().mockResolvedValue(mock_context),
+      create_readonly: vi.fn().mockResolvedValue(mock_context),
     };
 
     mock_manifests = {

--- a/packages/sharepoint/tests/unit/services/sharepoint-verification.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-verification.service.test.ts
@@ -89,6 +89,7 @@ function create_mocks() {
 
   const tenant_factory: TenantContextFactory = {
     create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
   };
 
   const manifests: SharePointManifestRepository = {

--- a/packages/types/src/ports/tenant/context.port.ts
+++ b/packages/types/src/ports/tenant/context.port.ts
@@ -37,6 +37,16 @@ export interface TenantContextFactory {
   create(tenant_id: string): Promise<TenantContext>;
 
   /**
+   * Loads an existing tenant context without provisioning anything: no
+   * CreateBucket, no DEK generation. Read-only paths (catalog listings, stats,
+   * identity registry dumps) MUST use this so a mistyped tenant id cannot
+   * leave a bucket and key material behind, and so read-only credentials need
+   * neither `s3:CreateBucket` nor write access to `_meta/`.
+   * Rejects when the tenant has no stored DEK.
+   */
+  create_readonly(tenant_id: string): Promise<TenantContext>;
+
+  /**
    * Ensures the tenant bucket exists and returns raw storage only (no DEK load).
    * Use for operations that delete or list ciphertext by key without decrypting,
    * e.g. `atlas delete --purge` when `_meta/dek.enc` is missing or unreadable.


### PR DESCRIPTION
Closes #93.

## Change

`TenantContextFactory` gains `create_readonly(tenant_id)` (`packages/s3/src/adapters/tenant-context.factory.ts`): it resolves the bucket name, loads the stored DEK, and issues **nothing else** — a single `GetObject` on `_meta/dek.enc`. No `HeadBucket`, no `CreateBucket`, no lifecycle config, no DEK write. A missing key or missing bucket becomes `No backups found for tenant <id>`; any other storage error (expired credentials, network) still surfaces as itself, so "no backups" never masks a misconfiguration.

Both paths now share one `build_context()` helper, so read-only and provisioning contexts cannot drift in their crypto bindings.

### Repointed to `create_readonly`

Every service that only reads stored manifests/blobs — verified with `grep` that none of them call `storage.put`:

- `core/services/catalog/catalog.service.ts` (4 sites, backing `atlas outlook list` / `read`)
- `core/services/stats/stats.service.ts` (4 sites, all `atlas stats` aggregations)
- `core/services/verification/verification.service.ts`, `onedrive-verification.service.ts`, `sharepoint-verification.service.ts`
- `onedrive-catalog.service.ts`, `sharepoint-catalog.service.ts`
- `outlook/status/mailbox-status.service.ts`, `onedrive-status.service.ts`, `sharepoint-status.service.ts`
- `cli/commands/list-users.command.tsx`

Status and verification are not named in the issue but are the same bug on the same shared factory: `atlas outlook status` against a typo provisioned too. Backup, restore, save, replicate, rehydrate, and delete keep `create()` / `create_storage_only()`.

## Verification

**E2E against MinIO** (`localhost:9000`), one real tenant present:

```
$ atlas stats -t 99999999-aaaa-bbbb-cccc-999999999999
[x] No backups found for tenant 99999999-aaaa-bbbb-cccc-999999999999   # exit 1
$ # bucket list unchanged: no atlas-99999999-... created

$ atlas outlook list -t 00000000-…   # existing tenant, unchanged
[*] 2 backed-up mailbox(es)
john.doe@example.com     user  6  1849   378.2 MB  2026-07-15
jane.roe@example.com     user  5  24550  2.0 GB    2026-07-15
```

`atlas stats -t 00000000-…` also renders normally, so the existing-tenant path still loads its DEK.

**Unit** — new `packages/s3/tests/unit/tenant-context-readonly.test.ts` (5 tests): asserts the command list issued by a read-only context is exactly `['GetObjectCommand']` (stronger and more deterministic than running with a credential that lacks `s3:CreateBucket` — an S3 call that is never made cannot be denied), that encrypt/decrypt round-trips with the loaded DEK, that missing key and missing bucket both report "no backups", and that a `SignatureDoesNotMatch` error is not swallowed into that message.

```
$ pnpm exec turbo run typecheck test lint format:check
Tasks:    43 successful, 43 total
```

Existing tenant-factory fakes across 27 test files gained a `create_readonly` entry mirroring `create`; the SharePoint catalog assertion now checks `create_readonly`.

## Docs

- `docs/security.md`: new **S3 Permissions by Command Class** section — read-only commands need only `s3:GetObject` + `s3:ListBucket`; write commands add `CreateBucket`/`PutObject`/delete/lock actions. States that `s3:CreateBucket` on an audit principal is now revocable.
- `docs/self-hosting/storage.md`: provisioning happens on write paths only.
- `pnpm run docs:build` exits 0 with no warnings.

---

### On the issue's closing note

Confirmed: no code in the tree creates `copyprobe-*` / `lock-probe-*` buckets (`grep` finds no such literal or template anywhere), and `packages/s3` has no bucket-deletion path, so those leftovers must be removed manually. Not folded into this PR.

skipped: a typed `TenantNotProvisionedError`; the message is what the operator sees and no caller branches on the type.
