### PR TITLE
feat(e2e): regression guards, weekly cron, and public-safe reporting

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,9 @@ on:
   push:
     branches: [main, dev]
   schedule:
+    # Weekly governance leg: the standing guard. Monday morning, so a red run has a working week
+    # in front of it rather than a weekend.
+    - cron: '0 3 * * 1'
     # Monthly compliance leg. Compliance-mode retention is undeletable until it expires, so this
     # cannot be the default cadence -- see the lock-mode note on the pytest step.
     - cron: '0 4 1 * *'
@@ -114,12 +117,42 @@ jobs:
           E2E_MAILBOX: ${{ secrets.E2E_MAILBOX }}
         run: uv run python -m atlas_e2e.sweep
 
-      - name: Upload test report
+      # Artifacts are public downloads: GitHub's log masking does not apply to a file in a zip. The
+      # transcript is written scrubbed, and this step refuses to publish it if that failed. It
+      # compares against the secrets without ever echoing them.
+      - name: Verify artifacts carry no tenant data
+        id: leakcheck
         if: always()
+        env:
+          E2E_TENANT_ID: ${{ secrets.E2E_TENANT_ID }}
+          E2E_MAILBOX: ${{ secrets.E2E_MAILBOX }}
+          E2E_ONEDRIVE_OWNER: ${{ secrets.E2E_ONEDRIVE_OWNER }}
+          E2E_SHAREPOINT_SITE: ${{ secrets.E2E_SHAREPOINT_SITE }}
+          E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
+          E2E_CLIENT_SECRET: ${{ secrets.E2E_CLIENT_SECRET }}
+          E2E_ENCRYPTION_PASSPHRASE: ${{ secrets.E2E_ENCRYPTION_PASSPHRASE }}
+        run: |
+          status=0
+          for name in E2E_TENANT_ID E2E_MAILBOX E2E_ONEDRIVE_OWNER E2E_SHAREPOINT_SITE \
+                      E2E_CLIENT_ID E2E_CLIENT_SECRET E2E_ENCRYPTION_PASSPHRASE; do
+            value="${!name}"
+            [ -z "$value" ] && continue
+            if grep -rqF -- "$value" e2e/report.xml e2e/logs 2>/dev/null; then
+              echo "$name appears in an artifact; refusing to upload" >&2
+              status=1
+            fi
+          done
+          [ "$status" -eq 0 ] && echo "Artifacts checked: no secret value present."
+          exit "$status"
+
+      - name: Upload test report and scrubbed CLI transcript
+        if: always() && steps.leakcheck.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-report
-          path: e2e/report.xml
+          path: |
+            e2e/report.xml
+            e2e/logs/
           retention-days: 30
 
       # The tenant wipe is asserted by the suite (`delete --purge`); this destroys the storage

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tools/perf/dist/
 e2e/.venv/
 e2e/.pytest_cache/
 e2e/report.xml
