### PR TITLE
feat(e2e): disaster-recovery and Object Lock suites

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,7 @@
 name: E2E
 
-# Runs on pushes to the long-lived branches, plus manual dispatch. The weekly and monthly crons
-# arrive with the remaining suites (issue #108).
+# Runs on pushes to the long-lived branches, on a monthly compliance-mode schedule, and on manual
+# dispatch. The weekly governance cron arrives with issue #108.
 #
 # Never add `pull_request`: this job holds tenant credentials, and a PR-triggered run of
 # fork-supplied code would be a secret-exfiltration path.
@@ -12,12 +12,22 @@ name: E2E
 on:
   push:
     branches: [main, dev]
+  schedule:
+    # Monthly compliance leg. Compliance-mode retention is undeletable until it expires, so this
+    # cannot be the default cadence -- see the lock-mode note on the pytest step.
+    - cron: '0 4 1 * *'
   workflow_dispatch:
     inputs:
       suite:
         description: 'pytest -k expression (empty runs everything)'
         required: false
         default: ''
+      lock_mode:
+        description: 'Object Lock mode for the immutability suite'
+        required: false
+        default: governance
+        type: choice
+        options: [governance, compliance]
 
 permissions:
   contents: read
@@ -80,6 +90,9 @@ jobs:
           E2E_MAILBOX: ${{ secrets.E2E_MAILBOX }}
           E2E_ONEDRIVE_OWNER: ${{ secrets.E2E_ONEDRIVE_OWNER }}
           E2E_SHAREPOINT_SITE: ${{ secrets.E2E_SHAREPOINT_SITE }}
+          # Compliance-mode objects cannot be deleted until retention expires, so only the monthly
+          # schedule (or an explicit dispatch) uses it. Every other run stays on governance.
+          E2E_LOCK_MODE: ${{ github.event.schedule == '0 4 1 * *' && 'compliance' || inputs.lock_mode || 'governance' }}
         run: uv run pytest ${{ inputs.suite && format('-k "{0}"', inputs.suite) || '' }}
 
       # Status is readable from the run page itself, so a red badge can be triaged without

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -38,10 +38,29 @@ everything the test owner and test site hold, and per-version assertions are wri
 around a second backup rather than as absolute object counts. Keep the test site small; the mailbox
 folder filter is what keeps the Outlook side cheap.
 
-Finally `test_90_purge.py` runs `outlook delete --purge -y` and asserts the bucket is empty. It is a
-module of its own so it executes after every workload: `--purge` sweeps the whole bucket, so the
-assertion should cover Outlook, OneDrive and SharePoint objects together. Teardown then sweeps every
-marked artifact from the mailbox and from both drives.
+Then the two suites that rehearse what backups exist for:
+
+- **Disaster recovery** (`test_40_replication.py`): replicates the mailbox to the **replica endpoint**
+  (a second MinIO, because Atlas derives the bucket name from the tenant id), checks `_meta/dek.enc`
+  and the ciphertext keys arrived, **purges primary**, rehydrates `--all` from the replica, and then
+  runs `outlook verify` — so the recovered data is proven to decrypt under the key that came back
+  with it. A drill that keeps its safety net proves nothing, which is why primary is really wiped.
+- **Immutability** (`test_95_immutability.py`): backs up with
+  `--retention-days 1 --lock-mode <mode> --require-immutability`, reads the retention back through
+  boto3, and asserts a blocked delete is reported as **retained**, not **failed** — the distinction
+  between "Object Lock is protecting this" and "something is broken".
+
+`test_90_purge.py` sits between them: `outlook delete --purge -y`, then the bucket must be empty. It
+is a module of its own so it runs after every workload, since `--purge` sweeps the whole bucket.
+
+**Ordering is load-bearing.** Atlas never sends `BypassGovernanceRetention`, so anything it locks is
+undeletable until expiry _even in governance mode_. The immutability suite therefore runs last
+(`test_95…`) — locking objects any earlier would make the purge assertion unsatisfiable. Its locked
+objects are deliberate survivors, and the workflow destroys the MinIO volumes afterwards.
+
+Lock mode comes from `E2E_LOCK_MODE` (`governance` default, `compliance` on the monthly cron).
+
+Teardown then sweeps every marked artifact from the mailbox and from both drives.
 
 ## Running locally
 

