### PR TITLE
chore(release): 2.1.0-beta.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-cli",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "description": "CLI for Atlas — secure Microsoft 365 backup and restore to S3-compatible storage.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-core",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/m365-graph/package.json
+++ b/packages/m365-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-m365-graph",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/onedrive/package.json
+++ b/packages/onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-onedrive",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/outlook/package.json
+++ b/packages/outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-outlook",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-s3",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-sdk",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "description": "Programmatic API for embedding Atlas M365 backup and restore in Node.js applications.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",

--- a/packages/sharepoint/package.json
+++ b/packages/sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-sharepoint",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-types",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Releases `v2.1.0-beta.1`. Merging this PR tags `v2.1.0-beta.1` on `main` and publishes `@wisecom/atlas-sdk` and `@wisecom/atlas-cli` to npm under the `beta` dist-tag.

First release cut entirely by the new automation:
- Staged by `release-start.yml` (`version=2.1.0-beta.1`, `from=dev`)
- Bump commit created via `createCommitOnBranch`, GitHub-signed (`verified: true`)
- All nine workspace packages moved in lockstep

Semver: everything since `v2.1.0-beta` is CI and documentation with zero changes under `packages/*/src`, so this is a prerelease increment rather than a promotion to stable `2.1.0`. `2.1.0-beta.1 > 2.1.0-beta` and `< 2.1.0`, and it restores the `-beta.N` convention used by the `2.0.0-beta.N` line.