+e2e/logs/
 # uv.lock is committed on purpose: CI must resolve the same dependency versions as a local run.
 e2e/.sweep-home/
 __pycache__/

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -85,6 +85,7 @@ export default defineConfig({
       {
         text: 'Development',
         items: [
+          { text: 'End-to-End Validation', link: '/development/e2e' },
           { text: 'Graph Request Tracing', link: '/development/graph-tap' },
           { text: 'Performance Profiling', link: '/development/performance-profiling' },
         ],

--- a/docs/development/e2e.md
+++ b/docs/development/e2e.md
@@ -1,0 +1,61 @@
+# Live-Tenant E2E Validation
+
+Atlas's unit suites mock Microsoft Graph and S3. That is the right default -- they run in seconds and gate every push -- but it means no unit test can catch a Graph endpoint that changes its contract, a permission that was never granted, or an S3 backend that silently declines to apply Object Lock. Those defects only exist against real infrastructure.
+
+The E2E pipeline exists to find them on a schedule instead of in production. It lives in `e2e/` and drives **the shipped CLI bundle** (`packages/cli/dist/cli.mjs`) against a real Microsoft 365 tenant, with MinIO providing S3 storage inside the GitHub Actions runner.
+
+```bash
+# from e2e/, with the seven E2E_* variables in the environment
+pnpm run build          # the suite runs dist/, not src
+docker compose -f docker-compose.e2e.yml up -d --wait
+uv run pytest           # ~35 tests, roughly two minutes
+```
+
+Full setup, fixtures, and the safety model are documented in [`e2e/README.md`](https://github.com/wisecom-oy/atlas/blob/main/e2e/README.md).
+
+## What a run proves
+
+Each suite is a lifecycle, not a collection of assertions -- every step depends on the previous one, so a break anywhere stops the chain.
+
+| Suite                  | Proves                                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `test_00_preflight`    | Every Graph permission the product calls is granted and consented; the S3 bucket is lock-capable             |
+| `test_10_outlook`      | Seed → backup → list → verify → save → delete from M365 → restore → compare through Graph → incremental      |
+| `test_20_onedrive`     | Two file versions → backup → per-file version index → restore with conflict rename → SHA-256 compare         |
+| `test_30_sharepoint`   | The same lifecycle per site, plus URL, short-form, and composite site identifiers addressing one stored tree |
+| `test_35_regressions`  | One case per shipped bug that only reproduces against real infrastructure                                    |
+| `test_40_replication`  | Replicate → **destroy primary** → rehydrate from the replica → verify decryption under the recovered key     |
+| `test_90_purge`        | `delete --purge` empties the bucket                                                                          |
+| `test_95_immutability` | Object Lock retention is applied and a blocked delete is reported as _retained_, not _failed_                |
+
+Two design rules make the results trustworthy:
+
+- **Assertions read the source of truth, not Atlas's output.** Restores are verified through Graph, storage through the S3 API, exit codes as exit codes. A tool that prints "restored 1 item" is not evidence that an item was restored.
+- **No automatic retry.** A retry that turns red into green hides exactly the flakiness the pipeline exists to surface.
+
+## Schedule
+
+| Trigger                   | Purpose                                                                       |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| Weekly, Monday 03:00 UTC  | Standing guard, governance-mode Object Lock                                   |
+| Monthly, 1st at 04:00 UTC | Compliance-mode leg: retention that cannot be lifted early, even by the owner |
+| Push to `main` / `dev`    | Catches a break at the moment it lands rather than days later                 |
+| `workflow_dispatch`       | Ad-hoc, with a `-k` expression and a lock-mode choice                         |
+
+The workflow **never** triggers on `pull_request`. It holds tenant credentials, and a PR-triggered run of fork-supplied code would be a straightforward secret-exfiltration path. It is also deliberately **not a required status check**: a live-tenant run depends on Graph and network availability, so a red E2E must inform an engineer, not block an unrelated merge. `ci.yml` remains the gate.
+
+## Security model for a public repository
+
+The tenant is real, the repository is open source, and Actions artifacts are public downloads. Three consequences shape the implementation:
+
+- **Everything identifying is a secret**, including the tenant id, mailbox address, OneDrive owner, and SharePoint site URL -- not just credentials. Derived values are masked too: the bucket name embeds the tenant id, so the workflow registers it with `::add-mask::` before first use.
+- **Artifacts are scrubbed on write, not on upload.** The CLI transcript passes through `atlas_e2e.scrub`, which replaces known secret values and then templates identifying _shapes_ -- GUIDs, bearer tokens, UPNs, Graph drive ids. A file that was never allowed to hold a secret cannot leak one later.
+- **The upload is gated by a check, not by trust.** A workflow step greps the artifacts for each secret value and fails the job before upload if any appears. It compares without ever echoing the values.
+
+Failure messages follow the same rule: marker names and counts, never message bodies or file contents.
+
+## Cleanup
+
+Every artifact the suite creates carries a run marker (`atlas-e2e-<run-id>`), and cleanup only ever deletes objects whose names match it. A bug in the suite therefore cannot destroy real data in the tenant. Teardown also removes markers older than 24 hours, so a run killed mid-flight does not leak fixtures forever.
+
+Storage is destroyed at two layers: the suite asserts the product's own erasure path (`delete --purge` leaves an empty bucket), and the workflow then removes the MinIO volumes outright -- so no ciphertext and no wrapped key survives the job even when the purge assertion is the thing that failed.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,7 +68,7 @@ Comprehensive security audit and restore-flow hardening driven by external revie
 - **Restore-integrity verification** — post-restore folder verification integrated into the restore pipeline
 - **Dependency security patches** — Dependabot vulnerability fixes
 
-### v2.0.0 — Multi-Workload & Monorepo _(current branch)_
+### v2.0.0 — Multi-Workload & Monorepo
 
 Extended Atlas beyond Outlook mailboxes to additional Microsoft 365 workloads and restructured the codebase for independent package releases.
 
@@ -78,6 +78,18 @@ Extended Atlas beyond Outlook mailboxes to additional Microsoft 365 workloads an
 - **Monorepo restructure** — split into dedicated packages (`@wisecom/atlas-cli`, `@wisecom/atlas-sdk`, shared domain/ports) with independent versioning and smaller install footprints
 - **Multi-workload replication** — `atlas replicate` and `atlas rehydrate` extended with `--site` for SharePoint; OneDrive and Outlook snapshots replicate through the same tenant bucket and DEK
 - **Unified encryption model** — all workloads share the per-tenant DEK and scrypt-derived KEK; storage layout documented per workload in [Storage Layout](/operations/storage-layout)
+
+### v2.1.0 — Live-Tenant E2E Validation _(current branch)_
+
+Replaced manual end-to-end testing with a scheduled pipeline that drives the shipped CLI bundle against a real Microsoft 365 tenant.
+
+- **Full lifecycle per workload** — Outlook, OneDrive, and SharePoint each run seed → backup → verify → export → delete from M365 → restore → compare through Graph
+- **Disaster recovery drill** — replicate to a second endpoint, destroy the primary bucket, rehydrate, and verify that recovered data decrypts under the recovered key
+- **Immutability coverage** — Object Lock retention asserted through the S3 API, with governance weekly and compliance monthly
+- **Regression guards** — one case per shipped bug that only reproduces against real infrastructure
+- **Weekly schedule with public-safe reporting** — per-suite results in the run summary, and artifacts scrubbed of tenant-identifying data before upload
+
+See [End-to-End Validation](/development/e2e) for the design and the security model.
 
 ---
 
@@ -94,10 +106,6 @@ Evaluate replacing scrypt with Argon2id for KEK derivation. The versioned DEK bl
 ### Performance Profiling & Optimization
 
 Instrument the backup and restore pipelines with flamechart analysis to identify bottlenecks. Candidates include S3 upload concurrency, Graph API page fetch parallelism, and encryption throughput. Targeted optimizations based on measured data rather than assumptions.
-
-### CI/CD Restore & Backup Validation
-
-Add automated end-to-end pipeline stages that run a full backup → verify → restore → compare cycle against a dedicated testing tenant on every merge request. This replaces manual E2E testing and catches regressions before they reach a release branch.
 
 ### SDK Documentation & Hosted Docs
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -38,6 +38,25 @@ everything the test owner and test site hold, and per-version assertions are wri
 around a second backup rather than as absolute object counts. Keep the test site small; the mailbox
 folder filter is what keeps the Outlook side cheap.
 
+`test_35_regressions.py` then holds one case per shipped bug, but only for bugs that need real
+infrastructure to reproduce:
+
+- **#93**: `outlook list`, `stats` and `list-users` against an unknown tenant id must create no
+  bucket. `ListBuckets` before and after is the assertion; a bucket-per-tenant layout makes an
+  accidental provision billable storage plus an untracked key.
+- **#76**: a blob whose AES-GCM tag fails must be reported as an authentication failure. Node sets no
+  `error.code` for that failure, so the fix suggested in the issue (`ERR_OSSL_BAD_DECRYPT`) would
+  have silently classified nothing — only a real decrypt on the real runtime tells you which is true.
+  The mirror direction (a storage authorization error must _not_ read as tampering) stays a unit
+  test: producing a genuine per-prefix S3 denial needs a scoped MinIO user that exists only to be
+  denied, and a fabricated credential failure is what a mock is for.
+- **SDK smoke**: `packages/sdk/dist/index.mjs` — the file published to npm — is imported and asked
+  for the snapshots the CLI just wrote. The CLI and the SDK are separate artifacts over one core; a
+  bundle that cannot resolve its own dependencies would otherwise surface as an integrator's issue.
+
+It is numbered 35 so the workload blobs still exist to tamper with, and so it runs before the
+replication suite empties the bucket.
+
 Then the two suites that rehearse what backups exist for:
 
 - **Disaster recovery** (`test_40_replication.py`): replicates the mailbox to the **replica endpoint**
@@ -140,8 +159,9 @@ Storage teardown happens twice over, at two layers:
 
 ## CI
 
-`.github/workflows/e2e.yml` runs on pushes to `main` and `dev`, and on manual dispatch. The weekly
-and monthly crons land with issue #108.
+`.github/workflows/e2e.yml` runs weekly (Monday 03:00 UTC, governance-mode Object Lock), monthly (1st
+at 04:00 UTC, compliance mode), on pushes to `main` and `dev`, and on manual dispatch with a `-k`
+expression and a lock-mode choice.
 
 It never runs on `pull_request` — the job holds tenant credentials, and a PR trigger would let
 fork-supplied code exfiltrate them. Secrets are repository secrets (`E2E_*`); no GitHub environment
@@ -149,5 +169,14 @@ is attached, because approval rules would leave unattended runs waiting for a hu
 
 **The workflow gates nothing.** A live-tenant run depends on Graph and network availability, so it
 is deliberately not a required status check: `ci.yml` remains the merge gate, while E2E reports
-status through its own badge and a per-test table on the run's summary page
+status through its own badge and a per-suite table on the run's summary page
 (`python -m atlas_e2e.summary`). A red E2E means "investigate", not "blocked".
+
+### Artifacts
+
+Two files are uploaded: `report.xml` (JUnit, test names only) and `logs/cli.log`, every CLI
+invocation the run issued with its output. Artifacts are public downloads, and GitHub's log masking
+does not apply inside a zip, so the transcript is scrubbed **as it is written** (`atlas_e2e.scrub`):
+known secret values are replaced, then identifying shapes are templated — GUIDs, bearer tokens, UPNs
+and Graph drive ids. A workflow step then greps the artifacts for each secret and fails the job
+before upload if one appears; it compares without echoing the values.

--- a/e2e/atlas_e2e/atlas.py
+++ b/e2e/atlas_e2e/atlas.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from atlas_e2e.config import Settings
+from atlas_e2e.scrub import scrub
 
 log = logging.getLogger(__name__)
 
@@ -37,12 +38,17 @@ class Result:
 class Cli:
     """A CLI bound to one settings object and one isolated HOME."""
 
-    def __init__(self, settings: Settings, home: Path) -> None:
+    def __init__(self, settings: Settings, home: Path, transcript: Path | None = None) -> None:
         self._settings = settings
         # An isolated HOME keeps ~/.atlas/config.enc and the OS keyring out of the run: the suite
         # must depend on the env vars it sets, not on whatever a developer configured locally.
         self._home = home
         home.mkdir(parents=True, exist_ok=True)
+        # Uploaded as an artifact, so it is written scrubbed rather than scrubbed later: a file that
+        # was never allowed to hold a secret cannot leak one through a forgotten code path.
+        self._transcript = transcript
+        if transcript:
+            transcript.parent.mkdir(parents=True, exist_ok=True)
 
     def run(self, *args: str, timeout: int = DEFAULT_TIMEOUT) -> Result:
         """Invokes `atlas <args>` and captures both streams. Never raises on a non-zero exit."""
@@ -64,7 +70,17 @@ class Cli:
             cwd=self._home,  # no repo-root atlas.config.json in scope
             env=env,
         )
-        return Result(argv=argv, code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+        result = Result(argv=argv, code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+        self._record(result)
+        return result
+
+    def _record(self, result: Result) -> None:
+        """Appends one scrubbed invocation to the transcript, when one is configured."""
+        if not self._transcript:
+            return
+        entry = f"$ atlas {' '.join(result.argv)}\n{result.out.strip()}\n[exit {result.code}]\n\n"
+        with self._transcript.open("a", encoding="utf-8") as handle:
+            handle.write(scrub(entry, self._settings))
 
     def ok(self, *args: str, timeout: int = DEFAULT_TIMEOUT) -> Result:
         """Runs and asserts a clean exit. Exit 2 (partial) is a failure here: E2E fixtures are tiny."""

--- a/e2e/atlas_e2e/scrub.py
+++ b/e2e/atlas_e2e/scrub.py
@@ -1,0 +1,55 @@
+"""Redaction for anything the run uploads.
+
+GitHub masks registered secrets in *logs*, but artifacts are raw files in a public repository -- a
+mask in the Actions UI does nothing for a downloaded zip. So every byte we persist passes through
+here first.
+
+Two layers, deliberately overlapping:
+
+1. **Exact values** we were given (tenant id, mailbox, site, keys). Precise, and useless the moment
+   a value appears in a form we did not anticipate.
+2. **Shape patterns** (GUIDs, bearer tokens, email addresses). Catches the derived identifiers layer
+   one cannot know about: a drive id, an owner object id, a site collection GUID.
+
+Reference behaviour is `tools/graph-tap/tap.mjs`: tokens elided, GUIDs and UPNs templated.
+"""
+
+from __future__ import annotations
+
+import re
+
+from atlas_e2e.config import Settings
+
+# Order matters only in that longer literals are replaced before shorter ones, so a mailbox
+# address is not left half-redacted by an earlier hit on its domain.
+_GUID = re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b")
+_BEARER = re.compile(r"(?i)\b(bearer\s+)[A-Za-z0-9._~+/-]{20,}=*")
+_EMAIL = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_SHAREPOINT_HOST = re.compile(r"(?i)\bhttps?://[A-Za-z0-9-]+\.sharepoint\.com\S*")
+# Graph drive ids (`b!<base64>`) embed the site and web GUIDs, so they identify the tenant as surely
+# as the site URL does.
+_DRIVE_ID = re.compile(r"\bb![A-Za-z0-9_-]{20,}")
+
+
+def scrub(text: str, settings: Settings) -> str:
+    """Replaces secrets and identifying shapes with stable placeholders."""
+    literals = {
+        settings.client_secret: "<client-secret>",
+        settings.passphrase: "<passphrase>",
+        settings.s3_secret_key: "<s3-secret-key>",
+        settings.s3_access_key: "<s3-access-key>",
+        settings.sharepoint_site: "<sharepoint-site>",
+        settings.mailbox: "<mailbox>",
+        settings.onedrive_owner: "<onedrive-owner>",
+        settings.tenant_id: "<tenant-id>",
+        settings.client_id: "<client-id>",
+    }
+    for value, placeholder in sorted(literals.items(), key=lambda kv: -len(kv[0])):
+        if value:
+            text = text.replace(value, placeholder)
+
+    text = _SHAREPOINT_HOST.sub("<sharepoint-url>", text)
+    text = _DRIVE_ID.sub("<drive-id>", text)
+    text = _BEARER.sub(r"\1<token>", text)
+    text = _EMAIL.sub("<upn>", text)
+    return _GUID.sub("<guid>", text)

--- a/e2e/atlas_e2e/summary.py
+++ b/e2e/atlas_e2e/summary.py
@@ -14,26 +14,51 @@ REPORT = Path("report.xml")
 
 
 def main() -> int:
-    """Prints a per-test Markdown table plus a one-line total."""
+    """Prints a per-suite Markdown table, the failing test names, and a one-line total."""
     if not REPORT.exists():
         print("E2E did not produce a report: the run failed before pytest started.")
         return 0
 
-    suites = ElementTree.parse(REPORT).getroot().iter("testsuite")
-    rows: list[str] = []
-    totals = {"passed": 0, "failed": 0, "skipped": 0}
+    root = ElementTree.parse(REPORT).getroot()
+    per_suite: dict[str, dict[str, int]] = {}
+    failures: list[str] = []
 
-    for suite in suites:
-        for case in suite.iter("testcase"):
-            outcome = _outcome(case)
-            totals[outcome] += 1
-            rows.append(f"| {_icon(outcome)} | `{case.get('classname', '')}` | {case.get('name', '')} |")
+    for case in root.iter("testcase"):
+        suite = _suite_name(case)
+        counts = per_suite.setdefault(suite, {"passed": 0, "failed": 0, "skipped": 0})
+        outcome = _outcome(case)
+        counts[outcome] += 1
+        if outcome == "failed":
+            failures.append(f"`{suite}` -- {case.get('name', '')}")
+
+    totals = {
+        key: sum(counts[key] for counts in per_suite.values())
+        for key in ("passed", "failed", "skipped")
+    }
 
     print("## E2E result\n")
     print(f"**{totals['passed']} passed, {totals['failed']} failed, {totals['skipped']} skipped**\n")
-    print("| | Suite | Test |")
-    print("| - | ----- | ---- |")
-    print("\n".join(rows))
+    print("| | Suite | Passed | Failed | Skipped |")
+    print("| - | ----- | ------ | ------ | ------- |")
+    for suite, counts in sorted(per_suite.items()):
+        # A suite that ran nothing must not read as green: absent coverage is not a pass.
+        verdict = "FAIL" if counts["failed"] else "PASS" if counts["passed"] else "SKIP"
+        print(
+            f"| {verdict} | {suite} | {counts['passed']} | {counts['failed']} | {counts['skipped']} |"
+        )
+
+    # The table answers "is it broken"; these lines answer "where", without needing the log.
+    if failures:
+        print("\n### Failed\n")
+        for failure in failures:
+            print(f"- {failure}")
+    return 0
+
+
+def _suite_name(case: ElementTree.Element) -> str:
+    """The suite a testcase belongs to, e.g. `test_10_outlook`."""
+    classname = case.get("classname", "")
+    return classname.split(".")[-1] or "unknown"
     return 0
 
 
@@ -44,11 +69,6 @@ def _outcome(case: ElementTree.Element) -> str:
     if case.find("skipped") is not None:
         return "skipped"
     return "passed"
-
-
-def _icon(outcome: str) -> str:
-    """Marker shown in the summary table."""
-    return {"passed": "PASS", "failed": "FAIL", "skipped": "SKIP"}[outcome]
 
 
 if __name__ == "__main__":

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -37,8 +37,12 @@ def atlas_home(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 @pytest.fixture(scope="session")
 def cli(settings: config.Settings, atlas_home: Path) -> Cli:
-    """The shipped CLI bundle, driven as a subprocess."""
-    return Cli(settings, atlas_home)
+    """The shipped CLI bundle, driven as a subprocess, recording a scrubbed transcript.
+
+    The transcript is what an operator triaging a red weekly run actually wants: every command the
+    suite issued and what came back. It is uploaded as an artifact, so it is scrubbed on write.
+    """
+    return Cli(settings, atlas_home, transcript=config.REPO_ROOT / "e2e" / "logs" / "cli.log")
 
 
 @pytest.fixture(scope="session")

--- a/e2e/sdk_smoke.mjs
+++ b/e2e/sdk_smoke.mjs
@@ -1,0 +1,32 @@
+/**
+ * Reads a mailbox's snapshots through the published SDK bundle and prints their ids as JSON.
+ *
+ * The point is the packaging boundary, not the logic: the CLI and the SDK are separate published
+ * artifacts, and the SDK is the one consumers embed. A build that ships a CLI which works and an
+ * SDK bundle that cannot even be imported is a release nobody would notice until an integrator
+ * files an issue -- so this loads `dist/index.mjs`, the file that goes to npm.
+ *
+ * Output is ids only. Manifests carry subjects and file names; those must never reach a public log.
+ */
+
+import { createAtlasInstance } from '../packages/sdk/dist/index.mjs';
+
+const required = (name) => {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is not set`);
+  return value;
+};
+
+const atlas = createAtlasInstance({
+  tenantId: required('ATLAS_TENANT_ID'),
+  clientId: required('ATLAS_CLIENT_ID'),
+  clientSecret: required('ATLAS_CLIENT_SECRET'),
+  s3Endpoint: required('ATLAS_S3_ENDPOINT'),
+  s3AccessKey: required('ATLAS_S3_ACCESS_KEY'),
+  s3SecretKey: required('ATLAS_S3_SECRET_KEY'),
+  s3Region: process.env.ATLAS_S3_REGION ?? 'us-east-1',
+  encryptionPassphrase: required('ATLAS_ENCRYPTION_PASSPHRASE'),
+});
+
+const snapshots = await atlas.outlook.listSnapshots(required('E2E_MAILBOX'));
+process.stdout.write(JSON.stringify(snapshots.map((manifest) => manifest.snapshot_id)));

--- a/e2e/tests/test_35_regressions.py
+++ b/e2e/tests/test_35_regressions.py
@@ -1,0 +1,139 @@
+"""One case per shipped bug, so a fix cannot quietly come back.
+
+These are not unit tests moved outdoors. Each case is here because the bug only exists once real
+infrastructure is involved: a bucket that gets provisioned, ciphertext that a real Node crypto
+implementation must reject, an npm bundle that must import.
+
+Bugs whose regression guard lives better elsewhere are named at the bottom of this file rather than
+faked here.
+
+Numbered 35 on purpose: after the workload suites, so their blobs exist to be tampered with, and
+before `test_40_replication.py`, which purges primary and rehydrates only what it replicated.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import uuid
+from typing import Any
+
+from atlas_e2e import storage
+from atlas_e2e.atlas import Cli
+from atlas_e2e.config import REPO_ROOT, Settings
+
+# A tenant id in valid GUID form that has certainly never been backed up.
+UNKNOWN_TENANT = str(uuid.UUID(int=0xE2E))
+
+
+def test_01_readonly_commands_provision_nothing(cli: Cli, s3: Any) -> None:
+    """Read-only commands against an unknown tenant create no bucket and no DEK (issue #93).
+
+    The original defect: `outlook list -t <unknown>` created the bucket and bootstrapped encryption
+    key material. A typo, or a tenant belonging to another environment, silently provisioned
+    infrastructure -- and in a bucket-per-tenant layout that is billable storage plus a key nobody
+    tracks. `ListBuckets` before and after is the ground truth here; the CLI's own message is not.
+    """
+    before = {b["Name"] for b in s3.list_buckets()["Buckets"]}
+
+    for argv in (
+        ("outlook", "list", "-t", UNKNOWN_TENANT),
+        ("stats", "-t", UNKNOWN_TENANT),
+        ("list-users", "-t", UNKNOWN_TENANT),
+    ):
+        result = cli.run(*argv)
+        after = {b["Name"] for b in s3.list_buckets()["Buckets"]}
+        assert after == before, f"`atlas {' '.join(argv)}` provisioned: {sorted(after - before)}"
+        # A read-only command against nothing must say so, not crash and not claim success.
+        assert result.code in (0, 1), result.describe()
+
+
+def test_02_corrupt_ciphertext_is_reported_as_tampering(
+    cli: Cli, settings: Settings, s3: Any
+) -> None:
+    """A blob that fails its AES-GCM tag check is classified as authentication failure (issue #76).
+
+    Issue #76 was the mirror of this: storage errors mentioning "auth" were reported as tampering.
+    Fixing it required pinning the classifier to Node's exact tag-failure message -- and the fix
+    suggested in the issue (`err.code === 'ERR_OSSL_BAD_DECRYPT'`) would have broken this direction
+    entirely, because Node sets no `code` on that error. Only a real decrypt against real ciphertext
+    proves which of those two is true, which is why this case lives out here.
+
+    The negative direction (a storage authorization error must *not* be reported as tampering) stays
+    a unit test: producing a genuine per-prefix S3 denial needs a scoped MinIO user that only exists
+    to be denied, and a fabricated credential failure is exactly what a mock is for.
+    """
+    blobs = storage.list_keys(s3, settings.bucket, "onedrive/data/")
+    assert blobs, "no OneDrive blob to corrupt; the OneDrive suite must have run first"
+    key = blobs[0]
+
+    original = s3.get_object(Bucket=settings.bucket, Key=key)["Body"].read()
+    # Flip one bit inside the ciphertext body, past the [IV][tag] envelope header, so the blob stays
+    # structurally valid and fails at the tag check rather than at parsing.
+    corrupted = bytearray(original)
+    corrupted[-1] ^= 0x01
+    s3.put_object(Bucket=settings.bucket, Key=key, Body=bytes(corrupted))
+
+    try:
+        result = cli.run(
+            "onedrive",
+            "restore",
+            "-o",
+            settings.onedrive_owner,
+            "--conflict",
+            "rename",
+        )
+        assert result.code != 0, f"restore of tampered ciphertext reported success\n{result.describe()}"
+        lower = result.out.lower()
+        assert "authentication failed" in lower, result.describe()
+        # The distinction that matters to an operator: this must not read as a transient or
+        # missing-object problem, because the honest diagnosis is wrong key or altered bytes.
+        assert "missing or unreadable" not in lower, result.describe()
+    finally:
+        s3.put_object(Bucket=settings.bucket, Key=key, Body=original)
+
+
+def test_03_sdk_lists_the_snapshots_the_cli_wrote(settings: Settings, s3: Any) -> None:
+    """The published SDK bundle sees exactly the snapshots in the bucket.
+
+    The CLI and the SDK are separately published artifacts over one core. This imports
+    `packages/sdk/dist/index.mjs` -- the file that goes to npm -- so a bundle that cannot resolve its
+    own dependencies fails here rather than in an integrator's issue.
+    """
+    owner = _sole_owner(s3, settings)
+    expected = set(storage.snapshot_ids(s3, settings.bucket, owner))
+    assert expected, "no Outlook snapshot in the bucket for the SDK to read"
+
+    proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        ["node", str(REPO_ROOT / "e2e" / "sdk_smoke.mjs")],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "E2E_MAILBOX": settings.mailbox,
+            **settings.cli_env(),
+        },
+    )
+    assert proc.returncode == 0, f"sdk_smoke.mjs -> exit {proc.returncode}\n{proc.stderr.strip()}"
+    assert set(json.loads(proc.stdout)) == expected, (
+        f"SDK reported {len(json.loads(proc.stdout))} snapshot(s), bucket holds {len(expected)}"
+    )
+
+
+def _sole_owner(s3: Any, settings: Settings) -> str:
+    """The one Outlook owner segment in the bucket, read from the manifest keys."""
+    owners = {key.split("/")[1] for key in storage.list_keys(s3, settings.bucket, "manifests/")}
+    assert len(owners) == 1, f"expected exactly one backed-up owner, found {sorted(owners)}"
+    return owners.pop()
+
+
+# Covered elsewhere, deliberately not duplicated here:
+#
+# * #90 (SharePoint site URLs reaching the storage key builder) -- `test_30_sharepoint.py` addresses
+#   the same library by browser URL, `hostname/sites/name` short form, and composite
+#   `hostname,siteGuid,webGuid` id, and asserts all three resolve to one stored tree. Asserting "no
+#   Graph resolve call was issued" would need request interception the suite has no other use for.
+# * #110 (SharePoint version-content 400) -- any first backup of a freshly uploaded file exercises
+#   it; `test_30_sharepoint.py` requires a clean exit, which is what regressed.

--- a/e2e/tests/test_35_regressions.py
+++ b/e2e/tests/test_35_regressions.py
@@ -64,16 +64,23 @@ def test_02_corrupt_ciphertext_is_reported_as_tampering(
     a unit test: producing a genuine per-prefix S3 denial needs a scoped MinIO user that only exists
     to be denied, and a fabricated credential failure is exactly what a mock is for.
     """
+    owners = {k.split("/")[2] for k in storage.list_keys(s3, settings.bucket, "onedrive/manifests/")}
+    assert len(owners) == 1, f"expected one backed-up OneDrive owner, found {sorted(owners)}"
+    owner = owners.pop()
+    snapshots = storage.snapshot_ids(s3, settings.bucket, owner, "onedrive")
+    assert snapshots, "no OneDrive snapshot to restore"
+
     blobs = storage.list_keys(s3, settings.bucket, "onedrive/data/")
     assert blobs, "no OneDrive blob to corrupt; the OneDrive suite must have run first"
-    key = blobs[0]
 
-    original = s3.get_object(Bucket=settings.bucket, Key=key)["Body"].read()
-    # Flip one bit inside the ciphertext body, past the [IV][tag] envelope header, so the blob stays
-    # structurally valid and fails at the tag check rather than at parsing.
-    corrupted = bytearray(original)
-    corrupted[-1] ^= 0x01
-    s3.put_object(Bucket=settings.bucket, Key=key, Body=bytes(corrupted))
+    # Flip one bit inside every blob's ciphertext body, past the [IV][tag] envelope header, so each
+    # blob stays structurally valid and fails at the tag check rather than at parsing. Corrupting
+    # all of them removes the question of which blob the chosen snapshot references.
+    originals = {key: s3.get_object(Bucket=settings.bucket, Key=key)["Body"].read() for key in blobs}
+    for key, original in originals.items():
+        corrupted = bytearray(original)
+        corrupted[-1] ^= 0x01
+        s3.put_object(Bucket=settings.bucket, Key=key, Body=bytes(corrupted))
 
     try:
         result = cli.run(
@@ -81,6 +88,8 @@ def test_02_corrupt_ciphertext_is_reported_as_tampering(
             "restore",
             "-o",
             settings.onedrive_owner,
+            "-s",
+            snapshots[0],
             "--conflict",
             "rename",
         )
@@ -91,7 +100,8 @@ def test_02_corrupt_ciphertext_is_reported_as_tampering(
         # missing-object problem, because the honest diagnosis is wrong key or altered bytes.
         assert "missing or unreadable" not in lower, result.describe()
     finally:
-        s3.put_object(Bucket=settings.bucket, Key=key, Body=original)
+        for key, original in originals.items():
+            s3.put_object(Bucket=settings.bucket, Key=key, Body=original)
 
 
 def test_03_sdk_lists_the_snapshots_the_cli_wrote(settings: Settings, s3: Any) -> None:


### PR DESCRIPTION
Closes #108. Part of #103. Stacked on #118 → #117 → #115; base retargets as those merge.

## Verified

[Run 32171769770](https://github.com/wisecom-oy/atlas/actions/runs/32171769770) — **50 passed, 1 skipped**, leak check clean, volumes destroyed.

The downloaded artifact (`e2e-report`) was audited directly: no GUID, email address, or `*.sharepoint.com` URL survives anywhere in it; the transcript carries `<tenant-id>`, `<upn>`, `<drive-id>` placeholders instead, and still reads as a complete command history.

## Regression guards (`test_35_regressions.py`)

Only bugs that need real infrastructure get a case here; the rest are named at the bottom of the file with where they are covered instead.

| Bug | Guard | Revert demonstration |
|-----|-------|----------------------|
| #93 read-only commands provision a bucket | `outlook list` / `stats` / `list-users` against an unknown tenant; `ListBuckets` identical before and after | Reverted the fix locally → guard failed, and the bucket it caught (`atlas-00000000-…-0e2e`) had actually been provisioned |
| #76 storage auth errors reported as tampering | A blob with one flipped ciphertext bit must surface as an **authentication failure**, restoring its bytes afterwards | The old substring classifier fails the SharePoint unit suite (`does not treat a decrypt-stage error mentioning auth as tampering`); the issue's suggested `ERR_OSSL_BAD_DECRYPT` classifier fails the *positive* direction — **Node sets no `error.code` on a GCM tag failure**, which only a real decrypt proves |
| SDK smoke | `packages/sdk/dist/index.mjs` — the file npm gets — must import and return the snapshots the CLI wrote | Import resolves standalone against built dist |

Two placement decisions, both recorded in the plan's §12:

- **Numbered 35, not 60.** The replication suite replicates Outlook only, then purges primary — by test 60 the OneDrive blobs the tamper case needs are gone. Regressions run after the workloads, before replication.
- **The #76 auth-denial direction stays a unit test.** MinIO root bypasses bucket policy (verified: a Deny on `data/*` still returned the object), so a genuine per-prefix denial needs a scoped MinIO user that exists only to be denied — permanent IAM plumbing in the harness for one assertion. Worse, MinIO's `AccessDenied` message contains no "auth" substring, so the realistic fixture is a *fabricated* credential error — which is exactly what a mock is. The unit suite pins both directions; the E2E case pins the one thing no mock can: the real Node crypto contract.

## Reporting and artifacts

- **Weekly cron** `0 3 * * 1` (Monday morning — a red run gets a working week, not a weekend) alongside the monthly compliance leg.
- **Step summary** is now per-suite with the failing test names listed, so triage starts on the run page.
- **CLI transcript** (`e2e/logs/cli.log`): every command the run issued, with output, uploaded next to `report.xml`. It is scrubbed **as it is written** — known secret values first, then identifying shapes (GUIDs, bearer tokens, UPNs, Graph drive ids, which embed site GUIDs). A file that never holds a secret cannot leak one later.
- **Upload gate**: a step greps the artifacts for every secret value and fails the job before upload if one appears, comparing without echoing. Upload is conditioned on that step, not on trust.

## Docs

- `docs/development/e2e.md` — the suites, the schedule, and why artifacts are scrubbed on write.
- Sidebar entry; roadmap item rewritten as shipped under v2.1.0.
- `pnpm run docs:build` clean.

## What did not make the cut

- The #90 "no Graph resolve call" assertion: would need request interception the suite has no other use for; the SharePoint suite already resolves the same site three ways and asserts one stored tree.
- A per-prefix S3 denial fixture (see above).

Acceptance item "at least one scheduled run green without manual intervention" lands Monday, 03:00 UTC.