--- a/e2e/atlas_e2e/config.py
+++ b/e2e/atlas_e2e/config.py
@@ -19,6 +19,8 @@ _DEFAULTS = {
     "E2E_S3_SECRET_KEY": "minioadmin",
     "E2E_S3_REGION": "us-east-1",
     "E2E_CLI": str(REPO_ROOT / "packages" / "cli" / "dist" / "cli.mjs"),
+    # governance on the weekly leg, compliance on the monthly one.
+    "E2E_LOCK_MODE": "governance",
 }
 
 
@@ -39,6 +41,7 @@ class Settings:
     cli: Path
     onedrive_owner: str
     sharepoint_site: str
+    lock_mode: str
 
     @property
     def bucket(self) -> str:
@@ -87,7 +90,16 @@ def load() -> Settings:
         s3_secret_key=value("E2E_S3_SECRET_KEY"),
         s3_region=value("E2E_S3_REGION"),
         cli=cli,
+        lock_mode=_lock_mode(value("E2E_LOCK_MODE")),
         # Phase 2 workloads: absent until their fixtures exist, so the Outlook suite can run alone.
         onedrive_owner=os.environ.get("E2E_ONEDRIVE_OWNER", ""),
         sharepoint_site=os.environ.get("E2E_SHAREPOINT_SITE", ""),
     )
+
+
+def _lock_mode(raw: str) -> str:
+    """Validates the Object Lock mode; a typo must not silently downgrade immutability coverage."""
+    mode = raw.strip().lower()
+    if mode not in {"governance", "compliance"}:
+        raise RuntimeError(f"E2E_LOCK_MODE must be 'governance' or 'compliance', got {raw!r}")
+    return mode

