### PR TITLE
fix(cli): replicate/rehydrate --site accept a site URL

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -370,6 +370,8 @@ Unlike Outlook (which stamps a per-object `retain_until` on each write), OneDriv
 
 Identifiers are matched case-insensitively: `--owner`, `--site`, and `--file-filter` all accept whatever case a listing or portal shows. Owner and site IDs are lowercased before they become storage keys, so one identifier always addresses one tree -- earlier releases wrote a second tree for a second spelling and deleted from whichever one they were handed.
 
+`--site` accepts the same three forms on **every** command that takes it, including `replicate` and `rehydrate`: a browser URL (`https://contoso.sharepoint.com/sites/Engineering`), the Graph short form (`contoso.sharepoint.com:/sites/Engineering`), or a composite site ID (`contoso.sharepoint.com,<siteGuid>,<webGuid>`). URLs and short forms are resolved through Graph before any storage key is built; a composite ID is passed through untouched, so disaster recovery with `rehydrate` still works when Graph is unreachable.
+
 **`atlas onedrive list-snapshots`**
 
 | Option              | Description                              |

--- a/packages/cli/src/commands/rehydrate.command.tsx
+++ b/packages/cli/src/commands/rehydrate.command.tsx
@@ -27,6 +27,7 @@ import { render_static_view } from '@/ui/render';
 import { format_bytes } from '@/command-formatters';
 import { logger, GRAPH_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-core';
 import type { UserIdentityResolver } from '@wisecom/atlas-types';
+import { resolve_site_id } from '@/commands/sharepoint-command.handlers';
 
 /**
  * Resolves an owner for recovery without touching primary storage.
@@ -132,15 +133,16 @@ async function execute_rehydrate(container: Container, options: RehydrateOptions
     const sharepoint_replication = container.get<SharePointReplicationUseCase>(
       SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
     );
+    const site_id = await resolve_site_id(container, tenant_id, options.site);
     if (options.snapshot) {
       result = await sharepoint_replication.rehydrate_site_snapshot(
         tenant_id,
-        options.site,
+        site_id,
         options.snapshot,
         source,
       );
     } else {
-      result = await sharepoint_replication.rehydrate_site(tenant_id, options.site, source);
+      result = await sharepoint_replication.rehydrate_site(tenant_id, site_id, source);
     }
   } else if (options.owner) {
     const onedrive_replication = container.get<OneDriveReplicationUseCase>(

--- a/packages/cli/src/commands/replicate.command.tsx
+++ b/packages/cli/src/commands/replicate.command.tsx
@@ -25,6 +25,7 @@ import { render_static_view } from '@/ui/render';
 import { format_bytes } from '@/command-formatters';
 import { logger } from '@wisecom/atlas-core';
 import { resolve_owner } from '@/commands/onedrive-command.handlers';
+import { resolve_site_id } from '@/commands/sharepoint-command.handlers';
 
 type ContainerFactory = () => Container;
 
@@ -80,7 +81,10 @@ async function execute_replicate(container: Container, options: ReplicateOptions
     const owner_scope = options.owner
       ? (await resolve_owner(container, tenant_id, options.owner)).object_id
       : undefined;
-    const scope_id = options.mailbox ?? options.site ?? owner_scope;
+    const site_scope = options.site
+      ? await resolve_site_id(container, tenant_id, options.site)
+      : undefined;
+    const scope_id = options.mailbox ?? site_scope ?? owner_scope;
     await show_status(use_case, tenant_id, options.snapshot, scope_id);
     return;
   }
@@ -99,46 +103,9 @@ async function execute_replicate(container: Container, options: ReplicateOptions
   );
 
   if (options.site) {
-    const sharepoint_replication = container.get<SharePointReplicationUseCase>(
-      SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
-    );
-    if (options.snapshot) {
-      const results = await sharepoint_replication.replicate_site(
-        tenant_id,
-        options.site,
-        options.snapshot,
-        [target],
-      );
-      await report_results(results);
-    } else {
-      const results = await sharepoint_replication.replicate_all_site_snapshots(
-        tenant_id,
-        options.site,
-        [target],
-      );
-      await report_results(results);
-    }
+    await replicate_site_scope(container, tenant_id, options, target);
   } else if (options.owner) {
-    const onedrive_replication = container.get<OneDriveReplicationUseCase>(
-      ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
-    );
-    const owner = await resolve_owner(container, tenant_id, options.owner);
-    if (options.snapshot) {
-      const results = await onedrive_replication.replicate_owner(
-        tenant_id,
-        owner.object_id,
-        options.snapshot,
-        [target],
-      );
-      await report_results(results);
-    } else {
-      const results = await onedrive_replication.replicate_all_owner_snapshots(
-        tenant_id,
-        owner.object_id,
-        [target],
-      );
-      await report_results(results);
-    }
+    await replicate_owner_scope(container, tenant_id, options, target);
   } else if (options.snapshot) {
     const results = await use_case.replicate_snapshot(tenant_id, options.snapshot, [target]);
     await report_results(results);
@@ -151,6 +118,40 @@ async function execute_replicate(container: Container, options: ReplicateOptions
     );
     process.exitCode = 1;
   }
+}
+
+/** Replicates one SharePoint site: a single snapshot with --snapshot, otherwise every unreplicated one. */
+async function replicate_site_scope(
+  container: Container,
+  tenant_id: string,
+  options: ReplicateOptions,
+  target: StorageTarget,
+): Promise<void> {
+  const replication = container.get<SharePointReplicationUseCase>(
+    SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
+  );
+  const site_id = await resolve_site_id(container, tenant_id, options.site!);
+  const results = options.snapshot
+    ? await replication.replicate_site(tenant_id, site_id, options.snapshot, [target])
+    : await replication.replicate_all_site_snapshots(tenant_id, site_id, [target]);
+  await report_results(results);
+}
+
+/** Replicates one OneDrive owner: a single snapshot with --snapshot, otherwise every unreplicated one. */
+async function replicate_owner_scope(
+  container: Container,
+  tenant_id: string,
+  options: ReplicateOptions,
+  target: StorageTarget,
+): Promise<void> {
+  const replication = container.get<OneDriveReplicationUseCase>(
+    ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
+  );
+  const owner = await resolve_owner(container, tenant_id, options.owner!);
+  const results = options.snapshot
+    ? await replication.replicate_owner(tenant_id, owner.object_id, options.snapshot, [target])
+    : await replication.replicate_all_owner_snapshots(tenant_id, owner.object_id, [target]);
+  await report_results(results);
 }
 
 function build_target(container: Container, options: ReplicateOptions): StorageTarget {

--- a/packages/cli/src/commands/sharepoint-command.handlers.tsx
+++ b/packages/cli/src/commands/sharepoint-command.handlers.tsx
@@ -64,6 +64,25 @@ function resolve_tenant_id(container: Container, options: SharePointTenantOption
   return container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
 }
 
+/**
+ * Resolves a `--site` input to the composite site id used in storage keys.
+ * A composite id (`hostname,siteGuid,webGuid`) is already what storage wants
+ * and is returned untouched, so disaster recovery keeps working when Graph is
+ * unreachable. Anything else -- a browser URL or `hostname:/sites/<name>` --
+ * goes through Graph like every other SharePoint command (issue #90).
+ */
+export async function resolve_site_id(
+  container: Container,
+  tenant_id: string,
+  site_input: string,
+): Promise<string> {
+  if (site_input.includes(',')) return site_input;
+  const connector = container.get<SharePointSiteConnector>(SHAREPOINT_CONNECTOR_TOKEN);
+  const site = await connector.resolve_site(tenant_id, site_input);
+  logger.info(`Resolved site: ${site.display_name} (${site.site_id})`);
+  return site.site_id;
+}
+
 interface SiteRow {
   site_id: string;
   display_name: string;

--- a/packages/cli/tests/unit/replication-site-scope.test.ts
+++ b/packages/cli/tests/unit/replication-site-scope.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { register_replicate_command } from '@/commands/replicate.command';
+import { register_rehydrate_command } from '@/commands/rehydrate.command';
+import {
+  REPLICATION_USE_CASE_TOKEN,
+  SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
+  SHAREPOINT_CONNECTOR_TOKEN,
+} from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
+import type { ReplicationResult } from '@wisecom/atlas-types';
+
+// Regression tests for issue #90: replicate/rehydrate --site accepted only a
+// composite site id; a browser URL went straight into the storage key builder
+// and failed with "Invalid storage key segment".
+
+const SITE_URL = 'https://contoso.sharepoint.com/sites/finance';
+const SITE_HOST_PATH = 'contoso.sharepoint.com:/sites/finance';
+const SITE_ID =
+  'contoso.sharepoint.com,11111111-1111-1111-1111-111111111111,22222222-2222-2222-2222-222222222222';
+
+const RESULT: ReplicationResult = {
+  snapshot_id: 'sp-snap-1',
+  target_id: 'replica',
+  status: 'COMPLETED',
+  objects_copied: 2,
+  objects_skipped: 0,
+  objects_failed: 0,
+  bytes_copied: 512,
+  elapsed_ms: 9,
+  errors: [],
+};
+
+interface SharePointReplicationMock {
+  replicate_site: Mock;
+  replicate_all_site_snapshots: Mock;
+  rehydrate_site_snapshot: Mock;
+  rehydrate_site: Mock;
+}
+
+const TARGET_ARGS = [
+  '--target-endpoint',
+  'http://replica:9000',
+  '--target-access-key',
+  'key',
+  '--target-secret-key',
+  'secret',
+];
+
+const SOURCE_ARGS = [
+  '--source-endpoint',
+  'http://replica:9000',
+  '--source-access-key',
+  'key',
+  '--source-secret-key',
+  'secret',
+];
+
+describe('replicate/rehydrate --site SharePoint scope', () => {
+  let container: Container;
+  let sharepoint: SharePointReplicationMock;
+  let resolve_site: Mock;
+  let program: Command;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    container = new Container();
+    sharepoint = {
+      replicate_site: vi.fn().mockResolvedValue([RESULT]),
+      replicate_all_site_snapshots: vi.fn().mockResolvedValue([RESULT]),
+      rehydrate_site_snapshot: vi.fn().mockResolvedValue(RESULT),
+      rehydrate_site: vi.fn().mockResolvedValue(RESULT),
+    };
+    resolve_site = vi.fn().mockResolvedValue({
+      site_id: SITE_ID,
+      site_url: SITE_URL,
+      display_name: 'Finance',
+    });
+
+    container.bind(SHAREPOINT_REPLICATION_USE_CASE_TOKEN).toConstantValue(sharepoint);
+    container.bind(REPLICATION_USE_CASE_TOKEN).toConstantValue({
+      get_replication_status: vi.fn().mockResolvedValue([]),
+      get_replication_status_by_owner: vi.fn().mockResolvedValue([]),
+    });
+    container.bind(SHAREPOINT_CONNECTOR_TOKEN).toConstantValue({ resolve_site });
+    container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({
+      tenant_id: 'test-tenant',
+      encryption_passphrase: 'pass',
+    });
+
+    program = new Command();
+    program.exitOverride();
+    register_replicate_command(program, () => container);
+    register_rehydrate_command(program, () => container);
+  });
+
+  it('replicates a site URL under the resolved composite id', async () => {
+    await program.parseAsync(['replicate', '--site', SITE_URL, ...TARGET_ARGS], { from: 'user' });
+
+    expect(resolve_site).toHaveBeenCalledWith('test-tenant', SITE_URL);
+    expect(sharepoint.replicate_all_site_snapshots).toHaveBeenCalledWith('test-tenant', SITE_ID, [
+      expect.objectContaining({ endpoint: 'http://replica:9000' }),
+    ]);
+  });
+
+  it('accepts the hostname:/sites/<name> form', async () => {
+    await program.parseAsync(
+      ['replicate', '--site', SITE_HOST_PATH, '-s', 'sp-snap-1', ...TARGET_ARGS],
+      { from: 'user' },
+    );
+
+    expect(resolve_site).toHaveBeenCalledWith('test-tenant', SITE_HOST_PATH);
+    expect(sharepoint.replicate_site).toHaveBeenCalledWith(
+      'test-tenant',
+      SITE_ID,
+      'sp-snap-1',
+      expect.any(Array),
+    );
+  });
+
+  it('passes a composite site id through without contacting Graph', async () => {
+    await program.parseAsync(['replicate', '--site', SITE_ID, ...TARGET_ARGS], { from: 'user' });
+
+    expect(resolve_site).not.toHaveBeenCalled();
+    expect(sharepoint.replicate_all_site_snapshots).toHaveBeenCalledWith(
+      'test-tenant',
+      SITE_ID,
+      expect.any(Array),
+    );
+  });
+
+  it('rehydrates a site URL under the resolved composite id', async () => {
+    await program.parseAsync(['rehydrate', '--site', SITE_URL, ...SOURCE_ARGS], { from: 'user' });
+
+    expect(sharepoint.rehydrate_site).toHaveBeenCalledWith(
+      'test-tenant',
+      SITE_ID,
+      expect.objectContaining({ endpoint: 'http://replica:9000' }),
+    );
+  });
+
+  it('rehydrates a single site snapshot from a URL', async () => {
+    await program.parseAsync(['rehydrate', '--site', SITE_URL, '-s', 'sp-snap-1', ...SOURCE_ARGS], {
+      from: 'user',
+    });
+
+    expect(sharepoint.rehydrate_site_snapshot).toHaveBeenCalledWith(
+      'test-tenant',
+      SITE_ID,
+      'sp-snap-1',
+      expect.anything(),
+    );
+  });
+
+  it('scopes --status by the resolved site id, not the raw URL', async () => {
+    const use_case = container.get<{ get_replication_status_by_owner: Mock }>(
+      REPLICATION_USE_CASE_TOKEN,
+    );
+    await program.parseAsync(['replicate', '--status', '--site', SITE_URL], { from: 'user' });
+
+    expect(use_case.get_replication_status_by_owner).toHaveBeenCalledWith('test-tenant', SITE_ID);
+  });
+});

--- a/packages/sharepoint/src/services/sharepoint-storage-keys.ts
+++ b/packages/sharepoint/src/services/sharepoint-storage-keys.ts
@@ -34,7 +34,12 @@ export function validate_key_segment(value: string): void {
   for (let i = 0; i < value.length; i++) {
     const ch = value.charCodeAt(i);
     if (ch === 47 || ch === 92 || ch === 0) {
-      throw new Error(`Invalid storage key segment: ${JSON.stringify(value)}`);
+      // A URL here means a caller skipped site resolution (issue #90); say so
+      // instead of blaming the key, which sends the operator to the wrong layer.
+      const hint = /^https?:\/\//i.test(value)
+        ? ' -- expected a resolved SharePoint site id (hostname,siteGuid,webGuid), got a URL'
+        : '';
+      throw new Error(`Invalid storage key segment: ${JSON.stringify(value)}${hint}`);
     }
   }
 }


### PR DESCRIPTION
Closes #90.

## Change

Resolution now happens in the command handlers, matching the pattern the SharePoint commands and `stats` already use. New shared helper `resolve_site_id()` in `packages/cli/src/commands/sharepoint-command.handlers.tsx`, deliberately shaped like the existing `resolve_owner`:

```ts
if (site_input.includes(',')) return site_input;      // composite id: already what storage wants
const site = await connector.resolve_site(tenant_id, site_input);
```

The pass-through matters for the command this bug is about: `rehydrate` is the DR path, and it must keep working when Graph is unreachable. Resolving unconditionally would have traded a URL bug for a worse one — a recovery that fails because the directory is down. URL and `hostname:/sites/<name>` forms go through `connector.resolve_site()` (Graph-only; no primary-storage write, so the `resolve_owner_for_recovery` DEK-bootstrap hazard does not apply).

Wired into all four entry points — `replicate_site` / `replicate_all_site_snapshots` (`replicate.command.tsx`) and `rehydrate_site_snapshot` / `rehydrate_site` (`rehydrate.command.tsx`) — plus one the issue did not name: `replicate --status --site <url>` used the raw URL as its scope id, so it silently matched no records instead of erroring.

The two `replicate` workload branches moved into `replicate_site_scope()` / `replicate_owner_scope()`; `execute_replicate` was at the sonarjs cognitive-complexity ceiling and adding the resolve step pushed it over.

Secondary, per the issue: `validate_key_segment` (`sharepoint-storage-keys.ts`) now appends `-- expected a resolved SharePoint site id (hostname,siteGuid,webGuid), got a URL` when the offending value starts with `http(s)://`, so a future regression diagnoses itself instead of blaming the key layer.

## Verification

**Behavioral, against the real CLI** (`dist/cli.mjs`, MinIO at `localhost:9000`):

```
$ atlas replicate --site "https://contoso.sharepoint.com/sites/finance" --target-endpoint …
Target: http://localhost:9000 (dbfb1154e4719f8e)
[x] AADSTS700016: Application with identifier 'x' was not found …   # Graph resolution attempted
```

The URL now reaches Graph (this sandbox has no valid app registration) instead of dying at `Invalid storage key segment` — the failure mode moved from "key builder" to "directory lookup", which is the whole point of the fix.

```
$ atlas replicate --site "contoso.sharepoint.com,1111…,2222…" --target-endpoint …
Snapshot  Target  Status  Copied  Skipped  Failed  Size  Elapsed
--------  ------  ------  ------  -------  ------  ----  -------
```

Composite id: no Graph call at all, straight to storage, empty result set for a site with no snapshots — offline DR preserved.

**Unit** — new `packages/cli/tests/unit/replication-site-scope.test.ts` (6 tests), built on the existing `replication-owner-scope.test.ts` harness: URL → `replicate_all_site_snapshots(tenant, <composite id>)`; `hostname:/sites/<name>` → `replicate_site(…)`; composite id → `resolve_site` never called; both rehydrate entry points; `--status` scoped by resolved id.

```
$ pnpm exec turbo run typecheck test lint format:check
Tasks:    43 successful, 43 total
```

## Docs

`docs/reference/cli.md` identifier section now states that `--site` takes URL, `hostname:/sites/<name>`, or composite ID uniformly on **every** command including `replicate`/`rehydrate`, and that a composite ID skips Graph so DR works without directory access. `pnpm run docs:build` exits 0.

---

skipped: pushing resolution down into `SharePointReplicationService` (the issue's alternative); that would inject a Graph connector into a core service and make the SDK's replication path depend on directory reachability.