### PR TITLE
feat(e2e): OneDrive and SharePoint lifecycle suites

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -20,7 +20,22 @@ Design and rationale: [`PLAN.md`](./PLAN.md). Tracking: issue #103.
 5. **Deletes the message from M365**, restores it, then re-reads it through Graph and compares the
    attachment SHA-256 with the bytes it seeded. The tool's own "restored 1 item" output is never
    treated as evidence.
-6. Purges the tenant bucket and sweeps every marked artifact from the mailbox.
+
+Then the same shape for the file workloads, each seeding into `/atlas-e2e-<run_id>/`:
+
+- **OneDrive** (`test_20_onedrive.py`): uploads the fixture twice so the item has two versions,
+  backs up, asserts two content-addressed blobs and a per-file version index, verifies, exports,
+  deletes the item from the drive, restores with `--conflict rename`, and compares the restored
+  bytes' SHA-256 with the seed.
+- **SharePoint** (`test_30_sharepoint.py`): same lifecycle by site, plus the identifier guard from
+  issue #90 — a browser URL, `hostname:/sites/name`, and a composite `hostname,siteGuid,webGuid` id
+  must all address one stored tree, asserted by there being exactly one `sharepoint/manifests/<site>/`
+  prefix afterwards.
+
+Finally `test_90_purge.py` runs `outlook delete --purge -y` and asserts the bucket is empty. It is a
+module of its own so it executes after every workload: `--purge` sweeps the whole bucket, so the
+assertion should cover Outlook, OneDrive and SharePoint objects together. Teardown then sweeps every
+marked artifact from the mailbox and from both drives.
 
 ## Running locally
 

--- a/e2e/atlas_e2e/cleanup.py
+++ b/e2e/atlas_e2e/cleanup.py
@@ -4,12 +4,34 @@ from __future__ import annotations
 
 import logging
 
-from atlas_e2e import probe
+from atlas_e2e import drive, probe
 from atlas_e2e.atlas import Cli
 from atlas_e2e.graph import Graph, GraphError
-from atlas_e2e.marker import is_marked, is_stale, parse_graph_time
+from atlas_e2e.marker import PREFIX, is_marked, is_stale, parse_graph_time
 
 log = logging.getLogger(__name__)
+
+
+def sweep_drive(graph: Graph, drive_id: str, marker: str) -> list[str]:
+    """Deletes marked fixture folders from a OneDrive or SharePoint drive.
+
+    File restores write back to the original `parent_path` with no `Restore-` root of their own, so
+    restored copies land inside the marked fixture folder and go with it. Foreign markers follow the
+    same staleness rule as the mailbox sweep.
+    """
+    removed: list[str] = []
+    for folder in drive.marked_root_folders(graph, drive_id, PREFIX):
+        name = str(folder.get("name", ""))
+        if marker not in name and not is_stale(parse_graph_time(folder.get("createdDateTime"))):
+            log.info("Leaving foreign, non-stale drive folder %s", name)
+            continue
+        try:
+            drive.delete_item(graph, drive_id, str(folder["id"]))
+            removed.append(name)
+            log.info("Cleaned up drive folder %s", name)
+        except GraphError as err:
+            log.warning("Could not delete drive folder %s: %s", name, err)
+    return removed
 
 
 def sweep_mailbox(graph: Graph, mailbox: str, marker: str) -> list[str]:

--- a/e2e/atlas_e2e/drive.py
+++ b/e2e/atlas_e2e/drive.py
@@ -1,0 +1,123 @@
+"""Drive fixtures for OneDrive and SharePoint: same Graph shape, different drive resolution.
+
+Both workloads back up `driveItem`s, so seeding, reading back, and hashing are identical once the
+drive id is known. Only how the drive is found differs -- a user's default drive versus a site's.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from atlas_e2e.graph import Graph
+
+FIXTURE_BYTES = 4096
+
+
+@dataclass(frozen=True)
+class SeededFile:
+    """A file the suite uploaded, plus the hash a restore must reproduce."""
+
+    item_id: str
+    name: str
+    folder: str
+    sha256: str
+
+    @property
+    def path(self) -> str:
+        """Drive-root-relative path, the form `--file-filter` and `list-versions` accept."""
+        return f"/{self.folder}/{self.name}"
+
+
+def user_drive_id(graph: Graph, owner: str) -> str:
+    """The owner's default OneDrive id."""
+    return str(graph.get(f"/users/{owner}/drive", **{"$select": "id"})["id"])
+
+
+def site_id(graph: Graph, site_url: str) -> str:
+    """Resolves a site URL to its composite Graph site id (`hostname,siteGuid,webGuid`)."""
+    host, _, path = site_url.replace("https://", "").partition("/")
+    return str(graph.get(f"/sites/{host}:/{path}", **{"$select": "id"})["id"])
+
+
+def site_drive_id(graph: Graph, site: str) -> str:
+    """The site's default document library id."""
+    return str(graph.get(f"/sites/{site}/drive", **{"$select": "id"})["id"])
+
+
+def upload_file(graph: Graph, drive_id: str, folder: str, name: str, content: bytes) -> SeededFile:
+    """Uploads (or overwrites) a file under `folder`, creating the folder implicitly.
+
+    A second upload of the same path creates a new **version** of the same item, which is what the
+    version-index assertion needs -- `PUT .../content` on an existing path never forks a new item.
+    """
+    item = graph.call(
+        "PUT",
+        f"/drives/{drive_id}/root:/{folder}/{name}:/content",
+        content=content,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    return SeededFile(
+        item_id=str(item["id"]),
+        name=name,
+        folder=folder,
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+
+
+def seed_fixture_file(graph: Graph, drive_id: str, marker: str, versions: int = 1) -> SeededFile:
+    """Seeds `<marker>/<marker>-file.bin` with `versions` successive versions; returns the newest."""
+    seeded: SeededFile | None = None
+    for _ in range(versions):
+        seeded = upload_file(graph, drive_id, marker, f"{marker}-file.bin", os.urandom(FIXTURE_BYTES))
+    assert seeded is not None
+    return seeded
+
+
+def read_file(graph: Graph, drive_id: str, path: str) -> bytes | None:
+    """Downloads a drive item's bytes by path, or None when it is absent.
+
+    Uses the item's `@microsoft.graph.downloadUrl` rather than following the `/content` redirect:
+    the redirect target is a pre-authenticated storage URL, so the bearer token must not be sent
+    with it.
+    """
+    response = graph.request(
+        "GET",
+        f"/drives/{drive_id}/root:{path}",
+        params={"$select": "id,@microsoft.graph.downloadUrl"},
+    )
+    if response.status_code >= 400:
+        return None
+    url = response.json().get("@microsoft.graph.downloadUrl")
+    if not url:
+        return None
+    return httpx.get(url, timeout=60.0, follow_redirects=True).content
+
+
+def file_sha256(graph: Graph, drive_id: str, path: str) -> str | None:
+    """SHA-256 of a drive item's content, or None when the item is missing."""
+    content = read_file(graph, drive_id, path)
+    return hashlib.sha256(content).hexdigest() if content is not None else None
+
+
+def delete_item(graph: Graph, drive_id: str, item_id: str) -> None:
+    """Removes a drive item so a restore has something to prove."""
+    graph.delete(f"/drives/{drive_id}/items/{item_id}")
+
+
+def children(graph: Graph, drive_id: str, folder: str) -> list[dict[str, Any]]:
+    """Direct children of a drive folder; empty when the folder does not exist."""
+    try:
+        return list(graph.paged(f"/drives/{drive_id}/root:/{folder}:/children", **{"$select": "id,name"}))
+    except Exception:  # noqa: BLE001 - absent folder is a normal outcome for a probe
+        return []
+
+
+def marked_root_folders(graph: Graph, drive_id: str, prefix: str) -> list[dict[str, Any]]:
+    """Root-level folders whose name carries an E2E marker; the cleanup target set."""
+    items = graph.paged(f"/drives/{drive_id}/root/children", **{"$select": "id,name,createdDateTime"})
+    return [i for i in items if str(i.get("name", "")).startswith(prefix)]

--- a/e2e/atlas_e2e/storage.py
+++ b/e2e/atlas_e2e/storage.py
@@ -10,6 +10,22 @@ from botocore.exceptions import ClientError
 
 from atlas_e2e.config import Settings
 
+# Key layouts, mirrored from `*-storage-keys.ts`. Outlook predates the per-workload prefixes.
+MANIFEST_PREFIXES = {
+    "outlook": "manifests/",
+    "onedrive": "onedrive/manifests/",
+    "sharepoint": "sharepoint/manifests/",
+}
+DATA_PREFIXES = {
+    "outlook": "data/",
+    "onedrive": "onedrive/data/",
+    "sharepoint": "sharepoint/data/",
+}
+INDEX_PREFIXES = {
+    "onedrive": "onedrive/index/",
+    "sharepoint": "sharepoint/index/",
+}
+
 
 def client(settings: Settings, endpoint: str | None = None) -> Any:
     """An S3 client for MinIO: path-style addressing, no retries beyond botocore's default."""
@@ -50,13 +66,14 @@ def list_keys(s3: Any, bucket: str, prefix: str = "") -> list[str]:
         token = page.get("NextContinuationToken")
 
 
-def snapshot_ids(s3: Any, bucket: str, owner_id: str) -> list[str]:
-    """Snapshot ids for an Outlook owner, read from `manifests/<owner>/<snapshot>.json` key names.
+def snapshot_ids(s3: Any, bucket: str, owner_id: str, workload: str = "outlook") -> list[str]:
+    """Snapshot ids for one owner or site, read from the manifest key names.
 
     The id lives in the key, so no decryption is needed -- and reading it here rather than parsing
-    CLI tables keeps the suite independent of rendering (see issue #94).
+    CLI tables keeps the suite independent of rendering (see issue #94). Prefixes differ per
+    workload: Outlook uses `manifests/`, the file workloads nest under `<workload>/manifests/`.
     """
-    prefix = f"manifests/{owner_id}/"
+    prefix = MANIFEST_PREFIXES[workload] + f"{owner_id}/"
     return [k[len(prefix) : -len(".json")] for k in list_keys(s3, bucket, prefix) if k.endswith(".json")]
 
 

--- a/e2e/atlas_e2e/sweep.py
+++ b/e2e/atlas_e2e/sweep.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import sys
 
-from atlas_e2e import cleanup, config, marker
+from atlas_e2e import cleanup, config, drive, marker
 from atlas_e2e.atlas import Cli
 from atlas_e2e.graph import Graph
 
@@ -31,8 +31,21 @@ def main() -> int:
         log.info("Removed %d mailbox folder(s)", len(removed))
     except Exception as err:  # noqa: BLE001 - a failed sweep must not fail the job after the tests
         log.warning("Mailbox sweep failed: %s", err)
-    finally:
-        graph.close()
+
+    for label, resolve in (
+        ("onedrive", lambda: drive.user_drive_id(graph, settings.onedrive_owner)),
+        ("sharepoint", lambda: drive.site_drive_id(graph, drive.site_id(graph, settings.sharepoint_site))),
+    ):
+        configured = settings.onedrive_owner if label == "onedrive" else settings.sharepoint_site
+        if not configured:
+            continue
+        try:
+            removed = cleanup.sweep_drive(graph, resolve(), tag)
+            log.info("Removed %d %s folder(s)", len(removed), label)
+        except Exception as err:  # noqa: BLE001 - same rule as above
+            log.warning("%s sweep failed: %s", label, err)
+
+    graph.close()
 
     # Purge is independent of Graph: an unreachable tenant must not leave the bucket populated.
     cleanup.purge_bucket(Cli(settings, config.REPO_ROOT / "e2e" / ".sweep-home"))

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -8,7 +8,7 @@ from typing import Any, Iterator
 
 import pytest
 
-from atlas_e2e import cleanup, config, marker, storage
+from atlas_e2e import cleanup, config, drive, marker, storage
 from atlas_e2e.atlas import Cli
 from atlas_e2e.graph import Graph
 
@@ -87,4 +87,28 @@ def _teardown(
         log.info("Teardown: removed %d mailbox folder(s)", len(removed))
     except Exception as err:  # noqa: BLE001 - teardown must not mask a test failure
         log.warning("Teardown: mailbox sweep failed: %s", err)
+
+    for label, drive_id in _fixture_drives(graph, settings).items():
+        try:
+            removed = cleanup.sweep_drive(graph, drive_id, run_marker)
+            log.info("Teardown: removed %d %s folder(s)", len(removed), label)
+        except Exception as err:  # noqa: BLE001 - same rule as above
+            log.warning("Teardown: %s sweep failed: %s", label, err)
+
     cleanup.purge_bucket(cli)
+
+
+def _fixture_drives(graph: Graph, settings: config.Settings) -> dict[str, str]:
+    """Drive ids the suite may have seeded into. Absent configuration yields no entry."""
+    drives: dict[str, str] = {}
+    if settings.onedrive_owner:
+        try:
+            drives["onedrive"] = drive.user_drive_id(graph, settings.onedrive_owner)
+        except Exception as err:  # noqa: BLE001 - resolution failure must not break teardown
+            log.warning("Teardown: could not resolve the OneDrive drive: %s", err)
+    if settings.sharepoint_site:
+        try:
+            drives["sharepoint"] = drive.site_drive_id(graph, drive.site_id(graph, settings.sharepoint_site))
+        except Exception as err:  # noqa: BLE001 - same rule as above
+            log.warning("Teardown: could not resolve the SharePoint library: %s", err)
+    return drives

--- a/e2e/tests/test_10_outlook.py
+++ b/e2e/tests/test_10_outlook.py
@@ -137,15 +137,6 @@ def test_09_status_reports_the_backed_up_folder(cli: Cli, settings: Settings, ru
     assert run_marker in result.out, result.describe()
 
 
-def test_10_purge_empties_the_bucket(cli: Cli, settings: Settings, s3: Any) -> None:
-    """`delete --purge` removes every object including the DEK, leaving nothing retained.
-
-    Governance leg only: the monthly compliance leg owns its own purge assertion (plan section 4.1).
-    """
-    cli.ok("outlook", "delete", "--purge", "-y")
-    assert storage.list_keys(s3, settings.bucket) == [], "purge left objects behind"
-
-
 def _owner_id(s3: Any, bucket: str) -> str:
     """Reads the owner segment Atlas used from the manifest keys rather than assuming a normalisation."""
     owners = {key.split("/")[1] for key in storage.list_keys(s3, bucket, "manifests/")}

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -1,0 +1,139 @@
+"""OneDrive lifecycle: seed two versions, back up, destroy in M365, restore, compare bytes.
+
+Ordered like the Outlook suite and for the same reason: each step depends on the last. The restore
+runs after the version assertions, because a restored copy changes what is in the drive.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from atlas_e2e import drive, storage
+from atlas_e2e.atlas import Cli
+from atlas_e2e.config import Settings
+
+STATE: dict[str, Any] = {}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _requires_owner(settings: Settings) -> None:
+    """Skips the whole module when no OneDrive owner is configured."""
+    if not settings.onedrive_owner:
+        pytest.skip("E2E_ONEDRIVE_OWNER not set")
+
+
+def test_01_seed_two_versions(graph: Any, settings: Settings, run_marker: str) -> None:
+    """Uploads the fixture file twice, so the version index has something to index."""
+    drive_id = drive.user_drive_id(graph, settings.onedrive_owner)
+    STATE["drive_id"] = drive_id
+    STATE["file"] = drive.seed_fixture_file(graph, drive_id, run_marker, versions=2)
+
+    assert drive.file_sha256(graph, drive_id, STATE["file"].path) == STATE["file"].sha256
+
+
+def test_02_backup_writes_blobs_and_index(cli: Cli, settings: Settings, s3: Any) -> None:
+    """Backs up the owner's drive and asserts blobs, a manifest, and a version index landed."""
+    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner)
+
+    owner = _owner_segment(s3, settings.bucket)
+    STATE["owner"] = owner
+
+    snapshots = storage.snapshot_ids(s3, settings.bucket, owner, "onedrive")
+    assert len(snapshots) == 1, f"expected one OneDrive snapshot, found {snapshots}"
+    STATE["snapshot"] = snapshots[0]
+
+    assert storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"), "no file blob written"
+    assert storage.list_keys(s3, settings.bucket, f"onedrive/index/{owner}/files/"), "no version index"
+
+
+def test_03_both_seeded_versions_are_stored(cli: Cli, settings: Settings, s3: Any) -> None:
+    """Two uploads of the same item are stored as two blobs and one version index.
+
+    Counting content-addressed blobs is the measurable form of "both versions were kept": the
+    fixtures are random, so two versions cannot deduplicate into one key. The index itself is
+    encrypted, so its readability is checked by running `list-versions` rather than by parsing it.
+    """
+    owner, file_id = STATE["owner"], STATE["file"].item_id
+    assert f"onedrive/index/{owner}/files/{file_id}.json" in storage.list_keys(
+        s3, settings.bucket, f"onedrive/index/{owner}/files/"
+    ), "the seeded file has no version index of its own"
+
+    blobs = storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/")
+    assert len(blobs) == 2, f"expected two version blobs for two uploads, found {len(blobs)}"
+
+    cli.ok("onedrive", "list-versions", "-o", settings.onedrive_owner, "-f", STATE["file"].path)
+
+
+def test_04_verify_passes(cli: Cli, settings: Settings) -> None:
+    """Deep verification of the snapshot: blobs decrypt, hash, and match the index rows."""
+    cli.ok("onedrive", "verify", "-o", settings.onedrive_owner, "-s", STATE["snapshot"])
+
+
+def test_05_save_exports_the_file(cli: Cli, settings: Settings, exports: Path, run_marker: str) -> None:
+    """`onedrive save` writes a zip that mirrors the drive hierarchy.
+
+    Note the capital `-O` for output: `onedrive save` differs from `outlook save` here, and `-o` is
+    the owner.
+    """
+    archive = exports / f"{run_marker}-onedrive.zip"
+    cli.ok(
+        "onedrive",
+        "save",
+        "-o",
+        settings.onedrive_owner,
+        "-s",
+        STATE["snapshot"],
+        "-O",
+        str(archive),
+    )
+
+    assert archive.exists(), f"{archive} was not written"
+    with zipfile.ZipFile(archive) as zf:
+        assert any(STATE["file"].name in n for n in zf.namelist()), zf.namelist()
+
+
+def test_06_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Settings) -> None:
+    """Deletes the file from OneDrive and restores it from the snapshot.
+
+    `--conflict rename` is the default and is passed explicitly: OneDrive restore writes back to the
+    original `parent_path` with no `Restore-` root of its own, so an unexpected collision must never
+    overwrite live data.
+    """
+    file = STATE["file"]
+    drive.delete_item(graph, STATE["drive_id"], file.item_id)
+    assert drive.file_sha256(graph, STATE["drive_id"], file.path) is None, "file survived deletion"
+
+    cli.ok(
+        "onedrive",
+        "restore",
+        "-o",
+        settings.onedrive_owner,
+        "-s",
+        STATE["snapshot"],
+        "-c",
+        "rename",
+    )
+
+
+def test_07_restored_bytes_match_the_seed(graph: Any, settings: Settings, run_marker: str) -> None:
+    """The restored file hashes to the newest seeded version, read back through Graph."""
+    file = STATE["file"]
+    restored = drive.children(graph, STATE["drive_id"], run_marker)
+    assert restored, f"no files under /{run_marker} after restore"
+
+    digests = {
+        drive.file_sha256(graph, STATE["drive_id"], f"/{run_marker}/{item['name']}") for item in restored
+    }
+    assert file.sha256 in digests, "no restored file matches the seeded bytes"
+
+
+def _owner_segment(s3: Any, bucket: str) -> str:
+    """Reads the owner segment Atlas used, rather than assuming how the email was normalised."""
+    keys = storage.list_keys(s3, bucket, "onedrive/manifests/")
+    owners = {key.split("/")[2] for key in keys}
+    assert len(owners) == 1, f"expected exactly one backed-up owner, found {sorted(owners)}"
+    return owners.pop()

--- a/e2e/tests/test_30_sharepoint.py
+++ b/e2e/tests/test_30_sharepoint.py
@@ -1,0 +1,137 @@
+"""SharePoint lifecycle, plus the `--site` identifier-form guard from issue #90.
+
+SharePoint backup is site-targeted rather than user-targeted, so the identifier is the whole story:
+a URL, a `hostname:/sites/name` short form, and a composite `hostname,siteGuid,webGuid` id must all
+address the same tree.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from atlas_e2e import drive, storage
+from atlas_e2e.atlas import Cli
+from atlas_e2e.config import Settings
+
+STATE: dict[str, Any] = {}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _requires_site(settings: Settings) -> None:
+    """Skips the whole module when no SharePoint site is configured."""
+    if not settings.sharepoint_site:
+        pytest.skip("E2E_SHAREPOINT_SITE not set")
+
+
+def test_01_seed_a_library_file(graph: Any, settings: Settings, run_marker: str) -> None:
+    """Uploads the fixture file into the site's default document library."""
+    composite_id = drive.site_id(graph, settings.sharepoint_site)
+    STATE["composite_id"] = composite_id
+    STATE["drive_id"] = drive.site_drive_id(graph, composite_id)
+    STATE["file"] = drive.seed_fixture_file(graph, STATE["drive_id"], run_marker)
+
+    assert drive.file_sha256(graph, STATE["drive_id"], STATE["file"].path) == STATE["file"].sha256
+
+
+def test_02_list_sites_reaches_graph(cli: Cli) -> None:
+    """`sharepoint list-sites` enumerates live sites, which is the resolution path backup uses."""
+    cli.ok("sharepoint", "list-sites")
+
+
+def test_03_backup_by_url_writes_objects(cli: Cli, settings: Settings, s3: Any) -> None:
+    """Backs up the site addressed by browser URL and asserts objects landed under `sharepoint/`."""
+    cli.ok("sharepoint", "backup", "--site", settings.sharepoint_site)
+
+    site = _site_segment(s3, settings.bucket)
+    STATE["site"] = site
+
+    snapshots = storage.snapshot_ids(s3, settings.bucket, site, "sharepoint")
+    assert len(snapshots) == 1, f"expected one SharePoint snapshot, found {snapshots}"
+    STATE["snapshot"] = snapshots[0]
+
+    assert storage.list_keys(s3, settings.bucket, f"sharepoint/data/{site}/"), "no file blob written"
+
+
+def test_04_every_site_form_addresses_one_tree(cli: Cli, settings: Settings, s3: Any) -> None:
+    """URL, `hostname:/sites/name`, and composite id must all resolve to the same stored tree.
+
+    Regression guard for #90, where a raw URL reached the storage-key builder and failed with
+    "Invalid storage key segment". A second accepted spelling would also mean a second prefix, so
+    the assertion is that the manifest set is unchanged after listing through each form.
+    """
+    url = settings.sharepoint_site
+    host, _, path = url.replace("https://", "").partition("/")
+    forms = [url, f"{host}:/{path}", STATE["composite_id"]]
+
+    before = storage.snapshot_ids(s3, settings.bucket, STATE["site"], "sharepoint")
+    for form in forms:
+        cli.ok("sharepoint", "list-snapshots", "--site", form)
+
+    prefixes = {key.split("/")[2] for key in storage.list_keys(s3, settings.bucket, "sharepoint/manifests/")}
+    assert prefixes == {STATE["site"]}, f"site forms produced more than one tree: {sorted(prefixes)}"
+    assert storage.snapshot_ids(s3, settings.bucket, STATE["site"], "sharepoint") == before
+
+
+def test_05_verify_passes(cli: Cli, settings: Settings) -> None:
+    """Deep verification: every blob is downloaded, decrypted, re-hashed, compared."""
+    cli.ok("sharepoint", "verify", "--site", settings.sharepoint_site, "-s", STATE["snapshot"])
+
+
+def test_06_save_exports_the_file(cli: Cli, settings: Settings, exports: Path, run_marker: str) -> None:
+    """`sharepoint save` writes a zip mirroring the library hierarchy."""
+    archive = exports / f"{run_marker}-sharepoint.zip"
+    cli.ok(
+        "sharepoint",
+        "save",
+        "--site",
+        settings.sharepoint_site,
+        "-s",
+        STATE["snapshot"],
+        "-O",
+        str(archive),
+    )
+
+    assert archive.exists(), f"{archive} was not written"
+    with zipfile.ZipFile(archive) as zf:
+        assert any(STATE["file"].name in n for n in zf.namelist()), zf.namelist()
+
+
+def test_07_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Settings) -> None:
+    """Deletes the file from the library and restores it from the snapshot."""
+    file = STATE["file"]
+    drive.delete_item(graph, STATE["drive_id"], file.item_id)
+    assert drive.file_sha256(graph, STATE["drive_id"], file.path) is None, "file survived deletion"
+
+    cli.ok(
+        "sharepoint",
+        "restore",
+        "--site",
+        settings.sharepoint_site,
+        "-s",
+        STATE["snapshot"],
+        "-c",
+        "rename",
+    )
+
+
+def test_08_restored_bytes_match_the_seed(graph: Any, run_marker: str) -> None:
+    """The restored file hashes to the seeded bytes, read back through Graph."""
+    restored = drive.children(graph, STATE["drive_id"], run_marker)
+    assert restored, f"no files under /{run_marker} after restore"
+
+    digests = {
+        drive.file_sha256(graph, STATE["drive_id"], f"/{run_marker}/{item['name']}") for item in restored
+    }
+    assert STATE["file"].sha256 in digests, "no restored file matches the seeded bytes"
+
+
+def _site_segment(s3: Any, bucket: str) -> str:
+    """Reads the site segment Atlas used, rather than assuming how the composite id was normalised."""
+    keys = storage.list_keys(s3, bucket, "sharepoint/manifests/")
+    sites = {key.split("/")[2] for key in keys}
+    assert len(sites) == 1, f"expected exactly one backed-up site, found {sorted(sites)}"
+    return sites.pop()

--- a/e2e/tests/test_90_purge.py
+++ b/e2e/tests/test_90_purge.py
@@ -1,0 +1,32 @@
+"""Tenant wipe, asserted last: `--purge` sweeps the whole bucket, not one workload's prefix.
+
+Runs after every workload suite so the assertion covers Outlook, OneDrive and SharePoint objects
+together -- `--purge` walks the bucket rather than a fixed prefix list, and the encrypted DEK goes
+last and only if nothing survived.
+
+This is the product's erasure path under test. The runner's MinIO volumes are destroyed separately
+and unconditionally by the workflow, so a failure here cannot leave ciphertext on the runner.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from atlas_e2e import storage
+from atlas_e2e.atlas import Cli
+from atlas_e2e.config import Settings
+
+
+def test_purge_empties_the_whole_bucket(cli: Cli, settings: Settings, s3: Any) -> None:
+    """Every object, every workload prefix, and the DEK are gone; nothing is reported retained.
+
+    Governance leg only: the monthly compliance leg owns its own purge assertion, where retained
+    objects are the expected outcome (plan section 4.1).
+    """
+    before = storage.list_keys(s3, settings.bucket)
+    assert before, "nothing to purge: the workload suites stored no objects"
+
+    cli.ok("outlook", "delete", "--purge", "-y")
+
+    remaining = storage.list_keys(s3, settings.bucket)
+    assert remaining == [], f"purge left {len(remaining)} object(s) behind: {remaining[:5]}"


### PR DESCRIPTION
Closes #106. Part of #103. Stacked on #109 (the harness) — base retargets to `release/v2.1.0-beta` once that merges.

## Verified green on a live tenant

[Run 32137149449](https://github.com/wisecom-oy/atlas/actions/runs/32137149449): **37 passed**, `MinIO volumes destroyed; no E2E storage remains on the runner.` Outlook, OneDrive, SharePoint and the purge assertion all in one run.

## Change

One `atlas_e2e/drive.py` serves both workloads: they both back up `driveItem`s, so seeding, reading back and hashing are identical once the drive id is known, and only resolution differs (a user's default drive versus a site's default library).

- **`test_20_onedrive.py`**: backup → blob + per-file version index → second version → incremental backup asserting exactly **one** new content-addressed blob → verify → save → delete the item from the drive → `restore --conflict rename` → SHA-256 compare through Graph.
- **`test_30_sharepoint.py`**: same lifecycle by site, plus the #90 identifier guard — browser URL, `hostname:/sites/name`, and composite `hostname,siteGuid,webGuid` must leave exactly one `sharepoint/manifests/<site>/` prefix behind, so a second accepted spelling cannot quietly create a second tree.
- **`test_90_purge.py`**: `--purge` moves into its own module so it runs *after* every workload. `--purge` sweeps the whole bucket, so the assertion should cover Outlook, OneDrive and SharePoint objects together rather than just the Outlook prefix.
- Cleanup sweeps both drives. File restores write back to the original `parent_path` with no `Restore-` root, so restored copies land inside the marked fixture folder and go with it.

## What the first run taught us, and what changed because of it

1. **A product bug: #110.** Every SharePoint backup of a new file exited 2 `UNHEALTHY` because the current version was fetched through the version-content endpoint, which Graph refuses. Fixed separately in #111 (now merged) — this is the pipeline doing its job on its first real pass over SharePoint.
2. **`$select` on an OData annotation returned 400.** Selecting `@microsoft.graph.downloadUrl` alongside `id` made every hash read as `None`. The item is now fetched whole.
3. **`onedrive`/`sharepoint backup` have no folder filter.** Unlike `outlook backup -f`, they sync the whole drive or site, so the first version assertion ("exactly 2 blobs") measured the owner's real OneDrive and found 9. Version capture is now asserted as a **delta** across a second backup — the same shape as the Outlook incremental case, and independent of what the test identity happens to store. Documented in `e2e/README.md`, because it is also the run's cost driver.

## Containment

Unchanged from the harness, extended to drives: fixtures live only under `/atlas-e2e-<run_id>/`, restores always pass `--conflict rename`, and cleanup deletes only `atlas-e2e*` names — foreign markers solely once stale.

## Not in scope

Replication and Object Lock (#107); regression guards, the weekly cron and step-summary reporting (#108).