--- a/e2e/tests/test_40_replication.py
+++ b/e2e/tests/test_40_replication.py
@@ -1,0 +1,116 @@
+"""Disaster recovery: replicate to a second endpoint, destroy primary, rehydrate, verify.
+
+This is the suite that matters most and is hardest to rehearse by hand. It deliberately destroys the
+primary bucket mid-flight, because a DR drill that keeps its safety net proves nothing.
+
+The replica must be a different *endpoint*, not a second bucket: Atlas derives the bucket name from
+the tenant id, so both sides carry the same name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from atlas_e2e import storage
+from atlas_e2e.atlas import Cli
+from atlas_e2e.config import Settings
+
+STATE: dict[str, Any] = {}
+
+
+def test_01_replica_endpoint_is_reachable(settings: Settings, s3_replica: Any) -> None:
+    """The second MinIO answers, and starts without the tenant bucket."""
+    assert storage.bucket_names(s3_replica) is not None
+    assert not storage.bucket_exists(s3_replica, settings.bucket), (
+        "the replica already holds the tenant bucket; the compose volumes were not recreated"
+    )
+
+
+def test_02_replicate_copies_ciphertext_and_the_key(
+    cli: Cli, settings: Settings, s3: Any, s3_replica: Any
+) -> None:
+    """Replication copies manifests, blobs and the wrapped DEK to the target endpoint.
+
+    The DEK matters more than the data: without `_meta/dek.enc` the replica is a pile of ciphertext
+    nobody can open, so a "successful" replication that omitted it would be worthless.
+    """
+    primary_keys = storage.list_keys(s3, settings.bucket)
+    assert primary_keys, "nothing on primary to replicate; earlier suites stored no objects"
+    STATE["snapshot"] = storage.snapshot_ids(s3, settings.bucket, _owner(s3, settings.bucket))[0]
+
+    cli.ok(
+        "replicate",
+        "-m",
+        settings.mailbox,
+        "--target-endpoint",
+        settings.s3_replica_endpoint,
+        "--target-access-key",
+        settings.s3_access_key,
+        "--target-secret-key",
+        settings.s3_secret_key,
+    )
+
+    replica_keys = storage.list_keys(s3_replica, settings.bucket)
+    assert "_meta/dek.enc" in replica_keys, "the wrapped DEK was not replicated"
+    assert [k for k in replica_keys if k.startswith("manifests/")], "no manifest reached the replica"
+    assert [k for k in replica_keys if k.startswith("data/")], "no message blob reached the replica"
+
+    # Ciphertext is copied as-is, so the replicated keys must be byte-identical addresses.
+    outlook_primary = {k for k in primary_keys if k.startswith(("manifests/", "data/", "attachments/"))}
+    outlook_replica = {k for k in replica_keys if k.startswith(("manifests/", "data/", "attachments/"))}
+    assert outlook_primary <= outlook_replica, sorted(outlook_primary - outlook_replica)[:5]
+
+
+def test_03_status_records_the_replication(cli: Cli, settings: Settings, s3: Any) -> None:
+    """`replicate --status` reads the sidecar records replication wrote on primary."""
+    cli.ok("replicate", "--status", "-m", settings.mailbox)
+    assert storage.list_keys(s3, settings.bucket, "_meta/replication/"), "no replication record written"
+
+
+def test_04_primary_is_destroyed(cli: Cli, settings: Settings, s3: Any) -> None:
+    """Wipes primary, including the DEK. Without this the rehydrate below proves nothing."""
+    cli.ok("outlook", "delete", "--purge", "-y")
+    assert storage.list_keys(s3, settings.bucket) == [], "primary still holds objects after purge"
+
+
+def test_05_rehydrate_recovers_from_the_replica(
+    cli: Cli, settings: Settings, s3: Any, s3_replica: Any
+) -> None:
+    """Recovers every workload from the replica into the emptied primary bucket.
+
+    `--all` rather than `-m`: the replica also holds whatever OneDrive and SharePoint objects the
+    earlier suites replicated, and a drill that recovers one workload while reporting success for the
+    tenant is the failure mode this asserts against.
+    """
+    cli.ok(
+        "rehydrate",
+        "--all",
+        "--source-endpoint",
+        settings.s3_replica_endpoint,
+        "--source-access-key",
+        settings.s3_access_key,
+        "--source-secret-key",
+        settings.s3_secret_key,
+    )
+
+    recovered = storage.list_keys(s3, settings.bucket)
+    assert "_meta/dek.enc" in recovered, "the DEK was not copied back; the data cannot be decrypted"
+
+    replicated = {k for k in storage.list_keys(s3_replica, settings.bucket) if k.startswith("manifests/")}
+    assert replicated <= set(recovered), "not every replicated manifest came back"
+
+
+def test_06_verify_passes_on_rehydrated_data(cli: Cli, settings: Settings) -> None:
+    """The recovered snapshot decrypts and hashes correctly under the copied key.
+
+    This is the assertion that makes the whole DR loop meaningful: `verify` downloads every object,
+    decrypts it with the DEK that came from the replica, and compares SHA-256 against the manifest.
+    """
+    cli.ok("outlook", "verify", "-m", settings.mailbox, "-s", STATE["snapshot"])
+
+
+def _owner(s3: Any, bucket: str) -> str:
+    """The Outlook owner segment Atlas used, read from the manifest keys."""
+    owners = {key.split("/")[1] for key in storage.list_keys(s3, bucket, "manifests/")}
+    assert len(owners) == 1, f"expected exactly one backed-up owner, found {sorted(owners)}"
+    return owners.pop()

--- a/e2e/tests/test_95_immutability.py
+++ b/e2e/tests/test_95_immutability.py
@@ -1,0 +1,99 @@
+"""Object Lock: retention is real, and a delete that hits it is reported as retained, not failed.
+
+Runs after `test_90_purge.py` on purpose. Atlas never sends `BypassGovernanceRetention`, so an object
+it locks stays undeletable until expiry **in governance mode too** -- locking anything earlier would
+make the purge assertion unsatisfiable. Everything this suite locks is left behind deliberately, and
+the workflow destroys the MinIO volumes afterwards, so nothing survives the job.
+
+Lock mode comes from `E2E_LOCK_MODE`: `governance` on the weekly leg, `compliance` on the monthly one.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from atlas_e2e import storage
+from atlas_e2e.atlas import Cli
+from atlas_e2e.config import Settings
+
+STATE: dict[str, Any] = {}
+
+
+def test_01_backup_applies_retention(cli: Cli, settings: Settings, s3: Any, run_marker: str) -> None:
+    """A backup with `--retention-days 1 --require-immutability` stamps retention on what it writes.
+
+    `--require-immutability` is the point: it makes the run fail rather than silently downgrade to
+    mutable writes, which is the failure mode an operator would never notice.
+    """
+    result = cli.ok(
+        "outlook",
+        "backup",
+        "-m",
+        settings.mailbox,
+        "-f",
+        run_marker,
+        "--retention-days",
+        "1",
+        "--lock-mode",
+        settings.lock_mode,
+        "--require-immutability",
+    )
+    assert "immutab" in result.out.lower(), result.describe()
+
+    owner_keys = [k for k in storage.list_keys(s3, settings.bucket) if k.startswith("data/")]
+    assert owner_keys, "the locked backup stored no message blob"
+    STATE["locked_key"] = owner_keys[0]
+
+
+def test_02_retention_is_present_on_the_object(settings: Settings, s3: Any) -> None:
+    """S3 itself reports the retention, not just Atlas's summary."""
+    retention = storage.retention(s3, settings.bucket, STATE["locked_key"])
+    assert retention, f"no Object Lock retention on {STATE['locked_key']}"
+
+    assert retention["Mode"].lower() == settings.lock_mode.lower(), retention
+    retain_until = retention["RetainUntilDate"]
+    if retain_until.tzinfo is None:
+        retain_until = retain_until.replace(tzinfo=timezone.utc)
+    assert retain_until > datetime.now(timezone.utc), f"retention already expired: {retain_until}"
+
+
+def test_03_storage_check_still_reports_lock_capable(cli: Cli, settings: Settings) -> None:
+    """The bucket remains classified as lock-capable for the mode that was just used."""
+    result = cli.ok("storage-check", "--lock-mode", settings.lock_mode, "--retention-days", "1")
+    assert "lock-capable" in result.out, result.describe()
+
+
+def test_04_delete_reports_retained_not_failed(cli: Cli, settings: Settings, s3: Any) -> None:
+    """A delete blocked by Object Lock is reported as retained, and the bytes are still there.
+
+    The distinction is the whole feature: `retained` means the backend named Object Lock and the
+    object becomes deletable when retention expires. `failed` means something that will not resolve
+    on its own, like an IAM denial. Conflating them would send an operator hunting a permissions bug
+    that does not exist -- or worse, treat an immutability guarantee as a transient error.
+    """
+    result = cli.run("outlook", "delete", "-m", settings.mailbox, "-y")
+
+    assert result.code != 0, "a delete blocked by retention must not report success"
+    assert "Retained and not deleted" in result.out, result.describe()
+
+    survivors = storage.list_keys(s3, settings.bucket)
+    assert STATE["locked_key"] in survivors, "a retained object was deleted anyway"
+
+
+@pytest.mark.compliance
+def test_05_compliance_objects_are_left_for_the_next_run(settings: Settings, s3: Any) -> None:
+    """On the compliance leg, the locked objects are expected survivors -- attributable, not stray.
+
+    Atlas has no governance bypass, so this holds for either mode: every object still in the bucket
+    at this point must be one this suite locked with `--retention-days 1`. The next run starts on a
+    fresh MinIO volume regardless.
+    """
+    if settings.lock_mode != "compliance":
+        pytest.skip("governance leg: retention semantics are asserted by the tests above")
+
+    survivors = storage.list_keys(s3, settings.bucket)
+    unattributable = [k for k in survivors if not k.startswith(("data/", "attachments/", "manifests/", "_meta/"))]
+    assert not unattributable, f"unexplained survivors in the bucket: {unattributable[:5]}"

