### PR TITLE
Outlook: request immutable Graph message IDs so folder moves stop duplicating messages

### DIFF
--- a/docs/operations/delta-sync.md
+++ b/docs/operations/delta-sync.md
@@ -36,8 +36,17 @@ Delta links are stored in the **encrypted manifest**, not in plaintext. They con
 | **Stale-delta safeguard** | A saved delta link returns zero items while the previous manifest had zero stored entries. That combination indicates the prior backup was interrupted before storing anything, so Atlas discards the link and enumerates the folder in full. |
 | **`syncStateNotFound`**   | Microsoft purges delta tokens after roughly 30 days of inactivity. Atlas detects the error, resyncs the folder in full, and logs a warning so you know the incremental chain was broken. |
 | **`--full`**              | `atlas outlook backup --full` ignores every saved delta link. Use it for periodic audits or when you suspect a delta link is corrupted. |
+| **Legacy message IDs**    | Snapshots taken before Atlas adopted immutable Outlook IDs recorded mutable IDs in their manifests and delta links. Mixing the two formats would break correlation, so the first backup after upgrading restarts the mailbox in full and stamps the new manifest with `id_format: immutable`. This happens once per mailbox. |
 
 The stale-delta safeguard exists to prevent a specific failure: an interrupted backup saving a delta link that skips all the messages it never actually stored.
