### PR TITLE
feat(e2e): live-tenant E2E harness, preflight, and the Outlook lifecycle suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,8 +57,12 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Start MinIO
-        run: docker compose -f e2e/docker-compose.e2e.yml up -d --wait
+      # `down -v` first: on a self-hosted or reused runner a stale volume would carry a previous
+      # run's ciphertext into this one, and the purge assertions would be judging old objects.
+      - name: Start MinIO on empty volumes
+        run: |
+          docker compose -f e2e/docker-compose.e2e.yml down -v --remove-orphans
+          docker compose -f e2e/docker-compose.e2e.yml up -d --wait
 
       - name: Mask derived values
         env:
@@ -105,6 +109,17 @@ jobs:
           path: e2e/report.xml
           retention-days: 30
 
-      - name: Stop MinIO
+      # The tenant wipe is asserted by the suite (`delete --purge`); this destroys the storage
+      # underneath it. Both matter: a passing purge proves the product erases, and a removed volume
+      # proves no ciphertext or DEK survives the job even when the purge assertion failed.
+      - name: Destroy MinIO and its volumes
         if: always()
-        run: docker compose -f e2e/docker-compose.e2e.yml down -v
+        run: |
+          docker compose -f e2e/docker-compose.e2e.yml down -v --remove-orphans
+          leftovers="$(docker volume ls -q --filter name=e2e_)"
+          if [ -n "$leftovers" ]; then
+            echo "MinIO volumes survived teardown: $leftovers" >&2
+            docker volume rm -f $leftovers
+            exit 1
+          fi
+          echo "MinIO volumes destroyed; no E2E storage remains on the runner."

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,17 @@
 name: E2E
 
-# Manual dispatch only for now. The weekly and monthly crons arrive with the remaining suites
-# (issue #108). Never add `pull_request`: this job holds tenant credentials, and a PR-triggered
-# run of fork-supplied code would be a secret-exfiltration path.
+# Runs on pushes to the long-lived branches, plus manual dispatch. The weekly and monthly crons
+# arrive with the remaining suites (issue #108).
+#
+# Never add `pull_request`: this job holds tenant credentials, and a PR-triggered run of
+# fork-supplied code would be a secret-exfiltration path.
+#
+# This workflow gates nothing. It is deliberately not a required status check -- a live-tenant run
+# depends on Graph and network availability, so a red E2E must inform, not block a merge. CI
+# (`ci.yml`) stays the gate.
 on:
+  push:
+    branches: [main, dev]
   workflow_dispatch:
     inputs:
       suite:
@@ -23,7 +31,8 @@ jobs:
   e2e:
     name: End-to-end against a live tenant
     runs-on: ubuntu-latest
-    environment: e2e
+    # No `environment:`: the E2E secrets are repository secrets, and an environment with approval
+    # rules would leave scheduled and push-triggered runs waiting for a human.
     timeout-minutes: 30
 
     steps:
@@ -57,6 +66,7 @@ jobs:
         run: echo "::add-mask::atlas-$E2E_TENANT_ID"
 
       - name: Run E2E suite
+        id: suite
         working-directory: e2e
         env:
           E2E_TENANT_ID: ${{ secrets.E2E_TENANT_ID }}
@@ -67,6 +77,13 @@ jobs:
           E2E_ONEDRIVE_OWNER: ${{ secrets.E2E_ONEDRIVE_OWNER }}
           E2E_SHAREPOINT_SITE: ${{ secrets.E2E_SHAREPOINT_SITE }}
         run: uv run pytest ${{ inputs.suite && format('-k "{0}"', inputs.suite) || '' }}
+
+      # Status is readable from the run page itself, so a red badge can be triaged without
+      # opening logs. The XML holds test names only -- no tenant data.
+      - name: Report status
+        if: always()
+        working-directory: e2e
+        run: uv run python -m atlas_e2e.summary >> "$GITHUB_STEP_SUMMARY"
 
       # Belt and braces: pytest teardown already sweeps, but a crashed interpreter never gets there.
       - name: Sweep leftovers

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,93 @@
+name: E2E
+
+# Manual dispatch only for now. The weekly and monthly crons arrive with the remaining suites
+# (issue #108). Never add `pull_request`: this job holds tenant credentials, and a PR-triggered
+# run of fork-supplied code would be a secret-exfiltration path.
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'pytest -k expression (empty runs everything)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+# Two runs seeding the same mailbox would fight over Graph delta cursors.
+concurrency:
+  group: atlas-e2e
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    name: End-to-end against a live tenant
+    runs-on: ubuntu-latest
+    environment: e2e
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build CLI
+        run: pnpm run build
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Start MinIO
+        run: docker compose -f e2e/docker-compose.e2e.yml up -d --wait
+
+      - name: Mask derived values
+        env:
+          E2E_TENANT_ID: ${{ secrets.E2E_TENANT_ID }}
+        run: echo "::add-mask::atlas-$E2E_TENANT_ID"
+
+      - name: Run E2E suite
+        working-directory: e2e
+        env:
+          E2E_TENANT_ID: ${{ secrets.E2E_TENANT_ID }}
+          E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
+          E2E_CLIENT_SECRET: ${{ secrets.E2E_CLIENT_SECRET }}
+          E2E_ENCRYPTION_PASSPHRASE: ${{ secrets.E2E_ENCRYPTION_PASSPHRASE }}
+          E2E_MAILBOX: ${{ secrets.E2E_MAILBOX }}
+          E2E_ONEDRIVE_OWNER: ${{ secrets.E2E_ONEDRIVE_OWNER }}
+          E2E_SHAREPOINT_SITE: ${{ secrets.E2E_SHAREPOINT_SITE }}
+        run: uv run pytest ${{ inputs.suite && format('-k "{0}"', inputs.suite) || '' }}
+
+      # Belt and braces: pytest teardown already sweeps, but a crashed interpreter never gets there.
+      - name: Sweep leftovers
+        if: always()
+        working-directory: e2e
+        env:
+          E2E_TENANT_ID: ${{ secrets.E2E_TENANT_ID }}
+          E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
+          E2E_CLIENT_SECRET: ${{ secrets.E2E_CLIENT_SECRET }}
+          E2E_ENCRYPTION_PASSPHRASE: ${{ secrets.E2E_ENCRYPTION_PASSPHRASE }}
+          E2E_MAILBOX: ${{ secrets.E2E_MAILBOX }}
+        run: uv run python -m atlas_e2e.sweep
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-report
+          path: e2e/report.xml
+          retention-days: 30
+
+      - name: Stop MinIO
+        if: always()
+        run: docker compose -f e2e/docker-compose.e2e.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,11 @@ docs/.vitepress/cache/
 .perf-output/
 .graph-tap/
 tools/perf/dist/
+
+# e2e (Python) artifacts
+e2e/.venv/
+e2e/.pytest_cache/
+e2e/report.xml
+# uv.lock is committed on purpose: CI must resolve the same dependency versions as a local run.
+e2e/.sweep-home/
+__pycache__/

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,5 @@ pnpm-lock.yaml
 tools/perf/dist/
 docs/.vitepress/dist/
 docs/.vitepress/cache/