--- a/e2e/tests/test_95_immutability.py
+++ b/e2e/tests/test_95_immutability.py
@@ -26,9 +26,11 @@ def test_01_backup_applies_retention(cli: Cli, settings: Settings, s3: Any, run_
     """A backup with `--retention-days 1 --require-immutability` stamps retention on what it writes.
 
     `--require-immutability` is the point: it makes the run fail rather than silently downgrade to
-    mutable writes, which is the failure mode an operator would never notice.
+    mutable writes, which is the failure mode an operator would never notice. A clean exit is the
+    whole signal here -- the flag's contract is to fail otherwise -- and whether retention actually
+    landed is read from S3 in the next test, not from the run's own summary.
     """
-    result = cli.ok(
+    cli.ok(
         "outlook",
         "backup",
         "-m",
@@ -41,7 +43,6 @@ def test_01_backup_applies_retention(cli: Cli, settings: Settings, s3: Any, run_
         settings.lock_mode,
         "--require-immutability",
     )
-    assert "immutab" in result.out.lower(), result.describe()
 
     owner_keys = [k for k in storage.list_keys(s3, settings.bucket) if k.startswith("data/")]
     assert owner_keys, "the locked backup stored no message blob"


### PR DESCRIPTION
Closes #107. Part of #103. Stacked on #117 → #115; base retargets as those merge.

## Verified on the live tenant, both legs

| Leg | Run | Result |
|-----|-----|--------|
| Governance (weekly/default) | [32150123443](https://github.com/wisecom-oy/atlas/actions/runs/32150123443) | **47 passed, 1 skipped** (the compliance-only case) |
| Compliance (monthly cron) | [32150514524](https://github.com/wisecom-oy/atlas/actions/runs/32150514524) | **48 passed** |

The compliance leg was exercised by temporarily pinning `E2E_LOCK_MODE` on a throwaway `dev` commit, since `workflow_dispatch` cannot reach a workflow that is not yet on the default branch. That commit is gone; this branch carries only the expression.

## `test_40_replication.py` — the DR drill

Replicate to the **replica endpoint** → assert `_meta/dek.enc` and the ciphertext keys arrived → **purge primary** → `rehydrate --all` → `outlook verify`.

Three deliberate choices:

- **Primary is really wiped.** A drill that keeps its safety net proves nothing, and this is also the only way to exercise the DEK-copy path: `rehydrate` refuses to overwrite a differing key unless the bucket is effectively empty (`DekOverwriteRefusedError`).
- **The DEK is asserted before the data.** Without `_meta/dek.enc` the replica is a pile of ciphertext nobody can open, so a "successful" replication that omitted it would be worthless.
- **`verify` closes the loop.** It downloads every recovered object, decrypts it with the key that came back from the replica, and compares SHA-256 against the manifest. Copied bytes alone would not prove recoverability.
- **`--all`, not `-m`.** The replica also holds OneDrive and SharePoint objects from the earlier suites; a recovery that restores one workload while reporting tenant success is exactly the failure mode this guards.

## `test_95_immutability.py` — retention is real

Backup with `--retention-days 1 --lock-mode <mode> --require-immutability`, read the retention back **through boto3**, then attempt a delete and require it to be reported as `Retained and not deleted` with the bytes still present.

That distinction is the feature: *retained* means the backend named Object Lock and the object becomes deletable at expiry; *failed* means something that will not resolve on its own, like an IAM denial. Conflating them sends an operator hunting a permissions bug that does not exist — or treats an immutability guarantee as a transient error.

## Ordering is load-bearing, and it changed the plan

`grep -rn BypassGovernanceRetention packages/` returns nothing: **Atlas never bypasses governance retention**, so anything it locks is undeletable until expiry *even in governance mode*. Consequences:

1. The immutability suite must run **after** `test_90_purge.py` (hence `test_95…`); locking anything earlier would make the purge assertion unsatisfiable.
2. The plan's §4.1 rule — "weekly governance asserts `retained == 0`" — was wrong. Governance and compliance behave identically for deletion from Atlas's side, so the assertion is instead that every survivor is attributable to a lock this suite applied.

Its locked objects are deliberate survivors; the workflow destroys the MinIO volumes afterwards, so nothing outlives the job.

## Also

- Monthly cron `0 4 1 * *` selects the compliance leg; `workflow_dispatch` gains a `lock_mode` choice. The weekly governance cron stays with #108.
- `E2E_LOCK_MODE` is validated at load, so a typo cannot silently downgrade immutability coverage to nothing.

One assertion of mine failed on the first run ([32149712603](https://github.com/wisecom-oy/atlas/actions/runs/32149712603)) because it grepped the backup summary for `immutab` — output parsing the plan rules out. It now relies on the exit code (the contract of `--require-immutability`) plus the boto3 read.