+
+## Immutable message IDs
+
+Graph returns two kinds of Outlook identifier. The default ID is **mutable**: it changes whenever a message moves between folders, so a user dragging mail into an archive folder looks like a deletion plus a brand-new message. Atlas would then re-download and re-store content it already held, and older manifest entries would point at IDs Graph no longer resolves.
+
+Atlas therefore sends `Prefer: IdType="ImmutableId"` on every Outlook request — delta pages, single-message reads, and attachment fetches alike. Microsoft requires the header on *every* request that handles an ID, because mixing formats within one dataset corrupts correlation. With it, a folder move keeps the message's identity: the manifest entry stays valid and only the message's changed folder metadata is re-stored.
+
+Two limits are worth knowing. Immutable IDs are stable within a mailbox, but not across mailboxes, and they still change when an item moves into an In-Place Archive or is exported and re-imported. See [Obtain immutable identifiers for Outlook resources](https://learn.microsoft.com/en-us/graph/outlook-immutable-id) for the underlying contract.
 
 ## Retry and error handling
 

--- a/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
@@ -40,6 +40,11 @@ import {
 // default 60s per-request window kills large bodies on slow links (issue #33).
 const LARGE_DOWNLOAD_TIMEOUT_MS = 1_800_000;
 
+// Graph's default message/folder IDs change on every folder move; immutable
+// IDs do not. Must be sent on EVERY request that produces or consumes an ID —
+// mixing formats corrupts correlation (issue #48).
+const IMMUTABLE_ID_PREFER = 'IdType="ImmutableId"';
+
 @injectable()
 export class GraphMailboxConnector implements MailboxConnector {
   constructor(@inject(GRAPH_CLIENT_TOKEN) private readonly _client: Client) {}
@@ -165,6 +170,7 @@ export class GraphMailboxConnector implements MailboxConnector {
         () =>
           this._client
             .api(`/users/${owner_id}/messages/${message_id}`)
+            .header('Prefer', IMMUTABLE_ID_PREFER)
             .get() as Promise<GraphDeltaMessage>,
       );
 
@@ -225,7 +231,11 @@ export class GraphMailboxConnector implements MailboxConnector {
     const url = `/users/${owner_id}/messages/${message_id}/attachments/${attachment_id}/$value`;
     const data = await with_graph_retry(
       () =>
-        this._client.api(url).responseType(ResponseType.ARRAYBUFFER).get() as Promise<ArrayBuffer>,
+        this._client
+          .api(url)
+          .header('Prefer', IMMUTABLE_ID_PREFER)
+          .responseType(ResponseType.ARRAYBUFFER)
+          .get() as Promise<ArrayBuffer>,
       { timeout_ms: LARGE_DOWNLOAD_TIMEOUT_MS },
     );
     return Buffer.from(data);
@@ -255,7 +265,7 @@ export class GraphMailboxConnector implements MailboxConnector {
       () =>
         this._client
           .api(this.delta_path(owner_id, folder_id))
-          .header('Prefer', `odata.maxpagesize=${page_size}`)
+          .header('Prefer', `odata.maxpagesize=${page_size}, ${IMMUTABLE_ID_PREFER}`)
           .select(DELTA_SELECT_FIELDS)
           .get() as Promise<GraphPageResponse>,
     );
@@ -263,7 +273,8 @@ export class GraphMailboxConnector implements MailboxConnector {
 
   /**
    * Fetches a page using a full @odata.nextLink or @odata.deltaLink URL.
-   * The Prefer header is re-sent on each request to ensure larger pages.
+   * The Prefer headers are re-sent on each request (page size + immutable IDs);
+   * Graph requires the IdType preference on every request that handles IDs.
    */
   private async fetch_continuation_page(
     full_url: string,
@@ -273,7 +284,7 @@ export class GraphMailboxConnector implements MailboxConnector {
       () =>
         this._client
           .api(full_url)
-          .header('Prefer', `odata.maxpagesize=${page_size}`)
+          .header('Prefer', `odata.maxpagesize=${page_size}, ${IMMUTABLE_ID_PREFER}`)
           .get() as Promise<GraphPageResponse>,
     );
   }

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -1,8 +1,7 @@
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type { TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
-import type { MailboxConnector, MailFolder } from '@wisecom/atlas-types';
-import type { ManifestRepository } from '@wisecom/atlas-types';
+import type { MailboxConnector, MailFolder, ManifestRepository } from '@wisecom/atlas-types';
 import type { ManifestEntry, ManifestObjectLockPolicy } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { assert_mailbox_exists } from '@wisecom/atlas-core/services/shared/mailbox-assertions';
@@ -17,6 +16,7 @@ import {
   build_manifest,
   create_pending_snapshot,
   mark_snapshot_completed,
+  resolve_saved_delta_links,
   resolve_sync_mode,
 } from '@/services/backup/snapshot-manifest-builder';
 import {
@@ -86,7 +86,7 @@ export class MailboxSyncService implements BackupUseCase {
       const previous = options.force_full
         ? undefined
         : await this._manifests.find_latest_by_owner(ctx, owner_id);
-      const saved_links = previous?.delta_links ?? {};
+      const saved_links = resolve_saved_delta_links(previous);
       const previous_entry_count = previous?.total_objects ?? 0;
       const mode = resolve_sync_mode(options.force_full, saved_links);
 

--- a/packages/outlook/src/services/backup/snapshot-manifest-builder.ts
+++ b/packages/outlook/src/services/backup/snapshot-manifest-builder.ts
@@ -8,6 +8,7 @@ import type {
   ManifestObjectLockPolicy,
 } from '@wisecom/atlas-types';
 import type { BackupSyncMode } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
 
 export interface OwnerIdentityHint {
   readonly owner_email?: string | undefined;
@@ -72,6 +73,7 @@ export function build_manifest(
     total_objects: Math.max(entries.length, previous_total_objects),
     total_size_bytes,
     delta_links,
+    id_format: 'immutable',
     ...(object_lock ? { object_lock } : {}),
     ...(mailbox_purpose ? { mailbox_purpose } : {}),
     entries,
@@ -85,4 +87,21 @@ export function resolve_sync_mode(
 ): BackupSyncMode {
   if (force_full) return 'full';
   return Object.keys(saved_links).length > 0 ? 'incremental' : 'initial';
+}
+
+/**
+ * Returns the previous manifest's delta links for an incremental sync.
+ * Manifests captured before the ImmutableId switch carry mutable IDs in both
+ * delta links and entries; resuming them would mix ID formats, so the first
+ * backup after upgrade restarts full (issue #48).
+ */
+export function resolve_saved_delta_links(previous: Manifest | undefined): Record<string, string> {
+  if (!previous) return {};
+  if (previous.id_format !== 'immutable') {
+    logger.info(
+      'previous snapshot uses legacy mutable message IDs; restarting with a full sync (issue #48)',
+    );
+    return {};
+  }
+  return previous.delta_links;
 }

--- a/packages/outlook/src/services/status/mailbox-status.service.ts
+++ b/packages/outlook/src/services/status/mailbox-status.service.ts
@@ -28,7 +28,10 @@ export class MailboxStatusService implements StatusUseCase {
     const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const previous = await this._manifests.find_latest_by_owner(ctx, owner_id);
-      const saved_links = previous?.delta_links ?? {};
+      // Legacy manifests carry mutable-ID delta links (issue #48); resuming
+      // them with the immutable preference would mix ID formats, so peek
+      // treats them as "no saved state" — every folder reports pending.
+      const saved_links = previous?.id_format === 'immutable' ? (previous?.delta_links ?? {}) : {};
 
       const all_folders = await this._connector.list_mail_folders(tenant_id, owner_id);
       const folder_statuses = await this.peek_all_folders(

--- a/packages/outlook/tests/unit/graph-mailbox-connector-immutable-id.test.ts
+++ b/packages/outlook/tests/unit/graph-mailbox-connector-immutable-id.test.ts
@@ -1,0 +1,68 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { GraphMailboxConnector } from '@/adapters/graph-mailbox-connector.adapter';
+import type { MockClient } from './graph-mailbox-connector.harness';
+import { create_mock_client, create_connector } from './graph-mailbox-connector.harness';
+
+// Issue #48: every Graph request that produces or consumes a message/folder ID
+// must carry Prefer: IdType="ImmutableId". Mixing ID formats corrupts
+// correlation between manifests, delta links, and live objects.
+
+const IMMUTABLE_ID = 'IdType="ImmutableId"';
+
+function prefer_headers_sent(mock_client: MockClient): string[] {
+  return mock_client._chain.header.mock.calls
+    .filter((c) => c[0] === 'Prefer')
+    .map((c) => c[1] as string);
+}
+
+describe('GraphMailboxConnector - immutable message IDs (issue #48)', () => {
+  let mock_client: MockClient;
+  let connector: GraphMailboxConnector;
+
+  beforeEach(() => {
+    mock_client = create_mock_client();
+    connector = create_connector(mock_client);
+  });
+
+  it('sends IdType=ImmutableId on the initial delta page', async () => {
+    mock_client._chain.get.mockResolvedValueOnce({ value: [] });
+
+    await connector.fetch_delta('t', 'owner-1', 'folder-1');
+
+    const headers = prefer_headers_sent(mock_client);
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toContain(IMMUTABLE_ID);
+    expect(headers[0]).toContain('odata.maxpagesize=');
+  });
+
+  it('sends IdType=ImmutableId on continuation pages from a saved delta link', async () => {
+    mock_client._chain.get.mockResolvedValueOnce({ value: [] });
+
+    await connector.fetch_delta('t', 'owner-1', 'folder-1', 'https://saved-delta-link');
+
+    const headers = prefer_headers_sent(mock_client);
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toContain(IMMUTABLE_ID);
+  });
+
+  it('sends IdType=ImmutableId when fetching a single message by ID', async () => {
+    mock_client._chain.get.mockResolvedValueOnce({ id: 'msg-1' });
+
+    await connector.fetch_message('t', 'owner-1', 'msg-1');
+
+    const headers = prefer_headers_sent(mock_client);
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toContain(IMMUTABLE_ID);
+  });
+
+  it('sends IdType=ImmutableId when listing attachments for a message', async () => {
+    mock_client._chain.get.mockResolvedValueOnce({ value: [] });
+
+    await connector.fetch_attachments('t', 'owner-1', 'msg-1');
+
+    const headers = prefer_headers_sent(mock_client);
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toContain(IMMUTABLE_ID);
+  });
+});

--- a/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
@@ -53,6 +53,7 @@ const PREVIOUS_MANIFEST: Manifest = {
   total_objects: 0,
   total_size_bytes: 0,
   delta_links: { 'folder-1': 'https://prev-delta' },
+  id_format: 'immutable',
   entries: [],
 };
 

--- a/packages/outlook/tests/unit/mailbox-status.service.test.ts
+++ b/packages/outlook/tests/unit/mailbox-status.service.test.ts
@@ -32,6 +32,7 @@ function make_manifest(owner_id: string, delta_links: Record<string, string>): M
     total_objects: 5,
     total_size_bytes: 1000,
     delta_links,
+    id_format: 'immutable',
     entries: [],
   };
 }

--- a/packages/outlook/tests/unit/mailbox-sync-delta-links.test.ts
+++ b/packages/outlook/tests/unit/mailbox-sync-delta-links.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Manifest, ManifestRepository } from '@wisecom/atlas-types';
+import { create_mailbox_sync_harness } from './mailbox-sync-test-fixtures';
+import type { MailboxSyncHarness } from './mailbox-sync-test-fixtures';
+
+function legacy_manifest(overrides: Partial<Manifest> = {}): Manifest {
+  return {
+    id: 'old-manifest',
+    tenant_id: 't',
+    owner_id: 'user@test.com',
+    snapshot_id: 'old-snap',
+    created_at: new Date(),
+    total_objects: 0,
+    total_size_bytes: 0,
+    delta_links: { 'folder-1': 'https://prev-delta' },
+    entries: [],
+    ...overrides,
+  };
+}
+
+describe('MailboxSyncService - delta link continuity', () => {
+  let harness: MailboxSyncHarness;
+  let mock_manifests: ManifestRepository;
+
+  beforeEach(() => {
+    harness = create_mailbox_sync_harness();
+    mock_manifests = harness.mock_manifests;
+  });
+
+  it('stores manifest with per-folder delta links', async () => {
+    vi.mocked(harness.mock_connector.fetch_delta).mockResolvedValue({
+      messages: [],
+      removed_ids: [],
+      delta_link: 'https://new-delta',
+      delta_reset: false,
+    });
+
+    await harness.service.sync_mailbox('t', 'user@test.com');
+
+    expect(mock_manifests.save).toHaveBeenCalledOnce();
+    const saved_manifest = vi.mocked(mock_manifests.save).mock.calls[0]![1];
+    expect(saved_manifest.delta_links).toEqual({ 'folder-1': 'https://new-delta' });
+    expect(saved_manifest.id_format).toBe('immutable');
+  });
+
+  it('passes previous delta link for incremental sync', async () => {
+    vi.mocked(mock_manifests.find_latest_by_owner).mockResolvedValue(
+      legacy_manifest({ id_format: 'immutable' }),
+    );
+
+    await harness.service.sync_mailbox('t', 'user@test.com');
+
+    expect(harness.mock_connector.fetch_delta).toHaveBeenCalledWith(
+      't',
+      'user@test.com',
+      'folder-1',
+      'https://prev-delta',
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it('restarts full when the previous manifest predates immutable IDs (issue #48)', async () => {
+    vi.mocked(mock_manifests.find_latest_by_owner).mockResolvedValue(legacy_manifest());
+
+    await harness.service.sync_mailbox('t', 'user@test.com');
+
+    // Legacy mutable-ID delta link must NOT be resumed — no prev link passed.
+    expect(harness.mock_connector.fetch_delta).toHaveBeenCalledWith(
+      't',
+      'user@test.com',
+      'folder-1',
+      undefined,
+      expect.any(Function),
+      undefined,
+    );
+  });
+});

--- a/packages/outlook/tests/unit/mailbox-sync-test-fixtures.ts
+++ b/packages/outlook/tests/unit/mailbox-sync-test-fixtures.ts
@@ -75,6 +75,7 @@ export interface MailboxSyncHarness {
   readonly service: MailboxSyncService;
   readonly mock_connector: MailboxConnector;
   readonly mock_context: TenantContext;
+  readonly mock_manifests: ManifestRepository;
 }
 
 export function create_mailbox_sync_harness(): MailboxSyncHarness {
@@ -117,5 +118,6 @@ export function create_mailbox_sync_harness(): MailboxSyncHarness {
     service: container.get(MailboxSyncService),
     mock_connector,
     mock_context,
+    mock_manifests,
   };
 }

--- a/packages/outlook/tests/unit/mailbox-sync.service.test.ts
+++ b/packages/outlook/tests/unit/mailbox-sync.service.test.ts
@@ -223,46 +223,6 @@ describe('MailboxSyncService', () => {
     expect(result.manifest.entries).toHaveLength(1);
   });
 
-  it('stores manifest with per-folder delta links', async () => {
-    const msg = make_message('msg-1', 'data');
-    vi.mocked(mock_connector.fetch_delta).mockResolvedValue(make_delta([msg], 'https://new-delta'));
-
-    await service.sync_mailbox('t', 'user@test.com');
-
-    expect(mock_manifests.save).toHaveBeenCalledOnce();
-    const [, saved_manifest] = (mock_manifests.save as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(saved_manifest.delta_links).toEqual({ 'folder-1': 'https://new-delta' });
-  });
-
-  it('passes previous delta link for incremental sync', async () => {
-    vi.mocked(mock_connector.list_mail_folders).mockResolvedValue([
-      make_folder('Inbox', 'folder-1', 0),
-    ]);
-
-    vi.mocked(mock_manifests.find_latest_by_owner).mockResolvedValue({
-      id: 'old-manifest',
-      tenant_id: 't',
-      owner_id: 'user@test.com',
-      snapshot_id: 'old-snap',
-      created_at: new Date(),
-      total_objects: 0,
-      total_size_bytes: 0,
-      delta_links: { 'folder-1': 'https://prev-delta' },
-      entries: [],
-    });
-
-    await service.sync_mailbox('t', 'user@test.com');
-
-    expect(mock_connector.fetch_delta).toHaveBeenCalledWith(
-      't',
-      'user@test.com',
-      'folder-1',
-      'https://prev-delta',
-      expect.any(Function),
-      undefined,
-    );
-  });
-
   it('returns completed snapshot with correct counts', async () => {
     const msg = make_message('msg-1', 'body');
     vi.mocked(mock_connector.fetch_delta).mockResolvedValue(make_delta([msg]));

--- a/packages/types/src/domain/manifest.ts
+++ b/packages/types/src/domain/manifest.ts
@@ -31,6 +31,11 @@ export interface Manifest {
   readonly total_size_bytes: number;
   /** Maps folder_id -> full @odata.deltaLink URL for the next incremental sync. */
   readonly delta_links: Record<string, string>;
+  /**
+   * ID format the delta links and entry IDs were captured with. Absent means
+   * legacy mutable IDs — the next sync must restart full (issue #48).
+   */
+  readonly id_format?: 'immutable' | undefined;
   readonly object_lock?: ManifestObjectLockPolicy;
   readonly entries: ManifestEntry[];
 }


### PR DESCRIPTION
Closes #48.

## What was wrong

Graph's default Outlook IDs are mutable: they change whenever a message moves between folders. Atlas never sent `Prefer: IdType="ImmutableId"`, so every user- or rule-driven move surfaced in delta as a `@removed` entry (old ID) plus a brand-new message (new ID) — full re-download, duplicate storage, and prior manifest entries keyed to IDs Graph no longer resolves.

## Change

- `Prefer: IdType="ImmutableId"` is sent on **every** Outlook request: initial delta pages, `nextLink`/`deltaLink` continuations, folder enumeration, single-message reads, attachment listings, and attachment `$value` downloads. Microsoft requires the header on every request that handles an ID — mixing formats within one dataset corrupts correlation.
- Manifests now carry `id_format: 'immutable'`. A manifest without that field was captured with mutable IDs, so its delta links cannot be resumed under the new format:
  - `outlook backup` restarts that mailbox in full once, then continues incrementally (`resolve_saved_delta_links`).
  - `outlook status` treats a legacy manifest as having no saved state instead of peeking with a mismatched ID format.
- Docs: new "Immutable message IDs" section in `docs/operations/delta-sync.md`, plus a row in the full-enumeration fallback table for the one-time migration.

## Validation

Verified against a live Microsoft 365 tenant using `tools/graph-tap`, not only mocks.

**1. Header on every ID-bearing request** — `graph-tap run --headers -- atlas outlook backup`:

```
users/{upn}/mailFolders                              odata.maxpagesize=100, IdType="ImmutableId"
users/{upn}/mailFolders/{id}/childFolders            odata.maxpagesize=100, IdType="ImmutableId"
users/{upn}/mailFolders/{id}/messages/delta   ×6     odata.maxpagesize=10,  IdType="ImmutableId"
users/{upn}/messages/{id}/attachments                odata.maxpagesize=100, IdType="ImmutableId"
users/{upn}/{id}/messages/delta              ×6     odata.maxpagesize=10,  IdType="ImmutableId"
```

The only two requests without the header are `GET /users/{upn}?$select=id` (mailbox existence) and `mailboxSettings?$select=userPurpose` — neither produces or consumes an Outlook item ID.

**2. Graph honours the header, and the ID survives a move** — same message read both ways, then moved between folders:

```
same subject : true
ids differ   : true   (mutable 152 chars vs immutable 68 chars)
move status  : 201
id preserved : true   (immutable ID unchanged across the folder move)
```

**3. Post-move incremental backup does not duplicate the message.** Initial backup stored 76 objects. After moving a message to another folder, the incremental run touched **1 object** (the moved message's changed folder metadata — `parentFolderId` is part of the stored payload), fetched **no** attachments, and the snapshot manifest contains exactly **1** entry. Under mutable IDs the same move would have re-downloaded the message and all its attachments under a new identity.

**4. Integrity intact** — `atlas outlook verify` on the snapshot: all 77 objects passed the checksum check.

## Tests

- New `graph-mailbox-connector-immutable-id.test.ts`: asserts the preference on delta initial pages, continuations, single-message reads, and attachment listings.
- New `mailbox-sync-delta-links.test.ts`: manifests are stamped `id_format: 'immutable'`; an immutable manifest resumes from its saved delta link; a legacy manifest resumes from nothing (full restart).
- Existing fixtures updated to the immutable format. Full suite green; lint, typecheck, and `docs:build` pass.

## Notes

- Immutable IDs are stable within a mailbox only. They still change on a move into an In-Place Archive (#46) or on export/re-import — documented, not worked around.
- No CLI or SDK surface changed, so no `--flag` docs updates were needed.
