### PR TITLE
docs(e2e): keep credential scoping out of the suite docs

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -97,14 +97,14 @@ The suite writes into a **real** mailbox, so containment is enforced, not assume
 | `E2E_S3_ENDPOINT` must be runner-local                                   | The bucket name embeds the real tenant id, so a shared endpoint would mean writing test data into a production bucket. Asserted in preflight. |
 | Outlook restore cannot overwrite existing mail                           | The product always builds a fresh `Restore-{timestamp}` root (`folder-restore-planner.ts:28-37`).                                             |
 
-Residual risk: the stored client secret can read and write the whole of that one mailbox, because
-Graph application permissions cannot be scoped below a user. An Exchange `ApplicationAccessPolicy`
-bounds it to a single identity — see issue #105.
+Residual risk: the stored client secret is a tenant-level Graph credential, so the rules above bound
+what the suite touches, not what the credential could reach. Scoping that credential is tenant
+administration and out of scope for this repository — it is configured and reviewed in the tenant.
 
 Storage teardown happens twice over, at two layers:
 
-1. **Tenant wipe, asserted.** `test_10_purge_empties_the_bucket` runs `outlook delete --purge -y`
-   and then lists the bucket with boto3, so the product's own erasure path is under test.
+1. **Tenant wipe, asserted.** `test_90_purge.py` runs `outlook delete --purge -y` after every
+   workload and then lists the bucket with boto3, so the product's own erasure path is under test.
 2. **Volume destruction, unconditional.** The workflow brings MinIO up on freshly created volumes
    (`down -v` before `up`) and destroys them afterwards in an `if: always()` step that fails if any
    `e2e_*` volume survives. So no ciphertext and no wrapped DEK outlive the job even when the purge


### PR DESCRIPTION
Stacked on #115; base retargets to `release/v2.1.0-beta` when that merges. Two paragraphs in `e2e/README.md`.

## Change

Scoping the E2E Graph credential is tenant administration, and the current Microsoft guidance is Exchange **Application RBAC** — service principal → application RBAC role → management scope → allowed mailboxes — which supersedes the `ApplicationAccessPolicy` → mail-enabled security group chain. Neither is a "select app → select mailbox → restrict" flow in EAC, and the configuration belongs where it can be reviewed and audited: the tenant.

So the README no longer names or prescribes a mechanism. It states the residual risk plainly — the stored secret is a tenant-level Graph credential, so the containment rules bound what the *suite* touches, not what the credential could reach — and records that scoping is out of scope for this repository.

The matching assertion is withdrawn in #116 (closed unmerged) rather than rewritten against RBAC: a test that stays red until someone finishes tenant administration would park a permanent failure on a badge whose job is to mean "backup and restore still work".

Also fixes a stale reference: the purge assertion moved to `test_90_purge.py` and now runs after every workload, not inside the Outlook suite.

## Verification

[Run 32140725460](https://github.com/wisecom-oy/atlas/actions/runs/32140725460) on this commit: **37 passed**, `MinIO volumes destroyed; no E2E storage remains on the runner.` The suite is green again with the guard removed.

`grep -rn 'ApplicationAccessPolicy\|#105' e2e/` returns nothing across docs, tests and helpers.