### PR TITLE
Route SDK sharepoint.backup through the site-tree use case (#164)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -128,8 +128,8 @@ const result = await atlas.outlook.backup('user@company.com');
 // OneDrive — mirrors `atlas onedrive backup`
 const odResult = await atlas.onedrive.backup('owner-id');
 
-// SharePoint — mirrors `atlas sharepoint backup`
-const spResult = await atlas.sharepoint.backup('site-id');
+// SharePoint — mirrors `atlas sharepoint backup`, one result per backed-up site
+const [spResult] = await atlas.sharepoint.backup('site-id');
 ```
 
 See the [SDK Reference](./reference/sdk.md) for all methods and [SDK Examples](./reference/examples.md) for production-ready patterns.

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -351,8 +351,8 @@ for (const site of sites) {
 const site = await atlas.sharepoint.resolveSite('https://contoso.sharepoint.com/sites/Engineering');
 console.log(`Site ID: ${site.id}`);
 
-// Back up the resolved site
-const result = await atlas.sharepoint.backup(site.id);
+// Back up the resolved site and every subsite beneath it
+const results = await atlas.sharepoint.backup(site.id, { include_subsites: true });
 ```
 
 ## Export and compliance

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -61,8 +61,9 @@ const od = await atlas.onedrive.backup('owner-id');
 await atlas.onedrive.verify('owner-id', 'od-snap-123');
 await atlas.onedrive.checkStatus('owner-id');
 
-// --- SharePoint ---
-const sp = await atlas.sharepoint.backup('site-id');
+// --- SharePoint (one result per backed-up site) ---
+const [sp] = await atlas.sharepoint.backup('site-id');
+const tree = await atlas.sharepoint.backup('site-id', { include_subsites: true });
 await atlas.sharepoint.verify('site-id', 'sp-snap-123');
 const sites = await atlas.sharepoint.listSites();
 

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -409,13 +409,19 @@ const atlas = createAtlasInstance({
   encryptionPassphrase: 'my-secret-passphrase',
 });
 
-// Incremental backup
-const result = await atlas.sharepoint.backup('contoso.sharepoint.com,site-guid,web-guid');
+// Incremental backup. One result per backed-up site, root first.
+const [result] = await atlas.sharepoint.backup('contoso.sharepoint.com,site-guid,web-guid');
 console.log(`Snapshot: ${result.snapshot?.snapshot_id}`);
 console.log(`Files stored: ${result.summary.files_stored}`);
+// With include_subsites unset, the root result warns about subsites it did not cover.
+console.log(result.summary.warnings);
 
 // Force full crawl
 const full = await atlas.sharepoint.backup('site-id', { force_full: true });
+
+// Include every subsite beneath the site: one snapshot, and one result, per site
+const tree = await atlas.sharepoint.backup('site-id', { include_subsites: true });
+console.log(`Backed up ${tree.length} site(s)`);
 
 // Verify snapshot integrity
 const verify = await atlas.sharepoint.verify('site-id', 'sp-snap-1735689600000-a1b2c3');

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -38,14 +38,14 @@ const atlas = createAtlasInstance({
 });
 
 // Outlook backup
-await atlas.outlook.backup({ mailbox: 'user@company.com' });
+await atlas.outlook.backup('user@company.com');
 
 // OneDrive backup
-await atlas.onedrive.backup({ owner: 'user@company.com' });
+await atlas.onedrive.backup('user@company.com');
 
-// SharePoint backup
-await atlas.sharepoint.backup({
-  siteUrl: 'https://contoso.sharepoint.com/sites/Engineering',
+// SharePoint backup: pass a site URL or Graph site id, add subsites when needed
+await atlas.sharepoint.backup('https://contoso.sharepoint.com/sites/Engineering', {
+  include_subsites: true,
 });
 ```
 

--- a/packages/sdk/src/sharepoint-api.factory.ts
+++ b/packages/sdk/src/sharepoint-api.factory.ts
@@ -1,7 +1,7 @@
 import type { Container } from 'inversify';
 import type {
   SharePointApi,
-  SharePointBackupUseCase,
+  SharePointSiteTreeBackupUseCase,
   SharePointCatalogUseCase,
   SharePointReplicationUseCase,
   SharePointRestoreUseCase,
@@ -12,7 +12,7 @@ import type {
   SharePointSiteConnector,
 } from '@wisecom/atlas-types';
 import {
-  SHAREPOINT_BACKUP_USE_CASE_TOKEN,
+  SHAREPOINT_SITE_TREE_BACKUP_USE_CASE_TOKEN,
   SHAREPOINT_CATALOG_USE_CASE_TOKEN,
   SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
   SHAREPOINT_RESTORE_USE_CASE_TOKEN,
@@ -26,7 +26,9 @@ import { adapt_operation_options } from '@/operation-options';
 
 /** Builds the SharePointApi sub-namespace from the DI container. */
 export function create_sharepoint_api(tenant_id: string, container: Container): SharePointApi {
-  const backup = container.get<SharePointBackupUseCase>(SHAREPOINT_BACKUP_USE_CASE_TOKEN);
+  const backup = container.get<SharePointSiteTreeBackupUseCase>(
+    SHAREPOINT_SITE_TREE_BACKUP_USE_CASE_TOKEN,
+  );
   const verification = container.get<SharePointVerificationUseCase>(
     SHAREPOINT_VERIFICATION_USE_CASE_TOKEN,
   );
@@ -42,7 +44,7 @@ export function create_sharepoint_api(tenant_id: string, container: Container): 
 
   return {
     async backup(site_id, options) {
-      return await backup.backup_site(tenant_id, site_id, adapt_operation_options(options));
+      return await backup.backup_site_tree(tenant_id, site_id, adapt_operation_options(options));
     },
     async verify(site_id, snapshot_id, options) {
       const adapted = adapt_operation_options(options);

--- a/packages/sdk/tests/unit/atlas-instance-async-contract.test.ts
+++ b/packages/sdk/tests/unit/atlas-instance-async-contract.test.ts
@@ -59,7 +59,7 @@ const mocks: Record<string, Record<string, ReturnType<typeof vi.fn>>> = {
     rehydrate_owner: resolved({}),
   },
   OneDriveStatusUseCase: { check_onedrive_status: resolved({}) },
-  SharePointBackupUseCase: { backup_site: resolved({}) },
+  SharePointSiteTreeBackupUseCase: { backup_site_tree: resolved([]) },
   SharePointVerificationUseCase: { verify_sharepoint_snapshot: resolved({}) },
   SharePointCatalogUseCase: {
     list_sharepoint_snapshots: resolved([]),

--- a/packages/sdk/tests/unit/atlas-instance.adapter.test.ts
+++ b/packages/sdk/tests/unit/atlas-instance.adapter.test.ts
@@ -53,7 +53,7 @@ const mock_onedrive_catalog = {
   list_onedrive_file_versions: vi.fn(),
 };
 const mock_onedrive_restore = { restore_onedrive: vi.fn() };
-const mock_sharepoint_backup = { backup_site: vi.fn() };
+const mock_sharepoint_site_tree_backup = { backup_site_tree: vi.fn() };
 const mock_sharepoint_verification = { verify_sharepoint_snapshot: vi.fn() };
 const mock_onedrive_save = { save_snapshot: vi.fn() };
 const mock_onedrive_deletion = { delete_owner_data: vi.fn(), delete_snapshot: vi.fn() };
@@ -106,7 +106,7 @@ vi.mock('@/container', () => ({
         OneDriveDeletionUseCase: mock_onedrive_deletion,
         OneDriveReplicationUseCase: mock_onedrive_replication,
         OneDriveStatusUseCase: mock_onedrive_status,
-        SharePointBackupUseCase: mock_sharepoint_backup,
+        SharePointSiteTreeBackupUseCase: mock_sharepoint_site_tree_backup,
         SharePointVerificationUseCase: mock_sharepoint_verification,
         SharePointCatalogUseCase: mock_sharepoint_catalog,
         SharePointRestoreUseCase: mock_sharepoint_restore,
@@ -218,16 +218,33 @@ describe('createAtlasInstance', () => {
   });
 
   describe('sharepoint', () => {
-    it('backup delegates to SharePointBackupUseCase with bound tenant_id', async () => {
-      const backup_result = { snapshot_id: 'sp-snap-1' };
-      vi.mocked(mock_sharepoint_backup.backup_site).mockResolvedValue(backup_result);
+    it('backup routes through the site-tree use case so include_subsites is honoured', async () => {
+      const results = [{ site_id: 'site-1' }, { site_id: 'subsite-1' }];
+      vi.mocked(mock_sharepoint_site_tree_backup.backup_site_tree).mockResolvedValue(results);
+
+      const result = await atlas.sharepoint.backup('site-1', { include_subsites: true });
+
+      // One result per backed-up site: a partially covered tree stays visible to the caller.
+      expect(result).toBe(results);
+      expect(mock_sharepoint_site_tree_backup.backup_site_tree).toHaveBeenCalledWith(
+        TENANT_ID,
+        'site-1',
+        { include_subsites: true },
+      );
+    });
+
+    it('backup forwards force_full and returns the single root result untouched', async () => {
+      const results = [{ site_id: 'site-1' }];
+      vi.mocked(mock_sharepoint_site_tree_backup.backup_site_tree).mockResolvedValue(results);
 
       const result = await atlas.sharepoint.backup('site-1', { force_full: true });
 
-      expect(result).toBe(backup_result);
-      expect(mock_sharepoint_backup.backup_site).toHaveBeenCalledWith(TENANT_ID, 'site-1', {
-        force_full: true,
-      });
+      expect(result).toEqual(results);
+      expect(mock_sharepoint_site_tree_backup.backup_site_tree).toHaveBeenCalledWith(
+        TENANT_ID,
+        'site-1',
+        { force_full: true },
+      );
     });
 
     it('verify delegates to SharePointVerificationUseCase with bound tenant_id', async () => {

--- a/packages/sdk/tests/unit/cli-sdk-parity.test.ts
+++ b/packages/sdk/tests/unit/cli-sdk-parity.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Strict parity guard: every application capability the CLI can reach must also be
+ * reachable through the SDK. The CLI and the SDK are two adapters over the same ports,
+ * so a capability wired into one and not the other is a wiring omission, not a design
+ * choice. The SDK may expose more (that direction is allowed and asserted loosely).
+ *
+ * Known gaps are allowlisted with their issue number so this test fails on *new*
+ * divergence instead of failing on the backlog.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = new URL('../../../../', import.meta.url).pathname;
+const PORTS_DIR = join(REPO_ROOT, 'packages/types/src/ports');
+const CLI_SRC = join(REPO_ROOT, 'packages/cli/src');
+const SDK_SRC = join(REPO_ROOT, 'packages/sdk/src');
+
+/** Port interfaces that carry application capability, as opposed to infrastructure. */
+const APP_PORT_PATTERN = /UseCase$/;
+const APP_PORT_EXTRAS: Record<string, true> = {
+  TenantBackupOrchestrator: true,
+  MailboxDiscoveryService: true,
+  SharePointSiteConnector: true,
+  UserIdentityResolver: true,
+  IdentityRegistryRepository: true,
+};
+
+/** CLI-reachable capabilities the SDK cannot reach yet, each with its tracking issue. */
+const KNOWN_METHOD_GAPS: Record<string, string> = {
+  'StatsUseCase.get_onedrive_stats': '#165',
+  'StatsUseCase.get_sharepoint_stats': '#165',
+  'TenantBackupOrchestrator.backup_tenant': '#165',
+};
+
+/** DI tokens the CLI resolves and the SDK does not. */
+const KNOWN_TOKEN_GAPS: Record<string, string> = {
+  // Retired with #166: the CLI tenant fan-out goes away, so this stops being a gap.
+  TENANT_ORCHESTRATOR_TOKEN: '#165',
+  // Intentional: the uncached inner resolver, used during rehydrate when the identity
+  // cache lives in the bucket being recovered. The SDK takes owner ids directly.
+  GRAPH_IDENTITY_RESOLVER_TOKEN: 'intentional',
+  // Intentional: the encrypted local config store is a CLI concern. The SDK takes
+  // tenant and credentials from AtlasInstanceConfig.
+  ATLAS_CONFIG_TOKEN: 'intentional',
+};
+
+function collect_sources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...collect_sources(full));
+    else if (/\.tsx?$/.test(entry)) out.push(readFileSync(full, 'utf8'));
+  }
+  return out;
+}
+
+/** Maps every application port interface to the method names it declares. */
+function read_app_port_methods(): Map<string, string[]> {
+  const interface_pattern = /export interface (\w+)\s*(?:extends [^{]+)?\{([\s\S]*?)\n\}/g;
+  const method_pattern = /^ {2}(?:readonly\s+)?(\w+)\s*(?:<[^>]*>)?\(/gm;
+  const found = new Map<string, string[]>();
+
+  for (const source of collect_sources(PORTS_DIR)) {
+    for (const [, name, body] of source.matchAll(interface_pattern)) {
+      if (!APP_PORT_PATTERN.test(name) && APP_PORT_EXTRAS[name] !== true) continue;
+      const methods = [...body.matchAll(method_pattern)].map((m) => m[1] as string);
+      if (methods.length > 0) found.set(name, methods);
+    }
+  }
+  return found;
+}
+
+function is_called(sources: string[], method: string): boolean {
+  const pattern = new RegExp(`\\.\\s*${method}\\s*\\(`);
+  return sources.some((source) => pattern.test(source));
+}
+
+function resolved_tokens(sources: string[]): Set<string> {
+  const found = new Set<string>();
+  for (const source of sources) {
+    for (const [, token] of source.matchAll(/container\.get<[^>]*>\(\s*([A-Z][A-Z0-9_]*_TOKEN)/g)) {
+      found.add(token as string);
+    }
+  }
+  return found;
+}
+
+describe('CLI/SDK capability parity', () => {
+  const ports = read_app_port_methods();
+  const cli = collect_sources(CLI_SRC);
+  const sdk = collect_sources(SDK_SRC);
+
+  it('finds the application ports to compare', () => {
+    expect(ports.size).toBeGreaterThan(20);
+    expect(ports.get('StatsUseCase')).toContain('get_onedrive_stats');
+  });
+
+  it('exposes every CLI-reachable port method through the SDK', () => {
+    const gaps: string[] = [];
+    for (const [port, methods] of ports) {
+      for (const method of methods) {
+        const key = `${port}.${method}`;
+        if (KNOWN_METHOD_GAPS[key] !== undefined) continue;
+        if (is_called(cli, method) && !is_called(sdk, method)) gaps.push(key);
+      }
+    }
+    expect(gaps, 'CLI reaches these capabilities and the SDK cannot').toEqual([]);
+  });
+
+  it('resolves every CLI-resolved use-case token in the SDK', () => {
+    const sdk_tokens = resolved_tokens(sdk);
+    const cli_only = [...resolved_tokens(cli)].filter(
+      (token) => !sdk_tokens.has(token) && KNOWN_TOKEN_GAPS[token] === undefined,
+    );
+    expect(cli_only, 'tokens the CLI resolves and the SDK never touches').toEqual([]);
+  });
+
+  it('keeps the allowlist honest: every listed gap is still a real gap', () => {
+    const fixed: string[] = [];
+    for (const key of Object.keys(KNOWN_METHOD_GAPS)) {
+      const [port, method] = key.split('.') as [string, string];
+      if (!ports.has(port)) {
+        fixed.push(`${key} (port no longer exists)`);
+        continue;
+      }
+      if (is_called(sdk, method)) fixed.push(`${key} (SDK reaches it now)`);
+    }
+    expect(fixed, 'remove these from KNOWN_METHOD_GAPS').toEqual([]);
+  });
+});

--- a/packages/sdk/tests/unit/progress-and-cancellation.test.ts
+++ b/packages/sdk/tests/unit/progress-and-cancellation.test.ts
@@ -9,7 +9,7 @@ import {
   ONEDRIVE_VERIFICATION_USE_CASE_TOKEN,
   ONEDRIVE_RESTORE_USE_CASE_TOKEN,
   ONEDRIVE_SAVE_USE_CASE_TOKEN,
-  SHAREPOINT_BACKUP_USE_CASE_TOKEN,
+  SHAREPOINT_SITE_TREE_BACKUP_USE_CASE_TOKEN,
   SHAREPOINT_VERIFICATION_USE_CASE_TOKEN,
   SHAREPOINT_RESTORE_USE_CASE_TOKEN,
   SHAREPOINT_SAVE_USE_CASE_TOKEN,
@@ -84,10 +84,10 @@ describe('SDK progress and cancellation option adaptation', () => {
   });
 
   it('adapts SharePoint backup onProgress and signal to internal hooks', async () => {
-    const backup_site = vi.fn().mockResolvedValue({ interrupted: false });
+    const backup_site_tree = vi.fn().mockResolvedValue([{ interrupted: false }]);
     const api = create_sharepoint_api(
       TENANT_ID,
-      container_with([SHAREPOINT_BACKUP_USE_CASE_TOKEN, { backup_site }]),
+      container_with([SHAREPOINT_SITE_TREE_BACKUP_USE_CASE_TOKEN, { backup_site_tree }]),
     );
     const controller = new AbortController();
     const on_progress = vi.fn();
@@ -97,7 +97,7 @@ describe('SDK progress and cancellation option adaptation', () => {
       signal: controller.signal,
     });
 
-    expect_adapted_options(backup_site.mock.calls[0]![2], on_progress, controller);
+    expect_adapted_options(backup_site_tree.mock.calls[0]![2], on_progress, controller);
   });
 
   it('adapts Outlook verify, restore, and save options', async () => {

--- a/packages/types/src/ports/atlas/sharepoint-api.port.ts
+++ b/packages/types/src/ports/atlas/sharepoint-api.port.ts
@@ -39,7 +39,13 @@ export type SharePointSdkSaveOptions = Omit<FileSaveOptions, 'on_progress' | 'sh
   SdkOperationOptions;
 
 export interface SharePointApi {
-  backup(siteId: string, options?: SharePointSdkBackupOptions): Promise<SharePointBackupResult>;
+  /**
+   * Backs up the site and, when `include_subsites` is set, every subsite beneath it.
+   * Returns one result per backed-up site, root first, so a partially covered tree is
+   * visible to the caller. With `include_subsites` unset, the single root result still
+   * carries warnings naming the subsites that were not covered.
+   */
+  backup(siteId: string, options?: SharePointSdkBackupOptions): Promise<SharePointBackupResult[]>;
   verify(
     siteId: string,
     snapshotId: string,


### PR DESCRIPTION
Fixes #164.

`SharePointSdkBackupOptions` derives from `SharePointBackupOptions`, so `atlas.sharepoint.backup(siteId, { include_subsites: true })` type-checked and ran. The factory then called `backup_site`, and only `backup_site_tree` reads that flag, so the subsites were skipped and the run reported success. The `uncovered_subsite_warnings` that `backup_site_tree` emits when `include_subsites` is false never fired either, so there was no signal that a tree was partially covered. The CLI was already correct (`sharepoint-command.handlers.tsx` calls `backup_site_tree`).

## Change

`SharePointApi.backup` now resolves `SHAREPOINT_SITE_TREE_BACKUP_USE_CASE_TOKEN` and returns `SharePointBackupResult[]`, one entry per backed-up site, root first. Same call the CLI makes.

**This is a breaking type change for SDK consumers**: `backup()` returned one result and now returns an array. It is in the v2.1.2 milestone, but a published return type changing shape argues for cutting the release as **2.2.0** rather than a patch. Flagging rather than deciding.

## Verification

- `packages/sdk/tests/unit/atlas-instance.adapter.test.ts`: two cases, one asserting `include_subsites` reaches `backup_site_tree` and every site's result comes back, one asserting `force_full` still forwards and a single-site tree returns one result.
- `progress-and-cancellation.test.ts` re-pointed at the tree use case, so `onProgress`/`signal` adaptation stays covered on this path.
- Checked the published artifact, not just the source: `packages/sdk/dist/index.mjs` contains `return await backup.backup_site_tree(tenant_id, site_id, adapt_operation_options(options))`.
- Full monorepo: build, test (15 tasks), lint, `format:check`, `docs:build` all green.

## Parity guard

This PR also lands `packages/sdk/tests/unit/cli-sdk-parity.test.ts`, which is what found the bug. It enumerates every method of every application port in `packages/types/src/ports`, checks which methods and DI tokens each adapter actually reaches, and fails when the CLI can reach a capability the SDK cannot. Remaining known gaps are allowlisted with issue numbers (#165), intentional CLI-only tokens are annotated, and a fourth assertion fails if an allowlisted entry has since been fixed but left in the list.

That last assertion did its job here: fixing this made `SharePointSiteTreeBackupUseCase.backup_site_tree` SDK-reachable, the test went red, and the allowlist entry was removed in the same change.

## Docs

`docs/reference/sdk.md`, `docs/sharepoint-backup.md`, `docs/reference/examples.md`, `docs/getting-started.md`, and `packages/sdk/README.md`. The README examples were also passing object arguments (`backup({ siteUrl })`) for all three workloads, which never matched the API; corrected to positional ids while in there, since npm renders that page.
