### PR TITLE
ci(release): automate tagging, publishing, and release documentation

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: release
+description: >-
+  Cut, verify, or repair an Atlas release. Covers version bumps, the release and
+  hotfix branch flow, tag creation, the npm publish pipeline, and recovery from a
+  failed or partial publish.
+when_to_use: >-
+  Use whenever the user asks to release, ship, cut, publish, tag, or bump a
+  version, to prepare a beta or release candidate, to hotfix production, or asks
+  what is in the next release or why a publish did not happen.
+---
+
+# Releasing Atlas
+
+The rule: **a release is a version bump reaching `main`.** Nothing else tags,
+and nothing else publishes. Releases happen when there is enough change to
+justify one -- never on a schedule, never automatically from commit messages.
+
+Full reference for humans: `docs/development/releases.md`. This skill is the
+operational procedure.
+
+## Hard rules
+
+1. **Never bump a version outside a release or hotfix PR.** The bump _is_ the
+   release trigger. A bump merged in an ordinary PR publishes to npm on arrival.
+2. **Never hand-edit the nine `packages/*/package.json` versions.** Use
+   `pnpm run release:version <version>`. They move in lockstep; a partial bump
+   fails the publish workflow's tag/version check.
+3. **Never delete a tag whose npm publish already succeeded.** npm versions are
+   immutable. Recovery is always forward, at the next patch version.
+4. **Never reuse a version.** If `v<version>` is tagged, that version is spent.
+5. **Do not push a tag by hand** unless repairing a broken run. `tag.yml` owns
+   tag creation; a hand-pushed tag that does not match the packages fails.
+6. **Never create the release commit with `git commit` in CI.** `main` requires
+   signed commits; the workflow uses GitHub's `createCommitOnBranch` mutation so
+   the commit is signed. A runner-side `git commit` produces an unsigned commit
+   and an unmergeable release PR.
+
+## Which flow applies
+
+| Situation                                | Flow    | Cut from |
+| ---------------------------------------- | ------- | -------- |
+| Enough accumulated work on `dev` to ship | Release | `dev`    |
+| Urgent fix that cannot wait for `dev`    | Hotfix  | `main`   |
+| A published release is broken            | Hotfix  | `main`   |
+
+## Cutting a release
+
+Before anything, establish what is actually unreleased. Do not trust the
+changelog or the roadmap:
+
+```bash
+git fetch --all --tags
+git log --oneline "$(git describe --tags --abbrev=0 origin/main)"..origin/dev
+node -p "require('./packages/sdk/package.json').version"
+git tag --sort=-creatordate | head -5
+```
+
+Choose the version from the nature of those commits: breaking change → major,
+new capability → minor, fixes only → patch. Prereleases use `-beta`, `-beta.N`,
+or `-rc.N` and publish under a matching npm dist-tag, never `latest`.
+
+Then trigger the workflow -- do not create the branch or the bump by hand:
+
+```bash
+gh workflow run release-start.yml -f version=2.2.0 -f from=dev
+gh run watch
+```
+
+It creates `release/v<version>`, bumps all nine packages, commits
+`chore(release): <version>`, and opens a PR into `main`.
+
+Before merging:
+
+- Confirm CI is green, including the `release-guard` job.
+- Confirm every PR in the release carries a label (`enhancement`, `bug`,
+  `documentation`, `security`) -- notes are categorised by label only, and
+  unlabelled PRs land under "Other changes".
+- Confirm the docs governance checklist in `.claude/CLAUDE.md` is satisfied for
+  everything in the release: CLI flags, SDK methods, config variables, and
+  security changes all have documentation in place.
+
+Merging the PR is the release. Then watch the pipeline:
+
+```bash
+gh run watch                                    # tag.yml, then publish.yml
+npm view @wisecom/atlas-sdk dist-tags
+npm view @wisecom/atlas-cli dist-tags
+```
+
+## Hotfixes
+
+```bash
+gh workflow run release-start.yml -f version=patch -f from=main
+```
+
+The fix itself goes on the generated `hotfix/v<version>` branch, which is cut
+from `main`, so unreleased `dev` work does not ship with it.
+
+**After the hotfix publishes, merge the back-merge PR that `tag.yml` opens**
+(`main` → `dev`). Skipping it means the next release branch is cut from a `dev`
+that lacks the fix, silently reverting it.
+
+## Verifying a release actually shipped
+
+A release can appear to succeed while nothing was published. Check all four:
+
+```bash
+git ls-remote --tags origin | grep "v<version>"     # tag exists
+npm view @wisecom/atlas-sdk@<version> version       # sdk published
+npm view @wisecom/atlas-cli@<version> version       # cli published
+gh release view "v<version>"                        # notes generated
+```
+
+The dist-tag must match the version shape: no `-` → `latest`; `-beta` → `beta`;
+`-rc.N` → `rc`. A prerelease sitting on `latest` is a production incident --
+correct it with `npm dist-tag add`, never by republishing.
+
+## When a release did not happen
+
+| Symptom                                | Cause                                                     | Fix                                                |
+| -------------------------------------- | --------------------------------------------------------- | -------------------------------------------------- |
+| Merged to `main`, no tag               | Version was already tagged -- no bump in the merge        | Cut a real release with a higher version           |
+| `release-guard` fails on branch name   | Branch version disagrees with `packages/sdk/package.json` | `pnpm run release:version <branch version>`        |
+| `release-guard` fails on existing tag  | Version already released                                  | Pick a higher version                              |
+| Tag exists, `publish.yml` never ran    | Tag pushed by hand with `GITHUB_TOKEN`                    | `gh workflow run publish.yml -f version=<version>` |
+| Publish failed on build, lint, or test | Broken release commit                                     | Delete the tag, fix via a PR into `dev`, cut again |
+| SDK published, CLI failed              | Partial publish; npm is immutable                         | Hotfix forward at the next patch version           |
+
+## Repairing a botched bump
+
+```bash
+pnpm run release:version 2.2.0        # explicit version, all nine packages
+pnpm run release:version patch        # or a keyword
+git diff --stat                       # expect exactly 9 package.json files
+```
+
+Nine files and nothing else. Internal dependencies are `workspace:*` and are
+rewritten by pnpm at publish time, so they never need editing. If the diff shows
+a different count, stop -- a package was added or the filter is wrong.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,10 @@
+<!--
+Target `dev` unless this is a release or a hotfix. Merging a version bump into
+`main` tags and publishes to npm -- see docs/development/releases.md.
+Add a label (enhancement / bug / documentation / security) so the generated
+release notes are categorised.
+-->
+
 ## Summary
 
 <!-- What does this PR do? Link related issues with "Closes #123". -->
