### PR TITLE
fix(sharepoint): stop fetching the current version through the version-content endpoint

### DIFF
--- a/packages/sharepoint/src/adapters/graph-sharepoint-connector.adapter.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-connector.adapter.ts
@@ -198,7 +198,18 @@ export class GraphSharePointConnector implements SharePointSiteConnector {
     return await resolve_download_url_helper(this._client, item);
   }
 
-  /** Lists historical versions of a file, following pagination. */
+  /**
+   * Lists a file's *historical* versions, following pagination.
+   *
+   * The newest entry is dropped: Graph returns versions newest-first, and its version-content
+   * endpoint refuses the current version ("Getting the content of the current version is not
+   * supported"), which surfaced as an HTTP 400 per new file and a `UNHEALTHY` run (issue #110).
+   * Current content already reaches storage through the item-content path.
+   *
+   * Dropping by position rather than by id is deliberate: SharePoint numbers versions `1.0`, `2.0`,
+   * ..., so comparing against a literal id silently matched nothing. This mirrors
+   * `GraphOneDriveConnector.list_file_versions`.
+   */
   async list_file_versions(drive_id: string, item_id: string): Promise<SharePointFileVersion[]> {
     const all_versions: SharePointFileVersion[] = [];
     let next_url: string | undefined;
@@ -229,8 +240,8 @@ export class GraphSharePointConnector implements SharePointSiteConnector {
       );
     }
 
-    if (all_versions.length === 0) return [];
-    return all_versions.filter((v) => v.version_id !== '1');
+    if (all_versions.length <= 1) return [];
+    return all_versions.slice(1);
   }
 
   /** Downloads a specific version's content with size-based timeout. */

--- a/packages/sharepoint/tests/unit/adapters/graph-sharepoint-connector-versions.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/graph-sharepoint-connector-versions.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { Container } from 'inversify';
+import { GRAPH_CLIENT_TOKEN } from '@wisecom/atlas-m365-graph';
+import { GraphSharePointConnector } from '@/adapters/graph-sharepoint-connector.adapter';
+
+interface MockGraphClient {
+  api: Mock;
+  _get: Mock;
+  _select: Mock;
+}
+
+function make_mock_client(versions_response: { value: unknown[] }): MockGraphClient {
+  const get_fn = vi.fn().mockResolvedValue(versions_response);
+  const select_fn = vi.fn().mockReturnValue({ get: get_fn });
+  const api_fn = vi.fn().mockReturnValue({ select: select_fn, get: get_fn });
+
+  return { api: api_fn, _get: get_fn, _select: select_fn };
+}
+
+describe('GraphSharePointConnector.list_file_versions', () => {
+  let connector: GraphSharePointConnector;
+  let mock_client: MockGraphClient;
+
+  beforeEach(() => {
+    mock_client = make_mock_client({ value: [] });
+    const container = new Container();
+    container.bind(GRAPH_CLIENT_TOKEN).toConstantValue(mock_client);
+    container.bind(GraphSharePointConnector).toSelf();
+    connector = container.get(GraphSharePointConnector);
+  });
+
+  // Issue #110: SharePoint numbers versions '1.0', '2.0', ..., so the previous guard compared
+  // against the literal id '1' and matched nothing. The current version then went to the
+  // version-content endpoint, which Graph rejects with HTTP 400.
+  it('excludes the current version when ids use SharePoint dotted numbering', async () => {
+    mock_client._get.mockResolvedValue({
+      value: [
+        { id: '3.0', lastModifiedDateTime: '2026-03-03T00:00:00Z', size: 300 },
+        { id: '2.0', lastModifiedDateTime: '2026-03-02T00:00:00Z', size: 200 },
+        { id: '1.0', lastModifiedDateTime: '2026-03-01T00:00:00Z', size: 100 },
+      ],
+    });
+
+    const versions = await connector.list_file_versions('drive-1', 'item-1');
+
+    expect(versions.map((v) => v.version_id)).toEqual(['2.0', '1.0']);
+  });
+
+  it('returns nothing for a freshly uploaded file whose only version is current', async () => {
+    mock_client._get.mockResolvedValue({
+      value: [{ id: '1.0', lastModifiedDateTime: '2026-03-01T00:00:00Z', size: 100 }],
+    });
+
+    expect(await connector.list_file_versions('drive-1', 'item-1')).toEqual([]);
+  });
+
+  it('returns nothing when the file has no versions at all', async () => {
+    mock_client._get.mockResolvedValue({ value: [] });
+
+    expect(await connector.list_file_versions('drive-1', 'item-1')).toEqual([]);
+  });
+
+  it('drops entries with no id before excluding the current version', async () => {
+    mock_client._get.mockResolvedValue({
+      value: [
+        { id: undefined, lastModifiedDateTime: '2026-03-04T00:00:00Z', size: 400 },
+        { id: '3.0', lastModifiedDateTime: '2026-03-03T00:00:00Z', size: 300 },
+        { id: '2.0', lastModifiedDateTime: '2026-03-02T00:00:00Z', size: 200 },
+      ],
+    });
+
+    expect(
+      await connector
+        .list_file_versions('drive-1', 'item-1')
+        .then((v) => v.map((x) => x.version_id)),
+    ).toEqual(['2.0']);
+  });
+
+  it('maps Graph fields and defaults missing metadata', async () => {
+    mock_client._get.mockResolvedValue({
+      value: [
+        { id: '2.0', lastModifiedDateTime: '2026-03-02T00:00:00Z', size: 200 },
+        { id: '1.0' },
+      ],
+    });
+
+    const versions = await connector.list_file_versions('drive-1', 'item-1');
+
+    expect(versions).toEqual([{ version_id: '1.0', last_modified_at: '', size_bytes: 0 }]);
+  });
+});


