### PR TITLE
fix(release): sync dev by pushing, and hand back a compare link

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -68,7 +68,14 @@ gh run watch
 ```
 
 It creates `release/v<version>`, bumps all nine packages, commits
-`chore(release): <version>`, and opens a PR into `main`.
+`chore(release): <version>`, and prints a prefilled compare link in the run
+summary. The organisation forbids GitHub Actions from creating pull requests, so
+open the release PR from that link:
+
+```bash
+gh run view --job "$(gh run list --workflow release-start.yml --limit 1 --json databaseId --jq '.[0].databaseId')" --log | grep 'compare/main'
+gh pr create --base main --head "release/v<version>" --title "chore(release): <version>" --body '...'
+```
 
 Before merging:
 
@@ -97,9 +104,10 @@ gh workflow run release-start.yml -f version=patch -f from=main
 The fix itself goes on the generated `hotfix/v<version>` branch, which is cut
 from `main`, so unreleased `dev` work does not ship with it.
 
-**After the hotfix publishes, merge the back-merge PR that `tag.yml` opens**
-(`main` → `dev`). Skipping it means the next release branch is cut from a `dev`
-that lacks the fix, silently reverting it.
+**After the hotfix publishes, confirm `tag.yml` fast-forwarded `dev` onto
+`main`.** If `dev` had diverged the push is refused and the job fails -- merge
+`main` into `dev` by hand at that point. Skipping it means the next release
+branch is cut from a `dev` that lacks the fix, silently reverting it.
 
 ## Verifying a release actually shipped
 

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -19,11 +19,10 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   open-release:
-    name: Bump and open the release PR
+    name: Bump and stage the release
     runs-on: ubuntu-latest
 
     steps:
@@ -113,14 +112,25 @@ jobs:
           gh api graphql --input commit.json
           rm commit.json
 
-      - name: Open the PR into main
+      # The organisation forbids GitHub Actions from creating pull requests, so the
+      # job hands back a compare link with the title and body prefilled instead.
+      - name: Link the release PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.bump.outputs.version }}
           BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore(release): $VERSION" \
-            --body "Releases \`v$VERSION\`. Merging this PR tags \`v$VERSION\` on \`main\` and publishes \`@wisecom/atlas-sdk\` and \`@wisecom/atlas-cli\` to npm. Label the PRs included in this release (\`enhancement\`, \`bug\`, \`documentation\`, \`security\`) so the generated notes are categorised."
+          BODY="Releases \`v$VERSION\`. Merging this PR tags \`v$VERSION\` on \`main\` and publishes @wisecom/atlas-sdk and @wisecom/atlas-cli to npm. Label the PRs in this release (enhancement, bug, documentation, security) so the generated notes are categorised."
+          URL=$(BODY="$BODY" node -p '
+            const q = new URLSearchParams({
+              expand: "1",
+              title: `chore(release): ${process.env.VERSION}`,
+              body: process.env.BODY,
+            });
+            `https://github.com/${process.env.GITHUB_REPOSITORY}/compare/main...${process.env.BRANCH}?${q}`
+          ')
+          {
+            echo "## Release v$VERSION is staged on \`$BRANCH\`"
+            echo
+            echo "[Open the release PR]($URL) -- merging it tags \`v$VERSION\` and publishes to npm."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "$URL"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,6 @@ on:
 permissions:
   contents: write
   id-token: write
-  pull-requests: write
 
 jobs:
   tag:
@@ -65,21 +64,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Open a back-merge PR when main is ahead of dev
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # The organisation forbids GitHub Actions from creating pull requests, so
+      # this syncs dev by pushing main's commits straight onto it. A release or
+      # hotfix merge leaves dev strictly behind main, which fast-forwards. If dev
+      # has diverged the push is refused and the job fails loudly -- silently
+      # skipping would let the next release branch revert a shipped hotfix.
+      - name: Fast-forward dev onto main
         run: |
           AHEAD=$(git rev-list --count origin/dev..origin/main)
           if [ "$AHEAD" -eq 0 ]; then
             echo "dev already contains main."
             exit 0
           fi
-          if [ -n "$(gh pr list --base dev --head main --state open --json number --jq '.[].number')" ]; then
-            echo "A back-merge PR is already open."
+          if git push origin "origin/main:refs/heads/dev"; then
+            echo "Fast-forwarded dev by $AHEAD commit(s)."
             exit 0
           fi
-          gh pr create \
-            --base dev \
-            --head main \
-            --title 'chore: back-merge main into dev' \
-            --body "\`main\` is $AHEAD commit(s) ahead of \`dev\`. Merge this so the next release branch is cut from a \`dev\` that already contains the release bump and any hotfixes."
+          echo "::error::dev has diverged from main and cannot be fast-forwarded. Merge main into dev manually: https://github.com/${GITHUB_REPOSITORY}/compare/dev...main"
+          exit 1

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -59,13 +59,15 @@ The workflow then:
    packages in lockstep. Internal dependencies are `workspace:*`, so pnpm
    rewrites them to the exact version at publish time -- there is nothing else to
    edit.
-3. Commits `chore(release): <version>` and opens a PR into `main`. The commit is
-   created through GitHub's `createCommitOnBranch` GraphQL mutation rather than
+3. Commits `chore(release): <version>` on that branch. The commit is created
+   through GitHub's `createCommitOnBranch` GraphQL mutation rather than
    `git commit`, so GitHub signs it -- an unsigned runner commit could not be
    merged into a `main` that requires signed commits.
 4. Fails early if `v<version>` is already tagged.
+5. Prints a compare link with the PR title and body prefilled, in the run summary.
 
-Review the PR, confirm CI is green, then merge it. Merging is the release.
+Follow that link to open the release PR, confirm CI is green, then merge it.
+Merging is the release.
 
 ## What happens on merge
 
@@ -74,7 +76,7 @@ Review the PR, confirm CI is green, then merge it. Merging is the release.
 | 1    | `tag.yml`     | Creates and pushes the annotated tag `v<version>`                                            |
 | 2    | `publish.yml` | Re-runs build, lint, and tests, then publishes `@wisecom/atlas-sdk` and `@wisecom/atlas-cli` |
 | 3    | `publish.yml` | Creates the GitHub Release with generated, categorised notes                                 |
-| 4    | `tag.yml`     | Opens a back-merge PR `main` → `dev` if `main` is ahead                                      |
+| 4    | `tag.yml`     | Fast-forwards `dev` onto `main` if `main` is ahead                                           |
 
 `publish.yml` is invoked as a reusable workflow rather than by its own
 `push: tags` trigger. A tag pushed with the default `GITHUB_TOKEN` does not
@@ -103,9 +105,20 @@ A hotfix is an urgent fix that cannot wait for `dev` to be release-ready. Run
 `dev` work.
 
 Because the fix lands on `main` first, `dev` would otherwise be missing it and
-the next release branch would silently revert it. `tag.yml` opens a back-merge PR
-`main` → `dev` after every push to `main` where `main` is ahead. **Merge that PR
-promptly** -- it is the mechanism that keeps the two branches from diverging.
+the next release branch would silently revert it. `tag.yml` therefore pushes
+`main` onto `dev` after every push to `main` where `main` is ahead.
+
+That push is a fast-forward, which is the normal case: a release or hotfix merge
+leaves `dev` strictly behind `main`. If `dev` has diverged -- someone landed work
+on `dev` between the hotfix merge and the sync -- the push is refused and the job
+**fails loudly** with a compare link. Merge `main` into `dev` by hand at that
+point; a job that skipped quietly would let the next release revert a shipped fix.
+
+The organisation forbids GitHub Actions from creating pull requests
+(`can_approve_pull_request_reviews` is disabled org-wide and a repository cannot
+override it), which is why this is a direct push rather than a back-merge PR, and
+why **Start release** hands back a prefilled compare link instead of opening the
+release PR itself.
 
 ## Release notes
 
@@ -138,22 +151,28 @@ Both failures print the exact `pnpm run release:version` command to fix them.
 
 ## Branch protection
 
-`main` carries a protection rule, and the settings interact with the automation in
-ways that are not obvious:
+`main` is governed by a repository **ruleset** (not classic branch protection --
+`/branches/main/protection` returns 404, the rules live under
+`/repos/:owner/:repo/rulesets`). The settings interact with the automation in ways
+that are not obvious:
 
-| Setting                        | State | Reason                                                                                              |
-| ------------------------------ | ----- | --------------------------------------------------------------------------------------------------- |
-| Require a pull request         | On    | Blocks a direct push of a version bump, which would publish to npm with no review                   |
-| Require approvals              | 0     | GitHub forbids self-approval; any higher number makes release PRs unmergeable for a solo maintainer |
-| Require status checks          | On    | `Build, Lint & Test`                                                                                |
-| Require signed commits         | On    | Every commit in the history is signed; the release commit is API-created so it stays signed         |
-| Do not allow bypassing         | On    | With bypass allowed, an admin push can still publish irreversibly -- this is what closes that hole  |
-| **Require linear history**     | Off   | Tags sit on merge commits and the `main` → `dev` back-merge must be a merge commit                  |
-| Allow force pushes / deletions | Off   | A force push can strand a published tag on an orphaned commit                                       |
+| Rule                       | State | Reason                                                                                               |
+| -------------------------- | ----- | ---------------------------------------------------------------------------------------------------- |
+| Require a pull request     | On    | Blocks a direct push of a version bump, which would publish to npm with no review                    |
+| Required approvals         | 0     | GitHub forbids self-approval; any higher number makes release PRs unmergeable for a solo maintainer  |
+| Require code owner review  | Off   | No `CODEOWNERS` file exists, and one naming the sole maintainer recreates the self-approval deadlock |
+| Restrict deletions         | On    | Deleting `main` would orphan every published tag                                                     |
+| Block force pushes         | On    | A force push can strand a published tag on an orphaned commit                                        |
+| **Require linear history** | Off   | Release tags sit on PR merge commits; requiring linear history would break the release path          |
+| Require signed commits     | Off   | Optional -- the release commit is API-created and signed, so enabling it would not break the flow    |
 
-Tag protection rules are deliberately **not** configured: a `v*` rule can block
+Tag rulesets are deliberately **not** configured: a `v*` rule can block
 `github-actions[bot]` from pushing the release tag, which stops every publish
 silently.
+
+Note that `gh pr merge` may refuse a release PR with a stale `BLOCKED` merge
+state while GitHub finishes recomputing rule evaluation. The REST endpoint is
+authoritative: `gh api -X PUT repos/:owner/:repo/pulls/:n/merge -f merge_method=merge`.
 
 ## Bumping versions by hand
 


### PR DESCRIPTION
The first live `tag.yml` run failed: `GitHub Actions is not permitted to create or approve pull requests`. Org-level policy, not overridable per-repo (`409`). `release-start.yml` would have failed identically at `gh pr create`.

- `tag.yml` fast-forwards `dev` onto `main` instead of opening a back-merge PR; a diverged `dev` fails the job loudly with a compare link rather than skipping.
- `release-start.yml` prints a prefilled compare URL in the run summary instead of creating the PR.
- `pull-requests: write` dropped from both.
- Docs and skill corrected; branch protection section now documents the actual **ruleset** (classic protection 404s) and the stale `BLOCKED` merge-state quirk.

The tag trigger itself already validated on the first run: `v2.1.0-beta` was already tagged, so `Publish` was skipped.