@@ -18,3 +25,6 @@
 - [ ] No file exceeds 300 effective lines
 - [ ] No relative imports (use `@/` path aliases)
 - [ ] Secrets and credentials are not committed
+- [ ] Targets `dev` (not `main`), unless this is a release or hotfix PR
+- [ ] No version bump in `packages/*/package.json` (releases only)
+- [ ] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+# Categories for the auto-generated release notes that publish.yml attaches to
+# every GitHub Release. GitHub matches on PR labels only -- it cannot read
+# conventional-commit prefixes -- so an unlabelled PR lands in "Other changes".
+changelog:
+  exclude:
+    authors: [dependabot, github-actions]
+  categories:
+    - title: Security
+      labels: [security]
+    - title: Features
+      labels: [enhancement]
+    - title: Fixes
+      labels: [bug]
+    - title: Documentation
+      labels: [documentation]
+    - title: Other changes
+      labels: ['*']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [main, 'release/**']
+    branches: [main, dev, 'release/**']
   pull_request:
-    # Release branches are integration targets for a whole beta line, so they
-    # need the same gate as main -- without this, PRs into release/** merge
-    # with no build, lint, format, or test run at all.
-    branches: [main, 'release/**']
+    # dev is the default target for feature work and release/** branches are
+    # integration targets for a whole line, so both need the same gate as main --
+    # without this, PRs merge with no build, lint, format, or test run at all.
+    branches: [main, dev, 'release/**']
 
 permissions:
   contents: read
