### PR TITLE
fix(sdk): pre-aborted operations no longer emit a discovering event

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -115,6 +115,8 @@ interface OperationProgressEvent {
 
 Cancellation returns normally with `interrupted: true`; it does not throw an abort error. Restore and save results contain partial counts, and save finalizes a valid zip with the completed files. A partially processed backup does not advance that folder, drive, or library's delta cursor, so the next run safely replays it. Completed units remain committed.
 
+If the signal is already aborted when the operation is called, no `discovering` event is emitted — the stream contains only `finalizing` followed by `interrupted`. The event stream never claims work that did not happen, so a progress bar driven by `discovering` will not paint a "starting..." state for a run that is already over.
+
 The callback is optional and runs inline with the operation. Keep it fast; move network writes or database updates to your own queue.
 
 ## Outlook API Reference

--- a/packages/core/src/services/shared/operation-progress.ts
+++ b/packages/core/src/services/shared/operation-progress.ts
@@ -3,14 +3,21 @@ import type { OperationControlOptions, OperationProgressEvent } from '@wisecom/a
 type Operation = OperationProgressEvent['operation'];
 type Workload = OperationProgressEvent['workload'];
 
-/** Emits discovery progress and reports whether cancellation was requested. */
+/**
+ * Emits discovery progress and reports whether cancellation was requested.
+ * A pre-aborted operation emits no `discovering` event — the stream only
+ * contains `finalizing` + terminal, never claiming work that did not happen.
+ */
 export function begin_operation_progress(
   control: OperationControlOptions,
   operation: Operation,
   workload: Workload,
 ): boolean {
+  if (control.should_interrupt?.() === true) {
+    return true;
+  }
   emit_operation_progress(control, { operation, workload, phase: 'discovering', processed: 0 });
-  return control.should_interrupt?.() === true;
+  return false;
 }
 
 /** Emits finalizing and exactly one terminal event, returning interruption state. */

--- a/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
+++ b/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
@@ -103,8 +103,8 @@ describe('OneDrive operation cancellation', () => {
     expect(factory.create).not.toHaveBeenCalled();
     expect(results.every((result) => result.interrupted)).toBe(true);
     for (const callback of callbacks) {
+      // Pre-aborted runs never claim discovery: finalizing + terminal only.
       expect(callback.mock.calls.map(([event]) => event.phase)).toEqual([
-        'discovering',
         'finalizing',
         'interrupted',
       ]);

--- a/packages/outlook/tests/unit/operation-pre-abort.test.ts
+++ b/packages/outlook/tests/unit/operation-pre-abort.test.ts
@@ -39,8 +39,8 @@ describe('Outlook operation cancellation', () => {
     expect(factory.create).not.toHaveBeenCalled();
     expect(results.every((result) => result.interrupted)).toBe(true);
     for (const callback of callbacks) {
+      // Pre-aborted runs never claim discovery: finalizing + terminal only.
       expect(callback.mock.calls.map(([event]) => event.phase)).toEqual([
-        'discovering',
         'finalizing',
         'interrupted',
       ]);

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-cancellation.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-cancellation.test.ts
@@ -74,8 +74,8 @@ describe('SharePoint restore cancellation', () => {
     expect(factory.create).not.toHaveBeenCalled();
     expect(results.every((result) => result.interrupted)).toBe(true);
     for (const callback of callbacks) {
+      // Pre-aborted runs never claim discovery: finalizing + terminal only.
       expect(callback.mock.calls.map(([event]) => event.phase)).toEqual([
-        'discovering',
         'finalizing',
         'interrupted',
       ]);


### PR DESCRIPTION
Closes #87.

## Contract chosen (option 1 from the issue)
A pre-aborted operation emits only `finalizing` + `interrupted` — the event stream never claims work that did not happen. Consumers driving a progress bar off `discovering` no longer paint a starting state for a run that is already over.

## Change
One guard in `begin_operation_progress` (`packages/core/src/services/shared/operation-progress.ts`): check `should_interrupt` before emitting `discovering`. Covers all 13 service entrypoints (outlook/onedrive/sharepoint backup, restore, save, verify) since they all route through this helper.

## Pinned
- `operation-pre-abort.test.ts` (outlook), `operation-cancellation.test.ts` (onedrive), `sharepoint-restore-cancellation.test.ts`: pre-abort sequence now asserts `['finalizing', 'interrupted']`
- `docs/reference/sdk.md` "Progress and Cancellation" states the contract

## Verification
- `pnpm run build`: 10/10
- `pnpm run test`: 15/15 tasks
- `pnpm run lint`: 9/9
- `pnpm run docs:build`: clean