+e2e/.venv/
+e2e/.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Atlas — open-source Microsoft 365 backup engine by Wisecom](assets/og-card.jpg)](https://wisecom.fi)
 
 [![CI](https://github.com/wisecom-oy/atlas/actions/workflows/ci.yml/badge.svg)](https://github.com/wisecom-oy/atlas/actions/workflows/ci.yml)
+[![E2E](https://github.com/wisecom-oy/atlas/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/wisecom-oy/atlas/actions/workflows/e2e.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/miikaok/34b7e6013b428e289db442d3d28f4f14/raw/m365-atlas-coverage.json)](https://github.com/wisecom-oy/atlas/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@wisecom/atlas-cli)](https://www.npmjs.com/package/@wisecom/atlas-cli)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](./LICENSE)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -78,6 +78,15 @@ Residual risk: the stored client secret can read and write the whole of that one
 Graph application permissions cannot be scoped below a user. An Exchange `ApplicationAccessPolicy`
 bounds it to a single identity — see issue #105.
 
+Storage teardown happens twice over, at two layers:
+
+1. **Tenant wipe, asserted.** `test_10_purge_empties_the_bucket` runs `outlook delete --purge -y`
+   and then lists the bucket with boto3, so the product's own erasure path is under test.
+2. **Volume destruction, unconditional.** The workflow brings MinIO up on freshly created volumes
+   (`down -v` before `up`) and destroys them afterwards in an `if: always()` step that fails if any
+   `e2e_*` volume survives. So no ciphertext and no wrapped DEK outlive the job even when the purge
+   assertion is the thing that failed.
+
 ## Adding a case
 
 - **New assertion on an existing workload**: one function in the matching `tests/test_*.py`, using

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -72,6 +72,14 @@ bounds it to a single identity — see issue #105.
 
 ## CI
 
-`.github/workflows/e2e.yml`, manual dispatch only for now; the weekly and monthly crons land with
-issue #108. It never runs on `pull_request` — the job holds tenant credentials, and a PR trigger
-would let fork-supplied code exfiltrate them. Secrets come from the `e2e` GitHub environment.
+`.github/workflows/e2e.yml` runs on pushes to `main` and `dev`, and on manual dispatch. The weekly
+and monthly crons land with issue #108.
+
+It never runs on `pull_request` — the job holds tenant credentials, and a PR trigger would let
+fork-supplied code exfiltrate them. Secrets are repository secrets (`E2E_*`); no GitHub environment
+is attached, because approval rules would leave unattended runs waiting for a human.
+
+**The workflow gates nothing.** A live-tenant run depends on Graph and network availability, so it
+is deliberately not a required status check: `ci.yml` remains the merge gate, while E2E reports
+status through its own badge and a per-test table on the run's summary page
+(`python -m atlas_e2e.summary`). A red E2E means "investigate", not "blocked".

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,77 @@
+# Atlas E2E suite
+
+End-to-end tests that drive the **shipped CLI bundle** (`packages/cli/dist/cli.mjs`) against a real
+Microsoft 365 tenant, with MinIO providing S3 storage inside the runner. Unit tests mock Graph and
+S3; nothing else in this repository makes a real Graph call, so this is the only place a broken
+restore path can be caught before a customer finds it.
+
+Design and rationale: [`PLAN.md`](./PLAN.md). Tracking: issue #103.
+
+## What a run does
+
+1. Seeds a mail folder named `atlas-e2e-<run_id>` in the test mailbox, with a message and a random
+   4 KB attachment (Graph).
+2. Backs up **only that folder** (`-m <mailbox> -f atlas-e2e-<run_id>`), then asserts real objects
+   exist under `manifests/`, `data/` and `attachments/` (boto3).
+3. Verifies, exports to `.eml`, then **deletes the message from M365** and restores it.
+4. Re-reads the restored message through Graph and compares the attachment SHA-256 with the bytes
+   it seeded. The tool's own "restored 1 item" output is never treated as evidence.
+5. Seeds a second message, re-runs the backup, and asserts the run resumed from saved delta state
+   and stored exactly one new blob.
+6. Purges the tenant bucket and sweeps every marked artifact from the mailbox.
+
+## Running locally
+
+```bash
+pnpm run build                                             # the suite runs dist/cli.mjs, not src
+docker compose -f e2e/docker-compose.e2e.yml up -d --wait  # MinIO on 9000 (+ replica on 9002)
+
+cd e2e
+export E2E_TENANT_ID=...            # Entra tenant GUID
+export E2E_CLIENT_ID=...            # the E2E app registration
+export E2E_CLIENT_SECRET=...
+export E2E_ENCRYPTION_PASSPHRASE=...  # not your production passphrase
+export E2E_MAILBOX=you@example.com  # mailbox the app is scoped to
+
+uv run pytest                       # everything
+uv run pytest -k preflight          # just the environment checks
+uv run pytest -k outlook            # just the Outlook lifecycle
+```
+
+Optional, used by the phase-2 suites: `E2E_ONEDRIVE_OWNER`, `E2E_SHAREPOINT_SITE`. Their preflight
+checks skip when unset.
+
+MinIO defaults (`E2E_S3_ENDPOINT`, `E2E_S3_ACCESS_KEY`, `E2E_S3_SECRET_KEY`,
+`E2E_S3_REPLICA_ENDPOINT`) need no configuration for a standard local run.
+
+## Safety model
+
+The suite writes into a **real** mailbox, so containment is enforced, not assumed:
+
+| Rule                                                                     | Why it holds                                                                                                                                  |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Backup always passes `-m` and `-f <marker>`                              | A bare `atlas outlook backup` enumerates every mailbox in the tenant.                                                                         |
+| Cleanup deletes only names starting `atlas-e2e`                          | A bug in the suite cannot reach real mail.                                                                                                    |
+| Foreign markers are only swept once stale (24 h)                         | A local run cannot delete a scheduled run's live fixtures.                                                                                    |
+| `Restore-*` roots are deleted only when they contain a marked descendant | Atlas names restore roots without our marker; an operator's own restore is never touched.                                                     |
+| `E2E_S3_ENDPOINT` must be runner-local                                   | The bucket name embeds the real tenant id, so a shared endpoint would mean writing test data into a production bucket. Asserted in preflight. |
+| Outlook restore cannot overwrite existing mail                           | The product always builds a fresh `Restore-{timestamp}` root (`folder-restore-planner.ts:28-37`).                                             |
+
+Residual risk: the stored client secret can read and write the whole of that one mailbox, because
+Graph application permissions cannot be scoped below a user. An Exchange `ApplicationAccessPolicy`
+bounds it to a single identity — see issue #105.
+
+## Adding a case
+
+- **New assertion on an existing workload**: one function in the matching `tests/test_*.py`, using
+  the existing fixtures (`cli`, `graph`, `s3`, `settings`, `run_marker`, `exports`).
+- **New workload**: one `tests/test_*.py`, plus seed/probe functions in `atlas_e2e/`.
+- Assertion sources, in order of preference: **Graph state** > **S3 keys and retention** > **process
+  exit code** > **`stats --json`**. Never parse Ink tables — they wrap and fragment (issue #94).
+- Anything created must carry `run_marker` in its name, or cleanup will not find it.
+
+## CI
+
+`.github/workflows/e2e.yml`, manual dispatch only for now; the weekly and monthly crons land with
+issue #108. It never runs on `pull_request` — the job holds tenant credentials, and a PR trigger
+would let fork-supplied code exfiltrate them. Secrets come from the `e2e` GitHub environment.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,11 +13,13 @@ Design and rationale: [`PLAN.md`](./PLAN.md). Tracking: issue #103.
    4 KB attachment (Graph).
 2. Backs up **only that folder** (`-m <mailbox> -f atlas-e2e-<run_id>`), then asserts real objects
    exist under `manifests/`, `data/` and `attachments/` (boto3).
-3. Verifies, exports to `.eml`, then **deletes the message from M365** and restores it.
-4. Re-reads the restored message through Graph and compares the attachment SHA-256 with the bytes
-   it seeded. The tool's own "restored 1 item" output is never treated as evidence.
-5. Seeds a second message, re-runs the backup, and asserts the run resumed from saved delta state
-   and stored exactly one new blob.
+3. Verifies the snapshot and exports it to `.eml`.
+4. Seeds a second message, re-runs the backup, and asserts the run resumed from saved delta state
+   and stored exactly one new blob. This happens before the restore, because a `--folder` selector
+   matches a bare folder name at any depth, so a restored copy would re-enter backup scope.
+5. **Deletes the message from M365**, restores it, then re-reads it through Graph and compares the
+   attachment SHA-256 with the bytes it seeded. The tool's own "restored 1 item" output is never
+   treated as evidence.
 6. Purges the tenant bucket and sweeps every marked artifact from the mailbox.
 
 ## Running locally

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -44,6 +44,23 @@ checks skip when unset.
 MinIO defaults (`E2E_S3_ENDPOINT`, `E2E_S3_ACCESS_KEY`, `E2E_S3_SECRET_KEY`,
 `E2E_S3_REPLICA_ENDPOINT`) need no configuration for a standard local run.
 
+## Required app permissions
+
+Application permissions (not delegated), admin-consented. Preflight probes each one and names the
+missing grant, so a permission gap fails in seconds instead of mid-backup:
+
+| Permission             | Needed for                                                  |
+| ---------------------- | ----------------------------------------------------------- |
+| `Mail.Read`            | backup, list, save, verify                                  |
+| `Mail.ReadWrite`       | seeding fixtures and restoring                              |
+| `MailboxSettings.Read` | folder enumeration and `userPurpose` (shared-mailbox) reads |
+| `User.Read.All`        | mailbox/owner discovery, email-to-object-id resolution      |
+| `Files.ReadWrite.All`  | OneDrive suite (backup and restore)                         |
+| `Sites.Read.All`       | SharePoint suite (site resolution and backup)               |
+| `Sites.Manage.All`     | SharePoint restore                                          |
+
+The canonical product-wide list lives in [`docs/azure-ad-setup.md`](../docs/azure-ad-setup.md).
+
 ## Safety model
 
 The suite writes into a **real** mailbox, so containment is enforced, not assumed:

--- a/e2e/atlas_e2e/__init__.py
+++ b/e2e/atlas_e2e/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers for the Atlas end-to-end suite. Test logic lives in `tests/`, never here."""

--- a/e2e/atlas_e2e/atlas.py
+++ b/e2e/atlas_e2e/atlas.py
@@ -1,0 +1,73 @@
+"""Runs the shipped CLI bundle as a subprocess, so the suite tests the artifact we release."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from atlas_e2e.config import Settings
+
+log = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 900
+
+
+@dataclass(frozen=True)
+class Result:
+    """One CLI invocation: what was asked, what came back."""
+
+    argv: tuple[str, ...]
+    code: int
+    stdout: str
+    stderr: str
+
+    @property
+    def out(self) -> str:
+        """Both streams. Atlas writes dashboards to stdout and per-item errors to stderr."""
+        return f"{self.stdout}\n{self.stderr}"
+
+    def describe(self) -> str:
+        """Failure text for an assertion: the command and its output, never the environment."""
+        return f"atlas {' '.join(self.argv)} -> exit {self.code}\n{self.out.strip()}"
+
+
+class Cli:
+    """A CLI bound to one settings object and one isolated HOME."""
+
+    def __init__(self, settings: Settings, home: Path) -> None:
+        self._settings = settings
+        # An isolated HOME keeps ~/.atlas/config.enc and the OS keyring out of the run: the suite
+        # must depend on the env vars it sets, not on whatever a developer configured locally.
+        self._home = home
+        home.mkdir(parents=True, exist_ok=True)
+
+    def run(self, *args: str, timeout: int = DEFAULT_TIMEOUT) -> Result:
+        """Invokes `atlas <args>` and captures both streams. Never raises on a non-zero exit."""
+        argv = tuple(str(a) for a in args)
+        env = {
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": str(self._home),
+            # Non-TTY output: Ink renders a static view, which is what we want in CI logs.
+            "CI": "1",
+            "NO_COLOR": "1",
+            **self._settings.cli_env(),
+        }
+        log.info("atlas %s", " ".join(argv))
+        proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["node", str(self._settings.cli), *argv],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=self._home,  # no repo-root atlas.config.json in scope
+            env=env,
+        )
+        return Result(argv=argv, code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+
+    def ok(self, *args: str, timeout: int = DEFAULT_TIMEOUT) -> Result:
+        """Runs and asserts a clean exit. Exit 2 (partial) is a failure here: E2E fixtures are tiny."""
+        result = self.run(*args, timeout=timeout)
+        assert result.code == 0, result.describe()
+        return result

--- a/e2e/atlas_e2e/cleanup.py
+++ b/e2e/atlas_e2e/cleanup.py
@@ -1,0 +1,69 @@
+"""Teardown. Deletes only what carries a marker, on both the Graph side and the S3 side."""
+
+from __future__ import annotations
+
+import logging
+
+from atlas_e2e import probe
+from atlas_e2e.atlas import Cli
+from atlas_e2e.graph import Graph, GraphError
+from atlas_e2e.marker import is_marked, is_stale, parse_graph_time
+
+log = logging.getLogger(__name__)
+
+
+def sweep_mailbox(graph: Graph, mailbox: str, marker: str) -> list[str]:
+    """Deletes this run's fixture folders, this run's restore roots, and stale foreign leftovers.
+
+    Foreign markers (another run's) are only removed once stale, so a local run cannot delete the
+    fixtures of a scheduled run that is still in flight.
+    """
+    removed: list[str] = []
+
+    for folder in probe.top_level_folders(graph, mailbox):
+        name = str(folder.get("displayName", ""))
+        if not is_marked(name):
+            continue
+        if marker not in name and not _folder_is_stale(graph, mailbox, str(folder["id"])):
+            log.info("Leaving foreign, non-stale fixture folder %s", name)
+            continue
+        _delete_folder(graph, mailbox, str(folder["id"]), name, removed)
+
+    # Restore roots are named `Restore-{timestamp}` by the product, so they are identified by
+    # holding a marked descendant rather than by their own name.
+    for root in probe.restore_roots_containing(graph, mailbox, marker):
+        _delete_folder(graph, mailbox, str(root["id"]), str(root.get("displayName", "")), removed)
+
+    return removed
+
+
+def purge_bucket(cli: Cli) -> None:
+    """Empties the tenant bucket through the product's own purge path.
+
+    Retained objects are expected on the compliance leg, so a non-zero exit is logged rather than
+    raised: the immutability suite owns that assertion (plan section 4.1).
+    """
+    result = cli.run("outlook", "delete", "--purge", "-y")
+    if result.code != 0:
+        log.warning("Purge exited %s: %s", result.code, result.out.strip()[:400])
+
+
+def _delete_folder(graph: Graph, mailbox: str, folder_id: str, name: str, removed: list[str]) -> None:
+    """Deletes one folder, recording it; a failure is logged, never raised out of teardown."""
+    try:
+        graph.delete(f"/users/{mailbox}/mailFolders/{folder_id}")
+        removed.append(name)
+        log.info("Cleaned up folder %s", name)
+    except GraphError as err:
+        log.warning("Could not delete folder %s: %s", name, err)
+
+
+def _folder_is_stale(graph: Graph, mailbox: str, folder_id: str) -> bool:
+    """Whether a marked folder's newest message is old enough that no live run owns it."""
+    messages = graph.get(
+        f"/users/{mailbox}/mailFolders/{folder_id}/messages",
+        **{"$select": "receivedDateTime", "$top": 1, "$orderby": "receivedDateTime desc"},
+    ).get("value", [])
+    if not messages:
+        return False
+    return is_stale(parse_graph_time(messages[0].get("receivedDateTime")))

--- a/e2e/atlas_e2e/config.py
+++ b/e2e/atlas_e2e/config.py
@@ -1,0 +1,93 @@
+"""Environment to typed settings. Fails fast, naming the variable that is missing."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Secrets: supplied by the `e2e` GitHub environment. No defaults -- a missing one is an error.
+_SECRETS = ("E2E_TENANT_ID", "E2E_CLIENT_ID", "E2E_CLIENT_SECRET", "E2E_ENCRYPTION_PASSPHRASE", "E2E_MAILBOX")
+
+# MinIO runs in the runner and is thrown away with it, so its credentials are not secrets.
+_DEFAULTS = {
+    "E2E_S3_ENDPOINT": "http://127.0.0.1:9000",
+    "E2E_S3_REPLICA_ENDPOINT": "http://127.0.0.1:9002",
+    "E2E_S3_ACCESS_KEY": "minioadmin",
+    "E2E_S3_SECRET_KEY": "minioadmin",
+    "E2E_S3_REGION": "us-east-1",
+    "E2E_CLI": str(REPO_ROOT / "packages" / "cli" / "dist" / "cli.mjs"),
+}
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Everything the suite needs to talk to Graph, S3, and the CLI."""
+
+    tenant_id: str
+    client_id: str
+    client_secret: str
+    passphrase: str
+    mailbox: str
+    s3_endpoint: str
+    s3_replica_endpoint: str
+    s3_access_key: str
+    s3_secret_key: str
+    s3_region: str
+    cli: Path
+    onedrive_owner: str
+    sharepoint_site: str
+
+    @property
+    def bucket(self) -> str:
+        """Atlas derives the bucket from the tenant id; the suite must not guess a different name."""
+        return f"atlas-{self.tenant_id}"
+
+    def cli_env(self) -> dict[str, str]:
+        """ATLAS_* variables for a CLI subprocess. Env wins over the secure store, so no config file is needed."""
+        return {
+            "ATLAS_TENANT_ID": self.tenant_id,
+            "ATLAS_CLIENT_ID": self.client_id,
+            "ATLAS_CLIENT_SECRET": self.client_secret,
+            "ATLAS_ENCRYPTION_PASSPHRASE": self.passphrase,
+            "ATLAS_S3_ENDPOINT": self.s3_endpoint,
+            "ATLAS_S3_ACCESS_KEY": self.s3_access_key,
+            "ATLAS_S3_SECRET_KEY": self.s3_secret_key,
+            "ATLAS_S3_REGION": self.s3_region,
+        }
+
+
+def load() -> Settings:
+    """Reads the environment into Settings, raising on the first missing secret."""
+    missing = [name for name in _SECRETS if not os.environ.get(name)]
+    if missing:
+        raise RuntimeError(
+            f"Missing required environment variable(s): {', '.join(missing)}. "
+            "See e2e/README.md; in CI these come from the `e2e` GitHub environment."
+        )
+
+    def value(name: str) -> str:
+        return os.environ.get(name) or _DEFAULTS[name]
+
+    cli = Path(value("E2E_CLI"))
+    if not cli.exists():
+        raise RuntimeError(f"CLI bundle not found at {cli}. Run `pnpm run build` first.")
+
+    return Settings(
+        tenant_id=os.environ["E2E_TENANT_ID"],
+        client_id=os.environ["E2E_CLIENT_ID"],
+        client_secret=os.environ["E2E_CLIENT_SECRET"],
+        passphrase=os.environ["E2E_ENCRYPTION_PASSPHRASE"],
+        mailbox=os.environ["E2E_MAILBOX"],
+        s3_endpoint=value("E2E_S3_ENDPOINT"),
+        s3_replica_endpoint=value("E2E_S3_REPLICA_ENDPOINT"),
+        s3_access_key=value("E2E_S3_ACCESS_KEY"),
+        s3_secret_key=value("E2E_S3_SECRET_KEY"),
+        s3_region=value("E2E_S3_REGION"),
+        cli=cli,
+        # Phase 2 workloads: absent until their fixtures exist, so the Outlook suite can run alone.
+        onedrive_owner=os.environ.get("E2E_ONEDRIVE_OWNER", ""),
+        sharepoint_site=os.environ.get("E2E_SHAREPOINT_SITE", ""),
+    )

--- a/e2e/atlas_e2e/graph.py
+++ b/e2e/atlas_e2e/graph.py
@@ -1,0 +1,121 @@
+"""Microsoft Graph client: client-credentials token, throttle-aware requests, paging."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Iterator
+
+import httpx
+import msal
+
+from atlas_e2e.config import Settings
+
+log = logging.getLogger(__name__)
+
+BASE_URL = "https://graph.microsoft.com/v1.0"
+SCOPE = ["https://graph.microsoft.com/.default"]
+RETRY_STATUSES = {429, 503, 504}
+MAX_ATTEMPTS = 5
+
+
+class GraphError(RuntimeError):
+    """A Graph call that failed for a reason retrying will not fix."""
+
+
+class Graph:
+    """Thin Graph wrapper. Mirrors what the product does: app-only auth, retry on throttling."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._app: msal.ConfidentialClientApplication | None = None
+        self._client = httpx.Client(base_url=BASE_URL, timeout=60.0)
+
+    def token(self) -> str:
+        """Acquires (or reuses msal's cached) app-only access token."""
+        result = self._msal().acquire_token_for_client(scopes=SCOPE)
+        token = result.get("access_token") if isinstance(result, dict) else None
+        if not token:
+            # Only the error code is surfaced: descriptions echo tenant and app identifiers.
+            code = result.get("error", "unknown") if isinstance(result, dict) else "unknown"
+            raise GraphError(f"Graph token request failed: {code}")
+        return str(token)
+
+    def _msal(self) -> msal.ConfidentialClientApplication:
+        """Builds the msal app on first use.
+
+        Construction performs OIDC discovery against the authority, i.e. a network call. Doing it
+        eagerly would make every storage-only test fail with an authority error when credentials
+        are wrong, instead of failing the one preflight check that owns that diagnosis.
+        """
+        if self._app is None:
+            try:
+                self._app = msal.ConfidentialClientApplication(
+                    client_id=self._settings.client_id,
+                    client_credential=self._settings.client_secret,
+                    authority=f"https://login.microsoftonline.com/{self._settings.tenant_id}",
+                )
+            except ValueError as err:
+                raise GraphError(f"Authority discovery failed for the configured tenant: {err}") from err
+        return self._app
+
+    def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        """Issues a request, retrying throttled and transient statuses per Retry-After."""
+        for attempt in range(1, MAX_ATTEMPTS + 1):
+            response = self._client.request(
+                method,
+                url,
+                headers={"Authorization": f"Bearer {self.token()}", **kwargs.pop("headers", {})},
+                **kwargs,
+            )
+            if response.status_code not in RETRY_STATUSES:
+                return response
+            delay = float(response.headers.get("Retry-After", 2 * attempt))
+            log.info("Graph %s on %s %s; retrying in %.0fs", response.status_code, method, url, delay)
+            time.sleep(delay)
+        return response
+
+    def call(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        """Issues a request and returns the JSON body, raising with the Graph error code on failure."""
+        response = self.request(method, url, **kwargs)
+        if response.status_code >= 400:
+            raise GraphError(f"{method} {url} -> {response.status_code} {_error_code(response)}")
+        if not response.content:
+            return {}
+        return dict(response.json())
+
+    def get(self, url: str, **params: Any) -> dict[str, Any]:
+        """GET returning the JSON body."""
+        return self.call("GET", url, params=params or None)
+
+    def post(self, url: str, json: dict[str, Any]) -> dict[str, Any]:
+        """POST returning the created entity."""
+        return self.call("POST", url, json=json)
+
+    def delete(self, url: str) -> None:
+        """DELETE, tolerating an already-absent target."""
+        response = self.request("DELETE", url)
+        if response.status_code not in {200, 202, 204, 404}:
+            raise GraphError(f"DELETE {url} -> {response.status_code} {_error_code(response)}")
+
+    def paged(self, url: str, **params: Any) -> Iterator[dict[str, Any]]:
+        """Yields every item across `@odata.nextLink` pages."""
+        page = self.get(url, **params)
+        while True:
+            yield from page.get("value", [])
+            next_link = page.get("@odata.nextLink")
+            if not next_link:
+                return
+            page = self.call("GET", next_link)
+
+    def close(self) -> None:
+        """Releases the HTTP connection pool."""
+        self._client.close()
+
+
+def _error_code(response: httpx.Response) -> str:
+    """Extracts Graph's error code. Messages are omitted: they quote identifiers we must not log."""
+    try:
+        return str(response.json().get("error", {}).get("code", ""))
+    except ValueError:
+        return ""

--- a/e2e/atlas_e2e/marker.py
+++ b/e2e/atlas_e2e/marker.py
@@ -1,0 +1,47 @@
+"""Run tagging. Every artifact the suite creates carries a marker; cleanup trusts nothing else."""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timedelta, timezone
+
+PREFIX = "atlas-e2e"
+
+# A run that dies mid-flight (runner killed, Graph outage) leaks fixtures. The next run sweeps
+# anything marked and older than this, so leftovers are bounded by a week, not by memory.
+STALE_AFTER = timedelta(hours=24)
+
+
+def new_run_id() -> str:
+    """GitHub run id in CI, wall-clock epoch locally. Unique per run either way."""
+    return os.environ.get("GITHUB_RUN_ID") or f"local-{int(time.time())}"
+
+
+def marker(run_id: str) -> str:
+    """The name every artifact of this run embeds."""
+    return f"{PREFIX}-{run_id}"
+
+
+def is_marked(name: str | None) -> bool:
+    """Whether a name belongs to some E2E run. Cleanup deletes only what this accepts."""
+    return bool(name) and name.startswith(PREFIX)  # type: ignore[union-attr]
+
+
+def is_stale(created: datetime | None) -> bool:
+    """Whether a marked artifact is old enough that no live run can still own it."""
+    if created is None:
+        return False
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - created > STALE_AFTER
+
+
+def parse_graph_time(value: str | None) -> datetime | None:
+    """Parses a Graph ISO-8601 timestamp; returns None when absent or unparseable."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/e2e/atlas_e2e/probe.py
+++ b/e2e/atlas_e2e/probe.py
@@ -1,0 +1,92 @@
+"""Reads M365 state back via Graph. Restore assertions are made here, never against CLI output."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import Any, Iterator
+
+from atlas_e2e.graph import Graph
+
+FOLDER_SELECT = "id,displayName,parentFolderId,totalItemCount"
+
+
+def top_level_folders(graph: Graph, mailbox: str) -> list[dict[str, Any]]:
+    """Every folder directly under the mailbox root."""
+    return list(graph.paged(f"/users/{mailbox}/mailFolders", **{"$select": FOLDER_SELECT, "$top": 100}))
+
+
+def child_folders(graph: Graph, mailbox: str, folder_id: str) -> list[dict[str, Any]]:
+    """Direct children of a folder."""
+    return list(
+        graph.paged(
+            f"/users/{mailbox}/mailFolders/{folder_id}/childFolders",
+            **{"$select": FOLDER_SELECT, "$top": 100},
+        )
+    )
+
+
+def walk_folders(graph: Graph, mailbox: str, folder_id: str) -> Iterator[dict[str, Any]]:
+    """Yields a folder's whole subtree, the folder itself included."""
+    for child in child_folders(graph, mailbox, folder_id):
+        yield child
+        yield from walk_folders(graph, mailbox, str(child["id"]))
+
+
+def find_top_level_folder(graph: Graph, mailbox: str, name: str) -> dict[str, Any] | None:
+    """Finds a top-level folder by exact display name."""
+    return next((f for f in top_level_folders(graph, mailbox) if f.get("displayName") == name), None)
+
+
+def messages_in(graph: Graph, mailbox: str, folder_id: str) -> list[dict[str, Any]]:
+    """Messages in a folder, with the fields the assertions need."""
+    return list(
+        graph.paged(
+            f"/users/{mailbox}/mailFolders/{folder_id}/messages",
+            **{"$select": "id,subject,body,hasAttachments", "$top": 100},
+        )
+    )
+
+
+def find_message_in_tree(graph: Graph, mailbox: str, root_id: str, subject: str) -> dict[str, Any] | None:
+    """Finds a message by exact subject anywhere beneath a folder, root included."""
+    for folder_id in [root_id, *(str(f["id"]) for f in walk_folders(graph, mailbox, root_id))]:
+        for message in messages_in(graph, mailbox, folder_id):
+            if message.get("subject") == subject:
+                return message
+    return None
+
+
+def attachment_sha256(graph: Graph, mailbox: str, message_id: str, name: str) -> str | None:
+    """SHA-256 of a named file attachment's bytes, or None when the attachment is absent."""
+    attachments = graph.paged(f"/users/{mailbox}/messages/{message_id}/attachments")
+    for attachment in attachments:
+        if attachment.get("name") != name:
+            continue
+        content = attachment.get("contentBytes")
+        if not content:
+            return None
+        return hashlib.sha256(base64.b64decode(content)).hexdigest()
+    return None
+
+
+def delete_message(graph: Graph, mailbox: str, message_id: str) -> None:
+    """Removes a message so a restore has something to prove."""
+    graph.delete(f"/users/{mailbox}/messages/{message_id}")
+
+
+def restore_roots_containing(graph: Graph, mailbox: str, marker: str) -> list[dict[str, Any]]:
+    """`Restore-*` roots that hold a marked descendant.
+
+    Atlas names its restore root `Restore-{timestamp}` with no marker of ours, so identifying ours
+    by name alone would risk deleting an operator's own restore. A root only counts as this run's
+    when a folder or message inside it carries the marker.
+    """
+    roots: list[dict[str, Any]] = []
+    for folder in top_level_folders(graph, mailbox):
+        if not str(folder.get("displayName", "")).startswith("Restore-"):
+            continue
+        subtree = list(walk_folders(graph, mailbox, str(folder["id"])))
+        if any(marker in str(f.get("displayName", "")) for f in subtree):
+            roots.append(folder)
+    return roots

--- a/e2e/atlas_e2e/seed.py
+++ b/e2e/atlas_e2e/seed.py
@@ -1,0 +1,72 @@
+"""Creates test data in M365 via Graph. Everything created here carries the run marker."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from dataclasses import dataclass
+
+from atlas_e2e.graph import Graph
+
+ATTACHMENT_BYTES = 4096
+
+
+@dataclass(frozen=True)
+class SeededMessage:
+    """A message the suite created, plus the hashes a restore must reproduce."""
+
+    message_id: str
+    subject: str
+    sentinel: str
+    attachment_name: str
+    attachment_sha256: str
+
+
+def create_folder(graph: Graph, mailbox: str, name: str, parent_id: str | None = None) -> str:
+    """Creates a mail folder (optionally nested) and returns its id."""
+    url = (
+        f"/users/{mailbox}/mailFolders/{parent_id}/childFolders"
+        if parent_id
+        else f"/users/{mailbox}/mailFolders"
+    )
+    folder = graph.post(url, {"displayName": name})
+    return str(folder["id"])
+
+
+def create_message(graph: Graph, mailbox: str, folder_id: str, marker: str, index: int) -> SeededMessage:
+    """Creates a message with a random binary attachment; the attachment is the restore fidelity proof.
+
+    Message bodies are normalised by Exchange (text is wrapped in HTML), so a body hash would be
+    fragile. Attachment bytes round-trip verbatim, so they carry the SHA-256 assertion, while the
+    body only has to still contain its sentinel.
+    """
+    subject = f"{marker}-mail-{index}"
+    sentinel = f"{marker}-sentinel-{index}"
+    created = graph.post(
+        f"/users/{mailbox}/mailFolders/{folder_id}/messages",
+        {
+            "subject": subject,
+            "body": {"contentType": "Text", "content": f"Atlas E2E fixture. {sentinel}"},
+            "toRecipients": [{"emailAddress": {"address": mailbox}}],
+        },
+    )
+    message_id = str(created["id"])
+
+    payload = os.urandom(ATTACHMENT_BYTES)
+    attachment_name = f"{marker}-attachment-{index}.bin"
+    graph.post(
+        f"/users/{mailbox}/messages/{message_id}/attachments",
+        {
+            "@odata.type": "#microsoft.graph.fileAttachment",
+            "name": attachment_name,
+            "contentBytes": base64.b64encode(payload).decode("ascii"),
+        },
+    )
+    return SeededMessage(
+        message_id=message_id,
+        subject=subject,
+        sentinel=sentinel,
+        attachment_name=attachment_name,
+        attachment_sha256=hashlib.sha256(payload).hexdigest(),
+    )

--- a/e2e/atlas_e2e/storage.py
+++ b/e2e/atlas_e2e/storage.py
@@ -1,0 +1,71 @@
+"""Direct S3 reads. Object keys and retention are ground truth; CLI output is not."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+from atlas_e2e.config import Settings
+
+
+def client(settings: Settings, endpoint: str | None = None) -> Any:
+    """An S3 client for MinIO: path-style addressing, no retries beyond botocore's default."""
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint or settings.s3_endpoint,
+        aws_access_key_id=settings.s3_access_key,
+        aws_secret_access_key=settings.s3_secret_key,
+        region_name=settings.s3_region,
+        config=Config(signature_version="s3v4", s3={"addressing_style": "path"}),
+    )
+
+
+def bucket_names(s3: Any) -> list[str]:
+    """Every bucket on the endpoint. Used to prove read-only commands provision nothing (#93)."""
+    return sorted(b["Name"] for b in s3.list_buckets().get("Buckets", []))
+
+
+def bucket_exists(s3: Any, bucket: str) -> bool:
+    """Whether the bucket exists, without creating it."""
+    return bucket in bucket_names(s3)
+
+
+def list_keys(s3: Any, bucket: str, prefix: str = "") -> list[str]:
+    """Every key under a prefix, paginated. Empty list when the bucket does not exist."""
+    if not bucket_exists(s3, bucket):
+        return []
+    keys: list[str] = []
+    token: str | None = None
+    while True:
+        kwargs: dict[str, Any] = {"Bucket": bucket, "Prefix": prefix, "MaxKeys": 1000}
+        if token:
+            kwargs["ContinuationToken"] = token
+        page = s3.list_objects_v2(**kwargs)
+        keys.extend(obj["Key"] for obj in page.get("Contents", []))
+        if not page.get("IsTruncated"):
+            return sorted(keys)
+        token = page.get("NextContinuationToken")
+
+
+def snapshot_ids(s3: Any, bucket: str, owner_id: str) -> list[str]:
+    """Snapshot ids for an Outlook owner, read from `manifests/<owner>/<snapshot>.json` key names.
+
+    The id lives in the key, so no decryption is needed -- and reading it here rather than parsing
+    CLI tables keeps the suite independent of rendering (see issue #94).
+    """
+    prefix = f"manifests/{owner_id}/"
+    return [k[len(prefix) : -len(".json")] for k in list_keys(s3, bucket, prefix) if k.endswith(".json")]
+
+
+def retention(s3: Any, bucket: str, key: str) -> dict[str, Any] | None:
+    """Object Lock retention on a key, or None when the object carries none."""
+    try:
+        return s3.get_object_retention(Bucket=bucket, Key=key).get("Retention")
+    except ClientError as err:
+        code = err.response.get("Error", {}).get("Code", "")
+        if code in {"NoSuchObjectLockConfiguration", "ObjectLockConfigurationNotFoundError"}:
+            return None
+        raise

--- a/e2e/atlas_e2e/summary.py
+++ b/e2e/atlas_e2e/summary.py
@@ -1,0 +1,55 @@
+"""Turns `report.xml` into a Markdown table: `python -m atlas_e2e.summary >> $GITHUB_STEP_SUMMARY`.
+
+A weekly job nobody opens is a job that fails silently, so the outcome has to be readable from the
+run page without expanding a log. Stdlib only -- pytest already wrote the XML.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree
+
+REPORT = Path("report.xml")
+
+
+def main() -> int:
+    """Prints a per-test Markdown table plus a one-line total."""
+    if not REPORT.exists():
+        print("E2E did not produce a report: the run failed before pytest started.")
+        return 0
+
+    suites = ElementTree.parse(REPORT).getroot().iter("testsuite")
+    rows: list[str] = []
+    totals = {"passed": 0, "failed": 0, "skipped": 0}
+
+    for suite in suites:
+        for case in suite.iter("testcase"):
+            outcome = _outcome(case)
+            totals[outcome] += 1
+            rows.append(f"| {_icon(outcome)} | `{case.get('classname', '')}` | {case.get('name', '')} |")
+
+    print("## E2E result\n")
+    print(f"**{totals['passed']} passed, {totals['failed']} failed, {totals['skipped']} skipped**\n")
+    print("| | Suite | Test |")
+    print("| - | ----- | ---- |")
+    print("\n".join(rows))
+    return 0
+
+
+def _outcome(case: ElementTree.Element) -> str:
+    """Classifies one testcase element."""
+    if case.find("failure") is not None or case.find("error") is not None:
+        return "failed"
+    if case.find("skipped") is not None:
+        return "skipped"
+    return "passed"
+
+
+def _icon(outcome: str) -> str:
+    """Marker shown in the summary table."""
+    return {"passed": "PASS", "failed": "FAIL", "skipped": "SKIP"}[outcome]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2e/atlas_e2e/sweep.py
+++ b/e2e/atlas_e2e/sweep.py
@@ -1,0 +1,43 @@
+"""Standalone teardown: `python -m atlas_e2e.sweep`.
+
+pytest already sweeps in a session fixture. This exists for the workflow's `if: always()` step,
+which has to clean up after a crashed interpreter or a cancelled job -- cases where no fixture runs.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from atlas_e2e import cleanup, config, marker
+from atlas_e2e.atlas import Cli
+from atlas_e2e.graph import Graph
+
+
+def main() -> int:
+    """Sweeps marked M365 fixtures and empties the tenant bucket. Never fails the job."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    log = logging.getLogger("sweep")
+    try:
+        settings = config.load()
+    except RuntimeError as err:
+        log.warning("Nothing to sweep: %s", err)
+        return 0
+
+    tag = marker.marker(marker.new_run_id())
+    graph = Graph(settings)
+    try:
+        removed = cleanup.sweep_mailbox(graph, settings.mailbox, tag)
+        log.info("Removed %d mailbox folder(s)", len(removed))
+    except Exception as err:  # noqa: BLE001 - a failed sweep must not fail the job after the tests
+        log.warning("Mailbox sweep failed: %s", err)
+    finally:
+        graph.close()
+
+    # Purge is independent of Graph: an unreachable tenant must not leave the bucket populated.
+    cleanup.purge_bucket(Cli(settings, config.REPO_ROOT / "e2e" / ".sweep-home"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,90 @@
+"""Fixtures only. Every test's setup and teardown is declared here so suites stay readable."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from atlas_e2e import cleanup, config, marker, storage
+from atlas_e2e.atlas import Cli
+from atlas_e2e.graph import Graph
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def settings() -> config.Settings:
+    """Typed environment. Fails the session immediately when a secret is missing."""
+    return config.load()
+
+
+@pytest.fixture(scope="session")
+def run_marker() -> str:
+    """The tag every artifact of this run embeds, e.g. `atlas-e2e-1234567890`."""
+    tag = marker.marker(marker.new_run_id())
+    log.info("Run marker: %s", tag)
+    return tag
+
+
+@pytest.fixture(scope="session")
+def atlas_home(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Throwaway HOME for the CLI, so no local secure store or keyring is involved."""
+    return tmp_path_factory.mktemp("atlas-home")
+
+
+@pytest.fixture(scope="session")
+def cli(settings: config.Settings, atlas_home: Path) -> Cli:
+    """The shipped CLI bundle, driven as a subprocess."""
+    return Cli(settings, atlas_home)
+
+
+@pytest.fixture(scope="session")
+def s3(settings: config.Settings) -> Any:
+    """S3 client for the primary MinIO."""
+    return storage.client(settings)
+
+
+@pytest.fixture(scope="session")
+def s3_replica(settings: config.Settings) -> Any:
+    """S3 client for the replica MinIO (used by the replication suite)."""
+    return storage.client(settings, settings.s3_replica_endpoint)
+
+
+@pytest.fixture(scope="session")
+def graph(settings: config.Settings) -> Iterator[Graph]:
+    """Graph client with app-only auth."""
+    client = Graph(settings)
+    yield client
+    client.close()
+
+
+@pytest.fixture(scope="session")
+def exports(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Directory for `atlas outlook save` output.
+
+    Unique per run because `save` prompts before overwriting an existing file and has no bypass
+    flag, so a reused path would hang the suite waiting for stdin.
+    """
+    return tmp_path_factory.mktemp("exports")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _teardown(
+    settings: config.Settings, cli: Cli, graph: Graph, run_marker: str
+) -> Iterator[None]:
+    """Sweeps M365 fixtures and empties the tenant bucket after the session, pass or fail.
+
+    Teardown never raises: an exception here would replace the real test failure with a cleanup
+    error. Anything it could not remove is logged, and the next run's stale sweep collects it.
+    """
+    yield
+    log.info("Teardown: sweeping %s", run_marker)
+    try:
+        removed = cleanup.sweep_mailbox(graph, settings.mailbox, run_marker)
+        log.info("Teardown: removed %d mailbox folder(s)", len(removed))
+    except Exception as err:  # noqa: BLE001 - teardown must not mask a test failure
+        log.warning("Teardown: mailbox sweep failed: %s", err)
+    cleanup.purge_bucket(cli)

--- a/e2e/docker-compose.e2e.yml
+++ b/e2e/docker-compose.e2e.yml
@@ -1,0 +1,49 @@
+# MinIO for the E2E run. Thrown away with the runner, so the credentials are not secrets.
+#
+# Four drives per container, not one: Object Lock requires bucket versioning, and MinIO's support
+# for versioning on a single-drive backend depends on the release. `server /data{1...4}` is the
+# configuration that works on every version, so an image bump cannot silently disable the
+# immutability suite. `test_00_preflight` asserts `storage-check` still reports `lock-capable`.
+#
+# Two endpoints, not two buckets: Atlas derives the bucket name from the tenant id, so a
+# replication target has to be a different endpoint.
+services:
+  minio-primary:
+    image: minio/minio:latest
+    container_name: atlas-e2e-minio-primary
+    # `/data/{1...4}`: the four drives must exist, so they live under one mounted volume.
+    command: server /data/{1...4} --console-address ":9001"
+    ports:
+      - '${E2E_S3_PORT:-9000}:9000'
+      - '${E2E_S3_CONSOLE_PORT:-9001}:9001'
+    environment:
+      MINIO_ROOT_USER: ${E2E_S3_ACCESS_KEY:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${E2E_S3_SECRET_KEY:-minioadmin}
+    volumes:
+      - e2e_primary:/data
+    healthcheck:
+      test: ['CMD', 'mc', 'ready', 'local']
+      interval: 3s
+      timeout: 5s
+      retries: 20
+
+  minio-replica:
+    image: minio/minio:latest
+    container_name: atlas-e2e-minio-replica
+    command: server /data/{1...4} --console-address ":9001"
+    ports:
+      - '${E2E_S3_REPLICA_PORT:-9002}:9000'
+    environment:
+      MINIO_ROOT_USER: ${E2E_S3_ACCESS_KEY:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${E2E_S3_SECRET_KEY:-minioadmin}
+    volumes:
+      - e2e_replica:/data
+    healthcheck:
+      test: ['CMD', 'mc', 'ready', 'local']
+      interval: 3s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  e2e_primary:
+  e2e_replica:

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "atlas-e2e"
+version = "0.1.0"
+description = "End-to-end tests driving the shipped Atlas CLI against a real M365 tenant"
+requires-python = ">=3.12"
+dependencies = [
+    "httpx>=0.28",
+    "msal>=1.31",
+    "boto3>=1.35",
+    "pytest>=8.3",
+]
+
+
+[tool.uv]
+# Helpers are imported from the working directory; there is nothing to build or install.
+package = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# -p no:randomly: the lifecycle suites are ordered on purpose (seed before restore).
+addopts = "-ra --strict-markers --junitxml=report.xml"
+markers = [
+    "compliance: Object Lock compliance-mode cases; monthly leg only",
+]
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s %(levelname)s %(message)s"

--- a/e2e/tests/test_00_preflight.py
+++ b/e2e/tests/test_00_preflight.py
@@ -1,0 +1,102 @@
+"""Preflight: fail in seconds with a named cause instead of cascading red through every suite."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from atlas_e2e import storage
+from atlas_e2e.atlas import Cli
+from atlas_e2e.config import Settings
+from atlas_e2e.graph import Graph, GraphError
+
+
+def test_cli_bundle_runs(cli: Cli) -> None:
+    """The built bundle is executable; otherwise `pnpm run build` was skipped."""
+    result = cli.ok("--version")
+    assert result.stdout.strip(), result.describe()
+
+
+def test_config_validate_probes_graph_and_s3(cli: Cli) -> None:
+    """`config validate` performs a live Graph token request and an S3 ListBuckets."""
+    cli.ok("config", "validate")
+
+
+def test_storage_check_reports_lock_capable(cli: Cli, settings: Settings, s3: Any) -> None:
+    """The backend must accept a lock-capable bucket, or the immutability suite tests nothing.
+
+    MinIO only supports Object Lock on a versioning-capable backend, which is why the compose file
+    gives each container four drives. A regressed image shows up here, not ten tests later.
+
+    The bucket is created here with `ObjectLockEnabledForBucket`, exactly as the product does on
+    first backup (`s3-bucket-manager.ts`). It cannot be left to `storage-check`, which is read-only
+    and reports `not-ready` for a bucket that does not exist yet -- and read-only commands provision
+    nothing since issue #93.
+    """
+    if not storage.bucket_exists(s3, settings.bucket):
+        s3.create_bucket(Bucket=settings.bucket, ObjectLockEnabledForBucket=True)
+
+    result = cli.ok("storage-check")
+    assert "lock-capable" in result.out, result.describe()
+    assert "Status:          ready" in result.out, result.describe()
+
+
+def test_storage_helpers_read_snapshot_ids(settings: Settings, s3: Any, run_marker: str) -> None:
+    """Guards the key parsing every later assertion depends on.
+
+    Snapshot ids are read out of `manifests/<owner>/<snapshot>.json` key names rather than from CLI
+    tables. If that parsing breaks, the lifecycle suites would compare empty lists and pass, so it
+    is checked here against a throwaway object.
+    """
+    key = f"manifests/{run_marker}/{run_marker}-snap.json"
+    s3.put_object(Bucket=settings.bucket, Key=key, Body=b"probe")
+    try:
+        assert storage.snapshot_ids(s3, settings.bucket, run_marker) == [f"{run_marker}-snap"]
+        assert key in storage.list_keys(s3, settings.bucket, "manifests/")
+    finally:
+        s3.delete_object(Bucket=settings.bucket, Key=key)
+
+
+
+def test_graph_token_is_issued(graph: Graph) -> None:
+    """App-only credentials are accepted by the tenant."""
+    assert graph.token()
+
+
+def test_mail_readwrite_permission(graph: Graph, settings: Settings) -> None:
+    """Mail.ReadWrite: required to seed, back up, and restore mail."""
+    _require(graph, f"/users/{settings.mailbox}/mailFolders", "Mail.ReadWrite", **{"$top": 1})
+
+
+def test_files_readwrite_permission(graph: Graph, settings: Settings) -> None:
+    """Files.ReadWrite.All: required by the OneDrive suite."""
+    if not settings.onedrive_owner:
+        pytest.skip("E2E_ONEDRIVE_OWNER not set")
+    _require(graph, f"/users/{settings.onedrive_owner}/drives", "Files.ReadWrite.All")
+
+
+def test_sites_read_permission(graph: Graph, settings: Settings) -> None:
+    """Sites.Read.All: required by the SharePoint suite."""
+    if not settings.sharepoint_site:
+        pytest.skip("E2E_SHAREPOINT_SITE not set")
+    _require(graph, "/sites", "Sites.Read.All", search="*")
+
+
+def test_tenant_bucket_is_local_only(settings: Settings, s3: Any) -> None:
+    """The endpoint under test is the runner's MinIO, never a production endpoint.
+
+    The bucket name carries the real tenant id, so pointing the suite at a shared endpoint would
+    write test data into a real tenant's bucket. Localhost-only is the guard.
+    """
+    assert any(host in settings.s3_endpoint for host in ("127.0.0.1", "localhost", "minio")), (
+        f"E2E_S3_ENDPOINT must be a runner-local MinIO, got {settings.s3_endpoint}"
+    )
+
+
+def _require(graph: Graph, path: str, permission: str, **params: Any) -> None:
+    """Asserts a Graph endpoint is reachable, naming the permission that is missing when it is not."""
+    try:
+        graph.get(path, **params)
+    except GraphError as err:
+        pytest.fail(f"{permission} appears to be missing or unconsented: {err}")

--- a/e2e/tests/test_00_preflight.py
+++ b/e2e/tests/test_00_preflight.py
@@ -65,8 +65,37 @@ def test_graph_token_is_issued(graph: Graph) -> None:
 
 
 def test_mail_readwrite_permission(graph: Graph, settings: Settings) -> None:
-    """Mail.ReadWrite: required to seed, back up, and restore mail."""
+    """Mail.ReadWrite: required to seed and to restore mail."""
     _require(graph, f"/users/{settings.mailbox}/mailFolders", "Mail.ReadWrite", **{"$top": 1})
+
+
+def test_mail_read_permission(graph: Graph, settings: Settings) -> None:
+    """Mail.Read: what backup, list, save and verify actually read with."""
+    _require(
+        graph,
+        f"/users/{settings.mailbox}/mailFolders/inbox/messages",
+        "Mail.Read",
+        **{"$top": 1, "$select": "id"},
+    )
+
+
+def test_mailbox_settings_read_permission(graph: Graph, settings: Settings) -> None:
+    """MailboxSettings.Read: folder enumeration and shared-mailbox detection (`userPurpose`).
+
+    Probed separately because listing `mailFolders` succeeds without it, so a missing grant would
+    otherwise only surface mid-backup as a bare 403 (as it did on run 32134203049).
+    """
+    _require(
+        graph,
+        f"/users/{settings.mailbox}/mailboxSettings",
+        "MailboxSettings.Read",
+        **{"$select": "userPurpose"},
+    )
+
+
+def test_user_read_all_permission(graph: Graph) -> None:
+    """User.Read.All: mailbox and owner discovery, and email-to-object-id resolution."""
+    _require(graph, "/users", "User.Read.All", **{"$top": 1, "$select": "id"})
 
 
 def test_files_readwrite_permission(graph: Graph, settings: Settings) -> None:

--- a/e2e/tests/test_10_outlook.py
+++ b/e2e/tests/test_10_outlook.py
@@ -69,7 +69,33 @@ def test_05_save_exports_an_eml_archive(cli: Cli, exports: Path, run_marker: str
         assert [n for n in zf.namelist() if n.endswith(".eml")], zf.namelist()
 
 
-def test_06_restore_recreates_a_deleted_message(
+def test_06_incremental_backup_adds_only_the_new_message(
+    cli: Cli, graph: Graph, settings: Settings, s3: Any, run_marker: str
+) -> None:
+    """A second run resumes from saved delta state and stores exactly the newly seeded message.
+
+    Ordered before the restore on purpose. A `--folder` selector matches a bare folder name at any
+    depth, so the restored copy at `Restore-<ts>/atlas-e2e-<run>/` would re-enter backup scope and a
+    later incremental run would legitimately store two new blobs. Measuring the delta first keeps
+    this assertion exact instead of approximate.
+    """
+    owner = STATE["owner"]
+    before = set(storage.list_keys(s3, settings.bucket, f"data/{owner}/"))
+
+    STATE["second"] = seed.create_message(graph, settings.mailbox, STATE["folder_id"], run_marker, 2)
+
+    result = cli.ok("outlook", "backup", "-m", settings.mailbox, "-f", run_marker)
+    assert "Resuming incremental sync" in result.out, result.describe()
+
+    after = set(storage.list_keys(s3, settings.bucket, f"data/{owner}/"))
+    assert len(after - before) == 1, f"expected exactly one new message blob, got {len(after - before)}"
+    assert before <= after, "an incremental run must not remove existing blobs"
+
+    snapshots = storage.snapshot_ids(s3, settings.bucket, owner)
+    assert len(snapshots) == 2, f"expected a second snapshot, found {snapshots}"
+
+
+def test_07_restore_recreates_a_deleted_message(
     cli: Cli, graph: Graph, settings: Settings, run_marker: str
 ) -> None:
     """Deletes the message from M365, restores it, and confirms Graph can see it again.
@@ -90,7 +116,7 @@ def test_06_restore_recreates_a_deleted_message(
     STATE["restore_root"] = roots[0]
 
 
-def test_07_restored_attachment_is_byte_identical(graph: Graph, settings: Settings) -> None:
+def test_08_restored_attachment_is_byte_identical(graph: Graph, settings: Settings) -> None:
     """The restored attachment hashes to the seeded bytes, and the body keeps its sentinel."""
     message = STATE["first"]
     restored = probe.find_message_in_tree(
@@ -103,27 +129,6 @@ def test_07_restored_attachment_is_byte_identical(graph: Graph, settings: Settin
 
     digest = probe.attachment_sha256(graph, settings.mailbox, str(restored["id"]), message.attachment_name)
     assert digest == message.attachment_sha256, "restored attachment does not match the seeded bytes"
-
-
-def test_08_incremental_backup_adds_only_the_new_message(
-    cli: Cli, graph: Graph, settings: Settings, s3: Any, run_marker: str
-) -> None:
-    """A second run resumes from saved delta state and stores exactly the newly seeded message."""
-    owner = STATE["owner"]
-    before = set(storage.list_keys(s3, settings.bucket, f"data/{owner}/"))
-
-    second = seed.create_message(graph, settings.mailbox, STATE["folder_id"], run_marker, 2)
-    STATE["second"] = second
-
-    result = cli.ok("outlook", "backup", "-m", settings.mailbox, "-f", run_marker)
-    assert "Resuming incremental sync" in result.out, result.describe()
-
-    after = set(storage.list_keys(s3, settings.bucket, f"data/{owner}/"))
-    assert len(after - before) == 1, f"expected exactly one new message blob, got {len(after - before)}"
-    assert before <= after, "an incremental run must not remove existing blobs"
-
-    snapshots = storage.snapshot_ids(s3, settings.bucket, owner)
-    assert len(snapshots) == 2, f"expected a second snapshot, found {snapshots}"
 
 
 def test_09_status_reports_the_backed_up_folder(cli: Cli, settings: Settings, run_marker: str) -> None:

--- a/e2e/tests/test_10_outlook.py
+++ b/e2e/tests/test_10_outlook.py
@@ -1,0 +1,148 @@
+"""Outlook lifecycle: seed, back up, export, destroy in M365, restore, prove it came back.
+
+The tests run in file order and share `STATE`, because the lifecycle is a sequence -- a restore
+cannot be asserted before a backup exists. Later steps fail loudly rather than being skipped, so a
+broken middle step is visible instead of silently green.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from atlas_e2e import probe, seed, storage
+from atlas_e2e.atlas import Cli
+from atlas_e2e.config import Settings
+from atlas_e2e.graph import Graph
+
+STATE: dict[str, Any] = {}
+
+
+def test_01_seed_folder_and_message(graph: Graph, settings: Settings, run_marker: str) -> None:
+    """Creates the fixture folder and one message with a random binary attachment."""
+    folder_id = seed.create_folder(graph, settings.mailbox, run_marker)
+    message = seed.create_message(graph, settings.mailbox, folder_id, run_marker, 1)
+
+    STATE["folder_id"] = folder_id
+    STATE["first"] = message
+
+    assert probe.find_message_in_tree(graph, settings.mailbox, folder_id, message.subject)
+
+
+def test_02_initial_backup_writes_objects(cli: Cli, settings: Settings, s3: Any, run_marker: str) -> None:
+    """Backs up only the fixture folder and asserts real objects landed in the bucket.
+
+    `-f <marker>` is mandatory: a bare backup would enumerate every mailbox in the tenant.
+    """
+    result = cli.ok("outlook", "backup", "-m", settings.mailbox, "-f", run_marker)
+    assert "Resuming incremental sync" not in result.out, "first run must be an initial sync"
+
+    owner = _owner_id(s3, settings.bucket)
+    STATE["owner"] = owner
+
+    snapshots = storage.snapshot_ids(s3, settings.bucket, owner)
+    assert len(snapshots) == 1, f"expected one snapshot, found {snapshots}"
+    STATE["snapshot"] = snapshots[0]
+
+    assert storage.list_keys(s3, settings.bucket, f"data/{owner}/"), "no message blob was written"
+    assert storage.list_keys(s3, settings.bucket, f"attachments/{owner}/"), "no attachment blob written"
+
+
+def test_03_list_reads_the_catalog(cli: Cli, settings: Settings) -> None:
+    """`outlook list` reads the manifest chain for the mailbox without error."""
+    cli.ok("outlook", "list", "-m", settings.mailbox)
+
+
+def test_04_verify_passes_on_a_fresh_snapshot(cli: Cli, settings: Settings) -> None:
+    """Deep verification: every blob is downloaded, decrypted, re-hashed, compared."""
+    cli.ok("outlook", "verify", "-m", settings.mailbox, "-s", STATE["snapshot"])
+
+
+def test_05_save_exports_an_eml_archive(cli: Cli, exports: Path, run_marker: str) -> None:
+    """`outlook save` produces a zip containing the message as `.eml`."""
+    archive = exports / f"{run_marker}.zip"
+    cli.ok("outlook", "save", "-s", STATE["snapshot"], "-o", str(archive))
+
+    assert archive.exists(), f"{archive} was not written"
+    with zipfile.ZipFile(archive) as zf:
+        assert [n for n in zf.namelist() if n.endswith(".eml")], zf.namelist()
+
+
+def test_06_restore_recreates_a_deleted_message(
+    cli: Cli, graph: Graph, settings: Settings, run_marker: str
+) -> None:
+    """Deletes the message from M365, restores it, and confirms Graph can see it again.
+
+    This is the assertion the whole pipeline exists for: the data is proven present in the mailbox,
+    not merely reported as restored by the tool that wrote it.
+    """
+    message = STATE["first"]
+    probe.delete_message(graph, settings.mailbox, message.message_id)
+    assert probe.find_message_in_tree(graph, settings.mailbox, STATE["folder_id"], message.subject) is None
+
+    cli.ok("outlook", "restore", "-s", STATE["snapshot"])
+
+    # Restore rebuilds the source tree under `Restore-{timestamp}`, so the fixture folder name is
+    # what identifies our root among any restores an operator made by hand.
+    roots = probe.restore_roots_containing(graph, settings.mailbox, run_marker)
+    assert roots, "no Restore-* folder holding this run's data was created"
+    STATE["restore_root"] = roots[0]
+
+
+def test_07_restored_attachment_is_byte_identical(graph: Graph, settings: Settings) -> None:
+    """The restored attachment hashes to the seeded bytes, and the body keeps its sentinel."""
+    message = STATE["first"]
+    restored = probe.find_message_in_tree(
+        graph, settings.mailbox, str(STATE["restore_root"]["id"]), message.subject
+    )
+    assert restored, f"restored message {message.subject} not found under the restore root"
+
+    body = str(restored.get("body", {}).get("content", ""))
+    assert message.sentinel in body, "restored body lost its sentinel"
+
+    digest = probe.attachment_sha256(graph, settings.mailbox, str(restored["id"]), message.attachment_name)
+    assert digest == message.attachment_sha256, "restored attachment does not match the seeded bytes"
+
+
+def test_08_incremental_backup_adds_only_the_new_message(
+    cli: Cli, graph: Graph, settings: Settings, s3: Any, run_marker: str
+) -> None:
+    """A second run resumes from saved delta state and stores exactly the newly seeded message."""
+    owner = STATE["owner"]
+    before = set(storage.list_keys(s3, settings.bucket, f"data/{owner}/"))
+
+    second = seed.create_message(graph, settings.mailbox, STATE["folder_id"], run_marker, 2)
+    STATE["second"] = second
+
+    result = cli.ok("outlook", "backup", "-m", settings.mailbox, "-f", run_marker)
+    assert "Resuming incremental sync" in result.out, result.describe()
+
+    after = set(storage.list_keys(s3, settings.bucket, f"data/{owner}/"))
+    assert len(after - before) == 1, f"expected exactly one new message blob, got {len(after - before)}"
+    assert before <= after, "an incremental run must not remove existing blobs"
+
+    snapshots = storage.snapshot_ids(s3, settings.bucket, owner)
+    assert len(snapshots) == 2, f"expected a second snapshot, found {snapshots}"
+
+
+def test_09_status_reports_the_backed_up_folder(cli: Cli, settings: Settings, run_marker: str) -> None:
+    """`outlook status` peeks at delta state for the mailbox and names the fixture folder."""
+    result = cli.ok("outlook", "status", "-m", settings.mailbox)
+    assert run_marker in result.out, result.describe()
+
+
+def test_10_purge_empties_the_bucket(cli: Cli, settings: Settings, s3: Any) -> None:
+    """`delete --purge` removes every object including the DEK, leaving nothing retained.
+
+    Governance leg only: the monthly compliance leg owns its own purge assertion (plan section 4.1).
+    """
+    cli.ok("outlook", "delete", "--purge", "-y")
+    assert storage.list_keys(s3, settings.bucket) == [], "purge left objects behind"
+
+
+def _owner_id(s3: Any, bucket: str) -> str:
+    """Reads the owner segment Atlas used from the manifest keys rather than assuming a normalisation."""
+    owners = {key.split("/")[1] for key in storage.list_keys(s3, bucket, "manifests/")}
+    assert len(owners) == 1, f"expected exactly one backed-up owner, found {sorted(owners)}"
+    return owners.pop()

--- a/e2e/uv.lock
+++ b/e2e/uv.lock
@@ -1,0 +1,557 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "atlas-e2e"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "boto3" },
+    { name = "httpx" },
+    { name = "msal" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.35" },
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "msal", specifier = ">=1.31" },
+    { name = "pytest", specifier = ">=8.3" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.73"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/e4/139572e2459b7e10cd3409888a7312b8b5054c85ea41b28af417002af1c4/boto3-1.43.73.tar.gz", hash = "sha256:6e6c755e5039f204882c01d7936a46abce539b3f5bbb534a23a3f2afbc86f576", size = 112665, upload-time = "2026-08-17T20:39:43.686Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/20/e4a415a5a3185bd13aec89603917203ff0b274caa9f0b0329d12aa397ff0/boto3-1.43.73-py3-none-any.whl", hash = "sha256:5b54da301c387abe30c5b3a5335652f1ebd73e814c725ba805d27a2d477ce547", size = 140024, upload-time = "2026-08-17T20:39:41.636Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.73"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ea/c8482ada4f409c91e6f9d640ee15838975f2a7c481dff98419a6d176b81a/botocore-1.43.73.tar.gz", hash = "sha256:0fa1e63c24b3531be3e1bc1687a88b3be9e63a430153f24edd93efc162bb1c51", size = 15963105, upload-time = "2026-08-17T20:39:37.94Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/9e/b0f2332029b4cc06281932f8e4908a9616ed756ad9da55fca07a949ea811/botocore-1.43.73-py3-none-any.whl", hash = "sha256:068433028e011ccbeab1dd7c46b1090c24e378397693c66e67ca571176498daa", size = 15653468, upload-time = "2026-08-17T20:39:34.332Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/27/78873dc8b6a56357517b74b6bb9568b80450e7bb4f6ef7e3fa9d22aa0bd7/charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b6d1386bf0096d26d3a863dc0a487a5b4eb9aa93cf5ba69683d29dde6b9d60f", size = 344456, upload-time = "2026-08-15T08:17:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/be49ada26b1f0232d57aa89bbebf997a5cc2332a5616b6eca26ff680044d/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa", size = 238530, upload-time = "2026-08-15T08:17:11.563Z" },
+    { url = "https://files.pythonhosted.org/packages/76/84/6f1290fa07ae6978d3960caa3eb1b8019bf9284ab7c2297b00c099ef4250/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1d1c7a53a6c2103925cdd6d7229f8c567379f211c869793df679f2e9f738c369", size = 230200, upload-time = "2026-08-15T08:17:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a0/47b18adeed31c8f16ba9700f32c1b18594cfa09f47eb672a488c273c22bf/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e6621fb2a4988d6e53eedc455e5903e2679f3967b8acb3d639f1b63c14a2e893", size = 262222, upload-time = "2026-08-15T08:17:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fe/341861ac118dae06f3ec0eb487488af52128f2ef2faf0b11003944d22259/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c0c10730342b0c9b35dd1d619beb8214e520bd96a1f870f452680b238aab3e0", size = 258951, upload-time = "2026-08-15T08:17:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08", size = 248801, upload-time = "2026-08-15T08:17:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/ef83ae3aca816393decfa3530976f38a79812d707b80b580ac33b83f9877/charset_normalizer-3.5.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9f8405c2c758532c74fed975dbee57be1f31a6e865c031870c79a6ed3212ada", size = 244070, upload-time = "2026-08-15T08:17:19.191Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0b/c5292a2462d69b7378ea89793bbb5b2b6fcf6f7dd6d1667f9619094ad553/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:96fef3e886d6a9874b14f27fc193fbdc69d5d8035783d86aa4e1cea594e695f9", size = 240110, upload-time = "2026-08-15T08:17:20.547Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/111e5be3b740d5c2a5bfcedb3d237b6591e5c2e82ae9d6ffcb121fe0909c/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5d8531a6569d025f68e2321e7638fb7978f23db58e5f69f56913837aae03816e", size = 232836, upload-time = "2026-08-15T08:17:21.895Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d2/d2aad6fe0dbb44b194bf3becb60f5a0ac48446ade999a47fe7bb41eb09a7/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:aae2ee51122d3ae968a3837d97dc24a0aeebb0dea23694422cd172bd30017cd6", size = 262712, upload-time = "2026-08-15T08:17:23.727Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/337e4663a5eae6de99db940ee8066d4145caafb61327db62deda15313cce/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7235dc28fc6dd9d832ac7c7bce95367dedb85929f17368a0c2bee1e080b9acbf", size = 242977, upload-time = "2026-08-15T08:17:25.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/85/f82f8a92e31c7519410e2e1afdc630f28ec47490ce2c09a11c1a43cbb459/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4abdc5f9ad448c1ecbfae2974b820535d6bc6e7eef63babbab3d81cf46968c71", size = 260207, upload-time = "2026-08-15T08:17:26.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/52/643d11ffd60e9ac2fd1fb87e167a19285b9eefeff4a40e63c87cbfbeab36/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba501e667c17d8411f98e67a022d9604ef179aff0e459b7e292c796837c13573", size = 250562, upload-time = "2026-08-15T08:17:27.971Z" },
+    { url = "https://files.pythonhosted.org/packages/62/16/46556278c2168d12df9da7fede5dc6fc70e60301b26a82bbeec238c9cfe3/charset_normalizer-3.5.1-cp312-cp312-win32.whl", hash = "sha256:cfa1c0cc3a8f9f53f1243a5a99ac36fd003880199383b37672e86ddda9cb07e2", size = 178507, upload-time = "2026-08-15T08:17:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/4c6c298171e6b3e745633180ff59350fc0ca0db1ffd28df1e369e0579f71/charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3617ac3cfd8b9888f145ad89dd6e692285834b0201c6074a5eeaad3fd4d668c2", size = 200551, upload-time = "2026-08-15T08:17:30.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d7/eb95a042f0dd22e304b0b6472b154f3546a1a039a9ee89ccb2a7f61591fc/charset_normalizer-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:88e85ab89cb822c1e635f51d6d32e488f94e002e70e2f492bdb8b945543f345a", size = 180700, upload-time = "2026-08-15T08:17:32.028Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/61/2cb6ad133dbbb449fa2d37ccae973232f4827e799af258d15e589a3d1e9e/charset_normalizer-3.5.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:4f298bdadb8f0b9e5672877f647d1be9373ef5320c9e2f049795e26cad28b6a9", size = 211584, upload-time = "2026-08-15T08:17:33.597Z" },
+    { url = "https://files.pythonhosted.org/packages/18/57/a305c968be1ca13f3dd1b32f445877e97addf55d80b65c7cb35fac82b777/charset_normalizer-3.5.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:88ca277405c2d3b71c4e1c2ee0e7966e807bcba86a69d11e19ba199d18ae4491", size = 223359, upload-time = "2026-08-15T08:17:35.022Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/d3646670292ce8d8f8cc11ac067d44885e697a5591f57a9221128da5e7b3/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9362dd90aa7dab48c0054a21187791ccf05473f7dba5d92b8033ae62164675e7", size = 194464, upload-time = "2026-08-15T08:17:36.452Z" },
+    { url = "https://files.pythonhosted.org/packages/de/93/d51ec556e01042fed6f993ea859311bc7917b466684182fbbceb6ca24762/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:977cdbd483a9cff38179bea4fd754289a6f2195c7abd414aba85410b3e66cc5e", size = 197676, upload-time = "2026-08-15T08:17:37.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a0/562247944386f7d4ef94467e84876600cc1e0f1b93239aaa9213d2bc3cbd/charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e90251c0c7bdd54a100a0dce3c07b7e637278c93af29dbf78ebb89a58c4bac7d", size = 340473, upload-time = "2026-08-15T08:17:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e7/1d994be1b93d41e9502b8b0460eaa88a1dd8df335df415db87d6c3e91ab2/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94d78ecec2605a8d0398b0f365d5f12a63248438516f5dac536a5eff7337df4a", size = 240156, upload-time = "2026-08-15T08:17:40.66Z" },
+    { url = "https://files.pythonhosted.org/packages/09/53/27923ce5cc6cbccb832037b27dca98882d9c53e9b69e866bbbef4aae7fc8/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d59b75732e9b6f27388e10c14b0259cc5f2e48c78627d185e6a177b58ad3cffe", size = 228246, upload-time = "2026-08-15T08:17:42.003Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5a97e84d63af1d55c07439cb80e56d99a8efb4295700eb4e18c0d1615d2c/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0d929fc574b4d6fd9e7c0f5c2ede8716a41911923aa7fa5fce38e0818aa4a1ac", size = 263660, upload-time = "2026-08-15T08:17:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/071575791dcc88316c0a9a65ce38897a82e4cfe4a325f0f7fe1b1ac47bcf/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:394fea06235c8543390050ed5f529187074b029fb027213f6c46ac11ab5d950e", size = 260354, upload-time = "2026-08-15T08:17:45.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3", size = 250638, upload-time = "2026-08-15T08:17:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/66/70dfad64f15be09c15ccfee81330a7e515895dbe296dd23114e9a231268a/charset_normalizer-3.5.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa48b1b63d639f9483e0633e092f5851e2348c352f1f9bb6c8182f87884ef876", size = 244583, upload-time = "2026-08-15T08:17:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/24/ef36367d38b9ddd4bccbf72888c342e8de1f5ae506fa0b2dcf970e2732a1/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c71fb0d56c920c269cd3e2e3fe7c610e3f1fdb21a6ce60efa6430ff63676cea6", size = 242038, upload-time = "2026-08-15T08:17:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ab/55e683ba0fff2e43adafc10daa3001eac90fdaa419a97227d5a7067eedde/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:485a0d363cafefcd2538a73c7c838daa2035f09b2c9f9b5e3133f80c6aeb84c2", size = 233677, upload-time = "2026-08-15T08:17:50.845Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/67/0f40eaf8d1b6e7cf15e82382a2965efaca787fc1c2794b7021d37aaf5036/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0ea61a470e070686aa30892fed79e297d2c8d0ab46b8bcdf027d38c51da591", size = 264491, upload-time = "2026-08-15T08:17:52.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/64/12b4c2a11ee8df4fcc518c78b0d93e3a92bd3d5253d1617ce74ff0e8c7ef/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90b7481fb62fbe172c558bc6fd1c4c98d82004a54a7551f20e11ac9bf0b8708c", size = 245196, upload-time = "2026-08-15T08:17:54.023Z" },
+    { url = "https://files.pythonhosted.org/packages/37/2e/651d910af6d0fba325eee1cda37ec5443462ed25360e666c144166eb6091/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:35fe081843b35aad20ffeccec3eeffbe637b15d14f3fb22cc1b59cd8ec17e93c", size = 261660, upload-time = "2026-08-15T08:17:55.491Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c6/b09e05e6db7f64338e0dc067c79577b1138da86c1e38369096851d96be88/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f", size = 252618, upload-time = "2026-08-15T08:17:57.025Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4e/362d4f9fdcdf5556fb2aa3ce7d4a58ebce03ed1ff03aa1d9aca8d02f13f3/charset_normalizer-3.5.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:9d9a0dc7cbe9bec24c3f767c9122c41fe5a1bc43f47cd099d00d393e09769de4", size = 140362, upload-time = "2026-08-15T08:17:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d4/703be739b26acce318bd29eb3b25b7209e1b1f527f9eae3d1f1f01fdde2b/charset_normalizer-3.5.1-cp313-cp313-win32.whl", hash = "sha256:d63600d620ad0064c3a748b950ac5ea38a80190e5498532efefa4b7b3f1da1f3", size = 177755, upload-time = "2026-08-15T08:18:00.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/56d97ade41c8db611e727168c52ae46c9224c362ec28d4b65d7e9869e8da/charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:aea996a6aba25260827c9ea511d1addfde2da9eb686ac961838509086188b7e6", size = 199295, upload-time = "2026-08-15T08:18:01.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/75/5b20dd1e6573a01a08158fe104104fa2c8abf941745596954185726cd46c/charset_normalizer-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:fd0a274c0e5f9a21565cd9d3dd749b61f96b7aa1e20a93aa1ba4029518f2e5c0", size = 179856, upload-time = "2026-08-15T08:18:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/29/cd/2b812ce5e888f1ce69a5350281e58aab07ae64a958ecae8912f30865718e/charset_normalizer-3.5.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:774d157f112367ff4abd29019f38f023c24e00e56edc7829c20e358a5a913ad8", size = 212318, upload-time = "2026-08-15T08:18:04.403Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/a6ee107430768a5334e6d63f31f148a04a1a491ef161a1ac9415a73f2fa8/charset_normalizer-3.5.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:26422d45fd13551cf564c58932f7d72b4f58b93b0fcf18c35ba6be12b46bb102", size = 224897, upload-time = "2026-08-15T08:18:05.997Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/35ae3f64f29d0179c35c3baefe575904df2913dde519129c7f75995a2b1d/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:09a7bba9f739468c8e78c36a75c33768e53cb1959fc638f510454c14683f00d5", size = 194848, upload-time = "2026-08-15T08:18:07.397Z" },
+    { url = "https://files.pythonhosted.org/packages/74/76/f2fc7380f056cc273a53af37f50d08ad54b2c59f61078f31432edcf1c2bd/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4c9548dc78002099910abaebc0a72ac58b7d30931869e0351c09b507dff4ece3", size = 198163, upload-time = "2026-08-15T08:18:08.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/40/095ce62fa078483cccc1fa2b36e6bc9580b85422a20ee9f925341c50e44f/charset_normalizer-3.5.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c428c6c31eb5f4277d7f8eccaf767fbd548ddd5ce3c8b4f4cbbfab3d96b5904c", size = 341823, upload-time = "2026-08-15T08:18:10.458Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/5a/0e58b1c04a1596e0256f407274a92d5fb2ee21324409d1fab1da48a65b5b/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f06b7eae9dbe77fe1d644ca244dad508de8d302870a43f3c559b521270938a0", size = 242458, upload-time = "2026-08-15T08:18:11.989Z" },
+    { url = "https://files.pythonhosted.org/packages/22/95/b4618ce912e6db0b1aae89ba788e38e8a7eba0f3025cc66e8c0699f977b2/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b7430cf5728e68f6c462254009a6ef4086e1bea43cf2f57aa9c55fb4f50ff96", size = 226717, upload-time = "2026-08-15T08:18:13.401Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/76/c681192bbda3d55356db5dadd64381d5202b37c6b598fcda5282e88b5d3d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab743e9bc90c1f73552ec33e10e3331315acd2c397b36065b591b0181de533cc", size = 266111, upload-time = "2026-08-15T08:18:14.961Z" },
+    { url = "https://files.pythonhosted.org/packages/88/be/55127bfca72c0cff6c022488d140d7c5b04c771e3b72e9bdb4836d54979d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6f7deae3feb4edfa2efaf7c574fe88cbf055038a6abdb40188e4fff66d5699f", size = 263128, upload-time = "2026-08-15T08:18:16.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/91/39c3af510b0aa32bbda03374259200f28430febfd1bf5e511fe765282ce5/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15f024313246a4ed976c60f440bb8d257815513a681d212ff74fd46f7d715a90", size = 251240, upload-time = "2026-08-15T08:18:18.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a5/cbe418bbc6ecdfc3e05a0116002897c4b403a5e838d697e64c78e9f0190d/charset_normalizer-3.5.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:823f82903d189af463d7df250ef1f7f696f3cee08cc8d91deb565e8d425f6506", size = 245282, upload-time = "2026-08-15T08:18:19.625Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a4/689bb42e8e7cd492f3cb64907c6bc00ad247ec9a3628cd3f8eed126e8ae1/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:01e93745f7f219b703b60ba7afead36cfc4242782be5af484673fc500df12da5", size = 244597, upload-time = "2026-08-15T08:18:21.121Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ce/9962938e179cf9f699d3f1e7b3114b5d7642dee6a893745229f9dd04f274/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329fc3ccb63ad22d867d84c2adea759a64079a37ba4a343433b02c7a2816871e", size = 231376, upload-time = "2026-08-15T08:18:22.57Z" },
+    { url = "https://files.pythonhosted.org/packages/85/54/46000450ada53bd9eac5429a2c8c54cd2d9b39c0c255f229aea9af0948a5/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:bb57753e36e4855b8ca375069482250a6246372331a3e4f3407eaebb007443f5", size = 266715, upload-time = "2026-08-15T08:18:24.235Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/bb/618749d70f792b44252a777bf89bfb86823b9bbc1ea13fe8ce759b07f38a/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fce8cbd4997efeb450bd298b54f755dcdff18d496f7a5ddbb4867c6d7c88fdc3", size = 245848, upload-time = "2026-08-15T08:18:25.726Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3f/ffb64458527c7668031d5eb095d978de561958dc9f5b53f8e488a533e603/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6c9cdde8becb25a7fde49924511aa2644d6f8081cc8df8e9452724303348d8e3", size = 264521, upload-time = "2026-08-15T08:18:27.193Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ab/74a55fd803916a35ac461daf002708191aac19b546b80dc8cabfedc63d98/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9ac4444d8d4fd4c4bd08bf451ed3167aa9e7ec6cdb41b648794f1d1103652e36", size = 253054, upload-time = "2026-08-15T08:18:28.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2a/6a9034b7d3c60b17499afb482df5878bf9fa20b50cc3887d5ef017a833db/charset_normalizer-3.5.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:f03ac127268b43ef4fe9e6ab6794a6794b49485a0cc0c1db79876d2f33f75bc7", size = 140580, upload-time = "2026-08-15T08:18:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/46/1d362e1a00d035d66b9869e1281eee115907f7e390a16a07824ab5737360/charset_normalizer-3.5.1-cp314-cp314-win32.whl", hash = "sha256:1f5883d77fd409a261abb5dc8ccbe335720d798b1de4abb3b1d47ccbbc76b53b", size = 180325, upload-time = "2026-08-15T08:18:31.877Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7c/4938c329b6a9d446f6a59aa2092ff7118f274209b5ed0e26893d1d30a63c/charset_normalizer-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:c658c50ac0c98cd755a2dd50b7977d3bca7df401dcc47fbdfa87db53ef7d4e8b", size = 204175, upload-time = "2026-08-15T08:18:33.466Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/33/eeb384dbd8dec570661354592f4f2e1b2fcc92585624d146a000caf53841/charset_normalizer-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:4bea7f8ebe90bbd7f0e4a2de42ca6924ba23e3e76418c408ff82f1d46fabd687", size = 184123, upload-time = "2026-08-15T08:18:34.913Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/6c/c73fa9d5a85f6ab05395de61c5f6984e0a9ff40bb5ff888d46dff02526c6/charset_normalizer-3.5.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fbc597639158fd7c14d55e808718848319540f51b0e6746e3eefa59723a4a348", size = 381682, upload-time = "2026-08-15T08:18:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c7/63565f860921457feba93bae6c86fb7746deb4cffeed2f375cb845318146/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71c909f353863b2b89c83de2ebed71ea6d0df8a6ef65a128193c5e650766bef", size = 240826, upload-time = "2026-08-15T08:18:37.887Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ae/7ae8807410dfa33f8e6f1715740adeaafa8a816cc4cb33508f54b1f7c896/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7ac76cf9afd34929d76eb7fcb63be476a4853d8a96f0dcf2d0db68a0cbdf9885", size = 227861, upload-time = "2026-08-15T08:18:39.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a3/887c1642f0da26000b0e0652d91071113c0e72cea33952e225cf589f49a9/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a3a370082ce34d0612f421e15fe011c53bb1feff21a26d06ad4fb244dab5a375", size = 260758, upload-time = "2026-08-15T08:18:40.88Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/e6f5b9a3d0e55b0ef7505cd3765cdd48f22db89994c947b316f52f801fd8/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:256dd4d85d9e4dc595e2bc983c980e73f62ddeb3165c58b4c3dfe78c5c8548c1", size = 259950, upload-time = "2026-08-15T08:18:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ee/e4e10a94d51cd1ee638aa7e00b65399e6b2a4e8376ab6d2eac9f95586671/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58d4aa13a59c969dbfdf9e6a9560e242cbfd9e8a8f50c2747714df1a423adf65", size = 249329, upload-time = "2026-08-15T08:18:43.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/25/d5f4198819e6059735a84e8d0bfb72dc33976da67b97adcd3fb5a5e07ec6/charset_normalizer-3.5.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0c6dfb5ca6723eeed15aa8e564a014d69fcb8812f94eef11fe3631e0508199f5", size = 243137, upload-time = "2026-08-15T08:18:45.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e925ca7569cf9fb9701fd82503fee73eea5268fdb856bdd64947092d3daa/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c010f5581d9c612804cc59fcf7b524b707fbcb72828551237ab545bb5c7034af", size = 242820, upload-time = "2026-08-15T08:18:46.842Z" },
+    { url = "https://files.pythonhosted.org/packages/34/17/672c251a888ed2aebcdd2fe830ad0104e25ff83c43f5c4f9c15e9fc6853c/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:52ec005752a56ae79547a05c0139ca2501a0c866390b6115008456b9f0e7cde1", size = 230504, upload-time = "2026-08-15T08:18:48.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/fc/f6a85abebd42ce4da2f1db0aa56cc6a0df1995e318b3875d14401b8381d1/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2bced4061f000f7187254a02ad3433ae17eaf991747ceea2f478422590a5bba9", size = 263087, upload-time = "2026-08-15T08:18:49.859Z" },
+    { url = "https://files.pythonhosted.org/packages/98/66/7c42677e739ba66746b297e2046918d793078094dc239e1e72768cffccc6/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9eea3ab2597a5e65fe65296e2d6a84570845a6b55532d90333d740d48bbc850a", size = 243269, upload-time = "2026-08-15T08:18:51.601Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d8/a50b79237f417af10f8c2a501ce8d1ca87829a22e69117891ca4ba20a69e/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:496846868fea80e479324862fa877f02411f2fd0f83b79ccee2607aa68b2a032", size = 258766, upload-time = "2026-08-15T08:18:53.23Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1d/0fc91aeaeb3c83b748f532399ce67cf84604b48297405d740000f7a9e786/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:85d5855daafc240cc045c026d7a15fd198a09b0fc8ff6f5ecbb5297b509cb11e", size = 250814, upload-time = "2026-08-15T08:18:54.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/10/3d8c777cf9024615295aa1b808324ad5b4a77855869c00824bad74ffaf8a/charset_normalizer-3.5.1-cp314-cp314t-win32.whl", hash = "sha256:58d3e12c88e0950bca850ae1f7c256055c097639c2edb9eb123af9807d8b15e4", size = 191074, upload-time = "2026-08-15T08:18:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/81/ae557d3c44d1a1d688696d60563413a0866a91b7ebc50f20df838be3d8c8/charset_normalizer-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:acaf604462bf330b0d07e7a07c1d6e4adac79e5fb13e9c5140590542cafacc00", size = 216476, upload-time = "2026-08-15T08:18:57.889Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e9/61c01fb8b804692569c036b3fc50495814502dcf13a60649c6055390b02c/charset_normalizer-3.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:fdb8a068947befafba9952162645dc2fecaeb400e64584829ed5e9b2fbe21a7f", size = 194115, upload-time = "2026-08-15T08:18:59.418Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4e/8544831ef59d8f27ce92c80871380fdacc8076a8a56ed62f82e54f991333/charset_normalizer-3.5.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9085f87b0e38a2b92b8923059b4e8789fe40d9279712d15dcc670048d77079af", size = 342048, upload-time = "2026-08-15T08:19:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a6/e3b46852424246065355644f4fb6dbccc0239a42a2eee27ecfc8957f0bcd/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2679de311c7946dde5d3b6f44941844133ff5c7cb86099c0061ab1e8901c20a8", size = 242997, upload-time = "2026-08-15T08:19:02.492Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3b/0cc9a26777334ab2f2e3089b948bbf4e4fe72ea70b897715ef6415043ec8/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:baf3775a2635e5a11fbd5e4e64ee69c7e86875d224a5c72aca4c141064589a90", size = 237014, upload-time = "2026-08-15T08:19:03.943Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c2/027335f0aa337a2a2e121bac1ad88c4f02ba6053ea0926802784f3db11af/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac8c94b6539074e0f40899301273ac8402b9b3e01c7b7ba269ff30340aaaf20", size = 266174, upload-time = "2026-08-15T08:19:05.598Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d3/e367787febe4e74769dec0f406f2c3c8d1b955fce5aee1fd0f94e8367a45/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8fe532b3c966d1fb794e0698e4589d0444017ae77fc0b31edea13c0e35bcc449", size = 263361, upload-time = "2026-08-15T08:19:07.251Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3d/391b193eb9f3e84b02f9314088c386debdc0debee843535aaea2e2c6715d/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c84bec0ab5ae0c64bfe73a7d2adcb5ce73b467523fc27fd6a28ab2aa6cbe35a", size = 252143, upload-time = "2026-08-15T08:19:08.816Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/57/de221f1745a90d418199761967e2776bfe2c275a1194220985e8c1d37833/charset_normalizer-3.5.1-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:854066be00447fa8de2ccbbe893e2ffc4b123ef16d897af794c1e18bd4a714b0", size = 252086, upload-time = "2026-08-15T08:19:10.255Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/d119f86a01f9331e8186175f24873b1d74a7ee9e2e4b4d68f9947dae5afd/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:21b82d8082f6f5e7f456ef0bd16323d08de1266efbfeb476e64b2a91d1471a4e", size = 245231, upload-time = "2026-08-15T08:19:11.807Z" },
+    { url = "https://files.pythonhosted.org/packages/26/de/d8e48c135ae480879539cdb179c8d3b50c7879497d75dd899b5763b69cee/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:838648accb3a7fd9803fd45c87bce8509648eb0c11bc34e216141300977244f2", size = 241546, upload-time = "2026-08-15T08:19:13.416Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c4/217755fd1abc50d326c252922cd642002758095a81ff45010337b8b3ef65/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:195ce897c6153c0700078142cf8efe3e6454ca4cf4357499e4078dfd83396626", size = 267033, upload-time = "2026-08-15T08:19:14.981Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/34d8e404e358d2adcc5a228c2134643af00104c8fb0bf525f3688d756f05/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:978eab16f55b4ab2c2a745be9a0a840bf8f09a7f227d9c76eb30214d078865a5", size = 252045, upload-time = "2026-08-15T08:19:16.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fa/40414471acf0aa0692ca77305aa00e434fcd8288f0941c93c30e9a5f8f2f/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:cc0329df4caaceb950d2f580b5ac716a377f7059624a0bafaeaf8a218c6ed774", size = 264866, upload-time = "2026-08-15T08:19:18.101Z" },
+    { url = "https://files.pythonhosted.org/packages/32/90/fcc850bae791abd2e0c041847f13e270aa08692a79f3e00de6d2dce1cb50/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:687c9ca3035544b113bea2055e180af96fb63c0c476e22a9180f51925186e7b7", size = 253932, upload-time = "2026-08-15T08:19:19.734Z" },
+    { url = "https://files.pythonhosted.org/packages/af/af/53afe99068b3c10b4cbae592a52ef72a7c92c0188440e83ee3a078fd8f75/charset_normalizer-3.5.1-cp315-cp315-win32.whl", hash = "sha256:706bfd38730a5ac7a365793269a00f4e988178cec121391f4248d84ad8c972e9", size = 180320, upload-time = "2026-08-15T08:19:21.37Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/bc/f46a132041b29e4a8779ed712d3df1bf112e94ca8de58b66d7ec2c0cf8b9/charset_normalizer-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:92caef967d287a407085d61176fce4012b1dd62daed4eb6d5ceb26d3d2538712", size = 204174, upload-time = "2026-08-15T08:19:23.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5d/9ed554480eda8e447b673648628fdc29574d23dbad01fe11837adedd1cae/charset_normalizer-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:5fc45d653ea8c9a20479167e11d4a0f8cb2fa3470737ab6f9c827532313187b7", size = 184126, upload-time = "2026-08-15T08:19:24.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/32/9b8929bf384061ee1fe5d9c27c6f9776d3d824039ad4e14c88ec00c7808e/charset_normalizer-3.5.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:59171c6e45bf07d0d5cab3b0bf81d945035530f6873398b3b531c31184d46663", size = 381441, upload-time = "2026-08-15T08:19:26.038Z" },
+    { url = "https://files.pythonhosted.org/packages/96/10/e9aa7923d3ddac652c99a1c5f7be494e737e151566a44abe018daf757f2c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9dbdd9205662134957cf0c324f639bdc5031c0ca056e2369e238db75187c0f11", size = 241742, upload-time = "2026-08-15T08:19:27.532Z" },
+    { url = "https://files.pythonhosted.org/packages/28/53/a2d249ebddf47b889a100c0bdcb61a2f9dbb8bc24ef325cc062e4f476877/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e4b018dc5a0eee4676e38fe84a47a427816c590b93b55d9025274ec4d6ffc2dc", size = 235298, upload-time = "2026-08-15T08:19:29.274Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/07/469f78af590f7d5cd48e20d8dbfa3d66deeff9ba37768c04d886b5afd45c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced3fdd71aaa83ce593746c2edb42b7a59cb4c19c8b5c407781c72e493aae55a", size = 262500, upload-time = "2026-08-15T08:19:30.955Z" },
+    { url = "https://files.pythonhosted.org/packages/55/66/3bb56a47f7dcba014055b1a1d33c6f08bbe9c1e74dba154cfa25f90ae885/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:19a3dd5aa73cef1c99687c4fc57db016a9c17104ae1185da88ba566a5d3bebe4", size = 258888, upload-time = "2026-08-15T08:19:32.458Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c1/2adc2800903fb013210349313b710a5376856578d9e33e6b9a1d8b36714a/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc5d36d96478aa9c60654bd932525bf32964c62a7281eafdf16d85003a8d6004", size = 250243, upload-time = "2026-08-15T08:19:33.94Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b5/a18d0dd1157ab655cc2cb14a545f4a4784bbad70ab3502412e36097502d9/charset_normalizer-3.5.1-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:04368edf83514385ffc3e1cfd4546e595f4f1272dd23ba437a93a9cc3741d47b", size = 249871, upload-time = "2026-08-15T08:19:35.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c3/525f508cd1e58d0450ac55ed40ac75bc3a97482c59def5278456a5fbf03c/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:9b5db6052055d34d41230fb78d7c439c23dc536a9896f6cb039e8dd92cfc1263", size = 243580, upload-time = "2026-08-15T08:19:36.886Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c1/49a91fe7e97c8140094ca5c64161ab623a70d9f636bf834eace14048acb5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:252d099029bcbea642f2a06c4ed5046bdf8b5a8150b64afa5e027e88b106e5ee", size = 239807, upload-time = "2026-08-15T08:19:38.392Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/58/56a48c296601274c4689b864a8e2dfb209b81dfcb39472753ce95eea662b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:6199d5606e2bbf2b096cf64d03f8b6790c91081d5ac866b8e7bb6422738cc60c", size = 264083, upload-time = "2026-08-15T08:19:39.856Z" },
+    { url = "https://files.pythonhosted.org/packages/10/4c/dc48409274a1817ff349711d26c62aa0c597df865d4d69ef79160c859193/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:77efcff2b23071c349402ac1066667a3d011f62398d81408c9b88ad991747c9e", size = 250317, upload-time = "2026-08-15T08:19:41.53Z" },
+    { url = "https://files.pythonhosted.org/packages/81/58/d325912115caec62d6bdd77bbab5e0b7da5d234a9f20affdffcbcb530d0b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:a5cbd90ecf0fc62e64726917ad083b73001f0563657a87ec3c0b504e277dc90d", size = 258173, upload-time = "2026-08-15T08:19:43.07Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/b13b1ccae2c8ec63980d13be1890eb73f8aeabbfce02a24aabc0908788f5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:4d26f14f041e83dd8edfd61f4cd4fa7285d31798b5bf1f28e70c367ba6c41d61", size = 251960, upload-time = "2026-08-15T08:19:44.587Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/25/ed3f9919c5aef8cc818be1f972f565f7610d7b2076b8ebb98839516ffc3c/charset_normalizer-3.5.1-cp315-cp315t-win32.whl", hash = "sha256:ac13b004224fb341e1e25a1ed5e19d32f57cdb2a403e01f003b46f051a550f6f", size = 191186, upload-time = "2026-08-15T08:19:46.293Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/43c2b3e9d8267092b913eb8b0603f0f71993c395632886bd37a7223f96cf/charset_normalizer-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:35aea775dc2bd5f54cd84a1cd2696cc3207c479cb9cf0bd346f0d343e4300ddb", size = 215947, upload-time = "2026-08-15T08:19:47.853Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/9aad3e9c8865e5e0efa9a7f6f81c37a67635a985145ecd44528a81e088ee/charset_normalizer-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:fb78f6e7fcd8ad785d28cd577168bc1aaee827b25bb8755638f694794ea98f0a", size = 193909, upload-time = "2026-08-15T08:19:49.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "50.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/951032a3bf22a5697c83183fb6294a4843772947a70e616c57b3ff5f522e/cryptography-50.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41", size = 3989258, upload-time = "2026-07-31T14:23:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/67/91eb047e69c5e845f2f14b8a2e4a1aab0f283cb885531e9e22c8adb176bc/cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc", size = 4700648, upload-time = "2026-07-31T14:24:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/30/82/85f0f7425c856b9f96459411eb12e74ef72df9caf6f8f15bf23a33ff131f/cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f", size = 4682442, upload-time = "2026-07-31T14:24:02.538Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/28/b555a365adff1cca2fbe7b9e487d68a40de6bc67ff2cb587473eb43de0e7/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3", size = 4707596, upload-time = "2026-07-31T14:24:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d8/f52538140cc719df62a01cf87d1c7142318d235817109d6f4054d7c352d6/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533", size = 5314552, upload-time = "2026-07-31T14:24:06.31Z" },
+    { url = "https://files.pythonhosted.org/packages/38/14/6120e5bd7c5aa022ad15424ba4d5c5269d0d9448ed4d55e492ea91e3c1c4/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037", size = 4717113, upload-time = "2026-07-31T14:24:08.349Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/190bf38c3ee2e0f8efc9860ae100c9df4169742eef274b91e7aa1cb133b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f", size = 4338580, upload-time = "2026-07-31T14:24:10.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/504ccfbbe61fd8aa983f7f146399cdf034c72c2fc55f5b2dfdcdcdb20c99/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11", size = 4707038, upload-time = "2026-07-31T14:24:12.169Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/2cf79bbfc4d12ca106437a6e170d6aaa01a373e93093118aaaef0e801bd4/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d", size = 5273110, upload-time = "2026-07-31T14:24:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/8aae2972c520145377ea3559a605a899bebe227bf070b33cdb445929a9b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c", size = 4716439, upload-time = "2026-07-31T14:24:16.415Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/20/4fe50b619a48c2525cc46e2dbc1ac490708d704be5d467bdaac6dc955682/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c", size = 4837383, upload-time = "2026-07-31T14:24:18.553Z" },
+    { url = "https://files.pythonhosted.org/packages/92/91/3a31366e183343d3703f8995c095f5734676bd6938118047e50fcf279eb4/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95", size = 4985772, upload-time = "2026-07-31T14:24:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9a/02ffe35b2853d121689871eb5dce862092562b3a1ed5cc98f1aaed441506/cryptography-50.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269", size = 3816291, upload-time = "2026-07-31T14:24:22.125Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "msal"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]


### PR DESCRIPTION
Closes #104. Part of #103.

## Change

Phase 1 of the E2E pipeline: the harness plus one workload proven end to end. Python 3.12 + pytest, `uv`-pinned, four dependencies (`httpx`, `msal`, `boto3`, `pytest`). The CLI is driven as a subprocess (`packages/cli/dist/cli.mjs`), so the suite tests the artifact we ship, exit codes included.

**Restore is proven through Graph, not through Atlas output.** The lifecycle seeds a message with a random 4 KB attachment, backs up only the marked folder, exports to `.eml`, **deletes the message from M365**, restores, then re-reads through Graph and compares the attachment SHA-256 with the seeded bytes. Attachment bytes carry the hash assertion rather than the body, because Exchange normalises bodies; the body only has to keep its sentinel.

Assertion sources, in order: Graph state > S3 keys and retention (boto3) > exit code. No Ink table is parsed (#94). Snapshot ids are read out of `manifests/<owner>/<snapshot>.json` key names, and the owner segment is discovered rather than assumed.

## Containment

The suite writes into a real mailbox, so this is enforced, not assumed:

- Backup always passes `-m <mailbox> -f atlas-e2e-<run_id>`; a bare `atlas outlook backup` would enumerate every mailbox in the tenant.
- Cleanup deletes only names starting `atlas-e2e`. Foreign markers are swept only once stale (24 h), so a local run cannot delete a scheduled run's live fixtures.
- `Restore-*` roots are deleted only when they hold a marked descendant -- the product names restore roots without our marker, so an operator's own restore is never touched.
- Preflight asserts `E2E_S3_ENDPOINT` is runner-local: the bucket name embeds the real tenant id, so a shared endpoint would mean writing test data into a production bucket.

## Two things the implementation found

1. **`storage-check` reports `not-ready` before any backup exists.** No read-only command provisions a bucket since #93, so preflight creates the tenant bucket with `ObjectLockEnabledForBucket` exactly as `s3-bucket-manager.ts` does on first backup, then asserts the classification is `lock-capable` / `ready`.
2. **`server /data{1...4}` needs the drives to exist.** MinIO sat at "waiting for a minimum of 2 drives" until the four paths were placed under a mounted volume (`/data/{1...4}`). Both containers now report healthy in ~5 s.

Also: msal's `ConfidentialClientApplication` performs OIDC discovery in its constructor, so building it eagerly made every storage-only test error with an authority failure. It is now lazy, and teardown never raises -- a cleanup error must not replace the real test failure.

## Verification

Against local MinIO from this compose file, with placeholder Graph credentials (the tenant-side prerequisites in #105 do not exist yet):

```
$ docker compose -f e2e/docker-compose.e2e.yml up -d --wait
 atlas-e2e-minio-primary  Up (healthy)
 atlas-e2e-minio-replica  Up (healthy)

$ uv run pytest -k "bundle_runs or storage_check or local_only or storage_helpers"
4 passed, 15 deselected
```

- `storage-check` printed `Bucket class: lock-capable` / `Status: ready` -- the four-drive requirement is verified, not asserted from documentation.
- `uv run python -m atlas_e2e.sweep` (the workflow's `if: always()` step) exits 0 and still purges when Graph is unreachable.
- `uv run pytest --collect-only`: 19 tests, no import errors.
- `turbo run format:check lint`: 18/18 tasks pass, pre-existing warnings only.

The Graph-dependent tests cannot be executed until #105 provides the app registration and secrets. Everything reachable without a tenant is green.

## Not in scope

OneDrive/SharePoint (#106), replication and Object Lock (#107), regression guards plus the weekly cron and step-summary reporting (#108). The workflow is `workflow_dispatch` only until those land. No VitePress docs page yet -- `docs/` and the roadmap item are rewritten in #108; `e2e/README.md` documents the suite for now.