### PR TITLE
Update the E2E storage assertion for MIME-first backup

### DIFF
--- a/e2e/tests/test_10_outlook.py
+++ b/e2e/tests/test_10_outlook.py
@@ -46,7 +46,12 @@ def test_02_initial_backup_writes_objects(cli: Cli, settings: Settings, s3: Any,
     STATE["snapshot"] = snapshots[0]
 
     assert storage.list_keys(s3, settings.bucket, f"data/{owner}/"), "no message blob was written"
-    assert storage.list_keys(s3, settings.bucket, f"attachments/{owner}/"), "no attachment blob written"
+    # Since #50 the stored blob is the message's original MIME, which embeds its own
+    # attachments, so no separate attachment object is written. test_08 proves the
+    # attachment still survives backup and restore byte-for-byte.
+    assert not storage.list_keys(s3, settings.bucket, f"attachments/{owner}/"), (
+        "a MIME snapshot must not write separate attachment blobs"
+    )
 
 
 def test_03_list_reads_the_catalog(cli: Cli, settings: Settings) -> None:


### PR DESCRIPTION
The nightly E2E fails on `test_02_initial_backup_writes_objects`:

```
> assert storage.list_keys(s3, settings.bucket, f"attachments/{owner}/"), "no attachment blob written"
E AssertionError: no attachment blob written
E assert []
1 failed, 49 passed
```

Not a regression — the assertion encodes the pre-#50 storage layout. Since MIME-first backup landed, the stored object is the message's original RFC 5322 MIME, which embeds its own attachments, so no separate `attachments/<owner>/` object is written. The run that failed was behaving correctly.

Inverted rather than deleted, so the invariant stays covered: a MIME snapshot must **not** write separate attachment blobs. If something reintroduces them, this fails and points at the decision in #50. Attachment fidelity end-to-end is already proven by `test_08_restored_attachment_is_byte_identical`, which restores the message and hashes the attachment against the seeded bytes — that test passed on the failing run, which is exactly the evidence that MIME embedding works.

Found while cutting the 2.1.1 release (#149): the last nightly predated the MIME/streaming/deletion merges, so I dispatched a fresh E2E against `dev` first.