### PR TITLE
test(e2e): assert the E2E app cannot read other mailboxes

### DIFF
--- a/e2e/tests/test_00_preflight.py
+++ b/e2e/tests/test_00_preflight.py
@@ -112,6 +112,42 @@ def test_sites_read_permission(graph: Graph, settings: Settings) -> None:
     _require(graph, "/sites", "Sites.Read.All", search="*")
 
 
+def test_app_cannot_read_other_mailboxes(graph: Graph, settings: Settings) -> None:
+    """The Exchange `ApplicationAccessPolicy` must bound this credential to the test mailbox (#105).
+
+    `Mail.ReadWrite` is tenant-wide: without a policy, the client secret stored in CI can read and
+    write **every** mailbox in the tenant. That is the single largest risk this suite carries, and it
+    is verifiable rather than attestable -- sample other users and require that none of their
+    mailboxes answer.
+
+    Only counts are reported. Addresses of real users must not reach a public workflow log.
+    """
+    others = [
+        str(user["id"])
+        for user in graph.paged("/users", **{"$select": "id,userPrincipalName,mail", "$top": 25})
+        if _address(user) and _address(user) != settings.mailbox.lower()
+    ][:10]
+    if not others:
+        pytest.skip("tenant has no second user to test the policy against")
+
+    readable = 0
+    for user_id in others:
+        response = graph.request("GET", f"/users/{user_id}/mailFolders", params={"$top": 1})
+        if response.status_code == 200:
+            readable += 1
+
+    assert readable == 0, (
+        f"the E2E app can read {readable} of {len(others)} other mailboxes. "
+        "Restrict it: New-ApplicationAccessPolicy -AppId <id> -PolicyScopeGroupId <mailbox> "
+        "-AccessRight RestrictAccess (issue #105)"
+    )
+
+
+def _address(user: dict[str, Any]) -> str:
+    """A user's mail address in lower case, or an empty string when it has none."""
+    return str(user.get("mail") or user.get("userPrincipalName") or "").lower()
+
+
 def test_tenant_bucket_is_local_only(settings: Settings, s3: Any) -> None:
     """The endpoint under test is the runner's MinIO, never a production endpoint.
 


### PR DESCRIPTION
Part of #105. Stacked on #115; base retargets to `release/v2.1.0-beta` when that merges.

## Why

`Mail.ReadWrite` is tenant-wide. Without an Exchange `ApplicationAccessPolicy`, the client secret stored in repository secrets can read and write **every** mailbox in the tenant — which is the single largest risk this suite carries, and the last open acceptance item of #105.

It was going to be settled by attestation ("paste the `Test-ApplicationAccessPolicy` output"). It is assertable instead, so the suite now proves the boundary on every run rather than trusting that someone did the portal work months ago.

## How

Sample up to ten other users via `/users`, request one mail folder from each, and require that **none** answer `200`.

Counts only are reported. These are real users in a public repository's workflow log, so addresses must not appear in a failure message.

## Result on the live tenant

[Run 32139647023](https://github.com/wisecom-oy/atlas/actions/runs/32139647023): 37 passed, **1 failed**

```
FAILED test_app_cannot_read_other_mailboxes
AssertionError: the E2E app can read 6 of 7 other mailboxes.
```

The assertion is doing exactly its job: the policy does not exist yet. This is a real finding about the tenant, not a defect in the test, so the suite is expected to stay red on this one case until #105 is completed:

```powershell
New-ApplicationAccessPolicy -AppId <e2e-app-id> -PolicyScopeGroupId <test-mailbox> `
  -AccessRight RestrictAccess -Description "Atlas E2E"
```

That is the intended behaviour of a pipeline that reports rather than gates: it names an unsafe configuration and keeps naming it until it is fixed. Merging this PR is a decision to keep the E2E badge red until the credential is scoped — which is the point.

Everything else in #105 is confirmed by the same run: app registration, six permissions with admin consent, the SharePoint site, and all seven secrets.