@@ -60,3 +60,32 @@ jobs:
       - name: Update coverage badge
         if: success() && github.ref == 'refs/heads/main' && vars.GIST_ID != ''
         run: echo "Coverage badge update skipped -- monorepo coverage aggregation TBD"
+
+  release-guard:
+    name: Release version guard
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/'))
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Branch name and package version must agree on an untagged version
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          VERSION=$(node -p "require('./packages/sdk/package.json').version")
+          BRANCH_VERSION="${HEAD_REF##*/v}"
+          if [ "$BRANCH_VERSION" != "$HEAD_REF" ] && [ "$BRANCH_VERSION" != "$VERSION" ]; then
+            echo "::error::Branch $HEAD_REF disagrees with packages/sdk/package.json ($VERSION). Run: pnpm run release:version $BRANCH_VERSION"
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "::error::v$VERSION is already tagged, so merging this PR would publish nothing. Bump the version: pnpm run release:version patch"
+            exit 1
+          fi
+          echo "v$VERSION is unreleased -- merging this PR will tag and publish it."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,20 @@ name: Publish to npm
 on:
   push:
     tags: ['v*']
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to publish, without the leading v'
+        required: true
+        type: string
+  # Repair path: republish an existing tag whose pipeline never ran or failed
+  # after the tag was already pushed.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish, without the leading v'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version && format('v{0}', inputs.version) || github.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -28,8 +44,11 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Verify tag matches package versions
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${INPUT_VERSION:-${GITHUB_REF_NAME#v}}"
+          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
           for pkg in sdk cli; do
             PKG_VERSION=$(node -p "require('./packages/$pkg/package.json').version")
             if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
@@ -92,4 +111,6 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ env.TAG_VERSION }}
+          prerelease: ${{ contains(env.TAG_VERSION, '-') }}
           generate_release_notes: true

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -1,0 +1,126 @@
+name: Start release
+
+# Opens a release. The version is the only decision a human makes; everything
+# after it -- branch, bump, commit, PR -- is derived. Merging the resulting PR
+# into main is what triggers the tag and the npm publish (see tag.yml).
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 2.2.0, 2.2.0-beta.1) or a bump keyword (patch, minor, major)'
+        required: true
+        type: string
+      from:
+        description: 'Branch to cut from -- dev for a release, main for a hotfix'
+        required: true
+        default: dev
+        type: choice
+        options: [dev, main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  open-release:
+    name: Bump and open the release PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.from }}
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Bump every workspace package
+        id: bump
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          pnpm run release:version "$INPUT_VERSION"
+          VERSION=$(node -p "require('./packages/sdk/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "::error::v$VERSION is already tagged -- pick a higher version"
+            exit 1
+          fi
+
+      # The bump commit is created through GitHub's createCommitOnBranch mutation
+      # rather than `git commit`, so GitHub signs it. A plain runner commit is
+      # unsigned and would be unmergeable while main requires signed commits.
+      - name: Commit the bump on a release branch
+        id: branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
+          FROM: ${{ inputs.from }}
+        run: |
+          if [ "$FROM" = "main" ]; then
+            BRANCH="hotfix/v$VERSION"
+          else
+            BRANCH="release/v$VERSION"
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+          # Push the branch at the unmodified base -- the bump is still uncommitted
+          # in the working tree, and the API supplies it as the branch's first commit.
+          HEAD_OID=$(git rev-parse HEAD)
+          git push origin "HEAD:refs/heads/$BRANCH"
+
+          BRANCH="$BRANCH" HEAD_OID="$HEAD_OID" node -e '
+            const { execSync } = require("node:child_process");
+            const fs = require("node:fs");
+            // Scoped so an incidentally dirty file -- a lockfile touched by install,
+            // for instance -- can never ride along in the release commit.
+            const files = execSync(String.raw`git diff --name-only -- "packages/*/package.json"`, { encoding: "utf8" }).trim().split("\n").filter(Boolean);
+            if (files.length === 0) throw new Error("release:version changed nothing -- version is already " + process.env.VERSION);
+            fs.writeFileSync("commit.json", JSON.stringify({
+              query: `mutation($input: CreateCommitOnBranchInput!) {
+                createCommitOnBranch(input: $input) { commit { oid } }
+              }`,
+              variables: {
+                input: {
+                  branch: {
+                    repositoryNameWithOwner: process.env.GITHUB_REPOSITORY,
+                    branchName: process.env.BRANCH,
+                  },
+                  expectedHeadOid: process.env.HEAD_OID,
+                  message: { headline: `chore(release): ${process.env.VERSION}` },
+                  fileChanges: {
+                    additions: files.map((path) => ({
+                      path,
+                      contents: fs.readFileSync(path).toString("base64"),
+                    })),
+                  },
+                },
+              },
+            }));
+            console.log(`Committing ${files.length} file(s): ${files.join(", ")}`);
+          '
+          gh api graphql --input commit.json
+          rm commit.json
+
+      - name: Open the PR into main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(release): $VERSION" \
+            --body "Releases \`v$VERSION\`. Merging this PR tags \`v$VERSION\` on \`main\` and publishes \`@wisecom/atlas-sdk\` and \`@wisecom/atlas-cli\` to npm. Label the PRs included in this release (\`enhancement\`, \`bug\`, \`documentation\`, \`security\`) so the generated notes are categorised."

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,85 @@
+name: Tag release
+
+# A release is defined by a version bump reaching main, not by which branch the
+# merge came from. History showed why: a docs-only merge (d27afb6) landed on main
+# right after v2.1.0-beta, and v1.2.3's tag sat on a commit with no bump at all.
+# Keying on the version makes non-release merges free and hotfixes work without a
+# second code path.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  tag:
+    name: Tag if the version is new
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      created: ${{ steps.check.outputs.created }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create the tag when the version has no tag yet
+        id: check
+        run: |
+          VERSION=$(node -p "require('./packages/sdk/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "v$VERSION is already tagged -- this merge is not a release."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish
+    needs: tag
+    if: needs.tag.outputs.created == 'true'
+    # A tag pushed with GITHUB_TOKEN does not trigger workflows, so publish.yml is
+    # called directly instead of relying on its own push:tags trigger.
+    uses: ./.github/workflows/publish.yml
+    with:
+      version: ${{ needs.tag.outputs.version }}
+    secrets: inherit
+
+  back-merge:
+    name: Keep dev in sync with main
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open a back-merge PR when main is ahead of dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          AHEAD=$(git rev-list --count origin/dev..origin/main)
+          if [ "$AHEAD" -eq 0 ]; then
+            echo "dev already contains main."
+            exit 0
+          fi
+          if [ -n "$(gh pr list --base dev --head main --state open --json number --jq '.[].number')" ]; then
+            echo "A back-merge PR is already open."
+            exit 0
+          fi
+          gh pr create \
+            --base dev \
+            --head main \
+            --title 'chore: back-merge main into dev' \
+            --body "\`main\` is $AHEAD commit(s) ahead of \`dev\`. Merge this so the next release branch is cut from a \`dev\` that already contains the release bump and any hotfixes."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,10 @@ pnpm run test
 
 ## Development workflow
 
-1. Create a branch from `main` for your change.
+`dev` is the integration branch. It accumulates work until there is enough for a
+release; `main` always reflects the newest version published to npm.
+
+1. Create a branch from `dev` for your change.
 2. Make your changes following the conventions below.
 3. Run the full quality gate before pushing:
 
@@ -41,7 +44,33 @@ pnpm run format:check
 pnpm run test
 ```
 
-4. Open a pull request against `main`. CI will run the same checks automatically.
+4. Open a pull request against **`dev`**. CI will run the same checks automatically.
+
+### Where to target your PR
+
+| You are doing                     | Branch from | Target your PR at       |
+| --------------------------------- | ----------- | ----------------------- |
+| A feature, fix, refactor, or docs | `dev`       | **`dev`**               |
+| Cutting a release                 | `dev`       | `main` (opened for you) |
+| An urgent production fix          | `main`      | `main` (opened for you) |
+
+Never open a feature PR against `main`. Merging a version bump into `main` is what
+tags and publishes a release, so anything landing there is treated as a release or
+a hotfix.
+
+### Do not bump the version in a normal PR
+
+Version bumps belong exclusively to release PRs, which are created by the **Start
+release** workflow. Bumping `packages/*/package.json` in an ordinary PR publishes
+to npm the moment it reaches `main`. See
+[Release Process](./docs/development/releases.md) for how releases are cut, how
+hotfixes work, and how release notes are categorised.
+
+### Label your PR
+
+Release notes are generated from PR labels (`enhancement`, `bug`,
+`documentation`, `security`). An unlabelled PR shows up under "Other changes", so
+label it before it is merged.
 
 ## Code conventions
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -87,6 +87,7 @@ export default defineConfig({
         items: [
           { text: 'Graph Request Tracing', link: '/development/graph-tap' },
           { text: 'Performance Profiling', link: '/development/performance-profiling' },
+          { text: 'Release Process', link: '/development/releases' },
         ],
       },
       {

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -1,0 +1,180 @@
+# Release Process
+
+Atlas releases when there is enough change to justify one -- not on a schedule.
+There is no weekly train and no automatic version bump from commit messages. A
+human decides _when_ and _what size_; everything after that decision is
+automated.
+
+## Where to target your pull request
+
+This is the only rule most contributors need:
+
+| You are doing                     | Branch from | Target your PR at       |
+| --------------------------------- | ----------- | ----------------------- |
+| A feature, fix, refactor, or docs | `dev`       | **`dev`**               |
+| Cutting a release                 | `dev`       | `main` (opened for you) |
+| An urgent production fix          | `main`      | `main` (opened for you) |
+
+`dev` is the integration branch and accumulates work between releases. `main`
+always reflects the newest published version. **Never open a feature PR against
+`main`** -- it bypasses the accumulation model and, if it happens to carry a
+version bump, publishes to npm immediately.
+
+## What triggers a release
+
+A release is defined by **a version bump reaching `main`**, not by the branch the
+merge came from:
+
+```
+merge into main
+  └─ .github/workflows/tag.yml reads packages/sdk/package.json
+       ├─ tag v<version> already exists  → nothing happens
+       └─ tag v<version> does not exist  → create the tag, then publish
+```
+
+This matters because merges into `main` are not all releases. A docs-only merge
+landed on `main` immediately after `v2.1.0-beta`, and the `v1.2.3` tag sat on a
+commit that contained no bump at all. Keying the tag on the version rather than
+on the branch name makes non-release merges free and lets a hotfix use the same
+path as a release without a second workflow.
+
+The consequence to internalise: **bumping the version is the act of releasing.**
+Do not bump the version in an ordinary PR.
+
+## Cutting a release
+
+Run the **Start release** workflow from the Actions tab (or
+`gh workflow run release-start.yml -f version=2.2.0 -f from=dev`). It takes one
+real input:
+
+| Input     | Meaning                                                          |
+| --------- | ---------------------------------------------------------------- |
+| `version` | `2.2.0`, `2.2.0-beta.1`, or a keyword: `patch`, `minor`, `major` |
+| `from`    | `dev` for a release, `main` for a hotfix                         |
+
+The workflow then:
+
+1. Branches `release/v<version>` from `dev` (or `hotfix/v<version>` from `main`).
+2. Runs `pnpm run release:version <version>`, bumping all nine workspace
+   packages in lockstep. Internal dependencies are `workspace:*`, so pnpm
+   rewrites them to the exact version at publish time -- there is nothing else to
+   edit.
+3. Commits `chore(release): <version>` and opens a PR into `main`. The commit is
+   created through GitHub's `createCommitOnBranch` GraphQL mutation rather than
+   `git commit`, so GitHub signs it -- an unsigned runner commit could not be
+   merged into a `main` that requires signed commits.
+4. Fails early if `v<version>` is already tagged.
+
+Review the PR, confirm CI is green, then merge it. Merging is the release.
+
+## What happens on merge
+
+| Step | Workflow      | Effect                                                                                       |
+| ---- | ------------- | -------------------------------------------------------------------------------------------- |
+| 1    | `tag.yml`     | Creates and pushes the annotated tag `v<version>`                                            |
+| 2    | `publish.yml` | Re-runs build, lint, and tests, then publishes `@wisecom/atlas-sdk` and `@wisecom/atlas-cli` |
+| 3    | `publish.yml` | Creates the GitHub Release with generated, categorised notes                                 |
+| 4    | `tag.yml`     | Opens a back-merge PR `main` → `dev` if `main` is ahead                                      |
+
+`publish.yml` is invoked as a reusable workflow rather than by its own
+`push: tags` trigger. A tag pushed with the default `GITHUB_TOKEN` does not
+trigger workflows, so relying on the tag event would silently publish nothing.
+The `push: tags` trigger is retained so a manually pushed tag still publishes.
+
+### npm dist-tags
+
+The dist-tag is derived from the prerelease suffix, so a prerelease can never
+become the default install:
+
+| Version      | npm dist-tag | `npm install @wisecom/atlas-cli` gets it? |
+| ------------ | ------------ | ----------------------------------------- |
+| `2.2.0`      | `latest`     | Yes                                       |
+| `2.1.0-beta` | `beta`       | No -- requires `@beta`                    |
+| `2.2.0-rc.1` | `rc`         | No -- requires `@rc`                      |
+
+GitHub Releases for prereleases are marked as prereleases automatically, on the
+same rule (any `-` in the version).
+
+## Hotfixes
+
+A hotfix is an urgent fix that cannot wait for `dev` to be release-ready. Run
+**Start release** with `from: main` and a `patch` version. It cuts
+`hotfix/v<version>` from `main`, so the fix ships without dragging in unreleased
+`dev` work.
+
+Because the fix lands on `main` first, `dev` would otherwise be missing it and
+the next release branch would silently revert it. `tag.yml` opens a back-merge PR
+`main` → `dev` after every push to `main` where `main` is ahead. **Merge that PR
+promptly** -- it is the mechanism that keeps the two branches from diverging.
+
+## Release notes
+
+Notes are generated by GitHub from the PRs merged since the previous tag, and
+categorised by `.github/release.yml`. GitHub matches on **labels only** -- it
+cannot read conventional-commit prefixes -- so an unlabelled PR lands under
+"Other changes":
+
+| Label           | Section       |
+| --------------- | ------------- |
+| `security`      | Security      |
+| `enhancement`   | Features      |
+| `bug`           | Fixes         |
+| `documentation` | Documentation |
+| _(none)_        | Other changes |
+
+Label PRs as you merge them, not at release time.
+
+## The version guard
+
+CI runs an extra `release-guard` job on PRs from `release/**` and `hotfix/**`
+branches. It fails the PR when:
+
+- the version in the branch name disagrees with
+  `packages/sdk/package.json` -- the tag would not match the branch; or
+- `v<version>` is already tagged -- merging would publish nothing at all, which
+  is how a release can appear to succeed while npm never changes.
+
+Both failures print the exact `pnpm run release:version` command to fix them.
+
+## Branch protection
+
+`main` carries a protection rule, and the settings interact with the automation in
+ways that are not obvious:
+
+| Setting                        | State | Reason                                                                                              |
+| ------------------------------ | ----- | --------------------------------------------------------------------------------------------------- |
+| Require a pull request         | On    | Blocks a direct push of a version bump, which would publish to npm with no review                   |
+| Require approvals              | 0     | GitHub forbids self-approval; any higher number makes release PRs unmergeable for a solo maintainer |
+| Require status checks          | On    | `Build, Lint & Test`                                                                                |
+| Require signed commits         | On    | Every commit in the history is signed; the release commit is API-created so it stays signed         |
+| Do not allow bypassing         | On    | With bypass allowed, an admin push can still publish irreversibly -- this is what closes that hole  |
+| **Require linear history**     | Off   | Tags sit on merge commits and the `main` → `dev` back-merge must be a merge commit                  |
+| Allow force pushes / deletions | Off   | A force push can strand a published tag on an orphaned commit                                       |
+
+Tag protection rules are deliberately **not** configured: a `v*` rule can block
+`github-actions[bot]` from pushing the release tag, which stops every publish
+silently.
+
+## Bumping versions by hand
+
+```bash
+pnpm run release:version 2.2.0   # explicit version
+pnpm run release:version patch   # 2.2.0 -> 2.2.1
+```
+
+This edits all nine `packages/*/package.json` files and nothing else -- no git
+tag, no commit. Prefer the **Start release** workflow; use this only when working
+offline or repairing a botched bump.
+
+## If a publish fails
+
+npm versions are immutable, so recovery is always forward, never a re-publish:
+
+1. **Failed before publishing** (build, lint, or test failure): delete the tag
+   (`git push --delete origin v<version>`), fix the problem on a normal PR into
+   `dev`, and cut the release again with the same version.
+2. **SDK published, CLI failed:** do not delete the tag. Fix forward with a
+   hotfix release at the next patch version. The two packages are versioned in
+   lockstep, so a partial publish must be resolved by moving both forward.
+3. **Wrong dist-tag:** correct it with `npm dist-tag add` rather than
+   republishing.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:watch": "vitest",
     "test:coverage": "turbo run test -- --coverage",
     "lint": "turbo run lint",
+    "release:version": "pnpm -r --filter './packages/*' exec npm version --no-git-tag-version",
     "link-cli": "pnpm --filter @wisecom/atlas-cli run build && pnpm --filter @wisecom/atlas-cli run link-cli",
     "lint:fix": "eslint packages/*/src/ packages/*/tests/ --fix",
     "format": "prettier --write \"packages/*/src/**/*.ts\" \"packages/*/tests/**/*.ts\"",


### PR DESCRIPTION
Automates the release cycle end to end. A release is now defined by a version bump reaching `main`, not by the branch a merge came from.

- `release-start.yml` — one dispatch, one input. Cuts `release/vX` from `dev` (or `hotfix/vX` from `main`), bumps all nine packages, opens the PR into `main`. The bump commit is created via `createCommitOnBranch` so GitHub signs it.
- `tag.yml` — on push to `main`, tags when the version is new, calls `publish.yml`, and opens a back-merge PR into `dev` when `main` is ahead.
- `publish.yml` — gains `workflow_call` (a tag pushed with `GITHUB_TOKEN` does not trigger workflows) and `workflow_dispatch` for repair; pins `tag_name` and flags prereleases.
- `ci.yml` — adds `dev` to both triggers (PRs into `dev` previously ran no checks at all) and a `release-guard` job for `release/**` and `hotfix/**` PRs.
- `.github/release.yml` — notes categorised on the existing labels.
- Docs: `docs/development/releases.md`, corrected `CONTRIBUTING.md` PR targets, PR template, and a `release` skill.

Verified locally: all workflows parse, every `run` block passes `bash -n`, the commit payload builds exactly 9 additions at the target version, and the tag decision replays correctly against real repo state.