### PR TITLE
fix(e2e): restore the drive-read and version-delta fix lost between branches

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,14 +23,20 @@ Design and rationale: [`PLAN.md`](./PLAN.md). Tracking: issue #103.
 
 Then the same shape for the file workloads, each seeding into `/atlas-e2e-<run_id>/`:
 
-- **OneDrive** (`test_20_onedrive.py`): uploads the fixture twice so the item has two versions,
-  backs up, asserts two content-addressed blobs and a per-file version index, verifies, exports,
-  deletes the item from the drive, restores with `--conflict rename`, and compares the restored
-  bytes' SHA-256 with the seed.
+- **OneDrive** (`test_20_onedrive.py`): backs up, asserts a blob and a per-file version index, then
+  uploads a second version and re-runs the backup asserting exactly **one** new content-addressed
+  blob, verifies, exports, deletes the item from the drive, restores with `--conflict rename`, and
+  compares the restored bytes' SHA-256 with the seed.
 - **SharePoint** (`test_30_sharepoint.py`): same lifecycle by site, plus the identifier guard from
   issue #90 — a browser URL, `hostname:/sites/name`, and a composite `hostname,siteGuid,webGuid` id
   must all address one stored tree, asserted by there being exactly one `sharepoint/manifests/<site>/`
   prefix afterwards.
+
+Note the scope difference from Outlook: `outlook backup` takes `-f <folder>`, but `onedrive backup`
+and `sharepoint backup` have no folder filter — they sync the whole drive or site. So a run reads
+everything the test owner and test site hold, and per-version assertions are written as **deltas**
+around a second backup rather than as absolute object counts. Keep the test site small; the mailbox
+folder filter is what keeps the Outlook side cheap.
 
 Finally `test_90_purge.py` runs `outlook delete --purge -y` and asserts the bucket is empty. It is a
 module of its own so it executes after every workload: `--purge` sweeps the whole bucket, so the

--- a/e2e/atlas_e2e/drive.py
+++ b/e2e/atlas_e2e/drive.py
@@ -7,6 +7,7 @@ drive id is known. Only how the drive is found differs -- a user's default drive
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 from dataclasses import dataclass
 from typing import Any
@@ -14,6 +15,8 @@ from typing import Any
 import httpx
 
 from atlas_e2e.graph import Graph
+
+log = logging.getLogger(__name__)
 
 FIXTURE_BYTES = 4096
 
@@ -84,16 +87,18 @@ def read_file(graph: Graph, drive_id: str, path: str) -> bytes | None:
     Uses the item's `@microsoft.graph.downloadUrl` rather than following the `/content` redirect:
     the redirect target is a pre-authenticated storage URL, so the bearer token must not be sent
     with it.
+
+    No `$select`: OData annotations are not selectable alongside ordinary properties on every drive
+    implementation, and asking for one returned 400 rather than the item (run 32136234300). The full
+    item is a few hundred bytes.
     """
-    response = graph.request(
-        "GET",
-        f"/drives/{drive_id}/root:{path}",
-        params={"$select": "id,@microsoft.graph.downloadUrl"},
-    )
+    response = graph.request("GET", f"/drives/{drive_id}/root:{path}")
     if response.status_code >= 400:
+        log.info("Drive item %s unavailable: HTTP %s", path, response.status_code)
         return None
     url = response.json().get("@microsoft.graph.downloadUrl")
     if not url:
+        log.info("Drive item %s carries no download URL", path)
         return None
     return httpx.get(url, timeout=60.0, follow_redirects=True).content
 

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -26,17 +26,22 @@ def _requires_owner(settings: Settings) -> None:
         pytest.skip("E2E_ONEDRIVE_OWNER not set")
 
 
-def test_01_seed_two_versions(graph: Any, settings: Settings, run_marker: str) -> None:
-    """Uploads the fixture file twice, so the version index has something to index."""
+def test_01_seed_a_file(graph: Any, settings: Settings, run_marker: str) -> None:
+    """Uploads the first version of the fixture file."""
     drive_id = drive.user_drive_id(graph, settings.onedrive_owner)
     STATE["drive_id"] = drive_id
-    STATE["file"] = drive.seed_fixture_file(graph, drive_id, run_marker, versions=2)
+    STATE["file"] = drive.seed_fixture_file(graph, drive_id, run_marker)
 
     assert drive.file_sha256(graph, drive_id, STATE["file"].path) == STATE["file"].sha256
 
 
 def test_02_backup_writes_blobs_and_index(cli: Cli, settings: Settings, s3: Any) -> None:
-    """Backs up the owner's drive and asserts blobs, a manifest, and a version index landed."""
+    """Backs up the owner's drive and asserts blobs, a manifest, and a version index landed.
+
+    `onedrive backup` has no folder scope -- it syncs the whole drive -- so absolute object counts
+    include whatever else the owner has. Assertions here are existence-based, and the per-version
+    assertion below is a delta.
+    """
     cli.ok("onedrive", "backup", "-o", settings.onedrive_owner)
 
     owner = _owner_segment(s3, settings.bucket)
