### PR TITLE
Resolve drive snapshots in replicate and rehydrate (#91)

### DIFF
--- a/docs/operations/replication.md
+++ b/docs/operations/replication.md
@@ -260,7 +260,7 @@ atlas rehydrate --all --source-config ./offsite.json
 ### SDK rehydration
 
 ```typescript
-// Recover a single Outlook snapshot
+// Recover a single snapshot. Outlook, OneDrive and SharePoint ids all resolve.
 await atlas.rehydrateSnapshot('snapshot-id', offsite);
 
 // Recover a mailbox

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -642,7 +642,7 @@ atlas replicate --status -o user@company.com
 
 | Option                      | Description                                                |
 | --------------------------- | ---------------------------------------------------------- |
-| `-s, --snapshot <id>`       | Replicate a specific snapshot                              |
+| `-s, --snapshot <id>`       | Replicate a specific snapshot, any workload                |
 | `-m, --mailbox <email>`     | Replicate all unreplicated snapshots for a mailbox         |
 | `--site <url-or-id>`        | Replicate all unreplicated snapshots for a SharePoint site |
 | `-o, --owner <email-or-id>` | Replicate all unreplicated snapshots for a OneDrive owner  |
@@ -692,7 +692,7 @@ atlas rehydrate -o user@company.com -s od-snap-1735689600000-a1b2c3 --source-con
 | `--source-config <path>`    | Path to JSON file with source S3 credentials                 |
 | `-t, --tenant <id>`         | Override tenant ID                                           |
 
-Scopes are matched in the order `--site`, `-o/--owner`, `-s/--snapshot`, `-m/--mailbox`, `--all`. Combining `--site` or `-o/--owner` with `-s/--snapshot` narrows the recovery to that single SharePoint or OneDrive snapshot; `-s` on its own resolves Outlook snapshots. Owner and site identifiers are lowercased before they become storage keys, so any casing addresses the same tree.
+Scopes are matched in the order `--site`, `-o/--owner`, `-s/--snapshot`, `-m/--mailbox`, `--all`. `-s/--snapshot` works for all three workloads: the snapshot id says which one it belongs to (`od-snap-*` OneDrive, `sp-snap-*` SharePoint, `snap-*` Outlook), and the owning owner or site is resolved from storage, so it does not have to be named again. Combining `--site` or `-o/--owner` with `-s/--snapshot` addresses the same single snapshot explicitly. Owner and site identifiers are lowercased before they become storage keys, so any casing addresses the same tree.
 
 `-o/--owner` accepts an email or a raw Entra ID object ID. Recovery resolves an email through Microsoft Graph only. Unlike `atlas onedrive` commands it does not write the resolved identity back to primary, because that write would bootstrap a fresh encryption key in the target bucket and block the replica's key from being copied (see _Encryption Key Safety_ below). Pass the object ID directly when Graph is unreachable or the user has been deleted from the directory.
 

--- a/packages/core/src/services/replication/drive-snapshot-router.ts
+++ b/packages/core/src/services/replication/drive-snapshot-router.ts
@@ -1,0 +1,121 @@
+import type {
+  OneDriveReplicationUseCase,
+  ReplicationResult,
+  SharePointReplicationUseCase,
+  StorageTarget,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { OD_MANIFEST_PREFIX } from '@/services/replication/onedrive-replication-helpers';
+import { SP_MANIFEST_PREFIX } from '@/services/replication/sharepoint-replication-helpers';
+
+/**
+ * Snapshot ids are self-describing: `od-snap-*` for OneDrive, `sp-snap-*` for SharePoint,
+ * `snap-*` for Outlook. The workload comes from the id; only the owning segment has to be
+ * looked up, because the drive replication use cases are addressed by owner or site.
+ */
+const OD_SNAPSHOT_PREFIX = 'od-snap-';
+const SP_SNAPSHOT_PREFIX = 'sp-snap-';
+
+interface DriveSnapshotLocation {
+  readonly workload: 'onedrive' | 'sharepoint';
+  /** Owner id for OneDrive, site id for SharePoint: the segment under the manifest root. */
+  readonly owner_segment: string;
+}
+
+/** True when the id belongs to a drive workload rather than Outlook. */
+export function is_drive_snapshot_id(snapshot_id: string): boolean {
+  return snapshot_id.startsWith(OD_SNAPSHOT_PREFIX) || snapshot_id.startsWith(SP_SNAPSHOT_PREFIX);
+}
+
+/**
+ * Resolves the owner or site that holds a drive snapshot by scanning its workload's manifest
+ * root, so `-s <id>` works without the operator also naming the owner. Undefined when the id
+ * is not a drive id, or when no manifest for it exists in the given context.
+ */
+export async function locate_drive_snapshot(
+  ctx: TenantContext,
+  snapshot_id: string,
+): Promise<DriveSnapshotLocation | undefined> {
+  const workload = snapshot_id.startsWith(OD_SNAPSHOT_PREFIX)
+    ? 'onedrive'
+    : snapshot_id.startsWith(SP_SNAPSHOT_PREFIX)
+      ? 'sharepoint'
+      : undefined;
+  if (workload === undefined) return undefined;
+
+  const root = workload === 'onedrive' ? OD_MANIFEST_PREFIX : SP_MANIFEST_PREFIX;
+  const keys = await ctx.storage.list(`${root}/`);
+  const match = keys.find((key) => key.endsWith(`/${snapshot_id}.json`));
+  if (match === undefined) return undefined;
+
+  // `<root>/<owner-or-site>/<snapshot-id>.json`: the segment before the file name.
+  const segments = match.split('/');
+  const owner_segment = segments[segments.length - 2];
+  if (owner_segment === undefined || owner_segment.length === 0) return undefined;
+  return { workload, owner_segment };
+}
+
+interface DriveReplicationDeps {
+  readonly onedrive: OneDriveReplicationUseCase;
+  readonly sharepoint: SharePointReplicationUseCase;
+}
+
+/**
+ * Replicates a drive snapshot through its own workload service. Undefined when the id is not a
+ * drive snapshot, which tells the caller to keep going with the Outlook path.
+ */
+export async function replicate_drive_snapshot(
+  ctx: TenantContext,
+  tenant_id: string,
+  snapshot_id: string,
+  targets: StorageTarget[],
+  deps: DriveReplicationDeps,
+): Promise<ReplicationResult[] | undefined> {
+  const location = await locate_drive_snapshot(ctx, snapshot_id);
+  if (location === undefined) return undefined;
+
+  if (location.workload === 'onedrive') {
+    return await deps.onedrive.replicate_owner(
+      tenant_id,
+      location.owner_segment,
+      snapshot_id,
+      targets,
+    );
+  }
+  return await deps.sharepoint.replicate_site(
+    tenant_id,
+    location.owner_segment,
+    snapshot_id,
+    targets,
+  );
+}
+
+/**
+ * Recovers a drive snapshot from a replica through its own workload service. The location is
+ * resolved against the source, because the snapshot is by definition missing from primary.
+ */
+export async function rehydrate_drive_snapshot(
+  source_ctx: TenantContext,
+  tenant_id: string,
+  snapshot_id: string,
+  source: StorageTarget,
+  deps: DriveReplicationDeps,
+): Promise<ReplicationResult | undefined> {
+  const location = await locate_drive_snapshot(source_ctx, snapshot_id);
+  if (location === undefined) return undefined;
+
+  if (location.workload === 'onedrive') {
+    return await deps.onedrive.rehydrate_owner_snapshot(
+      tenant_id,
+      location.owner_segment,
+      snapshot_id,
+      source,
+    );
+  }
+  return await deps.sharepoint.rehydrate_site_snapshot(
+    tenant_id,
+    location.owner_segment,
+    snapshot_id,
+    source,
+  );
+}

--- a/packages/core/src/services/replication/outlook-snapshot-copier.ts
+++ b/packages/core/src/services/replication/outlook-snapshot-copier.ts
@@ -1,0 +1,67 @@
+import type {
+  DekValidationFn,
+  Manifest,
+  ReplicationResult,
+  StorageTarget,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { replicate_snapshot_to_target } from '@/services/replication/snapshot-replicator';
+import { build_replication_result } from '@/services/replication/replication-result-builder';
+
+export interface CopyDeps {
+  readonly validate_dek: DekValidationFn;
+  readonly passphrase: string;
+  readonly tenant_id: string;
+}
+
+/**
+ * Copies an Outlook snapshot to a target it has to open itself, closing the target context
+ * even when the copy throws. Used by the replicate paths, where the target is a configured
+ * replica rather than an already-open context.
+ */
+export async function copy_outlook_snapshot_to_target(
+  source_ctx: TenantContext,
+  target: StorageTarget,
+  manifest: Manifest,
+  deps: CopyDeps,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  const target_ctx = await target.create_context(deps.tenant_id);
+  try {
+    await deps.validate_dek(
+      source_ctx.storage,
+      target_ctx.storage,
+      deps.passphrase,
+      deps.tenant_id,
+    );
+    const rep = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest);
+    return build_replication_result(
+      rep,
+      manifest.snapshot_id,
+      target.target_id,
+      Date.now() - start,
+    );
+  } finally {
+    target_ctx.destroy();
+  }
+}
+
+/**
+ * Copies an Outlook snapshot between two open contexts. `is_rehydration` suppresses the replica
+ * marker, so recovered data on primary is not labelled as a replica of itself.
+ */
+export async function copy_outlook_snapshot_between(
+  source_ctx: TenantContext,
+  target_ctx: TenantContext,
+  manifest: Manifest,
+  target_id: string,
+  deps: CopyDeps,
+  is_rehydration = false,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  await deps.validate_dek(source_ctx.storage, target_ctx.storage, deps.passphrase, deps.tenant_id);
+  const rep = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest, {
+    skip_marker: is_rehydration,
+  });
+  return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
+}

--- a/packages/core/src/services/replication/replication.service.ts
+++ b/packages/core/src/services/replication/replication.service.ts
@@ -24,7 +24,15 @@ import {
   ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
   SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
-import { replicate_snapshot_to_target } from '@/services/replication/snapshot-replicator';
+import {
+  replicate_drive_snapshot,
+  rehydrate_drive_snapshot,
+} from '@/services/replication/drive-snapshot-router';
+import {
+  copy_outlook_snapshot_to_target,
+  copy_outlook_snapshot_between,
+  type CopyDeps,
+} from '@/services/replication/outlook-snapshot-copier';
 import { rehydrate_manifests } from '@/services/replication/rehydration-manifests-runner';
 import {
   save_replication_status,
@@ -39,7 +47,6 @@ import {
 } from '@/services/replication/outlook-replication-helpers';
 import { ensure_source_dek_on_primary } from '@/services/replication/rehydration-dek-helper';
 import {
-  build_replication_result,
   build_skip_result,
   to_status_record,
   merge_replication_results,
@@ -68,6 +75,12 @@ export class ReplicationService implements ReplicationUseCase {
   ): Promise<ReplicationResult[]> {
     const source_ctx = await this._tenant_factory.create(tenant_id);
     try {
+      const drive = await replicate_drive_snapshot(source_ctx, tenant_id, snapshot_id, targets, {
+        onedrive: this._onedrive,
+        sharepoint: this._sharepoint,
+      });
+      if (drive !== undefined) return drive;
+
       const manifest = await require_outlook_manifest(this._manifests, source_ctx, snapshot_id);
       const results: ReplicationResult[] = [];
 
@@ -124,6 +137,12 @@ export class ReplicationService implements ReplicationUseCase {
     const primary_ctx = await this._tenant_factory.create(tenant_id);
     const source_ctx = await source.create_context(tenant_id);
     try {
+      const drive = await rehydrate_drive_snapshot(source_ctx, tenant_id, snapshot_id, source, {
+        onedrive: this._onedrive,
+        sharepoint: this._sharepoint,
+      });
+      if (drive !== undefined) return drive;
+
       const manifest = await require_outlook_manifest(
         this._manifests,
         source_ctx,
@@ -263,25 +282,12 @@ export class ReplicationService implements ReplicationUseCase {
     manifest: Manifest,
     tenant_id: string,
   ): Promise<ReplicationResult> {
-    const start = Date.now();
-    const target_ctx = await target.create_context(tenant_id);
-    try {
-      await this._validate_dek(
-        source_ctx.storage,
-        target_ctx.storage,
-        this._config.encryption_passphrase,
-        tenant_id,
-      );
-      const rep = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest);
-      return build_replication_result(
-        rep,
-        manifest.snapshot_id,
-        target.target_id,
-        Date.now() - start,
-      );
-    } finally {
-      target_ctx.destroy();
-    }
+    return await copy_outlook_snapshot_to_target(
+      source_ctx,
+      target,
+      manifest,
+      this.copy_deps(tenant_id),
+    );
   }
 
   private async copy_between(
@@ -292,17 +298,22 @@ export class ReplicationService implements ReplicationUseCase {
     tenant_id: string,
     is_rehydration = false,
   ): Promise<ReplicationResult> {
-    const start = Date.now();
-    await this._validate_dek(
-      source_ctx.storage,
-      target_ctx.storage,
-      this._config.encryption_passphrase,
-      tenant_id,
+    return await copy_outlook_snapshot_between(
+      source_ctx,
+      target_ctx,
+      manifest,
+      target_id,
+      this.copy_deps(tenant_id),
+      is_rehydration,
     );
-    const rep = await replicate_snapshot_to_target(source_ctx, target_ctx, manifest, {
-      skip_marker: is_rehydration,
-    });
-    return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
+  }
+
+  private copy_deps(tenant_id: string): CopyDeps {
+    return {
+      validate_dek: this._validate_dek,
+      passphrase: this._config.encryption_passphrase,
+      tenant_id,
+    };
   }
 
   private create_primary_target(): StorageTarget {

--- a/packages/core/tests/unit/services/replication/drive-snapshot-routing.test.ts
+++ b/packages/core/tests/unit/services/replication/drive-snapshot-routing.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ReplicationService } from '@/services/replication/replication.service';
+import type {
+  DekValidationFn,
+  ManifestRepository,
+  ObjectStorage,
+  OneDriveReplicationUseCase,
+  ReplicationResult,
+  SharePointReplicationUseCase,
+  StorageTarget,
+  StorageTargetFactory,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { ReplicationStatus, ReplicationVerificationStatus } from '@wisecom/atlas-types';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+import type { AtlasConfig } from '@/utils/config';
+
+vi.mock('@/services/replication/rehydration-dek-helper', () => ({
+  ensure_source_dek_on_primary: vi.fn().mockResolvedValue(undefined),
+}));
+
+const OD_SNAPSHOT = 'od-snap-1735689600000-a1b2c3';
+const SP_SNAPSHOT = 'sp-snap-1735689600000-d4e5f6';
+
+function make_result(snapshot_id: string): ReplicationResult {
+  return {
+    snapshot_id,
+    target_id: 'offsite',
+    status: ReplicationStatus.COMPLETED,
+    objects_total: 3,
+    objects_copied: 3,
+    objects_skipped: 0,
+    objects_failed: 0,
+    bytes_copied: 300,
+    elapsed_ms: 1,
+    errors: [],
+    verification_status: ReplicationVerificationStatus.PASSED,
+  };
+}
+
+function make_context(storage: ObjectStorage): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage,
+    encrypt: vi.fn((d: Buffer) => d),
+    decrypt: vi.fn((d: Buffer) => d),
+    create_cipher: stub_tenant_create_cipher,
+    create_decipher: vi.fn(),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+function make_storage(keys: string[]): ObjectStorage {
+  return {
+    put: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+    delete_version: vi.fn(),
+    exists: vi.fn().mockResolvedValue(false),
+    list: vi.fn(async (prefix: string) => keys.filter((key) => key.startsWith(prefix))),
+    list_versions: vi.fn(),
+    begin_multipart_upload: vi.fn(),
+    copy: vi.fn(),
+    abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+    probe_immutability: vi.fn(),
+  } as unknown as ObjectStorage;
+}
+
+/** Manifest keys as the drive backup paths write them, one per workload. */
+const STORED_KEYS = [
+  `onedrive/manifests/owner-object-id/${OD_SNAPSHOT}.json`,
+  `sharepoint/manifests/contoso.sharepoint.com,site-guid,web-guid/${SP_SNAPSHOT}.json`,
+  'manifests/mailbox-1/snap-1735689600000-999999.json',
+];
+
+describe('ReplicationService drive snapshot routing (issue #91)', () => {
+  let storage: ObjectStorage;
+  let manifests: ManifestRepository;
+  let onedrive: OneDriveReplicationUseCase;
+  let sharepoint: SharePointReplicationUseCase;
+  let target: StorageTarget;
+  let service: ReplicationService;
+
+  beforeEach(() => {
+    storage = make_storage(STORED_KEYS);
+    const ctx = make_context(storage);
+    const tenant_factory: TenantContextFactory = {
+      create: vi.fn().mockResolvedValue(ctx),
+    } as unknown as TenantContextFactory;
+
+    manifests = {
+      save: vi.fn(),
+      find_by_snapshot: vi.fn().mockResolvedValue(undefined),
+      find_latest_by_owner: vi.fn(),
+      list_all_manifests: vi.fn().mockResolvedValue([]),
+    };
+
+    const config: AtlasConfig = {
+      tenant_id: 'tenant-1',
+      client_id: 'c',
+      client_secret: 's',
+      s3_endpoint: 'http://primary:9000',
+      s3_access_key: 'k',
+      s3_secret_key: 's',
+      s3_region: 'us-east-1',
+      encryption_passphrase: 'pass',
+    };
+
+    target = {
+      target_id: 'offsite',
+      endpoint: 'http://offsite:9000',
+      create_context: vi.fn().mockResolvedValue(make_context(storage)),
+    };
+
+    onedrive = {
+      replicate_owner: vi.fn().mockResolvedValue([make_result(OD_SNAPSHOT)]),
+      replicate_all_owner_snapshots: vi.fn(),
+      rehydrate_owner_snapshot: vi.fn().mockResolvedValue(make_result(OD_SNAPSHOT)),
+      rehydrate_owner: vi.fn(),
+      rehydrate_all_owners: vi.fn(),
+    };
+    sharepoint = {
+      replicate_site: vi.fn().mockResolvedValue([make_result(SP_SNAPSHOT)]),
+      replicate_all_site_snapshots: vi.fn(),
+      rehydrate_site_snapshot: vi.fn().mockResolvedValue(make_result(SP_SNAPSHOT)),
+      rehydrate_site: vi.fn(),
+      rehydrate_all_sites: vi.fn(),
+    };
+
+    service = new ReplicationService(
+      tenant_factory,
+      manifests,
+      config,
+      vi.fn().mockResolvedValue(undefined) as unknown as DekValidationFn,
+      vi.fn().mockReturnValue(target) as unknown as StorageTargetFactory,
+      onedrive,
+      sharepoint,
+    );
+  });
+
+  it('replicates a OneDrive snapshot through the OneDrive service, resolving the owner from storage', async () => {
+    const results = await service.replicate_snapshot('tenant-1', OD_SNAPSHOT, [target]);
+
+    expect(results).toEqual([make_result(OD_SNAPSHOT)]);
+    expect(onedrive.replicate_owner).toHaveBeenCalledWith(
+      'tenant-1',
+      'owner-object-id',
+      OD_SNAPSHOT,
+      [target],
+    );
+    // The Outlook path must not be consulted: it would report the snapshot as nonexistent.
+    expect(manifests.find_by_snapshot).not.toHaveBeenCalled();
+  });
+
+  it('replicates a SharePoint snapshot through the SharePoint service, keeping the composite site id intact', async () => {
+    const results = await service.replicate_snapshot('tenant-1', SP_SNAPSHOT, [target]);
+
+    expect(results).toEqual([make_result(SP_SNAPSHOT)]);
+    expect(sharepoint.replicate_site).toHaveBeenCalledWith(
+      'tenant-1',
+      'contoso.sharepoint.com,site-guid,web-guid',
+      SP_SNAPSHOT,
+      [target],
+    );
+  });
+
+  it('rehydrates drive snapshots through their own workload service', async () => {
+    const od = await service.rehydrate_snapshot('tenant-1', OD_SNAPSHOT, target);
+    const sp = await service.rehydrate_snapshot('tenant-1', SP_SNAPSHOT, target);
+
+    expect(od).toEqual(make_result(OD_SNAPSHOT));
+    expect(sp).toEqual(make_result(SP_SNAPSHOT));
+    expect(onedrive.rehydrate_owner_snapshot).toHaveBeenCalledWith(
+      'tenant-1',
+      'owner-object-id',
+      OD_SNAPSHOT,
+      target,
+    );
+    expect(sharepoint.rehydrate_site_snapshot).toHaveBeenCalledWith(
+      'tenant-1',
+      'contoso.sharepoint.com,site-guid,web-guid',
+      SP_SNAPSHOT,
+      target,
+    );
+  });
+
+  it('leaves Outlook snapshot ids on the Outlook path', async () => {
+    await expect(
+      service.replicate_snapshot('tenant-1', 'snap-1735689600000-999999', [target]),
+    ).rejects.toThrow('No manifest found');
+
+    expect(manifests.find_by_snapshot).toHaveBeenCalled();
+    expect(onedrive.replicate_owner).not.toHaveBeenCalled();
+    expect(sharepoint.replicate_site).not.toHaveBeenCalled();
+  });
+
+  it('reports a drive snapshot that exists nowhere as missing rather than routing it blindly', async () => {
+    const empty = make_storage([]);
+    const ctx = make_context(empty);
+    const service_without_data = new ReplicationService(
+      { create: vi.fn().mockResolvedValue(ctx) } as unknown as TenantContextFactory,
+      manifests,
+      {
+        tenant_id: 'tenant-1',
+        client_id: 'c',
+        client_secret: 's',
+        s3_endpoint: 'http://primary:9000',
+        s3_access_key: 'k',
+        s3_secret_key: 's',
+        s3_region: 'us-east-1',
+        encryption_passphrase: 'pass',
+      },
+      vi.fn().mockResolvedValue(undefined) as unknown as DekValidationFn,
+      vi.fn().mockReturnValue(target) as unknown as StorageTargetFactory,
+      onedrive,
+      sharepoint,
+    );
+
+    await expect(
+      service_without_data.replicate_snapshot('tenant-1', OD_SNAPSHOT, [target]),
+    ).rejects.toThrow('No manifest found');
+    expect(onedrive.replicate_owner).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #91.

`-s/--snapshot` resolved through the Outlook manifest repository, which lists `manifests/` only, so `od-snap-*` and `sp-snap-*` ids came back as "No manifest found" while the manifest sat under `onedrive/manifests/` or `sharepoint/manifests/`.

## Approach

Snapshot ids are self-describing (`od-snap-*`, `sp-snap-*`, `snap-*`), so the workload comes from the id itself and only the owning owner or site needs a lookup. `drive-snapshot-router` scans that workload's manifest root for `<owner-or-site>/<snapshot-id>.json`, then delegates to `OneDriveReplicationUseCase.replicate_owner` / `rehydrate_owner_snapshot` or the SharePoint equivalents, which already own their ancillary keys, status records and presence checks.

This is deliberately not the widened-prefix scan the issue sketched in its acceptance criteria. `ManifestRepository.find_by_snapshot` returns an Outlook `Manifest`; drive snapshots are `OneDriveSnapshotManifest` and `SharePointSnapshotManifest`, so a shared repository lookup cannot return them without collapsing three types into one. Routing above the repository keeps each workload's manifest type and copy path intact, which is also why the hardcoded `manifests/<owner>/<snapshot>.json` presence probe in `replication.service.ts` needed no change: it is now only reached by Outlook ids, where it is correct.

`replication.service.ts` crossed the 300-line limit with the routing added, so the two Outlook copy helpers moved to `outlook-snapshot-copier.ts`. No behaviour change in that move.

## Verification against real object storage

Replication touches S3 only, no Graph, so the whole path is exercisable without a tenant. Two MinIO instances from `e2e/docker-compose.e2e.yml` (primary and replica), encrypted OneDrive/SharePoint/Outlook manifests plus data objects seeded through the real `TenantContextFactory` and `S3ManifestRepository`, then the built CLI bundle (`packages/cli/dist/cli.mjs`) driven against them.

**Before**, with the fix stashed and rebuilt:

```
$ atlas replicate -s od-snap-1735689600000-a1b2c3 --target-endpoint http://127.0.0.1:9002 ...
[x] No manifest found for snapshot od-snap-1735689600000-a1b2c3      (exit 1)
```

**After**, same seeded bucket:

| command | result |
| --- | --- |
| `replicate -s od-snap-*` | COMPLETED, 1 copied, 67 B |
| `replicate -s sp-snap-*` | COMPLETED, 1 copied, 67 B |
| `rehydrate -s od-snap-*` (after deleting `onedrive/` from primary) | COMPLETED, 1 copied; both keys back on primary |
| `rehydrate -s sp-snap-*` (after deleting `sharepoint/` from primary) | COMPLETED, 1 copied; both keys back on primary |
| `rehydrate -s od-snap-*` again, data already present | 0 copied, nothing re-copied |
| `replicate -s snap-*` (Outlook regression) | COMPLETED, 1 copied |

Replica contents after the two replicate runs, read back through the storage port:

```
_meta/dek.enc
_meta/replica.marker
onedrive/data/owner-object-id-91/aaaa…
onedrive/manifests/owner-object-id-91/od-snap-1735689600000-a1b2c3.json
sharepoint/data/contoso.sharepoint.com,site-guid-91,web-guid-91/aaaa…
sharepoint/manifests/contoso.sharepoint.com,site-guid-91,web-guid-91/sp-snap-1735689600000-d4e5f6.json
```

The composite SharePoint site id survives as one path segment, which was the specific thing to check: it contains commas and dots, and the router splits keys on `/` only.

MinIO and its volumes were destroyed afterwards; the primary was bound to port 9010 to avoid an unrelated container already on 9000.

## Unit tests

`packages/core/tests/unit/services/replication/drive-snapshot-routing.test.ts`: OneDrive and SharePoint ids route to their own service with the resolved owner/site, Outlook ids stay on the Outlook path, and a drive id with no manifest anywhere still fails as missing instead of being routed blindly. The OneDrive case also asserts `find_by_snapshot` is never consulted, since that call is what produced the wrong error.

## Known limitation, tracked separately

The idempotent rehydrate reports `0 copied | 0 skipped | 0 failed` rather than naming the skip. Nothing is re-copied, which is the behaviour this issue asks for, but the counters are the zeroed-`rehydrate -s` case in #94, in this same milestone. Not fixed here to keep the diff to the routing.

## Docs

`docs/reference/cli.md` said "`-s` on its own resolves Outlook snapshots"; that scope note and the `replicate` option table are updated. `docs/operations/replication.md` had an SDK comment implying `rehydrateSnapshot` was Outlook-only.
