### PR TITLE
Fix streaming decrypt aborting on every file above 4 MB — large OneDrive/SharePoint files were unrecoverable

### DIFF
--- a/docs/operations/delta-sync.md
+++ b/docs/operations/delta-sync.md
@@ -48,6 +48,31 @@ Atlas therefore sends `Prefer: IdType="ImmutableId"` on every Outlook request â€
 
 Two limits are worth knowing. Immutable IDs are stable within a mailbox, but not across mailboxes, and they still change when an item moves into an In-Place Archive or is exported and re-imported. See [Obtain immutable identifiers for Outlook resources](https://learn.microsoft.com/en-us/graph/outlook-immutable-id) for the underlying contract.
 
+## Original MIME retrieval
+
+A delta page tells Atlas which messages changed. For each new or changed message, backup then issues one more request to fetch that message's original **RFC 5322 MIME** -- the on-the-wire form of an email, headers and body parts exactly as the sending and relaying servers produced them -- and stores those bytes as the canonical encrypted object:
+
+```
+GET /users/{id}/messages/{id}/$value
+```
+
+Earlier versions stored `JSON.stringify()` of roughly 24 selected Graph fields and reconstructed an `.eml` at export time. The original bytes carry the `Received:` chain, `Authentication-Results` with DKIM/SPF/ARC results, `In-Reply-To`/`References` threading, and S/MIME payloads that no Graph field exposes. See [Backup Fidelity](/security#backup-fidelity) for what that recovers and why it matters.
+
+### What it costs per message
+
+| Message shape          | Requests before                                          | Requests now                                              |
+| ---------------------- | -------------------------------------------------------- | --------------------------------------------------------- |
+| No attachments         | None beyond the delta page, which carried the fields      | One `/$value` fetch                                       |
+| With attachments       | One attachment-list request plus one request per attachment | One `/$value` fetch; attachments arrive inside the MIME  |
+
+So the change costs one extra Graph request per new or changed message, offset by no longer issuing an attachment-list request plus one request per attachment. A message that carries attachments therefore costs fewer requests than it did before; a message without any costs one more.
+
+Incremental runs pay this only for messages that actually changed, which is the point of the delta query in the first place. A first full backup of a large mailbox is the expensive case, and the retry logic below -- up to 12 attempts, honoring the server's `Retry-After` header -- absorbs the throttling it provokes without operator involvement.
+
+There is deliberately **no `--fidelity` flag**. MIME is the only mode for new snapshots, so no configuration mistake can quietly archive a year of mail in the weaker format.
+
+If Graph cannot produce MIME for a particular item, Atlas stores that one message in the legacy JSON form and records the format in its manifest entry, so a single unusual item never costs you the rest of the mailbox. Entries with `payload_format: "mime"` hold original bytes; entries without the field hold legacy Graph JSON. Mixed snapshots are expected, and `save`, `read`, `restore`, and `verify` all read both.
+
 ## Retry and error handling
 
 Microsoft Graph rate-limits requests to protect the service, and its front end returns transient server errors under load. Atlas handles both transparently:

--- a/docs/operations/delta-sync.md
+++ b/docs/operations/delta-sync.md
@@ -36,8 +36,17 @@ Delta links are stored in the **encrypted manifest**, not in plaintext. They con
 | **Stale-delta safeguard** | A saved delta link returns zero items while the previous manifest had zero stored entries. That combination indicates the prior backup was interrupted before storing anything, so Atlas discards the link and enumerates the folder in full. |
 | **`syncStateNotFound`**   | Microsoft purges delta tokens after roughly 30 days of inactivity. Atlas detects the error, resyncs the folder in full, and logs a warning so you know the incremental chain was broken. |
 | **`--full`**              | `atlas outlook backup --full` ignores every saved delta link. Use it for periodic audits or when you suspect a delta link is corrupted. |
+| **Legacy message IDs**    | Snapshots taken before Atlas adopted immutable Outlook IDs recorded mutable IDs in their manifests and delta links. Mixing the two formats would break correlation, so the first backup after upgrading restarts the mailbox in full and stamps the new manifest with `id_format: immutable`. This happens once per mailbox. |
 
 The stale-delta safeguard exists to prevent a specific failure: an interrupted backup saving a delta link that skips all the messages it never actually stored.
+
+## Immutable message IDs
+
+Graph returns two kinds of Outlook identifier. The default ID is **mutable**: it changes whenever a message moves between folders, so a user dragging mail into an archive folder looks like a deletion plus a brand-new message. Atlas would then re-download and re-store content it already held, and older manifest entries would point at IDs Graph no longer resolves.
+
+Atlas therefore sends `Prefer: IdType="ImmutableId"` on every Outlook request — delta pages, single-message reads, and attachment fetches alike. Microsoft requires the header on *every* request that handles an ID, because mixing formats within one dataset corrupts correlation. With it, a folder move keeps the message's identity: the manifest entry stays valid and only the message's changed folder metadata is re-stored.
+
+Two limits are worth knowing. Immutable IDs are stable within a mailbox, but not across mailboxes, and they still change when an item moves into an In-Place Archive or is exported and re-imported. See [Obtain immutable identifiers for Outlook resources](https://learn.microsoft.com/en-us/graph/outlook-immutable-id) for the underlying contract.
 
 ## Retry and error handling
 

--- a/docs/operations/storage-layout.md
+++ b/docs/operations/storage-layout.md
@@ -15,10 +15,10 @@ atlas-{tenant_id}/
 │       └── sharepoint/{site_id}/            # SharePoint replication status
 ├── data/
 │   └── {mailbox_id}/
-│       └── {sha256}                         # encrypted message (content-addressed)
+│       └── {sha256}                         # encrypted message: RFC 5322 MIME (Graph JSON in legacy snapshots)
 ├── attachments/
 │   └── {mailbox_id}/
-│       └── {sha256}                         # encrypted attachment (content-addressed)
+│       └── {sha256}                         # encrypted attachment (legacy JSON entries only)
 ├── manifests/
 │   └── {mailbox_id}/
 │       └── {snapshot_id}.json               # encrypted Outlook manifest
@@ -51,11 +51,21 @@ For managed service providers backing up multiple tenants, this isolation means 
 | `_meta/dek.enc`                                | Wrapped data encryption key (one per tenant)   | **Most critical object.** Losing it means losing access to all tenant data     |
 | `_meta/outlook-manifests/owners/{mailbox}/`    | Pointer to the latest Outlook manifest         | Encrypted; updated after each successful manifest upload                       |
 | `_meta/outlook-manifests/snapshots/{snapshot}` | Pointer from snapshot ID to its manifest key   | Encrypted; avoids a tenant-wide manifest listing                               |
-| `data/{mailbox}/`                              | Encrypted email messages, addressed by SHA-256 | Content is encrypted; S3 metadata is not                                       |
-| `attachments/{mailbox}/`                       | Encrypted attachments, addressed by SHA-256    | Content is encrypted; S3 metadata is not                                       |
+| `data/{mailbox}/`                              | Encrypted email messages as RFC 5322 MIME, addressed by SHA-256 | Content is encrypted; S3 metadata is not                     |
+| `attachments/{mailbox}/`                       | Encrypted attachments from legacy JSON entries, by SHA-256 | Content is encrypted; S3 metadata is not                           |
 | `manifests/{mailbox}/`                         | Encrypted snapshot manifests (JSON)            | Contains subjects, folder names, and delta URLs, all encrypted                 |
 
 The lookup pointers keep incremental backup reads constant as snapshot history grows: Atlas reads the owner's `latest.json` pointer, then that one manifest. Buckets created by older Atlas versions remain compatible. Their first incremental run after upgrade falls back to the existing manifest scan, and saving the new snapshot creates the pointers used by later runs. The pointers contain only an encrypted manifest object key and are removed with their mailbox or snapshot.
+
+#### Message payload formats
+
+Objects under `data/{mailbox}/` hold one of two formats, and the manifest entry says which.
+
+Snapshots taken by this version store the message's original RFC 5322 MIME, fetched from `GET /users/{id}/messages/{id}/$value`. Because MIME carries its own attachments, these entries write **no** objects under `attachments/{mailbox}/` and their manifest entries list no attachment records. They do carry `payload_format: "mime"` and a `received_at` timestamp, the latter because there is no JSON payload left to read a receive time from.
+
+Legacy snapshots store a Graph JSON payload with each attachment as a separate content-addressed object under `attachments/{mailbox}/{sha256}`. Their manifest entries have no `payload_format` field. Nothing about them changes: they stay readable, restorable, verifiable, and exportable exactly as before, and a mailbox whose history spans the upgrade will contain both kinds in the same snapshot chain.
+
+If Graph cannot produce MIME for a single item, that message falls back to the legacy JSON form inside an otherwise MIME snapshot. `payload_format` is how an operator tells the two apart.
 
 #### Shared mailbox tracking
 
@@ -102,6 +112,8 @@ If `_meta/dek.enc` is deleted or corrupted, all data in the bucket becomes perma
 Messages and attachments use their **SHA-256 hash** as the object key (for example `data/{mailbox}/a1b2c3d4...`). The hash is taken over the **plaintext** content, before encryption.
 
 This gives automatic deduplication: if the same email appears in multiple snapshots, which is common with incremental backups, it is stored once. The manifest references the hash, and every snapshot containing that message points to the same S3 object.
+
+Embedding attachments in MIME narrows that property for message objects. Two messages carrying the same slide deck are two distinct MIME blobs with two distinct hashes, so the deck is stored once per message rather than once per mailbox. Base64 encoding inside MIME also costs roughly one third more bytes than the raw attachment, because base64 represents three binary bytes as four text bytes. Both are the deliberate price of byte-exact fidelity, since an attachment that has been extracted and re-encoded is no longer the object the sender signed. Legacy JSON entries keep the old per-attachment deduplication.
 
 Integrity verification follows from the same property. Decrypt the object, hash the result, and compare against the key. A match proves the content is exactly what was backed up.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -141,6 +141,8 @@ Either `--snapshot` or `--mailbox` is required. In mailbox mode, entries are ded
 
 Restored messages retain their original received/sent timestamps, appear as received mail (not drafts), and include all backed-up attachments. Large attachments (>3 MB) use Graph upload sessions with chunked transfer.
 
+Messages archived as RFC 5322 MIME are parsed at restore time and recreated through Graph's JSON message-create path rather than imported as MIME. That is a deliberate choice: Graph's MIME import always marks the created message as a draft, and neither an `X-Unsent: 0` header nor a `PR_MESSAGE_FLAGS` patch clears the flag, so importing would hand the user thousands of drafts. The restored copy is therefore normal mail with its original timestamps, but it does not carry the original `Received:` chain. The archived object still does -- use [`atlas outlook save`](#atlas-outlook-save) when you need the original bytes.
+
 ### `atlas outlook list`
 
 Browse backed-up data at three zoom levels. Subjects are hidden by default for data protection. The mailbox overview includes a `Type` column sourced from each mailbox's newest manifest that recorded a purpose (`user`, `shared`, `room`, ...; `--` when never recorded).
@@ -163,23 +165,30 @@ atlas outlook list -s <snapshot-id> -S          # reveal email subjects
 
 ### `atlas outlook read`
 
-Decrypt and display a single backed-up message. Messages are referenced by their `#` index from `atlas outlook list` output. Attachment metadata (name, MIME type, size) is listed below the body when present.
+Decrypt and display a single backed-up message. Messages are referenced by their `#` index from `atlas outlook list` output. Attachment metadata (name, MIME type, size) is listed below the body when present, including attachments embedded inside an archived MIME message.
 
 ```bash
 atlas outlook read -s <snapshot-id> --message 34
 atlas outlook read -s <snapshot-id> --message 34 --raw
+atlas outlook read -s <snapshot-id> --message 34 --raw > message.eml
 ```
 
-| Option                | Description                                                     |
-| --------------------- | --------------------------------------------------------------- |
-| `-s, --snapshot <id>` | Snapshot containing the message                                 |
-| `--message <ref>`     | Message `#` from `atlas outlook list`, or full Graph message ID |
-| `--raw`               | Output full JSON blob instead of formatted headers + body       |
-| `-t, --tenant <id>`   | Override tenant ID                                              |
+| Option                | Description                                                        |
+| --------------------- | ------------------------------------------------------------------ |
+| `-s, --snapshot <id>` | Snapshot containing the message                                    |
+| `--message <ref>`     | Message `#` from `atlas outlook list`, or full Graph message ID    |
+| `--raw`               | Output the stored object verbatim instead of formatted headers + body |
+| `-t, --tenant <id>`   | Override tenant ID                                                 |
+
+What `--raw` prints depends on the format of the stored object. For a message archived as RFC 5322 MIME -- the default for snapshots taken by this version -- Atlas writes the decrypted MIME bytes to stdout verbatim: no banner, no colour, no added trailing newline. Redirecting that output produces a valid `.eml` file with its original `Received:` chain, `Authentication-Results`, and any S/MIME payload intact, which is what you want when handing a single message to an investigator or verifying a DKIM signature by hand.
+
+For a legacy entry stored as a Graph JSON payload, `--raw` prints pretty-printed JSON with two-space indentation, exactly as it did before. Check a manifest entry's `payload_format` field if you need to know which to expect: `"mime"` means original bytes, an absent field means legacy JSON.
+
+The formatted view is identical for both formats -- subject, from, to, cc, date, a separator, then the decoded `text/plain` body, falling back to the HTML part converted to text. For MIME entries Atlas parses that view out of the archived bytes, so no separate attachment objects are needed to list the attachments.
 
 ### `atlas outlook save`
 
-Export backed-up emails as standard `.eml` files (RFC 5322) in a compressed zip archive. Messages include all backed-up attachments embedded as MIME parts. Every message and attachment is SHA-256 verified after decryption by default.
+Export backed-up emails as standard `.eml` files (RFC 5322) in a compressed zip archive. Messages archived as MIME are written **byte-for-byte** from the stored object -- no re-encoding, so the exported file is the message Exchange received. Legacy entries stored as Graph JSON are reconstructed into `.eml` at export time, as they always were. Attachments are embedded as MIME parts in both cases. Every message and attachment is SHA-256 verified after decryption by default.
 
 **Snapshot mode:**
 
@@ -226,6 +235,8 @@ Restore-2026-03-10T14-30-00.zip
 ```
 
 EML filenames use the format `YYYY-MM-DD_HHmmss_Sanitized-subject.eml` with timestamps from `receivedDateTime` for natural chronological sorting. Duplicate filenames within a folder get numeric suffixes (`_1`, `_2`).
+
+Mixed archives are normal. A mailbox that was backed up before this version and has kept receiving incremental snapshots contains both legacy JSON entries and MIME entries; `save` walks the whole snapshot chain and writes an `.eml` for each, regardless of format.
 
 If the output file already exists, Atlas prompts `Overwrite? [Y/n]` before proceeding.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -78,8 +78,8 @@ Every encrypt operation generates a **fresh random 12-byte IV** (initialization 
 
 | Data                                       | Encrypted | Notes                                                                      |
 | ------------------------------------------ | --------- | -------------------------------------------------------------------------- |
-| Email message bodies                       | Yes       | Stored as encrypted JSON under `data/{mailbox}/{sha256}`                   |
-| Attachments                                | Yes       | Stored as encrypted blobs under `attachments/{mailbox}/{sha256}`           |
+| Email messages                             | Yes       | RFC 5322 MIME (or legacy Graph JSON) under `data/{mailbox}/{sha256}`       |
+| Attachments                                | Yes       | Legacy JSON entries only, under `attachments/{mailbox}/{sha256}`; MIME entries embed attachments in the message object |
 | Manifests                                  | Yes       | Contains subjects, folder names, delta URLs, checksums                     |
 | OneDrive file blobs                        | Yes       | Keys under `onedrive/data/{owner_id}/{sha256}`                             |
 | OneDrive manifests / indexes / delta state | Yes       | Under `onedrive/manifests`, `onedrive/index`, `onedrive/_meta`             |
@@ -104,6 +104,58 @@ OneDrive data blobs carry no unencrypted S3 metadata. File identifiers, version 
 
 There is **no built-in S3 object rename** between email-keyed and ID-keyed mailbox prefixes in the open-source CLI as shipped; migrating layout is an operational exercise (re-backup, copy, or custom tooling) if you need to align naming.
 
+## Backup Fidelity
+
+Integrity checks prove that the archived bytes are the bytes Atlas stored. Fidelity is the separate question of *which* bytes Atlas stored in the first place, and it decides whether an archived message still carries evidentiary weight years after the mailbox is gone.
+
+| Artifact                                                     | Fidelity                                                                                                                       |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Archived object in S3, and the `.eml` files `atlas outlook save` writes | **Byte-exact.** The original RFC 5322 MIME as Exchange received it                                                    |
+| A message recreated in a mailbox by `atlas outlook restore`   | **Reconstructed.** Rebuilt from the archived MIME through Graph's JSON message-create path; the original `Received` chain is not reproduced inside the restored copy |
+| Snapshots taken before this version                          | **Reconstructed.** Graph's JSON field projection, with the `.eml` assembled at export time                                      |
+
+### The archived object is the original message
+
+Backup fetches every new or changed message as **RFC 5322 MIME** -- the on-the-wire form of an email, every header and body part exactly as the sending and relaying servers produced them -- with `GET /users/{id}/messages/{id}/$value`, and stores those bytes as the canonical encrypted object.
+
+Earlier Atlas versions stored `JSON.stringify()` of roughly 24 selected Microsoft Graph fields and *reconstructed* an `.eml` file at export time with the `mimetext` library. A reconstruction is a plausible email, not the original one: it carries the fields Atlas thought to select, re-encoded by a library that was never in the message's transit path. Everything an investigator would use to prove where a message came from was missing, because Graph's JSON projection never contained it.
+
+Storing the original bytes recovers the following. Each row is a question an operator or auditor eventually has to answer:
+
+| Recovered content                                                        | What it answers                                                                                                                                          |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The `Received:` chain                                                    | Chain of custody: which servers handled the message, in what order, and when it passed each hop                                                           |
+| `Authentication-Results` with DKIM, SPF, and ARC results, `DKIM-Signature` | Whether the message was authentic or forged. DKIM is a cryptographic signature over selected headers and the body, so it verifies only against the original bytes |
+| `In-Reply-To` and `References`                                           | Threading. Exported `.eml` files group into conversations in any mail client instead of arriving as unrelated messages                                    |
+| Original multipart structure and transfer encodings                      | Byte-level attestation: part boundaries, `Content-Transfer-Encoding`, and part order are preserved rather than regenerated                                |
+| S/MIME signed and encrypted payloads                                     | Signature verification and decryption, both of which are only possible over the original bytes                                                            |
+| Custom `X-` headers and mailing-list headers                             | Gateway, DLP, and list-server annotations that no Graph field exposes                                                                                     |
+
+There is deliberately no `--fidelity` flag. MIME is the only mode for new snapshots, so an operator cannot accidentally archive a year of mail in the weaker format.
+
+### Attachments move inside the message object
+
+MIME carries its attachments, so a MIME entry stores no separate objects under `attachments/{mailbox}/{sha256}` and its manifest entry lists no attachment records. Two consequences are worth stating plainly:
+
+- **Attachment content is no longer deduplicated across messages within a mailbox.** A slide deck mailed to a distribution list is stored once per message that carries it, not once per distinct payload.
+- **Base64 encoding inside MIME costs roughly one third more bytes** than the raw attachment, because base64 represents three bytes of binary as four bytes of text.
+
+That is the price of byte-exact fidelity. An attachment that has been re-encoded or extracted is no longer the object the sender signed.
+
+### When Graph cannot produce MIME
+
+If Graph cannot return MIME for a particular item, Atlas stores that one message in the legacy JSON form rather than skipping it. A single unusual item never costs you the rest of the mailbox.
+
+Each manifest entry records which format its object holds. Entries with `payload_format: "mime"` hold original bytes; entries with no `payload_format` field hold the legacy Graph JSON payload. Mixed snapshots are normal, and `save`, `read`, `restore`, and `verify` all handle both formats inside the same snapshot chain, so a fallback item needs no operator intervention.
+
+### Restore is reconstruction, and that is a deliberate choice
+
+Atlas does **not** import archived MIME back into Exchange. Live testing established why: Graph's MIME import path always marks the created message as a draft (`isDraft: true`), and that flag cannot be cleared -- neither an `X-Unsent: 0` header inside the MIME nor a `PR_MESSAGE_FLAGS` patch afterwards clears it. Restoring a mailbox that way would hand the user thousands of drafts instead of their mail.
+
+`atlas outlook restore` therefore parses the archived MIME and recreates each message through Graph's JSON message-create path. The result is normal, non-draft mail with its original timestamps, but the restored copy does not carry the original `Received` chain.
+
+The archived object keeps full fidelity either way. When an operator needs the original bytes -- for a legal hold, a forensic review, or DKIM verification -- `atlas outlook save` is the path that delivers them, and it never touches the live mailbox.
+
 ## Integrity Validation
 
 Atlas validates data integrity at three independent layers. Each layer catches a different class of failure:
@@ -123,7 +175,7 @@ When you run `atlas outlook verify`, Atlas performs a full integrity check for a
 3. Computes SHA-256 of the decrypted plaintext.
 4. Compares against the checksum stored in the manifest using **constant-time comparison** (`timingSafeEqual`) to prevent timing attacks.
 
-Currently, `atlas outlook verify` checks **message body entries** listed in the manifest. Attachments are implicitly protected by GCM authentication during any decrypt operation (backup, restore, save).
+`atlas outlook verify` checks the **message entries** listed in the manifest. For a MIME entry that covers the attachments too, because they are part of the message bytes being hashed. For a legacy JSON entry the separate attachment objects are not hashed against the manifest; they are protected by GCM authentication during any decrypt operation (backup, restore, save), which detects tampering but not a checksum recorded wrong at backup time.
 
 ### Content-MD5 on Uploads
 

--- a/packages/cli/src/commands/config.command.ts
+++ b/packages/cli/src/commands/config.command.ts
@@ -39,7 +39,7 @@ export function register_config_command(program: Command): void {
       ['', 'Keys:', ...CONFIG_KEYS.map((k) => `  ${k.key.padEnd(24)} ${k.description}`)].join('\n'),
     )
     .action(async (key: string | undefined, value: string | undefined) => {
-      load_dotenv();
+      load_dotenv({ quiet: true });
       if (key === undefined || key === 'list') return execute_list();
       if (key === 'validate') return execute_validate();
       if (key === 'unset') return execute_unset(value);

--- a/packages/cli/src/commands/outlook-catalog.handler.tsx
+++ b/packages/cli/src/commands/outlook-catalog.handler.tsx
@@ -11,6 +11,7 @@ import { Banner } from '@/ui/components/banner';
 import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { KeyValueList, type KeyValueItem } from '@/ui/components/key-value-list';
 import { render_static_view } from '@/ui/render';
+import { print_mime_message } from '@/commands/outlook-mime-message-view';
 
 export interface OutlookListOptions {
   tenant?: string;
@@ -65,14 +66,25 @@ export async function execute_outlook_read(
   options: OutlookReadOptions,
 ): Promise<void> {
   const tenant_id = options.tenant ?? container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
-  await render_static_view(<Banner title="Atlas Read" />);
-
   const catalog = container.get<CatalogUseCase>(CATALOG_USE_CASE_TOKEN);
   const result = await catalog.read_message(tenant_id, options.snapshot, options.message);
+
+  // Raw MIME goes to stdout verbatim so it can be piped straight into an .eml file.
+  if (options.raw && result?.payload_format === 'mime') {
+    process.stdout.write(result.raw);
+    return;
+  }
+
+  await render_static_view(<Banner title="Atlas Read" />);
 
   if (!result) {
     logger.error(`Message not found. Check the snapshot ID and message ID are correct.`);
     process.exitCode = 1;
+    return;
+  }
+
+  if (result.payload_format === 'mime') {
+    await print_mime_message(result.raw);
     return;
   }
 
@@ -81,7 +93,7 @@ export async function execute_outlook_read(
     return;
   }
 
-  await print_formatted_message(result.message);
+  await print_formatted_message(result.message ?? {});
   await print_attachment_list(result.attachments);
 }
 

--- a/packages/cli/src/commands/outlook-mime-message-view.tsx
+++ b/packages/cli/src/commands/outlook-mime-message-view.tsx
@@ -1,0 +1,66 @@
+import { Box, Text } from 'ink';
+import { html_to_text } from '@wisecom/atlas-core';
+import { parse_mime_message, type ParsedMimeMessage } from '@wisecom/atlas-outlook';
+import { format_bytes } from '@/command-formatters';
+import { KeyValueList, type KeyValueItem } from '@/ui/components/key-value-list';
+import { render_static_view } from '@/ui/render';
+
+/** Parses a stored RFC 5322 blob and prints its headers, body, and embedded attachments. */
+export async function print_mime_message(raw: Buffer): Promise<void> {
+  const parsed = await parse_mime_message(raw);
+  const cc = parsed.cc.map(format_address).join(', ');
+  const items: KeyValueItem[] = [
+    { label: 'Subject', value: parsed.subject },
+    { label: 'From', value: format_address(parsed.from) },
+    { label: 'To', value: parsed.to.map(format_address).join(', ') },
+  ];
+  if (cc) items.push({ label: 'Cc', value: cc });
+  items.push({ label: 'Date', value: parsed.date ?? '' });
+
+  await render_static_view(
+    <Box flexDirection="column">
+      <KeyValueList items={items} />
+      <Text dimColor>{'-'.repeat(60)}</Text>
+      <Text>{extract_mime_body(parsed)}</Text>
+    </Box>,
+  );
+
+  await print_mime_attachments(parsed.attachments);
+}
+
+/** Lists the attachments embedded in the MIME blob (name, MIME type, size). */
+async function print_mime_attachments(
+  attachments: ParsedMimeMessage['attachments'],
+): Promise<void> {
+  if (attachments.length === 0) return;
+
+  await render_static_view(
+    <Box flexDirection="column">
+      <Text dimColor>{'-'.repeat(60)}</Text>
+      <Text bold>{`Attachments (${attachments.length}):`}</Text>
+      {attachments.map((a, i) => (
+        <Text key={i}>
+          {`  ${i + 1}. ${a.name}  `}
+          <Text dimColor>{a.content_type}</Text>
+          {`  ${format_bytes(a.content.length)}`}
+          {a.is_inline ? <Text dimColor>{'  (inline)'}</Text> : undefined}
+        </Text>
+      ))}
+    </Box>,
+  );
+}
+
+/** Prefers the decoded text/plain part, falling back to the HTML part stripped to text. */
+function extract_mime_body(parsed: ParsedMimeMessage): string {
+  if (parsed.text) return parsed.text;
+  if (parsed.html) return html_to_text(parsed.html);
+  return '(no body)';
+}
+
+/** Formats a parsed MIME address as `Name <addr>`, or just the address. */
+function format_address(addr?: { readonly name: string; readonly address: string }): string {
+  if (!addr) return '(unknown)';
+  return addr.name && addr.name !== addr.address
+    ? `${addr.name} <${addr.address}>`
+    : addr.address || '(unknown)';
+}

--- a/packages/cli/tests/unit/outlook-read-command.test.ts
+++ b/packages/cli/tests/unit/outlook-read-command.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { execute_outlook_read } from '@/commands/outlook-catalog.handler';
+import { CATALOG_USE_CASE_TOKEN, type CatalogUseCase } from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
+
+const MIME = Buffer.from(
+  [
+    'Received: from mx.test.com by mail.test.com; Mon, 02 Mar 2026 10:00:01 +0000',
+    'Authentication-Results: spf=pass smtp.mailfrom=test.com; dkim=pass',
+    'From: Alice Example <alice@test.com>',
+    'To: Bob Example <bob@test.com>',
+    'Subject: Quarterly report',
+    'Date: Mon, 02 Mar 2026 10:00:00 +0000',
+    'Message-ID: <report-1@test.com>',
+    'MIME-Version: 1.0',
+    'Content-Type: multipart/mixed; boundary="B1"',
+    '',
+    '--B1',
+    'Content-Type: text/plain; charset=utf-8',
+    '',
+    'Numbers are attached.',
+    '--B1',
+    'Content-Type: text/csv; name="q1.csv"',
+    'Content-Disposition: attachment; filename="q1.csv"',
+    'Content-Transfer-Encoding: base64',
+    '',
+    'cSxhbW91bnQKMSwxMDAK',
+    '--B1--',
+    '',
+  ].join('\r\n'),
+);
+
+const JSON_MESSAGE = { subject: 'Legacy', body: { contentType: 'text', content: 'Plain body' } };
+
+describe('execute_outlook_read', () => {
+  let container: Container;
+  let catalog: CatalogUseCase;
+  let stdout_spy: MockInstance<typeof process.stdout.write>;
+  let log_spy: MockInstance<typeof console.log>;
+
+  beforeEach(() => {
+    catalog = {
+      list_mailboxes: vi.fn().mockResolvedValue([]),
+      list_snapshots: vi.fn().mockResolvedValue([]),
+      get_snapshot_detail: vi.fn().mockResolvedValue(undefined),
+      read_message: vi.fn().mockResolvedValue(undefined),
+    };
+
+    container = new Container();
+    container.bind(CATALOG_USE_CASE_TOKEN).toConstantValue(catalog);
+    container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({ tenant_id: 'test-tenant' });
+
+    // Records writes while still letting Ink flush its frames -- a stubbed
+    // write stalls Ink's unmount and the render never resolves.
+    stdout_spy = vi.spyOn(process.stdout, 'write');
+    log_spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    stdout_spy.mockRestore();
+    log_spy.mockRestore();
+  });
+
+  function captured_stdout(): string {
+    return stdout_spy.mock.calls
+      .map(([chunk]) => (Buffer.isBuffer(chunk) ? chunk.toString('utf-8') : String(chunk)))
+      .join('');
+  }
+
+  it('writes the MIME blob verbatim for --raw, with no banner or wrapping', async () => {
+    vi.mocked(catalog.read_message).mockResolvedValue({
+      raw: MIME,
+      payload_format: 'mime',
+      attachments: [],
+    });
+
+    await execute_outlook_read(container, { snapshot: 'snap-1', message: '1', raw: true });
+
+    expect(stdout_spy).toHaveBeenCalledTimes(1);
+    expect(stdout_spy.mock.calls[0]?.[0]).toBe(MIME);
+    expect(captured_stdout()).toBe(MIME.toString('utf-8'));
+    expect(log_spy).not.toHaveBeenCalled();
+  });
+
+  it('still prints pretty JSON for --raw on a legacy JSON entry', async () => {
+    const raw = Buffer.from(JSON.stringify(JSON_MESSAGE));
+    vi.mocked(catalog.read_message).mockResolvedValue({
+      raw,
+      message: JSON_MESSAGE,
+      attachments: [],
+    });
+
+    await execute_outlook_read(container, { snapshot: 'snap-1', message: '1', raw: true });
+
+    expect(log_spy).toHaveBeenCalledWith(JSON.stringify(JSON_MESSAGE, null, 2));
+  });
+
+  it('prints parsed headers, body, and embedded attachments for a MIME entry', async () => {
+    vi.mocked(catalog.read_message).mockResolvedValue({
+      raw: MIME,
+      payload_format: 'mime',
+      attachments: [],
+    });
+
+    await execute_outlook_read(container, { snapshot: 'snap-1', message: '1' });
+
+    const printed = captured_stdout();
+    expect(printed).toContain('Quarterly report');
+    expect(printed).toContain('alice@test.com');
+    expect(printed).toContain('bob@test.com');
+    expect(printed).toContain('Numbers are attached.');
+    expect(printed).toContain('Attachments (1):');
+    expect(printed).toContain('q1.csv');
+    expect(printed).toContain('text/csv');
+  });
+
+  it('reports a missing message with exit code 1', async () => {
+    await execute_outlook_read(container, { snapshot: 'snap-1', message: '99' });
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+  });
+});

--- a/packages/core/src/services/catalog/catalog.service.ts
+++ b/packages/core/src/services/catalog/catalog.service.ts
@@ -54,8 +54,9 @@ export class CatalogService implements CatalogUseCase {
 
   /**
    * Finds a message entry in the manifest, fetches the encrypted blob
-   * from object storage, decrypts it, and returns the parsed JSON
-   * together with any attachment metadata from the manifest.
+   * from object storage and decrypts it. MIME entries are returned as raw
+   * bytes; legacy Graph JSON entries are parsed and returned together with
+   * their attachment metadata from the manifest.
    *
    * @param message_ref - Either a 1-based numeric index (e.g. "34") matching the
    *   `atlas list` output, or a full Graph API message ID string.
@@ -74,9 +75,12 @@ export class CatalogService implements CatalogUseCase {
       if (!entry) return undefined;
 
       const encrypted = await ctx.storage.get(entry.storage_key);
-      const json = ctx.decrypt(encrypted);
-      const message = JSON.parse(json.toString('utf-8')) as Record<string, unknown>;
-      return { message, attachments: entry.attachments ?? [] };
+      const raw = ctx.decrypt(encrypted);
+      if (entry.payload_format === 'mime') {
+        return { raw, payload_format: 'mime', attachments: [] };
+      }
+      const message = JSON.parse(raw.toString('utf-8')) as Record<string, unknown>;
+      return { raw, message, attachments: entry.attachments ?? [] };
     } finally {
       ctx.destroy();
     }

--- a/packages/core/src/services/shared/index.ts
+++ b/packages/core/src/services/shared/index.ts
@@ -9,3 +9,5 @@ export {
   filter_manifests_by_date,
   merge_snapshot_entries,
 } from '@/services/shared/manifest-entry-merger';
+export { stream_decrypt_from_storage } from '@/services/shared/stream-decrypt';
+export type { StreamDecryptResult } from '@/services/shared/stream-decrypt';

--- a/packages/core/src/services/shared/stream-decrypt.ts
+++ b/packages/core/src/services/shared/stream-decrypt.ts
@@ -1,0 +1,84 @@
+import { createHash } from 'node:crypto';
+import { Readable } from 'node:stream';
+import type { TenantContext } from '@wisecom/atlas-types';
+
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const HEADER_LENGTH = IV_LENGTH + AUTH_TAG_LENGTH;
+
+export interface StreamDecryptResult {
+  readonly content: Buffer;
+  readonly sha256_hex: string;
+}
+
+/**
+ * Reads an encrypted object from storage as a stream, decrypts it with
+ * AES-256-GCM, and computes the plaintext SHA-256 incrementally.
+ *
+ * The IV and auth tag occupy the first {@link HEADER_LENGTH} bytes, which may
+ * arrive split across chunks, so the header is assembled inside the single
+ * iteration over the stream. Reading it in a separate `for await` loop and
+ * breaking out is what issue #143 was: an early exit from `for await` calls the
+ * async iterator's `return()`, which destroys the stream, and every subsequent
+ * read rejects with `AbortError: The operation was aborted`. One pass, no early
+ * exit, no `unshift`.
+ */
+export async function stream_decrypt_from_storage(
+  ctx: TenantContext,
+  storage_key: string,
+): Promise<StreamDecryptResult> {
+  const raw_stream = await ctx.storage.get_stream(storage_key);
+  const readable =
+    raw_stream instanceof Readable
+      ? raw_stream
+      : Readable.from(raw_stream as AsyncIterable<Buffer>);
+
+  const header_chunks: Buffer[] = [];
+  let header_length = 0;
+  let decipher: ReturnType<TenantContext['create_decipher']> | undefined;
+  const sha256 = createHash('sha256');
+  const plaintext_chunks: Buffer[] = [];
+
+  const consume = (payload: Buffer): void => {
+    if (payload.length === 0) return;
+    const decrypted = decipher!.update(payload);
+    if (decrypted.length > 0) {
+      plaintext_chunks.push(decrypted);
+      sha256.update(decrypted);
+    }
+  };
+
+  for await (const chunk of readable) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
+
+    if (decipher !== undefined) {
+      consume(buf);
+      continue;
+    }
+
+    header_chunks.push(buf);
+    header_length += buf.length;
+    if (header_length < HEADER_LENGTH) continue;
+
+    const combined = Buffer.concat(header_chunks);
+    decipher = ctx.create_decipher(
+      combined.subarray(0, IV_LENGTH),
+      combined.subarray(IV_LENGTH, HEADER_LENGTH),
+    );
+    consume(combined.subarray(HEADER_LENGTH));
+  }
+
+  if (decipher === undefined) {
+    throw new Error(
+      `Stream for ${storage_key} ended after ${header_length} bytes; expected at least ${HEADER_LENGTH}`,
+    );
+  }
+
+  const final_block = decipher.final();
+  if (final_block.length > 0) {
+    plaintext_chunks.push(final_block);
+    sha256.update(final_block);
+  }
+
+  return { content: Buffer.concat(plaintext_chunks), sha256_hex: sha256.digest('hex') };
+}

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -49,7 +49,9 @@ const ENV_MAP: Record<string, keyof AtlasConfig> = {
  * Throws if any required field is missing after merging.
  */
 export function load_config(): AtlasConfig {
-  load_dotenv();
+  // quiet: dotenv's load banner goes to stdout, which corrupts pipeable output
+  // such as `atlas outlook read --raw > message.eml`.
+  load_dotenv({ quiet: true });
   const file_config = try_load_config_file();
   const secure_config = read_secure_config();
   const env_overrides = read_env_overrides();

--- a/packages/core/tests/unit/services/catalog-read-message.test.ts
+++ b/packages/core/tests/unit/services/catalog-read-message.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import 'reflect-metadata';
+import type { CatalogService } from '@/services/catalog/catalog.service';
+import type { ManifestRepository, TenantContext } from '@wisecom/atlas-types';
+import { build_catalog_harness, make_manifest, stub_storage_get } from './catalog-service.fixtures';
+
+describe('CatalogService.read_message', () => {
+  let service: CatalogService;
+  let mock_manifests: ManifestRepository;
+  let mock_context: TenantContext;
+
+  beforeEach(() => {
+    ({ service, mock_manifests, mock_context } = build_catalog_harness());
+  });
+
+  it('decrypts and parses a stored JSON message with empty attachments', async () => {
+    const message_json = { subject: 'Hello', body: { content: 'World' } };
+    const plaintext = Buffer.from(JSON.stringify(message_json));
+    const ciphertext = Buffer.concat([Buffer.from('E'), plaintext]);
+
+    vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
+      make_manifest({
+        entries: [
+          { object_id: 'msg-1', storage_key: 'data/u/abc', checksum: 'abc', size_bytes: 100 },
+        ],
+      }),
+    );
+    stub_storage_get(mock_context, ciphertext);
+
+    const result = await service.read_message('t', 'snap-1', 'msg-1');
+
+    expect(result?.message).toEqual(message_json);
+    expect(result?.raw).toEqual(plaintext);
+    expect(result?.payload_format).toBeUndefined();
+    expect(result?.attachments).toEqual([]);
+    expect(mock_context.storage.get).toHaveBeenCalledWith('data/u/abc');
+    expect(mock_context.decrypt).toHaveBeenCalledWith(ciphertext);
+  });
+
+  it('returns attachment metadata from a JSON manifest entry', async () => {
+    const plaintext = Buffer.from(JSON.stringify({ subject: 'With PDF' }));
+    const ciphertext = Buffer.concat([Buffer.from('E'), plaintext]);
+
+    vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
+      make_manifest({
+        entries: [
+          {
+            object_id: 'msg-1',
+            storage_key: 'data/u/abc',
+            checksum: 'abc',
+            size_bytes: 100,
+            attachments: [
+              {
+                attachment_id: 'att-1',
+                name: 'report.pdf',
+                content_type: 'application/pdf',
+                size_bytes: 2048,
+                storage_key: 'attachments/u/sha',
+                checksum: 'sha',
+                is_inline: false,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    stub_storage_get(mock_context, ciphertext);
+
+    const result = await service.read_message('t', 'snap-1', 'msg-1');
+
+    expect(result?.attachments).toHaveLength(1);
+    expect(result?.attachments[0]?.name).toBe('report.pdf');
+  });
+
+  it('returns raw MIME bytes without parsing for a mime entry', async () => {
+    const mime = Buffer.from(
+      'Received: from mail.test.com\r\nAuthentication-Results: spf=pass\r\n' +
+        'Subject: Hello\r\n\r\nBody text\r\n',
+    );
+    const ciphertext = Buffer.concat([Buffer.from('E'), mime]);
+
+    vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
+      make_manifest({
+        entries: [
+          {
+            object_id: 'msg-mime',
+            storage_key: 'data/u/mime',
+            checksum: 'mime',
+            size_bytes: mime.length,
+            payload_format: 'mime',
+          },
+        ],
+      }),
+    );
+    stub_storage_get(mock_context, ciphertext);
+
+    const result = await service.read_message('t', 'snap-1', 'msg-mime');
+
+    expect(result?.payload_format).toBe('mime');
+    expect(result?.raw).toEqual(mime);
+    expect(result?.message).toBeUndefined();
+    expect(result?.attachments).toEqual([]);
+  });
+
+  it('returns undefined when snapshot does not exist', async () => {
+    const result = await service.read_message('t', 'missing', 'msg-1');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when message is not in manifest', async () => {
+    vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(make_manifest({ entries: [] }));
+
+    const result = await service.read_message('t', 'snap-1', 'no-such-msg');
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/core/tests/unit/services/catalog-service.fixtures.ts
+++ b/packages/core/tests/unit/services/catalog-service.fixtures.ts
@@ -1,0 +1,103 @@
+import { vi } from 'vitest';
+import { Container } from 'inversify';
+import { CatalogService } from '@/services/catalog/catalog.service';
+import {
+  MANIFEST_REPOSITORY_TOKEN,
+  TENANT_CONTEXT_FACTORY_TOKEN,
+  type ManifestRepository,
+  type TenantContext,
+  type TenantContextFactory,
+  type ObjectStorage,
+  type Manifest,
+} from '@wisecom/atlas-types';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+
+/** Builds a manifest with sensible defaults, overridable per test. */
+export function make_manifest(overrides: Partial<Manifest> = {}): Manifest {
+  return {
+    id: 'manifest-1',
+    tenant_id: 't',
+    owner_id: 'user@test.com',
+    snapshot_id: 'snap-1',
+    created_at: new Date('2026-03-01T10:00:00Z'),
+    total_objects: 50,
+    total_size_bytes: 5000,
+    delta_links: {},
+    entries: [],
+    ...overrides,
+  };
+}
+
+/** Fully stubbed object storage port. */
+export function make_mock_storage(): ObjectStorage {
+  return {
+    put: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+    delete_version: vi.fn(),
+    exists: vi.fn().mockResolvedValue(false),
+    list: vi.fn().mockResolvedValue([]),
+    list_versions: vi.fn().mockResolvedValue([]),
+    begin_multipart_upload: vi.fn().mockResolvedValue({
+      upload_part: vi.fn(),
+      complete: vi.fn(),
+      abort: vi.fn(),
+    }),
+    copy: vi.fn(),
+    abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+    probe_immutability: vi.fn().mockResolvedValue({
+      bucket: 'test-bucket',
+      reachable: true,
+      versioning_enabled: true,
+      object_lock_enabled: true,
+      mode_supported: true,
+    }),
+  };
+}
+
+/** Tenant context whose "encryption" just prefixes/strips a single marker byte. */
+export function make_mock_context(): TenantContext {
+  return {
+    tenant_id: 'test-tenant',
+    storage: make_mock_storage(),
+    encrypt: vi.fn((data: Buffer) => Buffer.concat([Buffer.from('E'), data])),
+    decrypt: vi.fn((data: Buffer) => data.subarray(1)),
+    create_cipher: stub_tenant_create_cipher,
+    destroy: vi.fn(),
+  };
+}
+
+export interface CatalogTestHarness {
+  readonly service: CatalogService;
+  readonly mock_manifests: ManifestRepository;
+  readonly mock_context: TenantContext;
+}
+
+/** Wires a CatalogService against mocked manifest repository and tenant context ports. */
+export function build_catalog_harness(): CatalogTestHarness {
+  const mock_context = make_mock_context();
+
+  const mock_manifests: ManifestRepository = {
+    save: vi.fn(),
+    find_by_snapshot: vi.fn().mockResolvedValue(undefined),
+    find_latest_by_owner: vi.fn().mockResolvedValue(undefined),
+    list_all_manifests: vi.fn().mockResolvedValue([]),
+  };
+
+  const mock_factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(mock_context),
+    create_readonly: vi.fn().mockResolvedValue(mock_context),
+  };
+
+  const container = new Container();
+  container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+  container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
+  container.bind(CatalogService).toSelf();
+
+  return { service: container.get(CatalogService), mock_manifests, mock_context };
+}
+
+/** Stubs the next `storage.get` call to return the given ciphertext. */
+export function stub_storage_get(ctx: TenantContext, ciphertext: Buffer): void {
+  vi.mocked(ctx.storage.get).mockResolvedValue(ciphertext);
+}

--- a/packages/core/tests/unit/services/catalog.service.test.ts
+++ b/packages/core/tests/unit/services/catalog.service.test.ts
@@ -1,97 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Container } from 'inversify';
 import 'reflect-metadata';
-import { CatalogService } from '@/services/catalog/catalog.service';
-import {
-  MANIFEST_REPOSITORY_TOKEN,
-  TENANT_CONTEXT_FACTORY_TOKEN,
-  type ManifestRepository,
-  type TenantContext,
-  type TenantContextFactory,
-  type ObjectStorage,
-  type Manifest,
-} from '@wisecom/atlas-types';
-import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
-
-function make_manifest(overrides: Partial<Manifest> = {}): Manifest {
-  return {
-    id: 'manifest-1',
-    tenant_id: 't',
-    owner_id: 'user@test.com',
-    snapshot_id: 'snap-1',
-    created_at: new Date('2026-03-01T10:00:00Z'),
-    total_objects: 50,
-    total_size_bytes: 5000,
-    delta_links: {},
-    entries: [],
-    ...overrides,
-  };
-}
-
-function make_mock_storage(): ObjectStorage {
-  return {
-    put: vi.fn(),
-    get: vi.fn(),
-    delete: vi.fn(),
-    delete_version: vi.fn(),
-    exists: vi.fn().mockResolvedValue(false),
-    list: vi.fn().mockResolvedValue([]),
-    list_versions: vi.fn().mockResolvedValue([]),
-    begin_multipart_upload: vi.fn().mockResolvedValue({
-      upload_part: vi.fn(),
-      complete: vi.fn(),
-      abort: vi.fn(),
-    }),
-    copy: vi.fn(),
-    abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
-    probe_immutability: vi.fn().mockResolvedValue({
-      bucket: 'test-bucket',
-      reachable: true,
-      versioning_enabled: true,
-      object_lock_enabled: true,
-      mode_supported: true,
-    }),
-  };
-}
-
-function make_mock_context(): TenantContext {
-  return {
-    tenant_id: 'test-tenant',
-    storage: make_mock_storage(),
-    encrypt: vi.fn((data: Buffer) => Buffer.concat([Buffer.from('E'), data])),
-    decrypt: vi.fn((data: Buffer) => data.subarray(1)),
-    create_cipher: stub_tenant_create_cipher,
-    destroy: vi.fn(),
-  };
-}
+import type { CatalogService } from '@/services/catalog/catalog.service';
+import type { ManifestRepository, TenantContext } from '@wisecom/atlas-types';
+import { build_catalog_harness, make_manifest } from './catalog-service.fixtures';
 
 describe('CatalogService', () => {
-  let container: Container;
   let mock_manifests: ManifestRepository;
   let mock_context: TenantContext;
   let service: CatalogService;
 
   beforeEach(() => {
-    mock_context = make_mock_context();
-
-    mock_manifests = {
-      save: vi.fn(),
-      find_by_snapshot: vi.fn().mockResolvedValue(undefined),
-      find_latest_by_owner: vi.fn().mockResolvedValue(undefined),
-      list_all_manifests: vi.fn().mockResolvedValue([]),
-    };
-
-    const mock_factory: TenantContextFactory = {
-      create: vi.fn().mockResolvedValue(mock_context),
-      create_readonly: vi.fn().mockResolvedValue(mock_context),
-    };
-
-    container = new Container();
-    container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
-    container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
-    container.bind(CatalogService).toSelf();
-
-    service = container.get(CatalogService);
+    ({ service, mock_manifests, mock_context } = build_catalog_harness());
   });
 
   // ---------------------------------------------------------------------------
@@ -267,82 +186,6 @@ describe('CatalogService', () => {
 
     it('returns undefined for unknown snapshot', async () => {
       const result = await service.get_snapshot_detail('t', 'nonexistent');
-      expect(result).toBeUndefined();
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // read_message
-  // ---------------------------------------------------------------------------
-
-  describe('read_message', () => {
-    it('decrypts and parses a stored message with empty attachments', async () => {
-      const message_json = { subject: 'Hello', body: { content: 'World' } };
-      const plaintext = Buffer.from(JSON.stringify(message_json));
-      const ciphertext = Buffer.concat([Buffer.from('E'), plaintext]);
-
-      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
-        make_manifest({
-          entries: [
-            { object_id: 'msg-1', storage_key: 'data/u/abc', checksum: 'abc', size_bytes: 100 },
-          ],
-        }),
-      );
-      vi.mocked(mock_context.storage.get as ReturnType<typeof vi.fn>).mockResolvedValue(ciphertext);
-
-      const result = await service.read_message('t', 'snap-1', 'msg-1');
-
-      expect(result?.message).toEqual(message_json);
-      expect(result?.attachments).toEqual([]);
-      expect(mock_context.storage.get).toHaveBeenCalledWith('data/u/abc');
-      expect(mock_context.decrypt).toHaveBeenCalledWith(ciphertext);
-    });
-
-    it('returns attachment metadata from manifest entry', async () => {
-      const message_json = { subject: 'With PDF' };
-      const plaintext = Buffer.from(JSON.stringify(message_json));
-      const ciphertext = Buffer.concat([Buffer.from('E'), plaintext]);
-
-      const attachment_entry = {
-        attachment_id: 'att-1',
-        name: 'report.pdf',
-        content_type: 'application/pdf',
-        size_bytes: 2048,
-        storage_key: 'attachments/u/sha',
-        checksum: 'sha',
-        is_inline: false,
-      };
-
-      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
-        make_manifest({
-          entries: [
-            {
-              object_id: 'msg-1',
-              storage_key: 'data/u/abc',
-              checksum: 'abc',
-              size_bytes: 100,
-              attachments: [attachment_entry],
-            },
-          ],
-        }),
-      );
-      vi.mocked(mock_context.storage.get as ReturnType<typeof vi.fn>).mockResolvedValue(ciphertext);
-
-      const result = await service.read_message('t', 'snap-1', 'msg-1');
-
-      expect(result?.attachments).toHaveLength(1);
-      expect(result?.attachments[0]?.name).toBe('report.pdf');
-    });
-
-    it('returns undefined when snapshot does not exist', async () => {
-      const result = await service.read_message('t', 'missing', 'msg-1');
-      expect(result).toBeUndefined();
-    });
-
-    it('returns undefined when message is not in manifest', async () => {
-      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(make_manifest({ entries: [] }));
-
-      const result = await service.read_message('t', 'snap-1', 'no-such-msg');
       expect(result).toBeUndefined();
     });
   });

--- a/packages/core/tests/unit/services/shared/stream-decrypt.test.ts
+++ b/packages/core/tests/unit/services/shared/stream-decrypt.test.ts
@@ -53,8 +53,9 @@ describe('stream_decrypt_from_storage', () => {
   });
 
   it('assembles the IV and auth tag when the header is split across chunks', async () => {
-    const plaintext = randomBytes(5 * 1024 * 1024);
-    // 7-byte chunks split the 28-byte header across four reads.
+    const plaintext = randomBytes(8 * 1024);
+    // 7-byte chunks split the 28-byte header across four reads; the payload
+    // stays small because chunk count, not size, is what this case exercises.
     const ctx = make_ctx(encrypt(plaintext), 7);
 
     const result = await stream_decrypt_from_storage(ctx, 'data/owner/checksum');

--- a/packages/core/tests/unit/services/shared/stream-decrypt.test.ts
+++ b/packages/core/tests/unit/services/shared/stream-decrypt.test.ts
@@ -1,0 +1,91 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import { Readable } from 'node:stream';
+import { describe, it, expect } from 'vitest';
+import type { TenantContext } from '@wisecom/atlas-types';
+import { stream_decrypt_from_storage } from '@/services/shared/stream-decrypt';
+
+const KEY = randomBytes(32);
+
+/**
+ * Encrypts a payload the way Atlas stores it: 12-byte IV, 16-byte auth tag,
+ * then ciphertext.
+ */
+function encrypt(plaintext: Buffer): Buffer {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 });
+  const body = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return Buffer.concat([iv, cipher.getAuthTag(), body]);
+}
+
+/** Builds a context whose storage streams `stored` back in fixed-size chunks. */
+function make_ctx(stored: Buffer, chunk_size: number): TenantContext {
+  return {
+    tenant_id: 'test-tenant',
+    storage: {
+      get_stream: async () => {
+        const chunks: Buffer[] = [];
+        for (let i = 0; i < stored.length; i += chunk_size) {
+          chunks.push(stored.subarray(i, Math.min(i + chunk_size, stored.length)));
+        }
+        return Readable.from(chunks);
+      },
+    },
+    create_decipher: (iv: Buffer, auth_tag: Buffer) => {
+      const decipher = createDecipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 });
+      decipher.setAuthTag(auth_tag);
+      return decipher;
+    },
+  } as unknown as TenantContext;
+}
+
+const sha256 = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex');
+
+describe('stream_decrypt_from_storage', () => {
+  it('decrypts a multi-megabyte object spanning many chunks (issue #143)', async () => {
+    const plaintext = randomBytes(9 * 1024 * 1024);
+    const ctx = make_ctx(encrypt(plaintext), 64 * 1024);
+
+    const result = await stream_decrypt_from_storage(ctx, 'data/owner/checksum');
+
+    expect(result.content.length).toBe(plaintext.length);
+    expect(Buffer.compare(result.content, plaintext)).toBe(0);
+    expect(result.sha256_hex).toBe(sha256(plaintext));
+  });
+
+  it('assembles the IV and auth tag when the header is split across chunks', async () => {
+    const plaintext = randomBytes(5 * 1024 * 1024);
+    // 7-byte chunks split the 28-byte header across four reads.
+    const ctx = make_ctx(encrypt(plaintext), 7);
+
+    const result = await stream_decrypt_from_storage(ctx, 'data/owner/checksum');
+
+    expect(Buffer.compare(result.content, plaintext)).toBe(0);
+    expect(result.sha256_hex).toBe(sha256(plaintext));
+  });
+
+  it('decrypts a payload delivered as one chunk', async () => {
+    const plaintext = randomBytes(1024);
+    const stored = encrypt(plaintext);
+    const ctx = make_ctx(stored, stored.length);
+
+    const result = await stream_decrypt_from_storage(ctx, 'data/owner/checksum');
+
+    expect(Buffer.compare(result.content, plaintext)).toBe(0);
+  });
+
+  it('rejects a stream that ends before the header is complete', async () => {
+    const ctx = make_ctx(randomBytes(20), 20);
+
+    await expect(stream_decrypt_from_storage(ctx, 'data/owner/truncated')).rejects.toThrow(
+      /expected at least 28/,
+    );
+  });
+
+  it('rejects when the ciphertext was tampered with', async () => {
+    const stored = encrypt(randomBytes(2 * 1024 * 1024));
+    stored[stored.length - 1] ^= 0xff;
+    const ctx = make_ctx(stored, 64 * 1024);
+
+    await expect(stream_decrypt_from_storage(ctx, 'data/owner/tampered')).rejects.toThrow();
+  });
+});

--- a/packages/m365-graph/src/rate-limited-graph-connector.adapter.ts
+++ b/packages/m365-graph/src/rate-limited-graph-connector.adapter.ts
@@ -143,6 +143,23 @@ export class RateLimitedGraphConnector implements MailboxConnector {
     );
   }
 
+  /**
+   * Forwards the MIME capture (issue #50). Counted as a full message read
+   * against the outlook pool, because that is what /$value costs.
+   */
+  async fetch_mime(
+    tenant_id: string,
+    owner_id: string,
+    message_id: string,
+  ): Promise<Buffer | undefined> {
+    if (!this._inner.fetch_mime) return undefined;
+    return this.rateLimited(owner_id, DEFAULT_REQUEST_COST, () =>
+      run_with_graph_operation({ pool: 'outlook', request_type: 'fetch_mime' }, () =>
+        this._inner.fetch_mime!(tenant_id, owner_id, message_id),
+      ),
+    );
+  }
+
   /** Shuts down all per-mailbox limiters. */
   shutdown(): void {
     this._factory.shutdown_all();

--- a/packages/onedrive/src/services/onedrive-restore-streaming.ts
+++ b/packages/onedrive/src/services/onedrive-restore-streaming.ts
@@ -1,62 +1,17 @@
-import { createHash } from 'node:crypto';
-import { Readable } from 'node:stream';
-import type { TenantContext, OneDriveManifestEntry } from '@wisecom/atlas-types';
+import type { OneDriveManifestEntry } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
-const IV_LENGTH = 12;
-const AUTH_TAG_LENGTH = 16;
-const HEADER_LENGTH = IV_LENGTH + AUTH_TAG_LENGTH;
+export {
+  stream_decrypt_from_storage,
+  type StreamDecryptResult,
+} from '@wisecom/atlas-core/services/shared/stream-decrypt';
 
-interface StreamDecryptResult {
-  content: Buffer;
-  sha256_hex: string;
-}
-
-/**
- * Reads encrypted data from S3 as a stream, decrypts via AES-256-GCM,
- * and computes SHA-256 incrementally — avoiding holding full ciphertext in memory.
- */
-export async function stream_decrypt_from_storage(
-  ctx: TenantContext,
-  storage_key: string,
-): Promise<StreamDecryptResult> {
-  const raw_stream = await ctx.storage.get_stream(storage_key);
-  const readable =
-    raw_stream instanceof Readable
-      ? raw_stream
-      : Readable.from(raw_stream as AsyncIterable<Buffer>);
-
-  const header = await read_exact_bytes(readable, HEADER_LENGTH);
-  const iv = header.subarray(0, IV_LENGTH);
-  const auth_tag = header.subarray(IV_LENGTH, HEADER_LENGTH);
-  const decipher = ctx.create_decipher(iv, auth_tag);
-  const sha256 = createHash('sha256');
-  const plaintext_chunks: Buffer[] = [];
-
-  for await (const chunk of readable) {
-    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
-    const decrypted = decipher.update(buf);
-    if (decrypted.length > 0) {
-      plaintext_chunks.push(decrypted);
-      sha256.update(decrypted);
-    }
-  }
-
-  const final_block = decipher.final();
-  if (final_block.length > 0) {
-    plaintext_chunks.push(final_block);
-    sha256.update(final_block);
-  }
-
-  return {
-    content: Buffer.concat(plaintext_chunks),
-    sha256_hex: sha256.digest('hex'),
-  };
-}
+/** Files above this size are decrypted as a stream rather than buffered whole. */
+const STREAM_THRESHOLD_BYTES = 4 * 1024 * 1024;
 
 /** Checks whether a file should use stream-based restore. */
 export function should_stream_restore(entry: OneDriveManifestEntry): boolean {
-  return entry.size_bytes > 4 * 1024 * 1024;
+  return entry.size_bytes > STREAM_THRESHOLD_BYTES;
 }
 
 /** Verifies the computed SHA-256 against the manifest entry. */
@@ -73,25 +28,4 @@ export function verify_streaming_checksum(
     return false;
   }
   return true;
-}
-
-async function read_exact_bytes(readable: Readable, count: number): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  let collected = 0;
-
-  for await (const chunk of readable) {
-    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
-    chunks.push(buf);
-    collected += buf.length;
-
-    if (collected >= count) {
-      const combined = Buffer.concat(chunks);
-      const header = combined.subarray(0, count);
-      const leftover = combined.subarray(count);
-      if (leftover.length > 0) readable.unshift(leftover);
-      return header;
-    }
-  }
-
-  throw new Error(`Stream ended after ${collected} bytes; expected at least ${count}`);
 }

--- a/packages/outlook/package.json
+++ b/packages/outlook/package.json
@@ -27,7 +27,11 @@
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "archiver": "^7.0.1",
     "inversify": "^7.11.0",
+    "mailparser": "^3.9.15",
     "mimetext": "^3.0.28",
     "reflect-metadata": "^0.2.2"
+  },
+  "devDependencies": {
+    "@types/mailparser": "^3.4.6"
   }
 }

--- a/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
@@ -40,6 +40,11 @@ import {
 // default 60s per-request window kills large bodies on slow links (issue #33).
 const LARGE_DOWNLOAD_TIMEOUT_MS = 1_800_000;
 
+// Graph's default message/folder IDs change on every folder move; immutable
+// IDs do not. Must be sent on EVERY request that produces or consumes an ID —
+// mixing formats corrupts correlation (issue #48).
+const IMMUTABLE_ID_PREFER = 'IdType="ImmutableId"';
+
 @injectable()
 export class GraphMailboxConnector implements MailboxConnector {
   constructor(@inject(GRAPH_CLIENT_TOKEN) private readonly _client: Client) {}
@@ -165,6 +170,7 @@ export class GraphMailboxConnector implements MailboxConnector {
         () =>
           this._client
             .api(`/users/${owner_id}/messages/${message_id}`)
+            .header('Prefer', IMMUTABLE_ID_PREFER)
             .get() as Promise<GraphDeltaMessage>,
       );
 
@@ -225,7 +231,11 @@ export class GraphMailboxConnector implements MailboxConnector {
     const url = `/users/${owner_id}/messages/${message_id}/attachments/${attachment_id}/$value`;
     const data = await with_graph_retry(
       () =>
-        this._client.api(url).responseType(ResponseType.ARRAYBUFFER).get() as Promise<ArrayBuffer>,
+        this._client
+          .api(url)
+          .header('Prefer', IMMUTABLE_ID_PREFER)
+          .responseType(ResponseType.ARRAYBUFFER)
+          .get() as Promise<ArrayBuffer>,
       { timeout_ms: LARGE_DOWNLOAD_TIMEOUT_MS },
     );
     return Buffer.from(data);
@@ -255,7 +265,7 @@ export class GraphMailboxConnector implements MailboxConnector {
       () =>
         this._client
           .api(this.delta_path(owner_id, folder_id))
-          .header('Prefer', `odata.maxpagesize=${page_size}`)
+          .header('Prefer', `odata.maxpagesize=${page_size}, ${IMMUTABLE_ID_PREFER}`)
           .select(DELTA_SELECT_FIELDS)
           .get() as Promise<GraphPageResponse>,
     );
@@ -263,7 +273,8 @@ export class GraphMailboxConnector implements MailboxConnector {
 
   /**
    * Fetches a page using a full @odata.nextLink or @odata.deltaLink URL.
-   * The Prefer header is re-sent on each request to ensure larger pages.
+   * The Prefer headers are re-sent on each request (page size + immutable IDs);
+   * Graph requires the IdType preference on every request that handles IDs.
    */
   private async fetch_continuation_page(
     full_url: string,
@@ -273,7 +284,7 @@ export class GraphMailboxConnector implements MailboxConnector {
       () =>
         this._client
           .api(full_url)
-          .header('Prefer', `odata.maxpagesize=${page_size}`)
+          .header('Prefer', `odata.maxpagesize=${page_size}, ${IMMUTABLE_ID_PREFER}`)
           .get() as Promise<GraphPageResponse>,
     );
   }

--- a/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
@@ -18,6 +18,7 @@ import {
   rethrow_if_mailbox_not_licensed,
   with_graph_retry,
 } from '@wisecom/atlas-m365-graph';
+import { fetch_message_mime } from '@/adapters/graph-message-mime-fetcher';
 import type {
   GraphUserRecord,
   GraphFolderRecord,
@@ -180,6 +181,15 @@ export class GraphMailboxConnector implements MailboxConnector {
       rethrow_if_access_denied(err);
       throw err;
     }
+  }
+
+  /** Fetches the message's original RFC 5322 MIME; undefined when Graph has none (issue #50). */
+  async fetch_mime(
+    _tenant_id: string,
+    owner_id: string,
+    message_id: string,
+  ): Promise<Buffer | undefined> {
+    return fetch_message_mime(this._client, owner_id, message_id, IMMUTABLE_ID_PREFER);
   }
 
   /**

--- a/packages/outlook/src/adapters/graph-message-mime-fetcher.ts
+++ b/packages/outlook/src/adapters/graph-message-mime-fetcher.ts
@@ -1,0 +1,67 @@
+import type { Client } from '@microsoft/microsoft-graph-client';
+import { ResponseType } from '@microsoft/microsoft-graph-client';
+import {
+  describe_graph_error,
+  is_retryable_error,
+  rethrow_if_access_denied,
+  rethrow_if_mailbox_not_licensed,
+  with_graph_retry,
+} from '@wisecom/atlas-m365-graph';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+// 30 min per attempt: a MIME body carries its attachments inline and runs to
+// Graph's message ceiling, which the default 60s window kills on slow links.
+const MIME_DOWNLOAD_TIMEOUT_MS = 1_800_000;
+
+/**
+ * Fetches a message's original RFC 5322 MIME via `/$value` — the bytes that
+ * transited SMTP, with the Received chain, DKIM/SPF results, threading headers,
+ * and any S/MIME payload intact (issue #50). Attachments are embedded, so a
+ * MIME capture needs no separate attachment requests.
+ *
+ * Resolves undefined when Graph permanently refuses MIME for this item (the
+ * message was hard-deleted between the delta page and this call, or it is an
+ * item type with no MIME representation). The caller then stores the JSON
+ * payload instead, so one odd item never costs a whole mailbox.
+ */
+export async function fetch_message_mime(
+  client: Client,
+  owner_id: string,
+  message_id: string,
+  immutable_id_prefer: string,
+): Promise<Buffer | undefined> {
+  const url = `/users/${owner_id}/messages/${message_id}/$value`;
+  try {
+    const data = await with_graph_retry(
+      () =>
+        client
+          .api(url)
+          .header('Prefer', immutable_id_prefer)
+          .responseType(ResponseType.ARRAYBUFFER)
+          .get() as Promise<ArrayBuffer>,
+      { timeout_ms: MIME_DOWNLOAD_TIMEOUT_MS },
+    );
+    return Buffer.from(data);
+  } catch (err) {
+    rethrow_if_mailbox_not_licensed(err);
+    rethrow_if_access_denied(err);
+    if (is_mime_unavailable_error(err)) {
+      logger.debug(`no MIME available for message ${message_id}: ${describe_graph_error(err)}`);
+      return undefined;
+    }
+    throw err;
+  }
+}
+
+/**
+ * True when Graph will never return MIME for this item, however many times we
+ * ask: the message is gone, or its type has no MIME representation. Retryable
+ * statuses (429/5xx) and network faults are deliberately excluded — those are
+ * handled by with_graph_retry and must surface as real failures, not as a
+ * silent downgrade to the lossy JSON payload.
+ */
+function is_mime_unavailable_error(err: unknown): boolean {
+  if (is_retryable_error(err)) return false;
+  const status = (err as { statusCode?: number } | undefined)?.statusCode;
+  return typeof status === 'number' && status >= 400 && status < 500;
+}

--- a/packages/outlook/src/services/backup/folder-sync-executor.ts
+++ b/packages/outlook/src/services/backup/folder-sync-executor.ts
@@ -1,5 +1,8 @@
-import { createHash } from 'node:crypto';
 import type { TenantContext } from '@wisecom/atlas-types';
+import {
+  capture_mime_payload,
+  store_single_message,
+} from '@/services/backup/message-payload-store';
 import type { MailboxConnector, MailMessage } from '@wisecom/atlas-types';
 import type { ManifestEntry } from '@wisecom/atlas-types';
 import { fetch_and_store_attachments } from '@/services/backup/attachment-storage-sync';
@@ -10,6 +13,7 @@ import type {
   OperationControlOptions,
 } from '@wisecom/atlas-types';
 import { emit_operation_progress } from '@wisecom/atlas-core/services/shared/operation-progress';
+import { logger } from '@wisecom/atlas-core/utils/logger';
 
 export interface FolderSyncResult {
   entries: ManifestEntry[];
@@ -50,7 +54,11 @@ interface PendingAttachment {
   message_id: string;
 }
 
-/** Processes a single message: dedup check, encrypt, store. Returns index for deferred attachment fetch. */
+/**
+ * Processes a single message: capture MIME, dedup check, encrypt, store.
+ * MIME embeds its attachments, so only a JSON fallback queues a separate
+ * attachment fetch.
+ */
 async function process_message(
   ctx: TenantContext,
   connector: MailboxConnector,
@@ -62,14 +70,15 @@ async function process_message(
   pending_attachments: PendingAttachment[],
   object_lock_policy?: ObjectLockPolicy,
 ): Promise<void> {
-  const entry = await store_single_message(ctx, message, owner_id, object_lock_policy);
+  const mime = await capture_mime_payload(connector, tenant_id, owner_id, message);
+  const entry = await store_single_message(ctx, message, owner_id, object_lock_policy, mime);
   if (entry.was_new) stats.stored++;
   else stats.deduplicated++;
 
   const entry_index = entries.length;
   entries.push(entry.manifest_entry);
 
-  if (message.has_attachments) {
+  if (!mime && message.has_attachments) {
     pending_attachments.push({ entry_index, message_id: message.message_id });
   }
 }
@@ -291,40 +300,4 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
     attachments_stored: stats.att_stored,
     folder_processed,
   };
-}
-
-/** Content-addressed storage with SHA-256 dedup: hash -> check exists -> encrypt -> upload. */
-export async function store_single_message(
-  ctx: TenantContext,
-  message: MailMessage,
-  owner_id: string,
-  object_lock_policy?: ObjectLockPolicy,
-): Promise<{ manifest_entry: ManifestEntry; was_new: boolean }> {
-  const checksum = createHash('sha256').update(message.raw_body).digest('hex');
-  const storage_key = `data/${owner_id}/${checksum}`;
-
-  const already_stored = await ctx.storage.exists(storage_key);
-  if (!already_stored) {
-    const ciphertext = ctx.encrypt(message.raw_body);
-    await ctx.storage.put(
-      storage_key,
-      ciphertext,
-      {
-        'x-message-id': message.message_id,
-        'x-plaintext-sha256': checksum,
-      },
-      object_lock_policy,
-    );
-  }
-
-  const manifest_entry: ManifestEntry = {
-    object_id: message.message_id,
-    storage_key,
-    checksum,
-    size_bytes: message.size_bytes,
-    subject: message.subject,
-    folder_id: message.folder_id,
-  };
-
-  return { manifest_entry, was_new: !already_stored };
 }

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -1,8 +1,7 @@
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type { TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
-import type { MailboxConnector, MailFolder } from '@wisecom/atlas-types';
-import type { ManifestRepository } from '@wisecom/atlas-types';
+import type { MailboxConnector, MailFolder, ManifestRepository } from '@wisecom/atlas-types';
 import type { ManifestEntry, ManifestObjectLockPolicy } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { assert_mailbox_exists } from '@wisecom/atlas-core/services/shared/mailbox-assertions';
@@ -17,6 +16,7 @@ import {
   build_manifest,
   create_pending_snapshot,
   mark_snapshot_completed,
+  resolve_saved_delta_links,
   resolve_sync_mode,
 } from '@/services/backup/snapshot-manifest-builder';
 import {
@@ -86,7 +86,7 @@ export class MailboxSyncService implements BackupUseCase {
       const previous = options.force_full
         ? undefined
         : await this._manifests.find_latest_by_owner(ctx, owner_id);
-      const saved_links = previous?.delta_links ?? {};
+      const saved_links = resolve_saved_delta_links(previous);
       const previous_entry_count = previous?.total_objects ?? 0;
       const mode = resolve_sync_mode(options.force_full, saved_links);
 

--- a/packages/outlook/src/services/backup/message-payload-store.ts
+++ b/packages/outlook/src/services/backup/message-payload-store.ts
@@ -1,0 +1,81 @@
+import { createHash } from 'node:crypto';
+import type {
+  MailboxConnector,
+  MailMessage,
+  ManifestEntry,
+  ObjectLockPolicy,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+export interface StoredMessage {
+  readonly manifest_entry: ManifestEntry;
+  readonly was_new: boolean;
+}
+
+/**
+ * Captures the message's original MIME, falling back to the JSON payload when
+ * Graph has no MIME for the item. Access and licensing failures are rethrown by
+ * the connector and propagate; anything else degrades this one message to JSON
+ * rather than failing the folder (issue #50).
+ */
+export async function capture_mime_payload(
+  connector: MailboxConnector,
+  tenant_id: string,
+  owner_id: string,
+  message: MailMessage,
+): Promise<Buffer | undefined> {
+  if (!connector.fetch_mime) return undefined;
+  try {
+    return await connector.fetch_mime(tenant_id, owner_id, message.message_id);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    logger.warn(`MIME capture failed for message ${message.message_id}: ${reason}`);
+    return undefined;
+  }
+}
+
+/**
+ * Content-addressed storage with SHA-256 dedup: hash -> check exists -> encrypt
+ * -> upload. Stores `mime` when Graph produced it, otherwise the JSON payload
+ * from the delta page; the manifest entry records which (issue #50).
+ */
+export async function store_single_message(
+  ctx: TenantContext,
+  message: MailMessage,
+  owner_id: string,
+  object_lock_policy?: ObjectLockPolicy,
+  mime?: Buffer,
+): Promise<StoredMessage> {
+  const payload = mime ?? message.raw_body;
+  const checksum = createHash('sha256').update(payload).digest('hex');
+  const storage_key = `data/${owner_id}/${checksum}`;
+
+  const already_stored = await ctx.storage.exists(storage_key);
+  if (!already_stored) {
+    const ciphertext = ctx.encrypt(payload);
+    await ctx.storage.put(
+      storage_key,
+      ciphertext,
+      {
+        'x-message-id': message.message_id,
+        'x-plaintext-sha256': checksum,
+      },
+      object_lock_policy,
+    );
+  }
+
+  const manifest_entry: ManifestEntry = {
+    object_id: message.message_id,
+    storage_key,
+    checksum,
+    size_bytes: payload.length,
+    subject: message.subject,
+    folder_id: message.folder_id,
+    ...(mime
+      ? { payload_format: 'mime' as const, received_at: message.received_at.toISOString() }
+      : {}),
+  };
+
+  return { manifest_entry, was_new: !already_stored };
+}

--- a/packages/outlook/src/services/backup/snapshot-manifest-builder.ts
+++ b/packages/outlook/src/services/backup/snapshot-manifest-builder.ts
@@ -8,6 +8,7 @@ import type {
   ManifestObjectLockPolicy,
 } from '@wisecom/atlas-types';
 import type { BackupSyncMode } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
 
 export interface OwnerIdentityHint {
   readonly owner_email?: string | undefined;
@@ -72,6 +73,7 @@ export function build_manifest(
     total_objects: Math.max(entries.length, previous_total_objects),
     total_size_bytes,
     delta_links,
+    id_format: 'immutable',
     ...(object_lock ? { object_lock } : {}),
     ...(mailbox_purpose ? { mailbox_purpose } : {}),
     entries,
@@ -85,4 +87,21 @@ export function resolve_sync_mode(
 ): BackupSyncMode {
   if (force_full) return 'full';
   return Object.keys(saved_links).length > 0 ? 'incremental' : 'initial';
+}
+
+/**
+ * Returns the previous manifest's delta links for an incremental sync.
+ * Manifests captured before the ImmutableId switch carry mutable IDs in both
+ * delta links and entries; resuming them would mix ID formats, so the first
+ * backup after upgrade restarts full (issue #48).
+ */
+export function resolve_saved_delta_links(previous: Manifest | undefined): Record<string, string> {
+  if (!previous) return {};
+  if (previous.id_format !== 'immutable') {
+    logger.info(
+      'previous snapshot uses legacy mutable message IDs; restarting with a full sync (issue #48)',
+    );
+    return {};
+  }
+  return previous.delta_links;
 }

--- a/packages/outlook/src/services/index.ts
+++ b/packages/outlook/src/services/index.ts
@@ -4,3 +4,4 @@ export { DefaultTenantBackupOrchestrator } from '@/services/backup/tenant-backup
 export { RestoreService } from '@/services/restore/restore.service';
 export { SaveService } from '@/services/save/save.service';
 export { MailboxStatusService } from '@/services/status/mailbox-status.service';
+export { parse_mime_message, type ParsedMimeMessage } from '@/services/shared/mime-message-parser';

--- a/packages/outlook/src/services/restore/restore-attachment-writer.ts
+++ b/packages/outlook/src/services/restore/restore-attachment-writer.ts
@@ -1,6 +1,7 @@
 import type { TenantContext } from '@wisecom/atlas-types';
 import type { RestoreConnector } from '@wisecom/atlas-types';
 import type { AttachmentEntry } from '@wisecom/atlas-types';
+import type { MimeAttachment } from '@/services/shared/mime-message-parser';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
 export interface AttachmentRestoreResult {
@@ -52,6 +53,39 @@ export async function restore_entry_attachments(
   }
 
   return { restored, skipped, errors };
+}
+
+/**
+ * Uploads attachments that were parsed out of a MIME blob. Unlike the JSON
+ * path these bytes are already in hand, so nothing is fetched from storage
+ * and nothing can be skipped for missing content.
+ */
+export async function restore_parsed_attachments(
+  restore_connector: RestoreConnector,
+  tenant_id: string,
+  owner_id: string,
+  new_message_id: string,
+  attachments: readonly MimeAttachment[],
+): Promise<AttachmentRestoreResult> {
+  let restored = 0;
+  const errors: string[] = [];
+
+  for (const att of attachments) {
+    try {
+      await restore_connector.add_attachment(tenant_id, owner_id, new_message_id, {
+        name: att.name,
+        content_type: att.content_type,
+        content: att.content,
+        is_inline: att.is_inline,
+        ...(att.content_id ? { content_id: att.content_id } : {}),
+      });
+      restored++;
+    } catch (err) {
+      errors.push(`${att.name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return { restored, skipped: 0, errors };
 }
 
 /** Fetches and decrypts a single attachment binary from object storage. */

--- a/packages/outlook/src/services/restore/restore-execution-orchestrator.ts
+++ b/packages/outlook/src/services/restore/restore-execution-orchestrator.ts
@@ -5,10 +5,15 @@ import type { ManifestEntry } from '@wisecom/atlas-types';
 import type { RestoreResult } from '@wisecom/atlas-types';
 import {
   decrypt_and_parse_message,
+  decrypt_and_parse_mime,
   sanitize_message_for_restore,
+  build_restore_payload_from_mime,
   extract_folder_id_from_json,
 } from '@/services/restore/restore-message-transformer';
-import { restore_entry_attachments } from '@/services/restore/restore-attachment-writer';
+import {
+  restore_entry_attachments,
+  restore_parsed_attachments,
+} from '@/services/restore/restore-attachment-writer';
 import {
   build_folder_map,
   create_restore_root,
@@ -19,8 +24,23 @@ import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import { emit_operation_progress } from '@wisecom/atlas-core/services/shared/operation-progress';
 
-/** Decrypts, sanitizes, creates one message via Graph, then uploads attachments. */
+/** Creates one message via Graph from its stored payload, then uploads attachments. */
 export async function restore_one_entry(
+  ctx: TenantContext,
+  restore_connector: RestoreConnector,
+  tenant_id: string,
+  owner_id: string,
+  target_folder_id: string,
+  entry: ManifestEntry,
+): Promise<{ att: number }> {
+  if (entry.payload_format === 'mime') {
+    return restore_mime_entry(ctx, restore_connector, tenant_id, owner_id, target_folder_id, entry);
+  }
+  return restore_json_entry(ctx, restore_connector, tenant_id, owner_id, target_folder_id, entry);
+}
+
+/** Restores a legacy Graph JSON entry, pulling attachments back from storage. */
+async function restore_json_entry(
   ctx: TenantContext,
   restore_connector: RestoreConnector,
   tenant_id: string,
@@ -51,6 +71,40 @@ export async function restore_one_entry(
   }
 
   return { att };
+}
+
+/**
+ * Restores a MIME entry by parsing the stored RFC 5322 bytes and feeding the
+ * normal JSON create path. Graph's MIME import is not used: imported messages
+ * are always drafts and the flag cannot be cleared. Attachments are embedded
+ * in the blob, so they come from the parse rather than from storage.
+ */
+async function restore_mime_entry(
+  ctx: TenantContext,
+  restore_connector: RestoreConnector,
+  tenant_id: string,
+  owner_id: string,
+  target_folder_id: string,
+  entry: ManifestEntry,
+): Promise<{ att: number }> {
+  const parsed = await decrypt_and_parse_mime(ctx, entry);
+  const new_msg_id = await restore_connector.create_message(
+    tenant_id,
+    owner_id,
+    target_folder_id,
+    build_restore_payload_from_mime(parsed),
+  );
+
+  if (parsed.attachments.length === 0) return { att: 0 };
+
+  const result = await restore_parsed_attachments(
+    restore_connector,
+    tenant_id,
+    owner_id,
+    new_msg_id,
+    parsed.attachments,
+  );
+  return { att: result.restored };
 }
 
 /** Restores all entries for a single folder, updating dashboard per-message. */
@@ -128,8 +182,7 @@ export async function restore_single_message(
   entry: ManifestEntry,
 ): Promise<RestoreResult> {
   const root = await create_restore_root(restore_connector, tenant_id, target_mailbox);
-  const message_json = await decrypt_and_parse_message(ctx, entry);
-  const folder_id = entry.folder_id ?? extract_folder_id_from_json(message_json);
+  const folder_id = await resolve_source_folder_id(ctx, entry);
 
   const folder_map = await build_folder_map(connector, tenant_id, source_mailbox);
   const created_folders = new Map<string, string>();
@@ -143,26 +196,14 @@ export async function restore_single_message(
     created_folders,
   );
 
-  const sanitized = sanitize_message_for_restore(message_json);
-  const new_msg_id = await restore_connector.create_message(
+  const { att: att_count } = await restore_one_entry(
+    ctx,
+    restore_connector,
     tenant_id,
     target_mailbox,
     target_fid,
-    sanitized,
+    entry,
   );
-
-  let att_count = 0;
-  if (entry.attachments && entry.attachments.length > 0) {
-    const att_result = await restore_entry_attachments(
-      ctx,
-      restore_connector,
-      tenant_id,
-      target_mailbox,
-      new_msg_id,
-      entry.attachments,
-    );
-    att_count = att_result.restored;
-  }
 
   logger.success(`Restored 1 message${att_count > 0 ? ` + ${att_count} attachments` : ''}`);
   return {
@@ -176,6 +217,17 @@ export async function restore_single_message(
     restore_folder_name: root.display_name,
     interrupted: false,
   };
+}
+
+/**
+ * Resolves the source folder of an entry. MIME entries always carry
+ * `folder_id` from backup; only legacy JSON manifests need the payload
+ * decrypted to recover `parentFolderId`.
+ */
+async function resolve_source_folder_id(ctx: TenantContext, entry: ManifestEntry): Promise<string> {
+  if (entry.folder_id) return entry.folder_id;
+  if (entry.payload_format === 'mime') return '__unknown__';
+  return extract_folder_id_from_json(await decrypt_and_parse_message(ctx, entry));
 }
 
 /** Backfills folder_id for legacy manifest entries by decrypting message JSON. */

--- a/packages/outlook/src/services/restore/restore-message-transformer.ts
+++ b/packages/outlook/src/services/restore/restore-message-transformer.ts
@@ -1,5 +1,7 @@
 import type { TenantContext } from '@wisecom/atlas-types';
 import type { ManifestEntry } from '@wisecom/atlas-types';
+import { parse_mime_message } from '@/services/shared/mime-message-parser';
+import type { MimeAddress, ParsedMimeMessage } from '@/services/shared/mime-message-parser';
 
 /**
  * Read-only fields that Graph returns on GET but rejects on POST.
@@ -61,6 +63,18 @@ export async function decrypt_and_parse_message(
 }
 
 /**
+ * Decrypts a `payload_format: 'mime'` manifest entry and parses the RFC 5322
+ * bytes stored during backup.
+ */
+export async function decrypt_and_parse_mime(
+  ctx: TenantContext,
+  entry: ManifestEntry,
+): Promise<ParsedMimeMessage> {
+  const ciphertext = await ctx.storage.get(entry.storage_key);
+  return parse_mime_message(ctx.decrypt(ciphertext));
+}
+
+/**
  * MAPI extended properties used to override Graph's default behavior
  * when restoring messages via POST (which always creates drafts with
  * the current timestamp).
@@ -92,31 +106,37 @@ export function sanitize_message_for_restore(
   }
 
   sanitized['isDraft'] = false;
-  sanitized['singleValueExtendedProperties'] = build_mapi_overrides(message_json);
+  sanitized['singleValueExtendedProperties'] = build_mapi_overrides({
+    is_read: Boolean(message_json['isRead']),
+    received_at: as_iso_string(message_json['receivedDateTime']),
+    sent_at: as_iso_string(message_json['sentDateTime']),
+  });
 
   return sanitized;
 }
 
+/** Timestamps and read state that drive the MAPI overrides, from JSON or MIME. */
+interface MapiOverrideSource {
+  readonly is_read: boolean;
+  readonly received_at?: string | undefined;
+  readonly sent_at?: string | undefined;
+}
+
 /** Builds the MAPI extended property array for draft flag and timestamps. */
-function build_mapi_overrides(
-  message_json: Record<string, unknown>,
-): Array<{ id: string; value: string }> {
-  const flags = message_json['isRead'] ? MSGFLAG_READ : 0;
+function build_mapi_overrides(source: MapiOverrideSource): Array<{ id: string; value: string }> {
   const props: Array<{ id: string; value: string }> = [
-    { id: PR_MESSAGE_FLAGS, value: String(flags) },
+    { id: PR_MESSAGE_FLAGS, value: String(source.is_read ? MSGFLAG_READ : 0) },
   ];
 
-  const received = message_json['receivedDateTime'];
-  if (typeof received === 'string') {
-    props.push({ id: PR_MESSAGE_DELIVERY_TIME, value: received });
-  }
-
-  const sent = message_json['sentDateTime'];
-  if (typeof sent === 'string') {
-    props.push({ id: PR_CLIENT_SUBMIT_TIME, value: sent });
-  }
+  if (source.received_at) props.push({ id: PR_MESSAGE_DELIVERY_TIME, value: source.received_at });
+  if (source.sent_at) props.push({ id: PR_CLIENT_SUBMIT_TIME, value: source.sent_at });
 
   return props;
+}
+
+/** Narrows an unknown stored field to a string, dropping non-string values. */
+function as_iso_string(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
 }
 
 /**
@@ -125,4 +145,45 @@ function build_mapi_overrides(
  */
 export function extract_folder_id_from_json(message_json: Record<string, unknown>): string {
   return (message_json['parentFolderId'] as string) ?? '__unknown__';
+}
+
+/**
+ * Builds the Graph create-message payload for a MIME-backed entry.
+ *
+ * Restore deliberately does not import MIME through Graph: messages created
+ * from MIME are always `isDraft: true` and that flag cannot be cleared, so a
+ * mailbox restore would land as thousands of drafts. Parsing the MIME and
+ * feeding the normal JSON create path keeps the existing restore quality.
+ */
+export function build_restore_payload_from_mime(
+  parsed: ParsedMimeMessage,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    subject: parsed.subject,
+    body: parsed.html
+      ? { contentType: 'html', content: parsed.html }
+      : { contentType: 'text', content: parsed.text ?? '' },
+    toRecipients: parsed.to.map(to_graph_recipient),
+    ccRecipients: parsed.cc.map(to_graph_recipient),
+    isDraft: false,
+    // ponytail: MIME carries no read state, so restored mail is marked read
+    // rather than dumping thousands of unread items on the user.
+    singleValueExtendedProperties: build_mapi_overrides({
+      is_read: true,
+      received_at: parsed.date,
+      sent_at: parsed.date,
+    }),
+  };
+
+  if (parsed.from) payload['from'] = to_graph_recipient(parsed.from);
+  if (parsed.message_id) payload['internetMessageId'] = parsed.message_id;
+
+  return payload;
+}
+
+/** Wraps a parsed MIME address in Graph's recipient envelope. */
+function to_graph_recipient(address: MimeAddress): {
+  emailAddress: { name: string; address: string };
+} {
+  return { emailAddress: { name: address.name, address: address.address } };
 }

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -1,25 +1,15 @@
 import type { TenantContext } from '@wisecom/atlas-types';
-import type { ManifestEntry, AttachmentEntry } from '@wisecom/atlas-types';
+import type { ManifestEntry } from '@wisecom/atlas-types';
 import type { SaveResult } from '@wisecom/atlas-types';
-import { build_eml, build_eml_filename, deduplicate_filename } from '@/services/save/eml-builder';
+import type { EntryResult } from '@/services/save/save-entry-writer';
+import { save_json_entry, save_mime_entry } from '@/services/save/save-entry-writer';
 import { verify_checksum } from '@/services/save/save-integrity-validator';
-import {
-  create_save_archive,
-  add_eml_to_archive,
-  finalize_archive,
-} from '@/services/save/save-zip-writer';
+import type { ArchiveWriter } from '@/services/save/save-zip-writer';
+import { create_save_archive, finalize_archive } from '@/services/save/save-zip-writer';
 import type { OperationControlOptions, TransferProgressReporter } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import { emit_operation_progress } from '@wisecom/atlas-core/services/shared/operation-progress';
-
-interface DecryptedAttachment {
-  readonly name: string;
-  readonly content_type: string;
-  readonly content: Buffer;
-  readonly is_inline: boolean;
-  readonly content_id?: string;
-}
 
 /**
  * Processes all grouped entries into a zip archive, updating the dashboard.
@@ -117,13 +107,6 @@ export async function save_entries_to_archive(
   };
 }
 
-interface EntryResult {
-  attachment_count: number;
-  integrity_ok: number;
-  integrity_fail: number;
-  integrity_failures: string[];
-}
-
 interface FolderEntryCounters {
   all_errors: string[];
   integrity_failures: string[];
@@ -136,7 +119,7 @@ async function process_folder_entries(
   folder_name: string,
   folder_index: number,
   skip_integrity: boolean,
-  archive: Parameters<typeof add_eml_to_archive>[0],
+  archive: ArchiveWriter,
   used_names: Set<string>,
   groups: Map<string, ManifestEntry[]>,
   global_total: number,
@@ -210,12 +193,13 @@ async function process_folder_entries(
   return { folder_saved, folder_processed, folder_att, error_count };
 }
 
+/** Decrypts one manifest entry, verifies it, and writes its .eml into the archive. */
 async function process_single_entry(
   ctx: TenantContext,
   entry: ManifestEntry,
   folder_name: string,
   skip_integrity: boolean,
-  archive: Parameters<typeof add_eml_to_archive>[0],
+  archive: ArchiveWriter,
   used_names: Set<string>,
 ): Promise<EntryResult> {
   const result: EntryResult = {
@@ -238,73 +222,22 @@ async function process_single_entry(
     }
   }
 
-  const message_json = JSON.parse(plaintext.toString('utf-8')) as Record<string, unknown>;
-  const attachments = await decrypt_entry_attachments(ctx, entry, skip_integrity, result);
-
-  const eml_buffer = build_eml(message_json, attachments);
-  const received = message_json['receivedDateTime'] as string | undefined;
-  const subject = message_json['subject'] as string | undefined;
-  const raw_filename = build_eml_filename(received, subject);
-  const filename = deduplicate_filename(raw_filename, used_names);
-
-  await add_eml_to_archive(archive, folder_name, filename, eml_buffer);
-  result.attachment_count = attachments.length;
+  if (entry.payload_format === 'mime') {
+    await save_mime_entry(entry, folder_name, plaintext, archive, used_names);
+  } else {
+    await save_json_entry(
+      ctx,
+      entry,
+      folder_name,
+      plaintext,
+      skip_integrity,
+      archive,
+      used_names,
+      result,
+    );
+  }
 
   return result;
-}
-
-async function decrypt_entry_attachments(
-  ctx: TenantContext,
-  entry: ManifestEntry,
-  skip_integrity: boolean,
-  result: EntryResult,
-): Promise<DecryptedAttachment[]> {
-  if (!entry.attachments || entry.attachments.length === 0) return [];
-
-  const decrypted: DecryptedAttachment[] = [];
-
-  for (const att of entry.attachments) {
-    if (!att.storage_key) continue;
-
-    try {
-      const content = await decrypt_and_verify_attachment(ctx, att, skip_integrity, result);
-      decrypted.push({
-        name: att.name,
-        content_type: att.content_type,
-        content,
-        is_inline: att.is_inline,
-        ...(att.content_id ? { content_id: att.content_id } : {}),
-      });
-    } catch (err) {
-      logger.warn(
-        `Failed to decrypt attachment "${att.name}": ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-  }
-
-  return decrypted;
-}
-
-async function decrypt_and_verify_attachment(
-  ctx: TenantContext,
-  att: AttachmentEntry,
-  skip_integrity: boolean,
-  result: EntryResult,
-): Promise<Buffer> {
-  const ciphertext = await ctx.storage.get(att.storage_key);
-  const plaintext = ctx.decrypt(ciphertext);
-
-  if (!skip_integrity && att.checksum) {
-    if (!verify_checksum(plaintext, att.checksum)) {
-      result.integrity_fail++;
-      result.integrity_failures.push(`attachment:${att.attachment_id}`);
-      logger.warn(`Integrity check failed for attachment "${att.name}"`);
-    } else {
-      result.integrity_ok++;
-    }
-  }
-
-  return plaintext;
 }
 
 function count_processed_before(

--- a/packages/outlook/src/services/save/save-entry-writer.ts
+++ b/packages/outlook/src/services/save/save-entry-writer.ts
@@ -1,0 +1,123 @@
+import type { TenantContext } from '@wisecom/atlas-types';
+import type { ManifestEntry, AttachmentEntry } from '@wisecom/atlas-types';
+import { build_eml, build_eml_filename, deduplicate_filename } from '@/services/save/eml-builder';
+import { verify_checksum } from '@/services/save/save-integrity-validator';
+import type { ArchiveWriter } from '@/services/save/save-zip-writer';
+import { add_eml_to_archive } from '@/services/save/save-zip-writer';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+interface DecryptedAttachment {
+  readonly name: string;
+  readonly content_type: string;
+  readonly content: Buffer;
+  readonly is_inline: boolean;
+  readonly content_id?: string;
+}
+
+/** Per-entry counters accumulated while writing one message into the archive. */
+export interface EntryResult {
+  attachment_count: number;
+  integrity_ok: number;
+  integrity_fail: number;
+  integrity_failures: string[];
+}
+
+/**
+ * Writes an entry whose stored blob already is RFC 5322 MIME straight into the
+ * archive, byte-for-byte. Graph embeds attachments in the MIME, so nothing is
+ * parsed, rebuilt or fetched — that is what preserves the Received chain,
+ * DKIM/ARC results, threading headers and S/MIME payloads.
+ */
+export async function save_mime_entry(
+  entry: ManifestEntry,
+  folder_name: string,
+  mime: Buffer,
+  archive: ArchiveWriter,
+  used_names: Set<string>,
+): Promise<void> {
+  const raw_filename = build_eml_filename(entry.received_at, entry.subject);
+  const filename = deduplicate_filename(raw_filename, used_names);
+
+  await add_eml_to_archive(archive, folder_name, filename, mime);
+}
+
+/**
+ * Writes a legacy Graph JSON entry by decrypting its separately stored
+ * attachments and reconstructing an EML from them.
+ */
+export async function save_json_entry(
+  ctx: TenantContext,
+  entry: ManifestEntry,
+  folder_name: string,
+  plaintext: Buffer,
+  skip_integrity: boolean,
+  archive: ArchiveWriter,
+  used_names: Set<string>,
+  result: EntryResult,
+): Promise<void> {
+  const message_json = JSON.parse(plaintext.toString('utf-8')) as Record<string, unknown>;
+  const attachments = await decrypt_entry_attachments(ctx, entry, skip_integrity, result);
+
+  const eml_buffer = build_eml(message_json, attachments);
+  const received = message_json['receivedDateTime'] as string | undefined;
+  const subject = message_json['subject'] as string | undefined;
+  const raw_filename = build_eml_filename(received, subject);
+  const filename = deduplicate_filename(raw_filename, used_names);
+
+  await add_eml_to_archive(archive, folder_name, filename, eml_buffer);
+  result.attachment_count = attachments.length;
+}
+
+async function decrypt_entry_attachments(
+  ctx: TenantContext,
+  entry: ManifestEntry,
+  skip_integrity: boolean,
+  result: EntryResult,
+): Promise<DecryptedAttachment[]> {
+  if (!entry.attachments || entry.attachments.length === 0) return [];
+
+  const decrypted: DecryptedAttachment[] = [];
+
+  for (const att of entry.attachments) {
+    if (!att.storage_key) continue;
+
+    try {
+      const content = await decrypt_and_verify_attachment(ctx, att, skip_integrity, result);
+      decrypted.push({
+        name: att.name,
+        content_type: att.content_type,
+        content,
+        is_inline: att.is_inline,
+        ...(att.content_id ? { content_id: att.content_id } : {}),
+      });
+    } catch (err) {
+      logger.warn(
+        `Failed to decrypt attachment "${att.name}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return decrypted;
+}
+
+async function decrypt_and_verify_attachment(
+  ctx: TenantContext,
+  att: AttachmentEntry,
+  skip_integrity: boolean,
+  result: EntryResult,
+): Promise<Buffer> {
+  const ciphertext = await ctx.storage.get(att.storage_key);
+  const plaintext = ctx.decrypt(ciphertext);
+
+  if (!skip_integrity && att.checksum) {
+    if (!verify_checksum(plaintext, att.checksum)) {
+      result.integrity_fail++;
+      result.integrity_failures.push(`attachment:${att.attachment_id}`);
+      logger.warn(`Integrity check failed for attachment "${att.name}"`);
+    } else {
+      result.integrity_ok++;
+    }
+  }
+
+  return plaintext;
+}

--- a/packages/outlook/src/services/save/save-zip-writer.ts
+++ b/packages/outlook/src/services/save/save-zip-writer.ts
@@ -6,6 +6,9 @@ export interface SaveArchive {
   readonly promise: Promise<number>;
 }
 
+/** The archiver instance EML entries are appended to. */
+export type ArchiveWriter = archiver.Archiver;
+
 /** Creates a zip archive with maximum compression, streaming to the output path. */
 export function create_save_archive(output_path: string): SaveArchive {
   const output = createWriteStream(output_path);
@@ -35,7 +38,7 @@ export function create_save_archive(output_path: string): SaveArchive {
  * peak memory at roughly one message + its attachments.
  */
 export function add_eml_to_archive(
-  archive: archiver.Archiver,
+  archive: ArchiveWriter,
   folder_path: string,
   filename: string,
   content: Buffer,
@@ -60,7 +63,7 @@ export function add_eml_to_archive(
 }
 
 /** Finalizes the archive. The returned promise resolves to total bytes written. */
-export async function finalize_archive(archive: archiver.Archiver): Promise<void> {
+export async function finalize_archive(archive: ArchiveWriter): Promise<void> {
   await archive.finalize();
 }
 

--- a/packages/outlook/src/services/shared/mime-message-parser.ts
+++ b/packages/outlook/src/services/shared/mime-message-parser.ts
@@ -1,0 +1,113 @@
+import { simpleParser } from 'mailparser';
+import type { AddressObject, Attachment, EmailAddress, ParsedMail } from 'mailparser';
+
+export interface MimeAddress {
+  readonly name: string;
+  readonly address: string;
+}
+
+export interface MimeHeader {
+  readonly name: string;
+  readonly value: string;
+}
+
+export interface MimeAttachment {
+  readonly name: string;
+  readonly content_type: string;
+  readonly content: Buffer;
+  readonly is_inline: boolean;
+  readonly content_id?: string;
+}
+
+export interface ParsedMimeMessage {
+  readonly subject: string;
+  readonly from?: MimeAddress;
+  readonly to: MimeAddress[];
+  readonly cc: MimeAddress[];
+  readonly date?: string;
+  readonly message_id?: string;
+  readonly text?: string;
+  readonly html?: string;
+  readonly headers: MimeHeader[];
+  readonly attachments: MimeAttachment[];
+}
+
+/** Parses RFC 5322 MIME bytes into the fields Atlas needs for restore and display. */
+export async function parse_mime_message(mime: Buffer): Promise<ParsedMimeMessage> {
+  const parsed: ParsedMail = await simpleParser(mime);
+  const from = flatten_addresses(parsed.from)[0];
+
+  return {
+    subject: parsed.subject ?? '',
+    ...(from ? { from } : {}),
+    to: flatten_addresses(parsed.to),
+    cc: flatten_addresses(parsed.cc),
+    ...(parsed.date ? { date: parsed.date.toISOString() } : {}),
+    ...(parsed.messageId ? { message_id: parsed.messageId } : {}),
+    ...(parsed.text ? { text: parsed.text } : {}),
+    ...(parsed.html ? { html: parsed.html } : {}),
+    headers: flatten_header_lines(parsed),
+    attachments: parsed.attachments.map(normalize_attachment),
+  };
+}
+
+/**
+ * Flattens mailparser's address containers into `{ name, address }` pairs.
+ * A header may parse to one container or several (repeated To/Cc headers),
+ * and group addresses nest their members under `group`.
+ */
+function flatten_addresses(source: AddressObject | AddressObject[] | undefined): MimeAddress[] {
+  if (!source) return [];
+  const containers = Array.isArray(source) ? source : [source];
+  return containers.flatMap((container) => container.value.flatMap(expand_address));
+}
+
+/** Expands one parsed address, recursing into group members. */
+function expand_address(entry: EmailAddress): MimeAddress[] {
+  if (entry.group) return entry.group.flatMap(expand_address);
+  if (!entry.address) return [];
+  return [{ name: entry.name ?? '', address: entry.address }];
+}
+
+/**
+ * Converts raw header lines into a flat name/value list, preserving order and
+ * duplicates. `headerLines` is used instead of the collapsed `headers` map
+ * because chains like Received appear multiple times and must all survive.
+ */
+function flatten_header_lines(parsed: ParsedMail): MimeHeader[] {
+  return parsed.headerLines.map(({ line }) => {
+    const separator = line.indexOf(':');
+    if (separator === -1) return { name: line.trim(), value: '' };
+    return {
+      name: line.slice(0, separator).trim(),
+      value: unfold_header_value(line.slice(separator + 1)),
+    };
+  });
+}
+
+/** Joins the continuation lines of a folded header into a single spaced value. */
+function unfold_header_value(value: string): string {
+  return value
+    .split(/\r?\n/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .join(' ');
+}
+
+/** Normalizes a mailparser attachment to the shape Graph's upload port expects. */
+function normalize_attachment(attachment: Attachment): MimeAttachment {
+  const content_id = strip_angle_brackets(attachment.cid);
+  return {
+    name: attachment.filename ?? content_id ?? 'attachment',
+    content_type: attachment.contentType,
+    content: attachment.content,
+    is_inline: attachment.contentDisposition === 'inline' || content_id !== undefined,
+    ...(content_id ? { content_id } : {}),
+  };
+}
+
+/** Strips the `<...>` wrapper mailparser may leave on a Content-ID. */
+function strip_angle_brackets(cid: string | undefined): string | undefined {
+  if (!cid) return undefined;
+  return cid.replace(/^<|>$/g, '');
+}

--- a/packages/outlook/src/services/status/mailbox-status.service.ts
+++ b/packages/outlook/src/services/status/mailbox-status.service.ts
@@ -28,7 +28,10 @@ export class MailboxStatusService implements StatusUseCase {
     const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
       const previous = await this._manifests.find_latest_by_owner(ctx, owner_id);
-      const saved_links = previous?.delta_links ?? {};
+      // Legacy manifests carry mutable-ID delta links (issue #48); resuming
+      // them with the immutable preference would mix ID formats, so peek
+      // treats them as "no saved state" — every folder reports pending.
+      const saved_links = previous?.id_format === 'immutable' ? (previous?.delta_links ?? {}) : {};
 
       const all_folders = await this._connector.list_mail_folders(tenant_id, owner_id);
       const folder_statuses = await this.peek_all_folders(

--- a/packages/outlook/tests/unit/graph-mailbox-connector-immutable-id.test.ts
+++ b/packages/outlook/tests/unit/graph-mailbox-connector-immutable-id.test.ts
@@ -1,0 +1,68 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { GraphMailboxConnector } from '@/adapters/graph-mailbox-connector.adapter';
+import type { MockClient } from './graph-mailbox-connector.harness';
+import { create_mock_client, create_connector } from './graph-mailbox-connector.harness';
+
+// Issue #48: every Graph request that produces or consumes a message/folder ID
+// must carry Prefer: IdType="ImmutableId". Mixing ID formats corrupts
+// correlation between manifests, delta links, and live objects.
+
+const IMMUTABLE_ID = 'IdType="ImmutableId"';
+
+function prefer_headers_sent(mock_client: MockClient): string[] {
+  return mock_client._chain.header.mock.calls
+    .filter((c) => c[0] === 'Prefer')
+    .map((c) => c[1] as string);
+}
+
+describe('GraphMailboxConnector - immutable message IDs (issue #48)', () => {
+  let mock_client: MockClient;
+  let connector: GraphMailboxConnector;
+
+  beforeEach(() => {
+    mock_client = create_mock_client();
+    connector = create_connector(mock_client);
+  });
+
+  it('sends IdType=ImmutableId on the initial delta page', async () => {
+    mock_client._chain.get.mockResolvedValueOnce({ value: [] });
+
+    await connector.fetch_delta('t', 'owner-1', 'folder-1');
+
+    const headers = prefer_headers_sent(mock_client);
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toContain(IMMUTABLE_ID);
+    expect(headers[0]).toContain('odata.maxpagesize=');
+  });
+
+  it('sends IdType=ImmutableId on continuation pages from a saved delta link', async () => {
+    mock_client._chain.get.mockResolvedValueOnce({ value: [] });
+
+    await connector.fetch_delta('t', 'owner-1', 'folder-1', 'https://saved-delta-link');
+
+    const headers = prefer_headers_sent(mock_client);
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toContain(IMMUTABLE_ID);
+  });
+
+  it('sends IdType=ImmutableId when fetching a single message by ID', async () => {
+    mock_client._chain.get.mockResolvedValueOnce({ id: 'msg-1' });
+
+    await connector.fetch_message('t', 'owner-1', 'msg-1');
+
+    const headers = prefer_headers_sent(mock_client);
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toContain(IMMUTABLE_ID);
+  });
+
+  it('sends IdType=ImmutableId when listing attachments for a message', async () => {
+    mock_client._chain.get.mockResolvedValueOnce({ value: [] });
+
+    await connector.fetch_attachments('t', 'owner-1', 'msg-1');
+
+    const headers = prefer_headers_sent(mock_client);
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toContain(IMMUTABLE_ID);
+  });
+});

--- a/packages/outlook/tests/unit/graph-mailbox-connector-mime.test.ts
+++ b/packages/outlook/tests/unit/graph-mailbox-connector-mime.test.ts
@@ -1,0 +1,109 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import { Container } from 'inversify';
+import { GRAPH_CLIENT_TOKEN } from '@wisecom/atlas-m365-graph';
+import { GraphMailboxConnector } from '@/adapters/graph-mailbox-connector.adapter';
+
+interface GraphError {
+  statusCode: number;
+  code: string;
+}
+
+function graph_error(status: number, code: string): GraphError {
+  return { statusCode: status, code };
+}
+
+interface MimeConnectorHarness {
+  readonly connector: GraphMailboxConnector;
+  readonly api: ReturnType<typeof vi.fn>;
+  readonly header: ReturnType<typeof vi.fn>;
+  readonly response_type: ReturnType<typeof vi.fn>;
+  readonly get: ReturnType<typeof vi.fn>;
+}
+
+function create_harness(get_impl: () => Promise<unknown>): MimeConnectorHarness {
+  const get = vi.fn(get_impl);
+  const response_type = vi.fn();
+  const header = vi.fn();
+  const api = vi.fn();
+  const chain = { header, responseType: response_type, get, select: vi.fn(), top: vi.fn() };
+  header.mockReturnValue(chain);
+  response_type.mockReturnValue(chain);
+  chain.select.mockReturnValue(chain);
+  chain.top.mockReturnValue(chain);
+  api.mockReturnValue(chain);
+
+  const container = new Container();
+  container.bind(GRAPH_CLIENT_TOKEN).toConstantValue({ api });
+  container.bind(GraphMailboxConnector).toSelf();
+
+  return { connector: container.get(GraphMailboxConnector), api, header, response_type, get };
+}
+
+const MIME = Buffer.from(
+  'Received: from mail.example.com\r\nAuthentication-Results: spf=pass\r\n\r\nbody\r\n',
+);
+
+describe('GraphMailboxConnector.fetch_mime', () => {
+  it('returns the original MIME bytes from /$value', async () => {
+    const harness = create_harness(async () =>
+      MIME.buffer.slice(MIME.byteOffset, MIME.byteOffset + MIME.byteLength),
+    );
+
+    const result = await harness.connector.fetch_mime('t', 'owner-1', 'msg-1');
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(Buffer.compare(result as Buffer, MIME)).toBe(0);
+    expect(harness.api).toHaveBeenCalledWith('/users/owner-1/messages/msg-1/$value');
+  });
+
+  it('requests immutable IDs and raw bytes', async () => {
+    const harness = create_harness(async () => new ArrayBuffer(0));
+
+    await harness.connector.fetch_mime('t', 'owner-1', 'msg-1');
+
+    expect(harness.header).toHaveBeenCalledWith('Prefer', 'IdType="ImmutableId"');
+    expect(harness.response_type).toHaveBeenCalledWith('arraybuffer');
+  });
+
+  it('resolves undefined when the message no longer exists', async () => {
+    const harness = create_harness(() =>
+      Promise.reject(graph_error(404, 'ErrorItemNotFound') as unknown as Error),
+    );
+
+    await expect(harness.connector.fetch_mime('t', 'owner-1', 'gone')).resolves.toBeUndefined();
+  });
+
+  it('resolves undefined when the item type has no MIME representation', async () => {
+    const harness = create_harness(() =>
+      Promise.reject(graph_error(400, 'ErrorInvalidRequest') as unknown as Error),
+    );
+
+    await expect(harness.connector.fetch_mime('t', 'owner-1', 'odd')).resolves.toBeUndefined();
+  });
+
+  it('rethrows access denied instead of silently downgrading to JSON', async () => {
+    const harness = create_harness(() =>
+      Promise.reject(graph_error(403, 'ErrorAccessDenied') as unknown as Error),
+    );
+
+    await expect(harness.connector.fetch_mime('t', 'owner-1', 'msg-1')).rejects.toThrow();
+  });
+
+  it('rethrows server failures instead of silently downgrading to JSON', async () => {
+    const harness = create_harness(() =>
+      Promise.reject(graph_error(500, 'InternalServerError') as unknown as Error),
+    );
+
+    vi.useFakeTimers();
+    try {
+      const attempt = harness.connector.fetch_mime('t', 'owner-1', 'msg-1');
+      const assertion = expect(attempt).rejects.toBeTruthy();
+      // 12 retries with exponential backoff capped at 300s; skip the wall clock.
+      await vi.advanceTimersByTimeAsync(3_600_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/interrupt-delta-safeguard.test.ts
@@ -53,6 +53,7 @@ const PREVIOUS_MANIFEST: Manifest = {
   total_objects: 0,
   total_size_bytes: 0,
   delta_links: { 'folder-1': 'https://prev-delta' },
+  id_format: 'immutable',
   entries: [],
 };
 

--- a/packages/outlook/tests/unit/mailbox-status.service.test.ts
+++ b/packages/outlook/tests/unit/mailbox-status.service.test.ts
@@ -32,6 +32,7 @@ function make_manifest(owner_id: string, delta_links: Record<string, string>): M
     total_objects: 5,
     total_size_bytes: 1000,
     delta_links,
+    id_format: 'immutable',
     entries: [],
   };
 }

--- a/packages/outlook/tests/unit/mailbox-sync-delta-links.test.ts
+++ b/packages/outlook/tests/unit/mailbox-sync-delta-links.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Manifest, ManifestRepository } from '@wisecom/atlas-types';
+import { create_mailbox_sync_harness } from './mailbox-sync-test-fixtures';
+import type { MailboxSyncHarness } from './mailbox-sync-test-fixtures';
+
+function legacy_manifest(overrides: Partial<Manifest> = {}): Manifest {
+  return {
+    id: 'old-manifest',
+    tenant_id: 't',
+    owner_id: 'user@test.com',
+    snapshot_id: 'old-snap',
+    created_at: new Date(),
+    total_objects: 0,
+    total_size_bytes: 0,
+    delta_links: { 'folder-1': 'https://prev-delta' },
+    entries: [],
+    ...overrides,
+  };
+}
+
+describe('MailboxSyncService - delta link continuity', () => {
+  let harness: MailboxSyncHarness;
+  let mock_manifests: ManifestRepository;
+
+  beforeEach(() => {
+    harness = create_mailbox_sync_harness();
+    mock_manifests = harness.mock_manifests;
+  });
+
+  it('stores manifest with per-folder delta links', async () => {
+    vi.mocked(harness.mock_connector.fetch_delta).mockResolvedValue({
+      messages: [],
+      removed_ids: [],
+      delta_link: 'https://new-delta',
+      delta_reset: false,
+    });
+
+    await harness.service.sync_mailbox('t', 'user@test.com');
+
+    expect(mock_manifests.save).toHaveBeenCalledOnce();
+    const saved_manifest = vi.mocked(mock_manifests.save).mock.calls[0]![1];
+    expect(saved_manifest.delta_links).toEqual({ 'folder-1': 'https://new-delta' });
+    expect(saved_manifest.id_format).toBe('immutable');
+  });
+
+  it('passes previous delta link for incremental sync', async () => {
+    vi.mocked(mock_manifests.find_latest_by_owner).mockResolvedValue(
+      legacy_manifest({ id_format: 'immutable' }),
+    );
+
+    await harness.service.sync_mailbox('t', 'user@test.com');
+
+    expect(harness.mock_connector.fetch_delta).toHaveBeenCalledWith(
+      't',
+      'user@test.com',
+      'folder-1',
+      'https://prev-delta',
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it('restarts full when the previous manifest predates immutable IDs (issue #48)', async () => {
+    vi.mocked(mock_manifests.find_latest_by_owner).mockResolvedValue(legacy_manifest());
+
+    await harness.service.sync_mailbox('t', 'user@test.com');
+
+    // Legacy mutable-ID delta link must NOT be resumed — no prev link passed.
+    expect(harness.mock_connector.fetch_delta).toHaveBeenCalledWith(
+      't',
+      'user@test.com',
+      'folder-1',
+      undefined,
+      expect.any(Function),
+      undefined,
+    );
+  });
+});

--- a/packages/outlook/tests/unit/mailbox-sync-mime-payload.test.ts
+++ b/packages/outlook/tests/unit/mailbox-sync-mime-payload.test.ts
@@ -1,0 +1,193 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  BackupProgressReporter,
+  MailboxConnector,
+  MailMessage,
+  ManifestEntry,
+  ObjectStorage,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { sync_single_folder } from '@/services/backup/folder-sync-executor';
+import { store_single_message } from '@/services/backup/message-payload-store';
+
+const MIME = Buffer.from('Received: from mx.example.com\r\nSubject: Hi\r\n\r\nbody\r\n');
+
+function make_message(overrides: Partial<MailMessage> = {}): MailMessage {
+  return {
+    message_id: 'msg-1',
+    folder_id: 'folder-1',
+    subject: 'Hi',
+    received_at: new Date('2026-03-10T14:30:22.000Z'),
+    size_bytes: 42,
+    raw_body: Buffer.from('{"id":"msg-1"}'),
+    has_attachments: false,
+    ...overrides,
+  };
+}
+
+interface StoreHarness {
+  readonly ctx: TenantContext;
+  readonly put: ReturnType<typeof vi.fn>;
+}
+
+function make_ctx(already_stored = false): StoreHarness {
+  const put = vi.fn();
+  const storage = {
+    put,
+    get: vi.fn(),
+    delete: vi.fn(),
+    delete_version: vi.fn(),
+    exists: vi.fn().mockResolvedValue(already_stored),
+    list: vi.fn().mockResolvedValue([]),
+    list_versions: vi.fn().mockResolvedValue([]),
+    begin_multipart_upload: vi.fn(),
+    copy: vi.fn(),
+    abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+    probe_immutability: vi.fn(),
+  } as unknown as ObjectStorage;
+
+  const ctx = {
+    tenant_id: 't',
+    storage,
+    encrypt: vi.fn((data: Buffer) => Buffer.concat([Buffer.from('E'), data])),
+    decrypt: vi.fn((data: Buffer) => data.subarray(1)),
+    create_cipher: vi.fn(),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  return { ctx, put };
+}
+
+function make_progress(): BackupProgressReporter {
+  return {
+    set_status: vi.fn(),
+    mark_active: vi.fn(),
+    update_active: vi.fn(),
+    update_paging: vi.fn(),
+    mark_done: vi.fn(),
+    mark_all_pending_interrupted: vi.fn(),
+    mark_error: vi.fn(),
+    update_total: vi.fn(),
+  } as unknown as BackupProgressReporter;
+}
+
+describe('store_single_message payload selection', () => {
+  it('stores the MIME bytes, not the JSON payload, when MIME was captured', async () => {
+    const { ctx, put } = make_ctx();
+
+    const { manifest_entry } = await store_single_message(
+      ctx,
+      make_message(),
+      'owner-1',
+      undefined,
+      MIME,
+    );
+
+    const [, ciphertext] = put.mock.calls[0]!;
+    expect(Buffer.compare((ciphertext as Buffer).subarray(1), MIME)).toBe(0);
+    expect(manifest_entry.payload_format).toBe('mime');
+    expect(manifest_entry.size_bytes).toBe(MIME.length);
+    expect(manifest_entry.received_at).toBe('2026-03-10T14:30:22.000Z');
+  });
+
+  it('addresses MIME entries by the hash of the MIME itself', async () => {
+    const { ctx } = make_ctx();
+    const mime_result = await store_single_message(ctx, make_message(), 'o', undefined, MIME);
+    const json_result = await store_single_message(ctx, make_message(), 'o');
+
+    expect(mime_result.manifest_entry.checksum).not.toBe(json_result.manifest_entry.checksum);
+    expect(mime_result.manifest_entry.storage_key).toContain(mime_result.manifest_entry.checksum);
+  });
+
+  it('falls back to the JSON payload and marks no format when MIME is absent', async () => {
+    const { ctx, put } = make_ctx();
+    const message = make_message();
+
+    const { manifest_entry } = await store_single_message(ctx, message, 'owner-1');
+
+    const [, ciphertext] = put.mock.calls[0]!;
+    expect(Buffer.compare((ciphertext as Buffer).subarray(1), message.raw_body)).toBe(0);
+    expect(manifest_entry.payload_format).toBeUndefined();
+    expect(manifest_entry.received_at).toBeUndefined();
+  });
+});
+
+interface SyncOutcome {
+  readonly fetch_attachments: ReturnType<typeof vi.fn>;
+  readonly entries: ManifestEntry[];
+}
+
+async function run_folder_sync(fetch_mime: MailboxConnector['fetch_mime']): Promise<SyncOutcome> {
+  const fetch_attachments = vi.fn().mockResolvedValue([]);
+  const message = make_message({ has_attachments: true });
+  const connector = {
+    list_mailboxes: vi.fn(),
+    mailbox_exists: vi.fn().mockResolvedValue(true),
+    list_mail_folders: vi.fn().mockResolvedValue([]),
+    fetch_message: vi.fn(),
+    fetch_attachments,
+    fetch_mime,
+    fetch_delta: vi.fn(
+      async (
+        _t: string,
+        _o: string,
+        _f: string,
+        _prev: string | undefined,
+        on_page?: (p: number, t: number, m: MailMessage[]) => Promise<boolean> | boolean | void,
+      ) => {
+        if (on_page) await on_page(1, 1, [message]);
+        return { messages: [], removed_ids: [], delta_link: 'd', delta_reset: false };
+      },
+    ),
+  } as unknown as MailboxConnector;
+
+  const { ctx } = make_ctx();
+  const never = (): boolean => false;
+  const result = await sync_single_folder({
+    ctx,
+    connector,
+    tenant_id: 't',
+    owner_id: 'owner-1',
+    folder_id: 'folder-1',
+    folder_index: 0,
+    folder_total: 1,
+    global_total: 1,
+    global_processed_before: 0,
+    sync_start: Date.now(),
+    progress: make_progress(),
+    is_interrupted: never,
+    is_hard_stopped: never,
+    operation_control: {},
+  });
+
+  return { fetch_attachments, entries: result.entries };
+}
+
+describe('MIME capture in the folder sync path', () => {
+  it('skips the separate attachment fetch when MIME embedded them', async () => {
+    const { fetch_attachments, entries } = await run_folder_sync(vi.fn().mockResolvedValue(MIME));
+
+    expect(fetch_attachments).not.toHaveBeenCalled();
+    expect(entries[0]?.payload_format).toBe('mime');
+  });
+
+  it('still fetches attachments separately for a JSON fallback entry', async () => {
+    const { fetch_attachments, entries } = await run_folder_sync(
+      vi.fn().mockResolvedValue(undefined),
+    );
+
+    expect(fetch_attachments).toHaveBeenCalled();
+    expect(entries[0]?.payload_format).toBeUndefined();
+  });
+
+  it('degrades one message to JSON when MIME capture throws', async () => {
+    const { fetch_attachments, entries } = await run_folder_sync(
+      vi.fn().mockRejectedValue(new Error('boom')),
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.payload_format).toBeUndefined();
+    expect(fetch_attachments).toHaveBeenCalled();
+  });
+});

--- a/packages/outlook/tests/unit/mailbox-sync-test-fixtures.ts
+++ b/packages/outlook/tests/unit/mailbox-sync-test-fixtures.ts
@@ -75,6 +75,7 @@ export interface MailboxSyncHarness {
   readonly service: MailboxSyncService;
   readonly mock_connector: MailboxConnector;
   readonly mock_context: TenantContext;
+  readonly mock_manifests: ManifestRepository;
 }
 
 export function create_mailbox_sync_harness(): MailboxSyncHarness {
@@ -117,5 +118,6 @@ export function create_mailbox_sync_harness(): MailboxSyncHarness {
     service: container.get(MailboxSyncService),
     mock_connector,
     mock_context,
+    mock_manifests,
   };
 }

--- a/packages/outlook/tests/unit/mailbox-sync.service.test.ts
+++ b/packages/outlook/tests/unit/mailbox-sync.service.test.ts
@@ -223,46 +223,6 @@ describe('MailboxSyncService', () => {
     expect(result.manifest.entries).toHaveLength(1);
   });
 
-  it('stores manifest with per-folder delta links', async () => {
-    const msg = make_message('msg-1', 'data');
-    vi.mocked(mock_connector.fetch_delta).mockResolvedValue(make_delta([msg], 'https://new-delta'));
-
-    await service.sync_mailbox('t', 'user@test.com');
-
-    expect(mock_manifests.save).toHaveBeenCalledOnce();
-    const [, saved_manifest] = (mock_manifests.save as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(saved_manifest.delta_links).toEqual({ 'folder-1': 'https://new-delta' });
-  });
-
-  it('passes previous delta link for incremental sync', async () => {
-    vi.mocked(mock_connector.list_mail_folders).mockResolvedValue([
-      make_folder('Inbox', 'folder-1', 0),
-    ]);
-
-    vi.mocked(mock_manifests.find_latest_by_owner).mockResolvedValue({
-      id: 'old-manifest',
-      tenant_id: 't',
-      owner_id: 'user@test.com',
-      snapshot_id: 'old-snap',
-      created_at: new Date(),
-      total_objects: 0,
-      total_size_bytes: 0,
-      delta_links: { 'folder-1': 'https://prev-delta' },
-      entries: [],
-    });
-
-    await service.sync_mailbox('t', 'user@test.com');
-
-    expect(mock_connector.fetch_delta).toHaveBeenCalledWith(
-      't',
-      'user@test.com',
-      'folder-1',
-      'https://prev-delta',
-      expect.any(Function),
-      undefined,
-    );
-  });
-
   it('returns completed snapshot with correct counts', async () => {
     const msg = make_message('msg-1', 'body');
     vi.mocked(mock_connector.fetch_delta).mockResolvedValue(make_delta([msg]));

--- a/packages/outlook/tests/unit/mime-message-parser.test.ts
+++ b/packages/outlook/tests/unit/mime-message-parser.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { parse_mime_message } from '@/services/shared/mime-message-parser';
+
+const ATTACHMENT_BYTES = Buffer.from('Atlas,MIME,restore\n1,2,3\n', 'utf-8');
+
+/**
+ * Realistic Graph /$value output: multipart/mixed wrapping a text+html
+ * alternative and a base64 attachment, with a two-hop Received chain,
+ * Authentication-Results and threading headers.
+ */
+function build_mime_fixture(): Buffer {
+  return Buffer.from(
+    [
+      'Received: from EXCH02.corp.example.com (10.0.0.12) by',
+      '\tMAIL01.corp.example.com (10.0.0.5) with Microsoft SMTP Server id',
+      '\t15.20.6455.021; Tue, 4 Mar 2025 09:15:04 +0000',
+      'Received: from smtp.partner.example (smtp.partner.example [203.0.113.9]) by',
+      '\tEXCH02.corp.example.com with ESMTPS id 4fk2m9; Tue, 4 Mar 2025 09:15:01 +0000',
+      'Authentication-Results: spf=pass (sender IP is 203.0.113.9)',
+      '\tsmtp.mailfrom=partner.example; dkim=pass header.d=partner.example',
+      'From: "Nora Partner" <nora@partner.example>',
+      'To: "Atlas Admin" <admin@corp.example.com>, ops@corp.example.com',
+      'Cc: "Audit Log" <audit@corp.example.com>',
+      'Subject: Q1 reconciliation figures',
+      'Date: Tue, 4 Mar 2025 09:14:58 +0000',
+      'Message-ID: <thread-root-9f21@partner.example>',
+      'In-Reply-To: <prior-msg-7a01@corp.example.com>',
+      'References: <prior-msg-7a01@corp.example.com> <older-5b02@corp.example.com>',
+      'MIME-Version: 1.0',
+      'Content-Type: multipart/mixed; boundary="OUTER"',
+      '',
+      '--OUTER',
+      'Content-Type: multipart/alternative; boundary="INNER"',
+      '',
+      '--INNER',
+      'Content-Type: text/plain; charset="utf-8"',
+      '',
+      'Figures attached.',
+      '',
+      '--INNER',
+      'Content-Type: text/html; charset="utf-8"',
+      '',
+      '<html><body><p>Figures attached.</p></body></html>',
+      '',
+      '--INNER--',
+      '',
+      '--OUTER',
+      'Content-Type: text/csv; name="q1.csv"',
+      'Content-Disposition: attachment; filename="q1.csv"',
+      'Content-Transfer-Encoding: base64',
+      '',
+      ATTACHMENT_BYTES.toString('base64'),
+      '',
+      '--OUTER--',
+      '',
+    ].join('\r\n'),
+    'utf-8',
+  );
+}
+
+describe('parse_mime_message', () => {
+  it('extracts subject, addresses and ISO date', async () => {
+    const parsed = await parse_mime_message(build_mime_fixture());
+
+    expect(parsed.subject).toBe('Q1 reconciliation figures');
+    expect(parsed.from).toEqual({ name: 'Nora Partner', address: 'nora@partner.example' });
+    expect(parsed.to).toEqual([
+      { name: 'Atlas Admin', address: 'admin@corp.example.com' },
+      { name: '', address: 'ops@corp.example.com' },
+    ]);
+    expect(parsed.cc).toEqual([{ name: 'Audit Log', address: 'audit@corp.example.com' }]);
+    expect(parsed.date).toBe('2025-03-04T09:14:58.000Z');
+    expect(parsed.message_id).toBe('<thread-root-9f21@partner.example>');
+  });
+
+  it('decodes both body alternatives', async () => {
+    const parsed = await parse_mime_message(build_mime_fixture());
+
+    expect(parsed.html).toContain('<p>Figures attached.</p>');
+    expect(parsed.text?.trim()).toBe('Figures attached.');
+  });
+
+  it('preserves every Received hop and the threading headers', async () => {
+    const parsed = await parse_mime_message(build_mime_fixture());
+    const received = parsed.headers.filter((h) => h.name.toLowerCase() === 'received');
+
+    expect(received).toHaveLength(2);
+    expect(received[0]?.value).toContain('EXCH02.corp.example.com');
+    expect(received[1]?.value).toContain('smtp.partner.example');
+
+    const names = parsed.headers.map((h) => h.name.toLowerCase());
+    expect(names).toContain('authentication-results');
+    expect(names).toContain('references');
+    expect(names).toContain('in-reply-to');
+
+    const references = parsed.headers.find((h) => h.name.toLowerCase() === 'references');
+    expect(references?.value).toContain('<older-5b02@corp.example.com>');
+  });
+
+  it('unfolds multi-line header values into one string', async () => {
+    const parsed = await parse_mime_message(build_mime_fixture());
+    const auth = parsed.headers.find((h) => h.name.toLowerCase() === 'authentication-results');
+
+    expect(auth?.value).toBe(
+      'spf=pass (sender IP is 203.0.113.9) smtp.mailfrom=partner.example; dkim=pass header.d=partner.example',
+    );
+  });
+
+  it('returns the attachment with exact decoded bytes', async () => {
+    const parsed = await parse_mime_message(build_mime_fixture());
+
+    expect(parsed.attachments).toHaveLength(1);
+    const att = parsed.attachments[0];
+    expect(att?.name).toBe('q1.csv');
+    expect(att?.content_type).toBe('text/csv');
+    expect(att?.is_inline).toBe(false);
+    expect(att?.content.equals(ATTACHMENT_BYTES)).toBe(true);
+  });
+
+  it('marks a cid attachment as inline and strips the angle brackets', async () => {
+    const mime = Buffer.from(
+      [
+        'From: sender@example.com',
+        'Subject: inline logo',
+        'MIME-Version: 1.0',
+        'Content-Type: multipart/related; boundary="REL"',
+        '',
+        '--REL',
+        'Content-Type: text/html',
+        '',
+        '<img src="cid:logo-1@example.com">',
+        '',
+        '--REL',
+        'Content-Type: image/png',
+        'Content-Disposition: inline',
+        'Content-ID: <logo-1@example.com>',
+        'Content-Transfer-Encoding: base64',
+        '',
+        Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'),
+        '',
+        '--REL--',
+        '',
+      ].join('\r\n'),
+      'utf-8',
+    );
+
+    const parsed = await parse_mime_message(mime);
+
+    expect(parsed.attachments).toHaveLength(1);
+    expect(parsed.attachments[0]?.is_inline).toBe(true);
+    expect(parsed.attachments[0]?.content_id).toBe('logo-1@example.com');
+  });
+
+  it('tolerates a bare message with no body parts or addresses', async () => {
+    const parsed = await parse_mime_message(Buffer.from('Subject: ping\r\n\r\n', 'utf-8'));
+
+    expect(parsed.subject).toBe('ping');
+    expect(parsed.from).toBeUndefined();
+    expect(parsed.to).toEqual([]);
+    expect(parsed.cc).toEqual([]);
+    expect(parsed.attachments).toEqual([]);
+  });
+});

--- a/packages/outlook/tests/unit/restore-mime-entry.test.ts
+++ b/packages/outlook/tests/unit/restore-mime-entry.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  restore_one_entry,
+  restore_single_message,
+} from '@/services/restore/restore-execution-orchestrator';
+import type { MailboxConnector, MailFolder } from '@wisecom/atlas-types';
+import type { ManifestEntry } from '@wisecom/atlas-types';
+import type { RestoreConnector } from '@wisecom/atlas-types';
+import type { TenantContext } from '@wisecom/atlas-types';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+
+const ATTACHMENT_BYTES = Buffer.from('col_a,col_b\n1,2\n', 'utf-8');
+const JSON_ATTACHMENT_BYTES = Buffer.from('stored-attachment-bytes', 'utf-8');
+
+/** RFC 5322 blob as backup stores it for a `payload_format: 'mime'` entry. */
+function build_stored_mime(): Buffer {
+  return Buffer.from(
+    [
+      'Received: from EXCH02.corp.example.com by MAIL01.corp.example.com;',
+      '\tTue, 4 Mar 2025 09:15:04 +0000',
+      'From: "Nora Partner" <nora@partner.example>',
+      'To: "Atlas Admin" <admin@corp.example.com>',
+      'Cc: "Audit Log" <audit@corp.example.com>',
+      'Subject: Q1 reconciliation figures',
+      'Date: Tue, 4 Mar 2025 09:14:58 +0000',
+      'Message-ID: <thread-root-9f21@partner.example>',
+      'MIME-Version: 1.0',
+      'Content-Type: multipart/mixed; boundary="OUTER"',
+      '',
+      '--OUTER',
+      'Content-Type: text/html; charset="utf-8"',
+      '',
+      '<html><body><p>Figures attached.</p></body></html>',
+      '',
+      '--OUTER',
+      'Content-Type: text/csv; name="q1.csv"',
+      'Content-Disposition: attachment; filename="q1.csv"',
+      'Content-Transfer-Encoding: base64',
+      '',
+      ATTACHMENT_BYTES.toString('base64'),
+      '',
+      '--OUTER--',
+      '',
+    ].join('\r\n'),
+    'utf-8',
+  );
+}
+
+/** Legacy Graph JSON blob, still the format for entries without payload_format. */
+function build_stored_json(): Buffer {
+  return Buffer.from(
+    JSON.stringify({
+      id: 'graph-id',
+      subject: 'Legacy JSON message',
+      body: { contentType: 'html', content: '<p>legacy</p>' },
+      toRecipients: [{ emailAddress: { name: 'Admin', address: 'admin@corp.example.com' } }],
+      parentFolderId: 'f1',
+      receivedDateTime: '2024-06-01T10:00:00Z',
+      isRead: true,
+    }),
+    'utf-8',
+  );
+}
+
+const MIME_ENTRY: ManifestEntry = {
+  object_id: 'msg-mime',
+  storage_key: 'data/user/mime-blob',
+  checksum: 'chk-mime',
+  size_bytes: 2048,
+  subject: 'Q1 reconciliation figures',
+  folder_id: 'f1',
+  payload_format: 'mime',
+  received_at: '2025-03-04T09:14:58.000Z',
+};
+
+const JSON_ENTRY: ManifestEntry = {
+  object_id: 'msg-json',
+  storage_key: 'data/user/json-blob',
+  checksum: 'chk-json',
+  size_bytes: 512,
+  subject: 'Legacy JSON message',
+  folder_id: 'f1',
+  attachments: [
+    {
+      attachment_id: 'att-1',
+      name: 'legacy.txt',
+      content_type: 'text/plain',
+      size_bytes: JSON_ATTACHMENT_BYTES.length,
+      is_inline: false,
+      storage_key: 'data/user/att-blob',
+    },
+  ],
+};
+
+describe('restore of MIME and legacy JSON entries', () => {
+  let ctx: TenantContext;
+  let restore_connector: RestoreConnector;
+  let connector: MailboxConnector;
+
+  /** Encryption is a 1-byte prefix, matching the other restore unit tests. */
+  function encrypted(plain: Buffer): Buffer {
+    return Buffer.concat([Buffer.from('E'), plain]);
+  }
+
+  beforeEach(() => {
+    const blobs: Record<string, Buffer> = {
+      'data/user/mime-blob': encrypted(build_stored_mime()),
+      'data/user/json-blob': encrypted(build_stored_json()),
+      'data/user/att-blob': encrypted(JSON_ATTACHMENT_BYTES),
+    };
+
+    ctx = {
+      tenant_id: 'test-tenant',
+      storage: {
+        put: vi.fn(),
+        get: vi.fn((key: string) => Promise.resolve(blobs[key] ?? Buffer.alloc(0))),
+        delete: vi.fn(),
+        delete_version: vi.fn(),
+        exists: vi.fn(),
+        list: vi.fn(),
+        list_versions: vi.fn().mockResolvedValue([]),
+        begin_multipart_upload: vi.fn().mockResolvedValue({
+          upload_part: vi.fn(),
+          complete: vi.fn(),
+          abort: vi.fn(),
+        }),
+        copy: vi.fn(),
+        abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+        probe_immutability: vi.fn(),
+      },
+      encrypt: vi.fn(),
+      decrypt: vi.fn((data: Buffer) => data.subarray(1)),
+      create_cipher: stub_tenant_create_cipher,
+      destroy: vi.fn(),
+    };
+
+    restore_connector = {
+      create_mail_folder: vi.fn().mockImplementation((_t, _o, display_name: string) =>
+        Promise.resolve({
+          folder_id: display_name === 'Inbox' ? 'restore-inbox' : 'restore-root',
+          display_name,
+          folder_path: display_name,
+          total_item_count: 0,
+        } satisfies MailFolder),
+      ),
+      create_message: vi.fn().mockResolvedValue('new-msg-id'),
+      add_attachment: vi.fn(),
+      create_upload_session: vi.fn(),
+      upload_attachment_chunk: vi.fn(),
+      count_folder_messages: vi.fn().mockResolvedValue(0),
+      list_folder_messages: vi.fn().mockResolvedValue([]),
+    };
+
+    connector = {
+      list_mailboxes: vi.fn(),
+      mailbox_exists: vi.fn().mockResolvedValue(true),
+      list_mail_folders: vi
+        .fn()
+        .mockResolvedValue([
+          { folder_id: 'f1', display_name: 'Inbox', folder_path: 'Inbox', total_item_count: 10 },
+        ] satisfies MailFolder[]),
+      fetch_delta: vi.fn(),
+      fetch_message: vi.fn(),
+      fetch_attachments: vi.fn(),
+    };
+  });
+
+  it('creates a MIME entry as a non-draft message from the parsed MIME', async () => {
+    const result = await restore_one_entry(
+      ctx,
+      restore_connector,
+      'test-tenant',
+      'target@corp.example.com',
+      'target-folder',
+      MIME_ENTRY,
+    );
+
+    expect(restore_connector.create_message).toHaveBeenCalledTimes(1);
+    const [tenant, owner, folder, payload] = vi.mocked(restore_connector.create_message).mock
+      .calls[0]!;
+    expect(tenant).toBe('test-tenant');
+    expect(owner).toBe('target@corp.example.com');
+    expect(folder).toBe('target-folder');
+
+    expect(payload['isDraft']).toBe(false);
+    expect(payload['subject']).toBe('Q1 reconciliation figures');
+    expect(payload['body']).toEqual({
+      contentType: 'html',
+      content: expect.stringContaining('<p>Figures attached.</p>'),
+    });
+    expect(payload['from']).toEqual({
+      emailAddress: { name: 'Nora Partner', address: 'nora@partner.example' },
+    });
+    expect(payload['toRecipients']).toEqual([
+      { emailAddress: { name: 'Atlas Admin', address: 'admin@corp.example.com' } },
+    ]);
+    expect(payload['ccRecipients']).toEqual([
+      { emailAddress: { name: 'Audit Log', address: 'audit@corp.example.com' } },
+    ]);
+    expect(payload['internetMessageId']).toBe('<thread-root-9f21@partner.example>');
+    expect(result.att).toBe(1);
+  });
+
+  it('derives the MAPI delivery and submit times from the MIME Date header', async () => {
+    await restore_one_entry(
+      ctx,
+      restore_connector,
+      'test-tenant',
+      'target@corp.example.com',
+      'target-folder',
+      MIME_ENTRY,
+    );
+
+    const payload = vi.mocked(restore_connector.create_message).mock.calls[0]![3];
+    expect(payload['singleValueExtendedProperties']).toEqual([
+      { id: 'Integer 0x0E07', value: '1' },
+      { id: 'SystemTime 0x0E06', value: '2025-03-04T09:14:58.000Z' },
+      { id: 'SystemTime 0x0039', value: '2025-03-04T09:14:58.000Z' },
+    ]);
+  });
+
+  it('uploads attachments parsed out of the MIME with the exact bytes', async () => {
+    await restore_one_entry(
+      ctx,
+      restore_connector,
+      'test-tenant',
+      'target@corp.example.com',
+      'target-folder',
+      MIME_ENTRY,
+    );
+
+    expect(restore_connector.add_attachment).toHaveBeenCalledTimes(1);
+    const [, , message_id, upload] = vi.mocked(restore_connector.add_attachment).mock.calls[0]!;
+    expect(message_id).toBe('new-msg-id');
+    expect(upload.name).toBe('q1.csv');
+    expect(upload.content_type).toBe('text/csv');
+    expect(upload.is_inline).toBe(false);
+    expect(upload.content.equals(ATTACHMENT_BYTES)).toBe(true);
+  });
+
+  it('never reads a separate attachment blob for a MIME entry', async () => {
+    await restore_one_entry(
+      ctx,
+      restore_connector,
+      'test-tenant',
+      'target@corp.example.com',
+      'target-folder',
+      MIME_ENTRY,
+    );
+
+    expect(ctx.storage.get).toHaveBeenCalledTimes(1);
+    expect(ctx.storage.get).toHaveBeenCalledWith('data/user/mime-blob');
+  });
+
+  it('still restores a legacy JSON entry through the sanitized JSON path', async () => {
+    const result = await restore_one_entry(
+      ctx,
+      restore_connector,
+      'test-tenant',
+      'target@corp.example.com',
+      'target-folder',
+      JSON_ENTRY,
+    );
+
+    const payload = vi.mocked(restore_connector.create_message).mock.calls[0]![3];
+    // sanitize_message_for_restore strips read-only Graph fields and forces isDraft.
+    expect(payload['id']).toBeUndefined();
+    expect(payload['parentFolderId']).toBeUndefined();
+    expect(payload['isDraft']).toBe(false);
+    expect(payload['subject']).toBe('Legacy JSON message');
+    expect(payload['singleValueExtendedProperties']).toEqual([
+      { id: 'Integer 0x0E07', value: '1' },
+      { id: 'SystemTime 0x0E06', value: '2024-06-01T10:00:00Z' },
+    ]);
+    expect(result.att).toBe(1);
+  });
+
+  it('restores legacy JSON attachments from their own storage blob', async () => {
+    await restore_one_entry(
+      ctx,
+      restore_connector,
+      'test-tenant',
+      'target@corp.example.com',
+      'target-folder',
+      JSON_ENTRY,
+    );
+
+    expect(ctx.storage.get).toHaveBeenCalledWith('data/user/json-blob');
+    expect(ctx.storage.get).toHaveBeenCalledWith('data/user/att-blob');
+
+    const [, , , upload] = vi.mocked(restore_connector.add_attachment).mock.calls[0]!;
+    expect(upload.name).toBe('legacy.txt');
+    expect(upload.content.equals(JSON_ATTACHMENT_BYTES)).toBe(true);
+  });
+
+  it('resolves the MIME entry folder from the manifest without parsing the blob', async () => {
+    const result = await restore_single_message(
+      ctx,
+      connector,
+      restore_connector,
+      'test-tenant',
+      'source@corp.example.com',
+      'target@corp.example.com',
+      'snap-1',
+      MIME_ENTRY,
+    );
+
+    expect(restore_connector.create_mail_folder).toHaveBeenCalledWith(
+      'test-tenant',
+      'target@corp.example.com',
+      'Inbox',
+      'restore-root',
+    );
+    expect(vi.mocked(restore_connector.create_message).mock.calls[0]![2]).toBe('restore-inbox');
+    // One decrypt only: the MIME blob. The folder came from entry.folder_id.
+    expect(ctx.storage.get).toHaveBeenCalledTimes(1);
+    expect(result.restored_count).toBe(1);
+    expect(result.attachment_count).toBe(1);
+  });
+});

--- a/packages/outlook/tests/unit/save-mime-passthrough.test.ts
+++ b/packages/outlook/tests/unit/save-mime-passthrough.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { save_entries_to_archive } from '@/services/save/save-entry-processor';
+import type { AttachmentEntry, ManifestEntry } from '@wisecom/atlas-types';
+import type { TenantContext } from '@wisecom/atlas-types';
+import type { OperationControlOptions, TransferProgressReporter } from '@wisecom/atlas-types';
+
+interface AppendedEml {
+  folder: string;
+  filename: string;
+  content: Buffer;
+}
+
+const { appended } = vi.hoisted(() => ({ appended: [] as AppendedEml[] }));
+
+vi.mock('@/services/save/save-zip-writer', () => ({
+  create_save_archive: vi.fn(() => ({ archive: {}, promise: Promise.resolve(2048) })),
+  add_eml_to_archive: vi.fn(
+    (_archive: unknown, folder: string, filename: string, content: Buffer) => {
+      appended.push({ folder, filename, content });
+      return Promise.resolve();
+    },
+  ),
+  finalize_archive: vi.fn(() => Promise.resolve()),
+}));
+
+const MIME_BLOB = Buffer.from(
+  [
+    'Received: from mail.partner.example (mail.partner.example [203.0.113.9])',
+    ' by outlook.office365.com with ESMTPS; Tue, 10 Mar 2026 14:30:22 +0000',
+    'Authentication-Results: spf=pass smtp.mailfrom=partner.example; dkim=pass',
+    'DKIM-Signature: v=1; a=rsa-sha256; d=partner.example; s=sel; b=AbC123',
+    'References: <thread-root@partner.example>',
+    ' <reply-1@partner.example>',
+    'In-Reply-To: <reply-1@partner.example>',
+    'Message-ID: <original@partner.example>',
+    'Subject: Quarterly Review',
+    'Content-Type: text/plain; charset="utf-8"',
+    '',
+    'Numbers attached.',
+    '',
+  ].join('\r\n'),
+  'utf-8',
+);
+
+const JSON_BLOB = Buffer.from(
+  JSON.stringify({
+    subject: 'Legacy Report',
+    receivedDateTime: '2026-03-11T09:05:00Z',
+    from: { emailAddress: { name: 'Ann', address: 'ann@example.com' } },
+    toRecipients: [{ emailAddress: { name: 'Bob', address: 'bob@example.com' } }],
+    body: { contentType: 'text', content: 'Legacy body' },
+  }),
+  'utf-8',
+);
+
+function make_attachment(storage_key: string): AttachmentEntry {
+  return {
+    attachment_id: 'att-1',
+    name: 'numbers.xlsx',
+    content_type: 'application/vnd.ms-excel',
+    size_bytes: 12,
+    storage_key,
+    checksum: '',
+    is_inline: false,
+  };
+}
+
+function make_mime_entry(): ManifestEntry {
+  return {
+    object_id: 'msg-mime',
+    storage_key: 'content/mime-blob',
+    checksum: '',
+    size_bytes: MIME_BLOB.length,
+    subject: 'Quarterly Review',
+    folder_id: 'f1',
+    payload_format: 'mime',
+    received_at: '2026-03-10T14:30:22Z',
+    // Present on purpose: a MIME entry must never read attachment blobs even
+    // if a manifest carries them, because the MIME already embeds them.
+    attachments: [make_attachment('content/should-never-be-read')],
+  };
+}
+
+function make_json_entry(): ManifestEntry {
+  return {
+    object_id: 'msg-json',
+    storage_key: 'content/json-blob',
+    checksum: '',
+    size_bytes: JSON_BLOB.length,
+    subject: 'Legacy Report',
+    folder_id: 'f1',
+    attachments: [make_attachment('content/json-attachment')],
+  };
+}
+
+describe('save archive payload_format routing', () => {
+  let ctx: TenantContext;
+  let dashboard: TransferProgressReporter;
+  const control: OperationControlOptions = {};
+
+  beforeEach(() => {
+    appended.length = 0;
+
+    const blobs: Record<string, Buffer> = {
+      'content/mime-blob': MIME_BLOB,
+      'content/json-blob': JSON_BLOB,
+      'content/json-attachment': Buffer.from('attachment-bytes'),
+      'content/should-never-be-read': Buffer.from('boom'),
+    };
+
+    ctx = {
+      storage: {
+        get: vi.fn((key: string) => Promise.resolve(blobs[key] ?? Buffer.alloc(0))),
+        put: vi.fn(),
+        exists: vi.fn(),
+        delete: vi.fn(),
+      },
+      decrypt: vi.fn((buf: Buffer) => buf),
+      encrypt: vi.fn((buf: Buffer) => buf),
+      destroy: vi.fn(),
+    } as unknown as TenantContext;
+
+    dashboard = {
+      mark_active: vi.fn(),
+      update_active: vi.fn(),
+      mark_done: vi.fn(),
+      mark_all_pending_interrupted: vi.fn(),
+      mark_error: vi.fn(),
+      update_total: vi.fn(),
+      show_finalizing: vi.fn(),
+      finish: vi.fn(),
+    };
+  });
+
+  async function run(entries: ManifestEntry[]): Promise<void> {
+    await save_entries_to_archive(
+      ctx,
+      'out.zip',
+      false,
+      new Map([['f1', entries]]),
+      new Map([['f1', 'Inbox']]),
+      dashboard,
+      () => false,
+      control,
+    );
+  }
+
+  it('writes a MIME entry into the archive byte-identical to the decrypted blob', async () => {
+    await run([make_mime_entry()]);
+
+    expect(appended).toHaveLength(1);
+    expect(Buffer.compare(appended[0]!.content, MIME_BLOB)).toBe(0);
+
+    const written = appended[0]!.content.toString('utf-8');
+    expect(written).toContain('Received: from mail.partner.example');
+    expect(written).toContain('Authentication-Results: spf=pass');
+    expect(written).toContain('DKIM-Signature: v=1;');
+    expect(written).toContain(
+      'References: <thread-root@partner.example>\r\n <reply-1@partner.example>',
+    );
+  });
+
+  it('does not read attachment blobs for a MIME entry', async () => {
+    await run([make_mime_entry()]);
+
+    const get = ctx.storage.get as Mock;
+    expect(get.mock.calls.map((c) => c[0])).toEqual(['content/mime-blob']);
+  });
+
+  it('names the MIME .eml from received_at and subject', async () => {
+    await run([make_mime_entry()]);
+
+    expect(appended[0]!.filename).toBe('2026-03-10_143022_Quarterly-Review.eml');
+    expect(appended[0]!.folder).toBe('Inbox');
+  });
+
+  it('still rebuilds a legacy JSON entry through build_eml with its attachments', async () => {
+    const result_count = await save_entries_to_archive(
+      ctx,
+      'out.zip',
+      false,
+      new Map([['f1', [make_json_entry()]]]),
+      new Map([['f1', 'Inbox']]),
+      dashboard,
+      () => false,
+      control,
+    );
+
+    expect(result_count.attachment_count).toBe(1);
+    expect(appended).toHaveLength(1);
+    expect(appended[0]!.filename).toBe('2026-03-11_090500_Legacy-Report.eml');
+
+    const eml = appended[0]!.content.toString('utf-8');
+    expect(eml).toContain('MIME-Version: 1.0');
+    expect(eml).toContain('Content-Type: multipart/mixed;');
+    expect(eml).toContain('Date: Wed, 11 Mar 2026 09:05:00 GMT');
+    expect(eml).toContain('Subject: =?utf-8?B?TGVnYWN5IFJlcG9ydA==?=');
+    expect(eml).toContain('<bob@example.com>');
+    expect(eml).toContain('filename="numbers.xlsx"');
+    expect(eml).toContain(Buffer.from('attachment-bytes').toString('base64'));
+    expect(eml).not.toContain('receivedDateTime');
+
+    const get = ctx.storage.get as Mock;
+    expect(get.mock.calls.map((c) => c[0])).toEqual([
+      'content/json-blob',
+      'content/json-attachment',
+    ]);
+  });
+});

--- a/packages/sharepoint/src/services/sharepoint-restore-streaming.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore-streaming.ts
@@ -1,62 +1,17 @@
-import { createHash } from 'node:crypto';
-import { Readable } from 'node:stream';
-import type { TenantContext, SharePointManifestEntry } from '@wisecom/atlas-types';
+import type { SharePointManifestEntry } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
-const IV_LENGTH = 12;
-const AUTH_TAG_LENGTH = 16;
-const HEADER_LENGTH = IV_LENGTH + AUTH_TAG_LENGTH;
+export {
+  stream_decrypt_from_storage,
+  type StreamDecryptResult,
+} from '@wisecom/atlas-core/services/shared/stream-decrypt';
 
-interface StreamDecryptResult {
-  content: Buffer;
-  sha256_hex: string;
-}
-
-/**
- * Reads encrypted data from S3 as a stream, decrypts via AES-256-GCM,
- * and computes SHA-256 incrementally.
- */
-export async function stream_decrypt_from_storage(
-  ctx: TenantContext,
-  storage_key: string,
-): Promise<StreamDecryptResult> {
-  const raw_stream = await ctx.storage.get_stream(storage_key);
-  const readable =
-    raw_stream instanceof Readable
-      ? raw_stream
-      : Readable.from(raw_stream as AsyncIterable<Buffer>);
-
-  const header = await read_exact_bytes(readable, HEADER_LENGTH);
-  const iv = header.subarray(0, IV_LENGTH);
-  const auth_tag = header.subarray(IV_LENGTH, HEADER_LENGTH);
-  const decipher = ctx.create_decipher(iv, auth_tag);
-  const sha256 = createHash('sha256');
-  const plaintext_chunks: Buffer[] = [];
-
-  for await (const chunk of readable) {
-    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
-    const decrypted = decipher.update(buf);
-    if (decrypted.length > 0) {
-      plaintext_chunks.push(decrypted);
-      sha256.update(decrypted);
-    }
-  }
-
-  const final_block = decipher.final();
-  if (final_block.length > 0) {
-    plaintext_chunks.push(final_block);
-    sha256.update(final_block);
-  }
-
-  return {
-    content: Buffer.concat(plaintext_chunks),
-    sha256_hex: sha256.digest('hex'),
-  };
-}
+/** Files above this size are decrypted as a stream rather than buffered whole. */
+const STREAM_THRESHOLD_BYTES = 4 * 1024 * 1024;
 
 /** Checks whether a file should use stream-based restore. */
 export function should_stream_restore(entry: SharePointManifestEntry): boolean {
-  return entry.size_bytes > 4 * 1024 * 1024;
+  return entry.size_bytes > STREAM_THRESHOLD_BYTES;
 }
 
 /** Verifies the computed SHA-256 against the manifest entry. */
@@ -73,25 +28,4 @@ export function verify_streaming_checksum(
     return false;
   }
   return true;
-}
-
-async function read_exact_bytes(readable: Readable, count: number): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  let collected = 0;
-
-  for await (const chunk of readable) {
-    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
-    chunks.push(buf);
-    collected += buf.length;
-
-    if (collected >= count) {
-      const combined = Buffer.concat(chunks);
-      const header = combined.subarray(0, count);
-      const leftover = combined.subarray(count);
-      if (leftover.length > 0) readable.unshift(leftover);
-      return header;
-    }
-  }
-
-  throw new Error(`Stream ended after ${collected} bytes; expected at least ${count}`);
 }

--- a/packages/types/src/domain/manifest.ts
+++ b/packages/types/src/domain/manifest.ts
@@ -31,6 +31,11 @@ export interface Manifest {
   readonly total_size_bytes: number;
   /** Maps folder_id -> full @odata.deltaLink URL for the next incremental sync. */
   readonly delta_links: Record<string, string>;
+  /**
+   * ID format the delta links and entry IDs were captured with. Absent means
+   * legacy mutable IDs — the next sync must restart full (issue #48).
+   */
+  readonly id_format?: 'immutable' | undefined;
   readonly object_lock?: ManifestObjectLockPolicy;
   readonly entries: ManifestEntry[];
 }

--- a/packages/types/src/domain/manifest.ts
+++ b/packages/types/src/domain/manifest.ts
@@ -58,5 +58,20 @@ export interface ManifestEntry {
   readonly size_bytes: number;
   readonly subject?: string;
   readonly folder_id?: string;
+  /**
+   * File attachments stored as separate content-addressed objects. Only JSON
+   * entries carry these; MIME entries embed their attachments in the blob.
+   */
   readonly attachments?: AttachmentEntry[];
+  /**
+   * Format of the stored blob. 'mime' means the RFC 5322 MIME Graph returned
+   * from /$value, byte-for-byte as it transited SMTP. Absent means the legacy
+   * Graph JSON payload, which is a lossy reconstruction (issue #50).
+   */
+  readonly payload_format?: 'mime' | undefined;
+  /**
+   * ISO 8601 receive timestamp. Recorded for MIME entries, which have no JSON
+   * payload to read `receivedDateTime` from.
+   */
+  readonly received_at?: string | undefined;
 }

--- a/packages/types/src/ports/catalog/use-case.port.ts
+++ b/packages/types/src/ports/catalog/use-case.port.ts
@@ -10,9 +10,20 @@ export interface MailboxSummary {
   readonly last_backup_at: Date;
 }
 
+/**
+ * A decrypted stored message. MIME entries (`payload_format: 'mime'`) expose the
+ * RFC 5322 bytes in `raw` and carry no `message` object and no separate
+ * attachments — their attachments are embedded in the MIME. Legacy Graph JSON
+ * entries expose the parsed payload in `message` plus manifest attachments.
+ */
 export interface ReadMessageResult {
-  readonly message: Record<string, unknown>;
+  /** Decrypted blob exactly as stored; always present. */
+  readonly raw: Buffer;
+  /** Parsed Graph JSON payload; absent for MIME entries. */
+  readonly message?: Record<string, unknown>;
   readonly attachments: AttachmentEntry[];
+  /** 'mime' = `raw` is RFC 5322 MIME. Absent = legacy Graph JSON payload. */
+  readonly payload_format?: 'mime' | undefined;
 }
 
 export interface CatalogUseCase {

--- a/packages/types/src/ports/mail/connector.port.ts
+++ b/packages/types/src/ports/mail/connector.port.ts
@@ -81,6 +81,16 @@ export interface MailboxConnector {
 
   fetch_message(tenant_id: string, owner_id: string, message_id: string): Promise<MailMessage>;
 
+  /**
+   * Fetches the message's RFC 5322 MIME via `GET /messages/{id}/$value` — the
+   * bytes that transited SMTP, including the Received chain, DKIM/SPF results,
+   * threading headers, and any S/MIME payload. Attachments are embedded.
+   * Resolves undefined when Graph cannot produce MIME for the item, so callers
+   * fall back to the JSON payload rather than losing the message (issue #50).
+   */
+  // ponytail: optional method — keeps existing MailboxConnector test literals compiling; make it required when a second caller needs it guaranteed
+  fetch_mime?(tenant_id: string, owner_id: string, message_id: string): Promise<Buffer | undefined>;
+
   /** Fetches file attachments for a message, decoding contentBytes from base64. */
   fetch_attachments(
     tenant_id: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,12 +234,19 @@ importers:
       inversify:
         specifier: ^7.11.0
         version: 7.11.0(reflect-metadata@0.2.2)
+      mailparser:
+        specifier: ^3.9.15
+        version: 3.9.15
       mimetext:
         specifier: ^3.0.28
         version: 3.0.28
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
+    devDependencies:
+      '@types/mailparser':
+        specifier: ^3.4.6
+        version: 3.4.6
 
   packages/s3:
     dependencies:
@@ -1178,6 +1185,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@selderee/plugin-htmlparser2@0.12.0':
+    resolution: {integrity: sha512-oELmoyA6ML9jDRMV3kgcMQFKxUfBU0yFVn6yTctVaLT5ygXnxH52I3TZEgV9EhXJC68/uFvE5Daj1/25c0Xa/A==}
+    peerDependencies:
+      selderee: ~0.12.0
+
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
 
@@ -1288,6 +1300,9 @@ packages:
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/mailparser@3.4.6':
+    resolution: {integrity: sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q==}
 
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
@@ -1511,6 +1526,9 @@ packages:
 
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
+
+  '@zone-eu/mailsplit@5.4.15':
+    resolution: {integrity: sha512-c7ZpxauvF4AEkDJlKDYO7iMUtMuqJMBnDWNff1cyx+d7zaBVR3iFEmXhNHOVoMmVyVF3pTZLsLIJsEFKDldOAA==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -2038,6 +2056,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge-ts@7.1.6:
+    resolution: {integrity: sha512-gQhL1ksGBLQbHeAo47YU6cs2ahd3Pv+8PFYoWogNZbQnNwQyOh9Ad5kbeHFiWwbKdeWQJ5Z7Y7mwb9ew2hXBLw==}
+    engines: {node: '>=16.0.0'}
+
   default-browser-id@5.0.1:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
     engines: {node: '>=18'}
@@ -2090,6 +2112,9 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
   dom-serializer@3.1.1:
     resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
     engines: {node: '>=20.19.0'}
@@ -2098,13 +2123,23 @@ packages:
     resolution: {integrity: sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==}
     engines: {node: '>=0.4', npm: '>=1.2'}
 
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
   domelementtype@3.0.0:
     resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
     engines: {node: '>=20.19.0'}
 
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   domhandler@6.0.1:
     resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
     engines: {node: '>=20.19.0'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   domutils@4.0.2:
     resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
@@ -2158,8 +2193,16 @@ packages:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
     engines: {node: '>=14'}
 
+  encoding-japanese@2.2.0:
+    resolution: {integrity: sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==}
+    engines: {node: '>=8.10.0'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -2482,6 +2525,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
@@ -2497,12 +2544,19 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-to-text@10.0.0:
+    resolution: {integrity: sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==}
+    engines: {node: '>=20.19.0'}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   htmlescape@1.1.1:
     resolution: {integrity: sha512-eVcrzgbR4tim7c7soKQKtxa/kQM4TzjnlU83rcZ9bHU6t31ehfV7SktN6McWgwPWg+JYMA/O3qpGxBvFq1z2Jg==}
     engines: {node: '>=0.10'}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   htmlparser2@12.0.0:
     resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
@@ -2529,6 +2583,14 @@ packages:
 
   hyperx@2.5.4:
     resolution: {integrity: sha512-iOkSh7Yse7lsN/B9y7OsevLWjeXPqGuHQ5SbwaiJM5xAhWFqhoN6erpK1dQsS12OFU36lyai1pnx1mmzWLQqcA==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -2774,9 +2836,24 @@ packages:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
 
+  leac@0.7.0:
+    resolution: {integrity: sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libbase64@1.3.0:
+    resolution: {integrity: sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==}
+
+  libmime@5.4.2:
+    resolution: {integrity: sha512-+IQnCOdPiufGBkOii+Ze8F7iniyBzOwvWDbn1DyExBpc9pT2B3IEMQi7GUc/PpqhNUh/sr1SG9UXDITQoR0VIA==}
+
+  libqp@2.1.1:
+    resolution: {integrity: sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==}
+
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
@@ -2839,6 +2916,9 @@ packages:
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  mailparser@3.9.15:
+    resolution: {integrity: sha512-/5hgybKDMKFS05jAh8OPeEE7N53lj8nF6ywlo89VPjF2TtwqIQbjaxumQWnJIkmaagnJ6u1eansMOViHFxIXwQ==}
 
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -2986,6 +3066,10 @@ packages:
   no-case@2.3.2:
     resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
 
+  nodemailer@9.0.5:
+    resolution: {integrity: sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==}
+    engines: {node: '>=6.0.0'}
+
   normalize-html-whitespace@0.2.0:
     resolution: {integrity: sha512-5CZAEQ4bQi8Msqw0GAT6rrkrjNN4ZKqAG3+jJMwms4O6XoMvh6ekwOueG4mRS1LbPUR1r9EdnhxxfpzMTOdzKw==}
     engines: {node: '>= 0.10'}
@@ -3068,6 +3152,9 @@ packages:
     resolution: {integrity: sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==}
     engines: {node: '>= 0.10'}
 
+  parseley@0.13.1:
+    resolution: {integrity: sha512-uNBJZzmb60l6p6VWLTmevizNAGnE0xoSf1n0B4q3ntegDNzcS68NRCcBDZTcyXHxt2XhBChsCuqj4M+nChvE/A==}
+
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3108,6 +3195,9 @@ packages:
   pbkdf2@3.1.6:
     resolution: {integrity: sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==}
     engines: {node: '>= 0.10'}
+
+  peberminta@0.10.0:
+    resolution: {integrity: sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ==}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -3174,6 +3264,10 @@ packages:
 
   pumpify@2.0.1:
     resolution: {integrity: sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
@@ -3337,6 +3431,9 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -3346,6 +3443,9 @@ packages:
 
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
+
+  selderee@0.12.0:
+    resolution: {integrity: sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3604,6 +3704,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tlds@1.261.0:
+    resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
+    hasBin: true
+
   to-buffer@1.2.2:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
     engines: {node: '>= 0.4'}
@@ -3705,6 +3809,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   umd@3.0.3:
     resolution: {integrity: sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==}
@@ -4811,6 +4918,12 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@selderee/plugin-htmlparser2@0.12.0(selderee@0.12.0)':
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      selderee: 0.12.0
+
   '@shikijs/core@2.5.0':
     dependencies:
       '@shikijs/engine-javascript': 2.5.0
@@ -4933,6 +5046,11 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/linkify-it@5.0.0': {}
+
+  '@types/mailparser@3.4.6':
+    dependencies:
+      '@types/node': 25.9.5
+      iconv-lite: 0.6.3
 
   '@types/markdown-it@14.1.2':
     dependencies:
@@ -5220,6 +5338,12 @@ snapshots:
       vue: 3.5.39(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
+
+  '@zone-eu/mailsplit@5.4.15':
+    dependencies:
+      libbase64: 1.3.0
+      libmime: 5.4.2
+      libqp: 2.1.1
 
   JSONStream@1.3.5:
     dependencies:
@@ -5860,6 +5984,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge-ts@7.1.6: {}
+
   default-browser-id@5.0.1: {}
 
   default-browser@5.5.0:
@@ -5919,6 +6045,12 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
   dom-serializer@3.1.1:
     dependencies:
       domelementtype: 3.0.0
@@ -5927,11 +6059,23 @@ snapshots:
 
   domain-browser@1.2.0: {}
 
+  domelementtype@2.3.0: {}
+
   domelementtype@3.0.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
 
   domhandler@6.0.1:
     dependencies:
       domelementtype: 3.0.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   domutils@4.0.2:
     dependencies:
@@ -5986,9 +6130,13 @@ snapshots:
 
   empathic@2.0.1: {}
 
+  encoding-japanese@2.2.0: {}
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@4.5.0: {}
 
   entities@7.0.1: {}
 
@@ -6369,6 +6517,8 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
 
+  he@1.2.0: {}
+
   hmac-drbg@1.0.1:
     dependencies:
       hash.js: 1.1.7
@@ -6383,9 +6533,24 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-to-text@10.0.0:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.12.0(selderee@0.12.0)
+      deepmerge-ts: 7.1.6
+      dom-serializer: 2.0.0
+      htmlparser2: 10.1.0
+      selderee: 0.12.0
+
   html-void-elements@3.0.0: {}
 
   htmlescape@1.1.1: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   htmlparser2@12.0.0:
     dependencies:
@@ -6417,6 +6582,14 @@ snapshots:
   hyperx@2.5.4:
     dependencies:
       hyperscript-attribute-to-property: 1.0.2
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -6672,10 +6845,27 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
+  leac@0.7.0: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libbase64@1.3.0: {}
+
+  libmime@5.4.2:
+    dependencies:
+      encoding-japanese: 2.2.0
+      iconv-lite: 0.7.3
+      libbase64: 1.3.0
+      libqp: 2.1.1
+
+  libqp@2.1.1: {}
+
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
 
   lint-staged@16.4.0:
     dependencies:
@@ -6744,6 +6934,19 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
+
+  mailparser@3.9.15:
+    dependencies:
+      '@zone-eu/mailsplit': 5.4.15
+      encoding-japanese: 2.2.0
+      he: 1.2.0
+      html-to-text: 10.0.0
+      iconv-lite: 0.7.3
+      libmime: 5.4.2
+      linkify-it: 5.0.2
+      nodemailer: 9.0.5
+      punycode.js: 2.3.1
+      tlds: 1.261.0
 
   make-dir@3.1.0:
     dependencies:
@@ -6914,6 +7117,8 @@ snapshots:
     dependencies:
       lower-case: 1.1.4
 
+  nodemailer@9.0.5: {}
+
   normalize-html-whitespace@0.2.0: {}
 
   normalize-path@3.0.0: {}
@@ -7001,6 +7206,11 @@ snapshots:
       pbkdf2: 3.1.6
       safe-buffer: 5.2.1
 
+  parseley@0.13.1:
+    dependencies:
+      leac: 0.7.0
+      peberminta: 0.10.0
+
   patch-console@2.0.0: {}
 
   path-browserify@1.0.1: {}
@@ -7032,6 +7242,8 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
       to-buffer: 1.2.2
+
+  peberminta@0.10.0: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -7086,6 +7298,8 @@ snapshots:
       duplexify: 4.1.3
       inherits: 2.0.4
       pump: 3.0.4
+
+  punycode.js@2.3.1: {}
 
   punycode@1.4.1: {}
 
@@ -7295,6 +7509,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   scheduler@0.27.0: {}
 
   scslre@0.3.0:
@@ -7304,6 +7520,10 @@ snapshots:
       regexp-ast-analysis: 0.7.1
 
   search-insights@2.17.3: {}
+
+  selderee@0.12.0:
+    dependencies:
+      parseley: 0.13.1
 
   semver@6.3.1: {}
 
@@ -7596,6 +7816,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tlds@1.261.0: {}
+
   to-buffer@1.2.2:
     dependencies:
       isarray: 2.0.5
@@ -7709,6 +7931,8 @@ snapshots:
       vscode-languageserver-protocol: 3.18.2
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   umd@3.0.3: {}
 


### PR DESCRIPTION
Fixes #143.

## Root cause

`read_exact_bytes` pulled the 12-byte IV and 16-byte auth tag in its own loop and broke out once it had them:

```ts
for await (const chunk of readable) {
  ...
  if (collected >= count) { ...; return header; }   // early exit
}
```

An early exit from `for await` invokes the async iterator's `return()`, and Node's stream iterator **destroys the stream** on return. Every read after that rejects with `AbortError: The operation was aborted` — the exact message operators saw. Reduced to 12 lines:

```
header bytes: 28 destroyed: true
SECOND LOOP THREW: AbortError The operation was aborted
```

`should_stream_restore` sends every entry above 4 MB down this path, so **no OneDrive or SharePoint file above 4 MB could be exported or restored**. Backup and `verify` use the buffered path and passed, which is why snapshots looked healthy and the failure only appeared at recovery time — the worst moment to discover it.

## Fix

The header is assembled inside the single pass over the stream. No early exit, no `unshift`, and the decipher is constructed as soon as the first 28 bytes have arrived, no matter how the transport chunked them. A stream that ends mid-header now throws instead of silently short-reading.

Both workloads carried byte-identical copies of this helper — which is how one subtle streaming bug became two. `stream_decrypt_from_storage` moves to `@wisecom/atlas-core/services/shared/stream-decrypt`; the per-workload modules keep only their typed `should_stream_restore` and `verify_streaming_checksum`. Net −148/+191 lines with the tests included.

## Verification against a live tenant

Same snapshot, before and after, on a drive holding three files above the threshold:

| | `save` | `restore` |
| --- | --- | --- |
| Before | 18 saved, **3 skipped** (aborted) | 18 restored, **3 failed** |
| After | **21 saved, 0 skipped** (193.4 MB) | **21 restored, 0 failed** |

Byte-identity of the previously unrecoverable files, SHA-256 against fresh Graph downloads:

| File | Size | Exported | Restored |
| --- | --- | --- | --- |
| `Recording.mp4` | 143.1 MB | IDENTICAL | IDENTICAL |
| `agent-installer` | 6.2 MB | IDENTICAL | IDENTICAL |
| `Setup.exe` | 40.4 MB | IDENTICAL | IDENTICAL |

The restored copies were removed afterwards, leaving the tenant as found.

## Tests

`packages/core/tests/unit/services/shared/stream-decrypt.test.ts` — 5 cases, all of which fail against the old implementation:

- 9 MB payload across 64 KB chunks (the regression itself)
- header split across four 7-byte chunks
- whole payload in a single chunk
- stream ending mid-header rejects
- tampered ciphertext rejects (auth tag still enforced)

Full suite: 976 tests green across 9 packages. Lint and typecheck clean.

## Note

No docs change: this restores the documented behaviour rather than altering it. The 4 MB streaming threshold and its rationale are unchanged.