@@ -47,23 +52,34 @@ def test_02_backup_writes_blobs_and_index(cli: Cli, settings: Settings, s3: Any)
     STATE["snapshot"] = snapshots[0]
 
     assert storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"), "no file blob written"
-    assert storage.list_keys(s3, settings.bucket, f"onedrive/index/{owner}/files/"), "no version index"
-
-
-def test_03_both_seeded_versions_are_stored(cli: Cli, settings: Settings, s3: Any) -> None:
-    """Two uploads of the same item are stored as two blobs and one version index.
-
-    Counting content-addressed blobs is the measurable form of "both versions were kept": the
-    fixtures are random, so two versions cannot deduplicate into one key. The index itself is
-    encrypted, so its readability is checked by running `list-versions` rather than by parsing it.
-    """
-    owner, file_id = STATE["owner"], STATE["file"].item_id
-    assert f"onedrive/index/{owner}/files/{file_id}.json" in storage.list_keys(
+    assert f"onedrive/index/{owner}/files/{STATE['file'].item_id}.json" in storage.list_keys(
         s3, settings.bucket, f"onedrive/index/{owner}/files/"
     ), "the seeded file has no version index of its own"
 
-    blobs = storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/")
-    assert len(blobs) == 2, f"expected two version blobs for two uploads, found {len(blobs)}"
+
+def test_03_a_new_version_is_stored_incrementally(
+    cli: Cli, graph: Any, settings: Settings, s3: Any, run_marker: str
+) -> None:
+    """Uploading a second version and re-running the backup stores exactly one more blob.
+
+    Measured as a delta rather than an absolute count: the backup covers the whole drive, so a
+    fixed expectation would depend on what else the owner keeps in OneDrive. Random fixtures cannot
+    deduplicate, so exactly one new content-addressed key is the honest signal that the new version
+    was captured and the old one retained.
+    """
+    owner = STATE["owner"]
+    before = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
+
+    STATE["file"] = drive.seed_fixture_file(graph, STATE["drive_id"], run_marker)
+    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner)
+
+    after = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
+    assert len(after - before) == 1, f"expected one new version blob, got {len(after - before)}"
+    assert before <= after, "an incremental run must not remove existing blobs"
+
+    snapshots = storage.snapshot_ids(s3, settings.bucket, owner, "onedrive")
+    assert len(snapshots) == 2, f"expected a second snapshot, found {snapshots}"
+    STATE["snapshot"] = snapshots[-1]
 
     cli.ok("onedrive", "list-versions", "-o", settings.onedrive_owner, "-f", STATE["file"].path)
 


### PR DESCRIPTION
Reopens and then closes #106. One recovered commit, three files.

## What happened

PR #112 was opened from `feat/106-e2e-file-workloads` **before** its final commit was pushed to that branch, so it merged only `feat(e2e): add OneDrive and SharePoint lifecycle suites`. The follow-up commit lived on my local branch and on `dev` — which is where [run 32137149449](https://github.com/wisecom-oy/atlas/actions/runs/32137149449) went green with 37 passed. Resetting `dev` to the release branch during branch cleanup then discarded the only remote copy.

So the release branch carried code that had never passed, while I reported green from a run of code that was not on release. My error, and worth naming precisely: the run link and the branch content have to be checked against each other, not assumed to match.

## How it surfaced

The very next run caught it, on release content: [32138082875](https://github.com/wisecom-oy/atlas/actions/runs/32138082875)

```
FAILED test_01_seed_two_versions - assert None == '1bb90a1c...'
FAILED test_03_both_seeded_versions_are_stored - expected two version blobs for two uploads, found 9
```

Those are the pre-fix test *names*, which is the proof of which code ran, and the two failures are exactly the bugs the missing commit fixes:

1. `$select=id,@microsoft.graph.downloadUrl` returns 400 rather than the item, so every hash read as `None`. The item is now fetched whole.
2. `onedrive backup` has no folder filter — it syncs the whole drive — so an absolute count of 2 blobs measured the owner's real OneDrive and found 9. Version capture is now asserted as a **delta** across a second backup.

## Verification

[Run 32138976779](https://github.com/wisecom-oy/atlas/actions/runs/32138976779) on this exact commit: **37 passed**, `MinIO volumes destroyed; no E2E storage remains on the runner.`

The recovered commit is byte-identical to what passed originally (cherry-picked from the dangling object, `3 files changed, 52 insertions(+), 25 deletions(-)`).

## Note on the process

Branch pruning is what exposed this, and it is also what made recovery necessary. Both are on me; the pipeline behaved exactly as designed — it failed loudly on the first push of unverified code, which is the entire point of running it on `main`/`dev` pushes rather than only on a schedule.