### PR DESCRIPTION
Closes #110. Found by the E2E pipeline (#106) against a real SharePoint site: [run 32136234300](https://github.com/wisecom-oy/atlas/actions/runs/32136234300).

## Problem

`atlas sharepoint backup` exited **2 (partial)** and printed `Status: UNHEALTHY` for every newly created file:

```
[+] Snapshot sp-snap-1787055701221-eb0750 created
1 changed | 1 stored | 0 dedup

[!] Version 1.0 of atlas-e2e-<run>-file.bin: HTTP 400
[x]   file error: 1 version download(s) failed unexpectedly
[x] Backup incomplete: 1 file error(s) -- exit 2
```

`list_file_versions` tried to exclude the current version by comparing the id against the literal `'1'`:

```ts
return all_versions.filter((v) => v.version_id !== '1');
```

SharePoint numbers versions `1.0`, `2.0`, …, so nothing was ever filtered. The current version then went to `/versions/{id}/content`, which Graph refuses — ["Getting the content of the current version is not supported"](https://learn.microsoft.com/en-us/graph/api/driveitemversion-get-contents) — producing the HTTP 400.

No data was lost: current content reaches storage through the item-content path, and `verify` passes. What was lost is the meaning of the exit code — every routine run looked partially failed, which is how real partial failures end up ignored.

## Change

Drop the newest entry positionally (Graph returns versions newest-first), exactly as `GraphOneDriveConnector.list_file_versions` already does:

```ts
if (all_versions.length <= 1) return [];
return all_versions.slice(1);
```

Positional rather than id-based is the point: it cannot be defeated by a version-numbering format. The two workloads now share one rule, and the JSDoc records why, so the string compare cannot be reintroduced as a "cleanup".

## Verification

- New `packages/sharepoint/tests/unit/adapters/graph-sharepoint-connector-versions.test.ts`, mirroring the OneDrive test: 5 passed, including `'1.0'`-style ids and the freshly-uploaded single-version case that reproduced the bug.
- `turbo run typecheck test lint format:check`: **43/43 tasks pass**.
- End-to-end confirmation follows on the #106 branch, where a SharePoint backup of a freshly uploaded file must exit 0 with no version errors.

Docs need no change: `docs/sharepoint-backup.md:30` already describes the versions call as storing *historical* versions after the current one is processed — which is what the code now does. The `.one`-file caveat at line 396 is unrelated and still accurate.