### PR TITLE
Detect OneDrive/SharePoint deletions — drive delta uses the deleted facet, not @removed

### DIFF
--- a/packages/onedrive/src/adapters/graph-onedrive-delta-mapper.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-delta-mapper.ts
@@ -15,6 +15,12 @@ export interface GraphDeltaDriveItem {
   file?: Record<string, unknown>;
   folder?: Record<string, unknown>;
   package?: { type?: string };
+  /**
+   * Removal marker for `driveItem` delta. Graph uses this facet, NOT the
+   * `@removed` annotation that `messages/delta` uses (issue #139). It must be
+   * requested explicitly: `$select` strips it otherwise.
+   */
+  deleted?: { state?: string };
   '@removed'?: { reason: string };
   '@microsoft.graph.downloadUrl'?: string;
 }
@@ -35,6 +41,7 @@ export const DRIVE_DELTA_SELECT_FIELDS = [
   'file',
   'folder',
   'package',
+  'deleted',
   '@microsoft.graph.downloadUrl',
 ].join(',');
 
@@ -51,11 +58,26 @@ function extract_parent_path(raw_path: string | undefined): string {
   return result.length === 0 ? '/' : result;
 }
 
+/**
+ * True when Graph returned the carcass of a removed item: an id and facets, but
+ * no name.
+ *
+ * The `deleted` facet is the documented signal, but a saved `@odata.deltaLink`
+ * pins the `$select` it was created with, so cursors written before `deleted`
+ * joined the field list keep answering without it. Every live item carries a
+ * name (the drive root included), so a nameless item is a removed one, and this
+ * keeps deletions visible on existing cursors instead of waiting for a full
+ * re-enumeration.
+ */
+function is_removed_shape(raw: GraphDeltaDriveItem): boolean {
+  return raw.id !== undefined && raw.name === undefined;
+}
+
 /** Maps a raw Graph delta drive item to the domain delta item. */
 export function map_delta_item(raw: GraphDeltaDriveItem, drive_id: string): OneDriveDeltaItem {
   const parent_path = normalize_path(extract_parent_path(raw.parentReference?.path));
   const file_name = normalize_path(raw.name ?? '');
-  const is_deleted = Boolean(raw['@removed']);
+  const is_deleted = Boolean(raw.deleted ?? raw['@removed']) || is_removed_shape(raw);
   const kind: 'file' | 'folder' = raw.file
     ? 'file'
     : raw.folder

--- a/packages/onedrive/src/services/onedrive-delta-item-processor.ts
+++ b/packages/onedrive/src/services/onedrive-delta-item-processor.ts
@@ -79,8 +79,11 @@ export async function process_delta_item(
   }
 
   if (item.deleted) {
+    // Graph omits `name` for a removed item, so the last name we saw is the
+    // only one there is (issue #139).
+    const file_name = item.file_name || (state.previous_name_by_file_id[item.item_id] ?? '');
     return {
-      entry: build_deleted_entry(item, change_type),
+      entry: build_deleted_entry({ ...item, file_name }, change_type),
       files_stored: 0,
       files_deduplicated: 0,
       deleted_items: 1,

--- a/packages/onedrive/tests/unit/adapters/graph-onedrive-delta-mapper.test.ts
+++ b/packages/onedrive/tests/unit/adapters/graph-onedrive-delta-mapper.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DRIVE_DELTA_SELECT_FIELDS,
+  map_delta_item,
+  type GraphDeltaDriveItem,
+} from '@/adapters/graph-onedrive-delta-mapper';
+
+// Issue #139: driveItem delta signals removal with the `deleted` facet. The
+// `@removed` annotation belongs to messages/delta and never appears here, and
+// the facet is stripped unless $select asks for it.
+
+const DRIVE_ID = 'd1';
+
+describe('DRIVE_DELTA_SELECT_FIELDS', () => {
+  it('requests the deleted facet, without which removals are invisible', () => {
+    expect(DRIVE_DELTA_SELECT_FIELDS.split(',')).toContain('deleted');
+  });
+});
+
+describe('map_delta_item deletion detection', () => {
+  it('treats the deleted facet as a removal', () => {
+    const raw: GraphDeltaDriveItem = {
+      id: 'i1',
+      parentReference: { path: '/drive/root:/Folder' },
+      file: {},
+      size: 1024,
+      deleted: { state: 'deleted' },
+    };
+
+    const item = map_delta_item(raw, DRIVE_ID);
+
+    expect(item.deleted).toBe(true);
+    expect(item.kind).toBe('file');
+    expect(item.item_id).toBe('i1');
+  });
+
+  it('still honours the @removed annotation', () => {
+    const item = map_delta_item(
+      { id: 'i2', file: {}, '@removed': { reason: 'deleted' } },
+      DRIVE_ID,
+    );
+
+    expect(item.deleted).toBe(true);
+  });
+
+  it('maps a removed item that Graph returns without name or downloadUrl', () => {
+    // Exactly what Graph sends: no name, no size, no download URL.
+    const item = map_delta_item(
+      {
+        id: 'i3',
+        parentReference: { path: '/drive/root:/Folder' },
+        file: {},
+        deleted: { state: 'deleted' },
+      },
+      DRIVE_ID,
+    );
+
+    expect(item.deleted).toBe(true);
+    expect(item.file_name).toBe('');
+    expect(item.download_url).toBeUndefined();
+    expect(item.parent_path).toBe('/Folder');
+  });
+
+  it('leaves a live item undeleted', () => {
+    const item = map_delta_item(
+      {
+        id: 'i4',
+        name: 'Report.docx',
+        file: {},
+        size: 10,
+        parentReference: { path: '/drive/root:/' },
+        '@microsoft.graph.downloadUrl': 'https://example.invalid/content',
+      },
+      DRIVE_ID,
+    );
+
+    expect(item.deleted).toBe(false);
+    expect(item.file_name).toBe('Report.docx');
+    expect(item.download_url).toBe('https://example.invalid/content');
+  });
+
+  it('classifies a removed folder as a folder, not a file', () => {
+    const item = map_delta_item({ id: 'i5', folder: {}, deleted: { state: 'deleted' } }, DRIVE_ID);
+
+    expect(item.deleted).toBe(true);
+    expect(item.kind).toBe('folder');
+  });
+
+  it('detects a removal from its shape when a legacy delta link omits the facet', () => {
+    // A saved deltaLink pins the $select it was created with, so cursors written
+    // before `deleted` joined the field list answer without it. Graph still
+    // sends no name for a removed item.
+    const item = map_delta_item(
+      { id: 'i6', parentReference: { path: '/drive/root:/Folder' }, file: {}, size: 2048 },
+      DRIVE_ID,
+    );
+
+    expect(item.deleted).toBe(true);
+  });
+
+  it('does not mistake the drive root for a removal', () => {
+    const item = map_delta_item({ id: 'root-id', name: 'root', folder: {} }, DRIVE_ID);
+
+    expect(item.deleted).toBe(false);
+  });
+});

--- a/packages/onedrive/tests/unit/services/onedrive-deletion-detection.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-deletion-detection.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  OneDriveConnector,
+  OneDriveDeltaItem,
+  OneDriveFileVersionIndexRepository,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import {
+  process_delta_item,
+  type DriveTrackingState,
+  type VersionStats,
+} from '@/services/onedrive-delta-item-processor';
+
+// Issue #139: a removed item arrives with no name and no download URL. It must
+// become a deleted manifest entry, never a download attempt, and never a
+// failed-item ledger entry.
+
+const OWNER_ID = 'owner-1';
+const SNAPSHOT_ID = 'od-snap-test';
+
+function make_state(overrides: Partial<DriveTrackingState> = {}): DriveTrackingState {
+  return {
+    previous_path_by_file_id: {},
+    previous_name_by_file_id: {},
+    previous_etag_by_file_id: {},
+    previous_kind_by_file_id: {},
+    ...overrides,
+  };
+}
+
+function make_connector(): { connector: OneDriveConnector; downloads: string[] } {
+  const downloads: string[] = [];
+  const connector = {
+    download_file_content: vi.fn(async (item: OneDriveDeltaItem) => {
+      downloads.push(item.item_id);
+      return Buffer.from('content');
+    }),
+    list_file_versions: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveConnector;
+  return { connector, downloads };
+}
+
+function make_ctx(): TenantContext {
+  return {
+    tenant_id: 't',
+    storage: {
+      exists: vi.fn().mockResolvedValue(false),
+      put: vi.fn().mockResolvedValue(undefined),
+    },
+    encrypt: (buffer: Buffer) => buffer,
+  } as unknown as TenantContext;
+}
+
+function deleted_item(item_id: string): OneDriveDeltaItem {
+  // The shape Graph actually returns: no file_name, no download_url.
+  return {
+    item_id,
+    drive_id: 'd1',
+    kind: 'file',
+    file_name: '',
+    parent_path: '/Folder',
+    size_bytes: 0,
+    deleted: true,
+  };
+}
+
+const version_stats = (): VersionStats => ({
+  total_versions_stored: 0,
+  total_versions_unavailable: 0,
+  total_versions_failed: 0,
+});
+
+describe('process_delta_item deletion handling (issue #139)', () => {
+  it('records a deleted entry and never attempts a download', async () => {
+    const { connector, downloads } = make_connector();
+    const state = make_state({
+      previous_name_by_file_id: { i1: 'Report.docx' },
+      previous_path_by_file_id: { i1: '/Folder' },
+      previous_kind_by_file_id: { i1: 'file' },
+    });
+
+    const outcome = await process_delta_item(
+      connector,
+      {} as OneDriveFileVersionIndexRepository,
+      deleted_item('i1'),
+      OWNER_ID,
+      SNAPSHOT_ID,
+      make_ctx(),
+      state,
+      version_stats(),
+      () => {},
+    );
+
+    expect(outcome.error).toBeUndefined();
+    expect(outcome.deleted_items).toBe(1);
+    expect(outcome.entry?.change_type).toBe('deleted');
+    expect(outcome.entry?.storage_key).toBeUndefined();
+    expect(downloads).toEqual([]);
+  });
+
+  it('names the deleted entry from the last known name, since Graph omits it', async () => {
+    const { connector } = make_connector();
+    const state = make_state({
+      previous_name_by_file_id: { i1: 'Budget.xlsx' },
+      previous_path_by_file_id: { i1: '/Folder' },
+      previous_kind_by_file_id: { i1: 'file' },
+    });
+
+    const outcome = await process_delta_item(
+      connector,
+      {} as OneDriveFileVersionIndexRepository,
+      deleted_item('i1'),
+      OWNER_ID,
+      SNAPSHOT_ID,
+      make_ctx(),
+      state,
+      version_stats(),
+      () => {},
+    );
+
+    expect(outcome.entry?.file_name).toBe('Budget.xlsx');
+  });
+
+  it('still records a deletion for an item it never saw stored', async () => {
+    const { connector, downloads } = make_connector();
+
+    const outcome = await process_delta_item(
+      connector,
+      {} as OneDriveFileVersionIndexRepository,
+      deleted_item('unknown-item'),
+      OWNER_ID,
+      SNAPSHOT_ID,
+      make_ctx(),
+      make_state(),
+      version_stats(),
+      () => {},
+    );
+
+    expect(outcome.deleted_items).toBe(1);
+    expect(outcome.entry?.file_name).toBe('');
+    expect(downloads).toEqual([]);
+  });
+
+  it('downloads a live file, confirming the deletion branch is not over-eager', async () => {
+    const { connector, downloads } = make_connector();
+
+    const outcome = await process_delta_item(
+      connector,
+      { append: vi.fn() } as unknown as OneDriveFileVersionIndexRepository,
+      {
+        item_id: 'i2',
+        drive_id: 'd1',
+        kind: 'file',
+        file_name: 'Report.docx',
+        parent_path: '/',
+        size_bytes: 7,
+        deleted: false,
+        etag: 'etag-1',
+        download_url: 'https://example.invalid/content',
+      },
+      OWNER_ID,
+      SNAPSHOT_ID,
+      make_ctx(),
+      make_state(),
+      version_stats(),
+      () => {},
+    );
+
+    expect(downloads).toEqual(['i2']);
+    expect(outcome.entry?.change_type).toBe('created');
+    expect(outcome.entry?.storage_key).toBeDefined();
+  });
+});

--- a/packages/sharepoint/src/adapters/graph-sharepoint-delta-fetch.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-delta-fetch.ts
@@ -20,6 +20,7 @@ const DRIVE_DELTA_SELECT_FIELDS = [
   'file',
   'folder',
   'package',
+  'deleted',
   '@microsoft.graph.downloadUrl',
 ].join(',');
 

--- a/packages/sharepoint/src/adapters/graph-sharepoint-delta-mapper.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-delta-mapper.ts
@@ -11,15 +11,34 @@ export interface GraphDeltaDriveItem {
   file?: Record<string, unknown>;
   folder?: Record<string, unknown>;
   package?: { type?: string };
+  /**
+   * Removal marker for `driveItem` delta. Graph uses this facet, NOT the
+   * `@removed` annotation that `messages/delta` uses (issue #139). It must be
+   * requested explicitly: `$select` strips it otherwise.
+   */
+  deleted?: { state?: string };
   '@removed'?: { reason: string };
   '@microsoft.graph.downloadUrl'?: string;
+}
+
+/**
+ * True when Graph returned the carcass of a removed item: an id and facets, but
+ * no name.
+ *
+ * The `deleted` facet is the documented signal, but a saved `@odata.deltaLink`
+ * pins the `$select` it was created with, so cursors written before `deleted`
+ * joined the field list keep answering without it. Every live item carries a
+ * name, so a nameless item is a removed one.
+ */
+function is_removed_shape(raw: GraphDeltaDriveItem): boolean {
+  return raw.id !== undefined && raw.name === undefined;
 }
 
 /** Maps a raw Graph drive delta item to the domain SharePointDeltaItem model. */
 export function map_delta_item(raw: GraphDeltaDriveItem, drive_id: string): SharePointDeltaItem {
   const parent_path = normalize_path(extract_parent_path(raw.parentReference?.path));
   const file_name = normalize_path(raw.name ?? '');
-  const is_deleted = Boolean(raw['@removed']);
+  const is_deleted = Boolean(raw.deleted ?? raw['@removed']) || is_removed_shape(raw);
   const kind: 'file' | 'folder' = raw.file
     ? 'file'
     : raw.folder

--- a/packages/sharepoint/src/services/sharepoint-library-item-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-library-item-processor.ts
@@ -80,9 +80,12 @@ export async function process_delta_item(
   if (!change_type) return;
 
   if (item.deleted) {
+    // Graph omits `name` for a removed item, so the last name we saw is the
+    // only one there is (issue #139).
+    const file_name = item.file_name || (tracking.previous_name_by_file_id[item.item_id] ?? '');
     library_state.library_deleted_items++;
     library_state.library_entries.push(
-      build_deleted_entry(item, change_type, library_state.library_name),
+      build_deleted_entry({ ...item, file_name }, change_type, library_state.library_name),
     );
     library_state.failed_items = clear_item_failure(library_state.failed_items, item.item_id);
     return;

--- a/packages/sharepoint/tests/unit/adapters/graph-sharepoint-delta-mapper.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/graph-sharepoint-delta-mapper.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { map_delta_item, type GraphDeltaDriveItem } from '@/adapters/graph-sharepoint-delta-mapper';
+
+// Issue #139: driveItem delta signals removal with the `deleted` facet, not the
+// `@removed` annotation used by messages/delta.
+
+const DRIVE_ID = 'lib1';
+
+describe('map_delta_item deletion detection', () => {
+  it('treats the deleted facet as a removal', () => {
+    const raw: GraphDeltaDriveItem = {
+      id: 'i1',
+      parentReference: { path: '/drives/lib1/root:/Shared Documents' },
+      file: {},
+      deleted: { state: 'deleted' },
+    };
+
+    const item = map_delta_item(raw, DRIVE_ID);
+
+    expect(item.deleted).toBe(true);
+    expect(item.kind).toBe('file');
+    expect(item.parent_path).toBe('/Shared Documents');
+  });
+
+  it('still honours the @removed annotation', () => {
+    const item = map_delta_item(
+      { id: 'i2', file: {}, '@removed': { reason: 'deleted' } },
+      DRIVE_ID,
+    );
+
+    expect(item.deleted).toBe(true);
+  });
+
+  it('maps a removed item that Graph returns without name or downloadUrl', () => {
+    const item = map_delta_item({ id: 'i3', file: {}, deleted: { state: 'deleted' } }, DRIVE_ID);
+
+    expect(item.deleted).toBe(true);
+    expect(item.file_name).toBe('');
+    expect(item.download_url).toBeUndefined();
+  });
+
+  it('leaves a live item undeleted', () => {
+    const item = map_delta_item(
+      {
+        id: 'i4',
+        name: 'Budget.xlsx',
+        file: {},
+        size: 20,
+        '@microsoft.graph.downloadUrl': 'https://example.invalid/content',
+      },
+      DRIVE_ID,
+    );
+
+    expect(item.deleted).toBe(false);
+    expect(item.file_name).toBe('Budget.xlsx');
+  });
+
+  it('detects a removal from its shape when a legacy delta link omits the facet', () => {
+    // A saved deltaLink pins its original $select, so older cursors answer
+    // without the `deleted` facet; a nameless item is a removed one.
+    const item = map_delta_item({ id: 'i5', file: {}, size: 4096 }, DRIVE_ID);
+
+    expect(item.deleted).toBe(true);
+  });
+
+  it('does not mistake the library root for a removal', () => {
+    const item = map_delta_item({ id: 'root-id', name: 'root', folder: {} }, DRIVE_ID);
+
+    expect(item.deleted).toBe(false);
+  });
+});

--- a/packages/sharepoint/tests/unit/services/sharepoint-deletion-detection.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-deletion-detection.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  FailedItemLedger,
+  SharePointDeltaItem,
+  SharePointFileVersionIndexRepository,
+  SharePointSiteConnector,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import {
+  process_delta_item,
+  type LibraryProcessingState,
+} from '@/services/sharepoint-library-item-processor';
+import type { FileTrackingState } from '@/services/sharepoint-file-tracking';
+
+// Issue #139: removals arrive with the `deleted` facet, no name, and no download
+// URL. They must produce a deleted entry, skip the download, and clear any
+// ledger entry left behind while removals were being misread as failures.
+
+const SITE_ID = 'site-1';
+const SNAPSHOT_ID = 'sp-snap-test';
+
+function make_tracking(overrides: Partial<FileTrackingState> = {}): FileTrackingState {
+  return {
+    previous_path_by_file_id: {},
+    previous_name_by_file_id: {},
+    previous_etag_by_file_id: {},
+    previous_kind_by_file_id: {},
+    ...overrides,
+  } as FileTrackingState;
+}
+
+function make_library_state(failed_items: FailedItemLedger = {}): LibraryProcessingState {
+  return {
+    library_entries: [],
+    library_name: 'Documents',
+    library_files_stored: 0,
+    library_files_deduplicated: 0,
+    library_deleted_items: 0,
+    failed_items,
+    failed_item_ids: new Set<string>(),
+  };
+}
+
+function deleted_item(item_id: string): SharePointDeltaItem {
+  return {
+    item_id,
+    drive_id: 'lib1',
+    kind: 'file',
+    file_name: '',
+    parent_path: '/Shared Documents',
+    size_bytes: 0,
+    deleted: true,
+  };
+}
+
+function make_ctx(): TenantContext {
+  return {
+    tenant_id: 't',
+    storage: { exists: vi.fn().mockResolvedValue(false), put: vi.fn() },
+    encrypt: (buffer: Buffer) => buffer,
+  } as unknown as TenantContext;
+}
+
+describe('SharePoint deletion handling (issue #139)', () => {
+  it('records a deleted entry named from the last known name, without downloading', async () => {
+    const download = vi.fn();
+    const connector = { download_file_content: download } as unknown as SharePointSiteConnector;
+    const library_state = make_library_state();
+
+    await process_delta_item(
+      connector,
+      deleted_item('i1'),
+      SITE_ID,
+      SNAPSHOT_ID,
+      make_ctx(),
+      make_tracking({
+        previous_name_by_file_id: { i1: 'Budget.xlsx' },
+        previous_path_by_file_id: { i1: '/Shared Documents' },
+        previous_kind_by_file_id: { i1: 'file' },
+      }),
+      library_state,
+      {} as SharePointFileVersionIndexRepository,
+      { total_versions_stored: 0, total_versions_unavailable: 0, total_versions_failed: 0 },
+    );
+
+    expect(library_state.library_deleted_items).toBe(1);
+    expect(library_state.library_entries).toHaveLength(1);
+    expect(library_state.library_entries[0]?.file_name).toBe('Budget.xlsx');
+    expect(library_state.library_entries[0]?.change_type).toBe('deleted');
+    expect(library_state.library_entries[0]?.storage_key).toBeUndefined();
+    expect(download).not.toHaveBeenCalled();
+  });
+
+  it('clears a ledger entry left by a removal that used to be read as a failure', async () => {
+    const connector = { download_file_content: vi.fn() } as unknown as SharePointSiteConnector;
+    const poisoned: FailedItemLedger = {
+      i1: {
+        item_id: 'i1',
+        drive_id: 'lib1',
+        name: '',
+        reason: 'file content could not be downloaded',
+        attempts: 3,
+        first_failed_at: '2026-08-01T00:00:00Z',
+        last_failed_at: '2026-08-03T00:00:00Z',
+      },
+    };
+    const library_state = make_library_state(poisoned);
+
+    await process_delta_item(
+      connector,
+      deleted_item('i1'),
+      SITE_ID,
+      SNAPSHOT_ID,
+      make_ctx(),
+      make_tracking({
+        previous_name_by_file_id: { i1: 'Report.docx' },
+        previous_kind_by_file_id: { i1: 'file' },
+      }),
+      library_state,
+      {} as SharePointFileVersionIndexRepository,
+      { total_versions_stored: 0, total_versions_unavailable: 0, total_versions_failed: 0 },
+    );
+
+    expect(library_state.failed_items.i1).toBeUndefined();
+    expect(library_state.failed_item_ids.has('i1')).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #139.

## Root cause

Both drive delta mappers tested `raw['@removed']`:

```ts
const is_deleted = Boolean(raw['@removed']);
```

That annotation is the `messages/delta` convention. `driveItem` delta signals removal with the **`deleted` facet** — and `deleted` was not in either `$select`, so Graph stripped it from the response entirely. Verified against Graph v1.0, varying only `$select`:

| `$select` | `@removed` | `deleted` facet |
| --- | --- | --- |
| the old field list | absent | **absent** |
| no `$select` | absent | present |
| old list + `deleted` | absent | present |

The same probe against `mailFolders/{id}/messages/delta` returns `"@removed": {"reason": "deleted"}`, so Outlook was always correct; the drive path inherited an assumption that was never true for it.

A removed item still arrives — id plus its `file` facet, but **no `name` and no `@microsoft.graph.downloadUrl`**. Atlas read it as a live file, asked for a download URL, got `404`, and filed the item in the failed-item ledger. Result on any tenant where people delete files:

- no `change_type: 'deleted'` entry, ever — the file stays "current" in every later snapshot and comes back on restore
- run status `UNHEALTHY`, permanently
- a phantom ledger entry retried for five runs, logged with an empty filename (`Failed to process file  (<item-id>)`)

## Fix

Detection reads the `deleted` facet, which is now requested in both `$select` lists, and still honours `@removed` so nothing changes for mail.

**One extra wrinkle the `graph-tap` capture caught before this shipped:** a saved `@odata.deltaLink` pins the `$select` it was created with. Adding `deleted` to the field list does nothing for cursors written earlier — the first live test after the fix still recorded no deletion, and the capture showed why:

```
GET /users/{guid}/drives/{id}/root/delta?$select=...,file,folder,package,@microsoft.graph.downloadUrl&token=<130b>
```

Forcing a full re-enumeration would re-download every file in every existing deployment. Instead a nameless item is recognised as removed on shape alone: every live item carries a name, the drive root included. Deletions therefore work on existing cursors immediately, and the facet takes over once a cursor is next rebuilt.

Two smaller points:

- Graph omits `name` for a removed item, so the deleted entry takes the last name Atlas saw for that id. These entries were previously written with an empty filename.
- No ledger migration is needed: the success path already clears an item's failure, and a recognised deletion is a success. Confirmed live — `Previously failed item (<item-id>) no longer exists`, and the phantom entries cleared themselves on the next run.

## Verification against a live tenant

Create → back up → delete → back up, on the **same pre-existing cursor** (no reset):

```
1 changed | 0 stored | 0 dedup | 1 deleted
[+] Snapshot od-snap-<id> created
```

Before the fix, the identical sequence produced:

```
[x] Status: UNHEALTHY
[!]   Not backed up:  (<item-id>) -- Failed to process file  (<item-id>); will retry (attempt 1 of 5)
```

The capture of the fixed run contains **zero 4xx responses** — no download is attempted for a removed item. The one remaining unhealthy item on that tenant is an EICAR test file whose download Defender blocks with 403, which is #53 and correctly named in the report.

SharePoint could not be exercised live — every document library on the test tenant is empty — so its coverage is the unit tests plus code parity with OneDrive; the two mappers and processors are byte-identical in this logic.

## Tests

16 new tests, 8 of which fail against the previous implementation (verified by stashing the fix and re-running):

- `graph-onedrive-delta-mapper.test.ts` (8) — `deleted` facet, `@removed` still honoured, `$select` contains `deleted`, removed item without name/downloadUrl, removed folder stays a folder, legacy-delta-link shape rule, drive root is not a removal
- `graph-sharepoint-delta-mapper.test.ts` (6) — same coverage for the library path
- `onedrive-deletion-detection.test.ts` — deleted entry recorded with no download attempt, name resolved from tracking state, unknown item still recorded, live file still downloads
- `sharepoint-deletion-detection.test.ts` — deleted entry with resolved name and no download, plus a poisoned ledger entry clearing on a recognised deletion

The mappers previously had **no tests at all**: existing deletion tests constructed domain items with `deleted: true` directly, bypassing the Graph→domain boundary where the bug lived.

Full suite: 996 tests green across 9 packages. Lint clean (3 pre-existing warnings untouched).

## Note

No docs change — this restores documented behaviour. Snapshot semantics are unchanged; deletions simply start appearing as the `deleted` entries the manifest format already defines.
