### PR TITLE
fix(cli): output bundle - table width budget, pipeable --raw, basename list-versions, real rehydrate skip counters

### DIFF
--- a/packages/cli/src/commands/outlook-catalog.handler.tsx
+++ b/packages/cli/src/commands/outlook-catalog.handler.tsx
@@ -69,9 +69,19 @@ export async function execute_outlook_read(
   const catalog = container.get<CatalogUseCase>(CATALOG_USE_CASE_TOKEN);
   const result = await catalog.read_message(tenant_id, options.snapshot, options.message);
 
-  // Raw MIME goes to stdout verbatim so it can be piped straight into an .eml file.
-  if (options.raw && result?.payload_format === 'mime') {
-    process.stdout.write(result.raw);
+  // Machine-readable output suppresses all decorative output so stdout stays pipeable.
+  if (options.raw) {
+    if (!result) {
+      logger.error(`Message not found. Check the snapshot ID and message ID are correct.`);
+      process.exitCode = 1;
+      return;
+    }
+    // Raw MIME goes to stdout verbatim so it can be piped straight into an .eml file.
+    if (result.payload_format === 'mime') {
+      process.stdout.write(result.raw);
+      return;
+    }
+    console.log(JSON.stringify(result.message, null, 2));
     return;
   }
 
@@ -85,11 +95,6 @@ export async function execute_outlook_read(
 
   if (result.payload_format === 'mime') {
     await print_mime_message(result.raw);
-    return;
-  }
-
-  if (options.raw) {
-    console.log(JSON.stringify(result.message, null, 2));
     return;
   }
 

--- a/packages/cli/src/ui/components/data-table.tsx
+++ b/packages/cli/src/ui/components/data-table.tsx
@@ -26,6 +26,28 @@ function fit(text: string, width: number, align: 'left' | 'right'): string {
   return align === 'right' ? truncated.padStart(width) : truncated.padEnd(width);
 }
 
+const MIN_COLUMN_WIDTH = 8;
+
+/**
+ * Shrinks columns widest-first until the table (plus inter-column gaps) fits the terminal.
+ * Columns never go below their header length or MIN_COLUMN_WIDTH, whichever is larger.
+ */
+function fit_widths_to_terminal(widths: number[], header_lengths: number[]): void {
+  const gaps = 2 * Math.max(widths.length - 1, 0);
+  const budget = (process.stdout.columns || 80) - gaps;
+  let total = widths.reduce((sum, w) => sum + w, 0);
+  while (total > budget) {
+    let widest = -1;
+    for (let i = 0; i < widths.length; i++) {
+      const floor = Math.max(header_lengths[i] ?? 0, MIN_COLUMN_WIDTH);
+      if (widths[i]! > floor && (widest === -1 || widths[i]! > widths[widest]!)) widest = i;
+    }
+    if (widest === -1) break;
+    widths[widest]!--;
+    total--;
+  }
+}
+
 /** Column-aligned table with bold headers; replaces hand-padded console tables. */
 export function DataTable<Row extends object>({
   columns,
@@ -38,6 +60,10 @@ export function DataTable<Row extends object>({
     );
     return Math.min(content, col.max_width ?? content);
   });
+  fit_widths_to_terminal(
+    widths,
+    columns.map((col) => col.header.length),
+  );
 
   return (
     <Box flexDirection="column">

--- a/packages/cli/tests/unit/ui/components/data-table.test.tsx
+++ b/packages/cli/tests/unit/ui/components/data-table.test.tsx
@@ -48,4 +48,30 @@ describe('DataTable', () => {
     expect(lines[2]!.endsWith('    1')).toBe(true);
     expect(lines[3]!.endsWith('12345')).toBe(true);
   });
+
+  it('shrinks the widest columns so the table fits the terminal width', () => {
+    const original_columns = process.stdout.columns;
+    Object.defineProperty(process.stdout, 'columns', { value: 40, configurable: true });
+    try {
+      const wide: TableColumn<{ a: string; b: string }>[] = [
+        { key: 'a', header: 'Site' },
+        { key: 'b', header: 'Url' },
+      ];
+      const { lastFrame } = render(
+        <DataTable
+          columns={wide}
+          rows={[{ a: 'x'.repeat(90), b: 'https://example.com/'.repeat(4) }]}
+        />,
+      );
+      for (const line of lastFrame()!.split('\n')) {
+        expect(line.length).toBeLessThanOrEqual(40);
+      }
+      expect(lastFrame()).toContain('~');
+    } finally {
+      Object.defineProperty(process.stdout, 'columns', {
+        value: original_columns,
+        configurable: true,
+      });
+    }
+  });
 });

--- a/packages/core/src/services/replication/onedrive-replication.service.ts
+++ b/packages/core/src/services/replication/onedrive-replication.service.ts
@@ -135,7 +135,7 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
       const manifest_key = `${OD_MANIFEST_PREFIX}/${owner_id}/${snapshot_id}.json`;
 
       if (await primary_ctx.storage.exists(manifest_key)) {
-        return build_skip_result(snapshot_id, source.target_id);
+        return build_skip_result(snapshot_id, source.target_id, manifest.entries.length);
       }
 
       const ancillary = await collect_od_ancillary_keys(source_ctx, owner_id);

--- a/packages/core/src/services/replication/replication-result-builder.ts
+++ b/packages/core/src/services/replication/replication-result-builder.ts
@@ -48,14 +48,22 @@ export function build_replication_result(
   };
 }
 
-export function build_skip_result(snapshot_id: string, target_id: string): ReplicationResult {
+/**
+ * Result for a snapshot already present at the target. `objects_present` is the manifest's
+ * entry count, reported as skipped so the summary distinguishes "nothing to do" from "nothing found".
+ */
+export function build_skip_result(
+  snapshot_id: string,
+  target_id: string,
+  objects_present = 0,
+): ReplicationResult {
   return {
     snapshot_id,
     target_id,
     status: ReplicationStatus.COMPLETED,
-    objects_total: 0,
+    objects_total: objects_present,
     objects_copied: 0,
-    objects_skipped: 0,
+    objects_skipped: objects_present,
     objects_failed: 0,
     bytes_copied: 0,
     elapsed_ms: 0,

--- a/packages/core/src/services/replication/replication.service.ts
+++ b/packages/core/src/services/replication/replication.service.ts
@@ -152,7 +152,7 @@ export class ReplicationService implements ReplicationUseCase {
 
       const manifest_key = `manifests/${manifest.owner_id}/${snapshot_id}.json`;
       if (await primary_ctx.storage.exists(manifest_key)) {
-        return build_skip_result(snapshot_id, source.target_id);
+        return build_skip_result(snapshot_id, source.target_id, manifest.entries.length);
       }
 
       return await this.copy_between(

--- a/packages/core/src/services/replication/sharepoint-replication.service.ts
+++ b/packages/core/src/services/replication/sharepoint-replication.service.ts
@@ -139,7 +139,7 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
       const manifest_key = `${SP_MANIFEST_PREFIX}/${site_id}/${snapshot_id}.json`;
 
       if (await primary_ctx.storage.exists(manifest_key)) {
-        return build_skip_result(snapshot_id, source.target_id);
+        return build_skip_result(snapshot_id, source.target_id, manifest.entries.length);
       }
 
       const ancillary = await collect_sp_ancillary_keys(source_ctx, site_id);

--- a/packages/core/tests/unit/services/replication/replication-result-builder.test.ts
+++ b/packages/core/tests/unit/services/replication/replication-result-builder.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { build_skip_result } from '@/services/replication/replication-result-builder';
+
+describe('build_skip_result', () => {
+  it('reports the present objects as skipped so "nothing to do" is visible', () => {
+    const result = build_skip_result('snap-1', 'target-1', 35);
+
+    expect(result.objects_total).toBe(35);
+    expect(result.objects_skipped).toBe(35);
+    expect(result.objects_copied).toBe(0);
+    expect(result.objects_failed).toBe(0);
+  });
+
+  it('defaults to zero when no manifest count is given', () => {
+    const result = build_skip_result('snap-1', 'target-1');
+
+    expect(result.objects_total).toBe(0);
+    expect(result.objects_skipped).toBe(0);
+  });
+});

--- a/packages/onedrive/src/services/onedrive-catalog.service.ts
+++ b/packages/onedrive/src/services/onedrive-catalog.service.ts
@@ -67,7 +67,8 @@ export class OneDriveCatalogService implements OneDriveCatalogUseCase {
     const trimmed = file_ref.trim();
     if (!this.looks_like_path(trimmed)) {
       const direct = await this._indexes.find_by_file_id(ctx, owner_id, trimmed);
-      return direct ? trimmed : undefined;
+      if (direct) return trimmed;
+      return this.match_by_file_name(ctx, owner_id, trimmed);
     }
     const want = normalize_path_ref(trimmed);
     const indexes = await this._indexes.list_by_owner(ctx, owner_id);
@@ -77,6 +78,30 @@ export class OneDriveCatalogService implements OneDriveCatalogUseCase {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Matches a bare filename against every indexed version of the owner's files.
+   * Throws with the candidate paths when the name maps to more than one file.
+   */
+  private async match_by_file_name(
+    ctx: TenantContext,
+    owner_id: string,
+    file_name: string,
+  ): Promise<string | undefined> {
+    const matches = new Map<string, string>();
+    for (const idx of await this._indexes.list_by_owner(ctx, owner_id)) {
+      for (const v of idx.versions) {
+        if (v.file_name === file_name) matches.set(idx.file_id, version_logical_path(v));
+      }
+    }
+    if (matches.size > 1) {
+      const candidates = [...new Set(matches.values())].sort().join(', ');
+      throw new Error(
+        `'${file_name}' matches ${matches.size} files: ${candidates}. Pass a full path instead.`,
+      );
+    }
+    return [...matches.keys()][0];
   }
 
   /** Paths contain a slash; Graph ids do not. */

--- a/packages/onedrive/tests/unit/services/onedrive-catalog.service.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-catalog.service.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  OneDriveFileVersionIndex,
+  OneDriveFileVersionRecord,
+  OneDriveManifestRepository,
+  OneDriveFileVersionIndexRepository,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveCatalogService } from '@/services/onedrive-catalog.service';
+
+const TENANT_ID = 'tenant-1';
+const OWNER_ID = 'owner-abc';
+
+const ctx: TenantContext = {
+  storage: {} as TenantContext['storage'],
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  create_cipher: vi.fn(),
+  destroy: vi.fn(),
+} as unknown as TenantContext;
+
+function make_version(
+  overrides: Partial<OneDriveFileVersionRecord> = {},
+): OneDriveFileVersionRecord {
+  return {
+    snapshot_id: 'snap-1',
+    backup_at: '2026-01-15T10:00:00Z',
+    drive_id: 'drive-1',
+    file_name: 'report.xlsx',
+    parent_path: '/Documents',
+    size_bytes: 2048,
+    change_type: 'created',
+    ...overrides,
+  };
+}
+
+function make_index(
+  file_id: string,
+  versions: OneDriveFileVersionRecord[],
+): OneDriveFileVersionIndex {
+  return { file_id, owner_id: OWNER_ID, versions };
+}
+
+function create_mocks() {
+  const tenant_factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+    create_storage_only: vi.fn().mockResolvedValue(ctx),
+  };
+
+  const manifests = {
+    list_snapshots_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveManifestRepository;
+
+  const indexes: OneDriveFileVersionIndexRepository = {
+    find_by_file_id: vi.fn().mockResolvedValue(undefined),
+    append_version: vi.fn(),
+    list_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveFileVersionIndexRepository;
+
+  return { tenant_factory, manifests, indexes };
+}
+
+describe('OneDriveCatalogService', () => {
+  let service: OneDriveCatalogService;
+  let mocks: ReturnType<typeof create_mocks>;
+
+  beforeEach(() => {
+    mocks = create_mocks();
+    service = new OneDriveCatalogService(
+      mocks.tenant_factory as unknown as TenantContextFactory,
+      mocks.manifests,
+      mocks.indexes,
+    );
+  });
+
+  describe('list_onedrive_file_versions bare filename fallback', () => {
+    it('resolves a bare filename to a unique basename match', async () => {
+      const idx = make_index('file-bare', [make_version()]);
+      vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue([idx]);
+      vi.mocked(mocks.indexes.find_by_file_id).mockImplementation(async (_ctx, _owner, fid) =>
+        fid === 'file-bare' ? idx : undefined,
+      );
+
+      const result = await service.list_onedrive_file_versions(TENANT_ID, OWNER_ID, 'report.xlsx');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].file_name).toBe('report.xlsx');
+    });
+
+    it('throws with candidate paths when a bare filename matches multiple files', async () => {
+      const idx1 = make_index('file-one', [
+        make_version({ parent_path: '/Documents', file_name: 'report.xlsx' }),
+      ]);
+      const idx2 = make_index('file-two', [
+        make_version({ parent_path: '/Archive', file_name: 'report.xlsx' }),
+      ]);
+      vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue([idx1, idx2]);
+
+      await expect(
+        service.list_onedrive_file_versions(TENANT_ID, OWNER_ID, 'report.xlsx'),
+      ).rejects.toThrow(/matches 2 files.*\/Archive\/report\.xlsx.*\/Documents\/report\.xlsx/);
+    });
+
+    it('returns empty when a bare filename matches nothing', async () => {
+      const result = await service.list_onedrive_file_versions(TENANT_ID, OWNER_ID, 'unknown.xlsx');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/sharepoint/src/services/sharepoint-catalog.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-catalog.service.ts
@@ -67,7 +67,8 @@ export class SharePointCatalogService implements SharePointCatalogUseCase {
     const trimmed = file_ref.trim();
     if (!this.looks_like_path(trimmed)) {
       const direct = await this._indexes.find_by_file_id(ctx, site_id, trimmed);
-      return direct ? trimmed : undefined;
+      if (direct) return trimmed;
+      return this.match_by_file_name(ctx, site_id, trimmed);
     }
     const want = normalize_path_ref(trimmed);
     const indexes = await this._indexes.list_by_site(ctx, site_id);
@@ -77,6 +78,30 @@ export class SharePointCatalogService implements SharePointCatalogUseCase {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Matches a bare filename against every indexed version of the site's files.
+   * Throws with the candidate paths when the name maps to more than one file.
+   */
+  private async match_by_file_name(
+    ctx: TenantContext,
+    site_id: string,
+    file_name: string,
+  ): Promise<string | undefined> {
+    const matches = new Map<string, string>();
+    for (const idx of await this._indexes.list_by_site(ctx, site_id)) {
+      for (const v of idx.versions) {
+        if (v.file_name === file_name) matches.set(idx.file_id, version_logical_path(v));
+      }
+    }
+    if (matches.size > 1) {
+      const candidates = [...new Set(matches.values())].sort().join(', ');
+      throw new Error(
+        `'${file_name}' matches ${matches.size} files: ${candidates}. Pass a full path instead.`,
+      );
+    }
+    return [...matches.keys()][0];
   }
 
   /** Paths contain a slash; Graph ids do not. */

--- a/packages/sharepoint/tests/unit/services/sharepoint-catalog.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-catalog.service.test.ts
@@ -272,5 +272,47 @@ describe('SharePointCatalogService', () => {
       expect(result).toHaveLength(1);
       expect(result[0].file_name).toBe('b.docx');
     });
+
+    it('resolves a bare filename to a unique basename match', async () => {
+      const versions = [
+        make_version({ parent_path: '/Shared Documents', file_name: 'report.docx' }),
+      ];
+      const idx = make_index('file-bare', versions);
+      vi.mocked(mocks.indexes.list_by_site).mockResolvedValue([idx]);
+      vi.mocked(mocks.indexes.find_by_file_id).mockImplementation(async (_ctx, _site, fid) =>
+        fid === 'file-bare' ? idx : undefined,
+      );
+
+      const result = await service.list_sharepoint_file_versions(TENANT_ID, SITE_ID, 'report.docx');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].file_name).toBe('report.docx');
+    });
+
+    it('throws with candidate paths when a bare filename matches multiple files', async () => {
+      const idx1 = make_index('file-one', [
+        make_version({ parent_path: '/Docs', file_name: 'report.docx' }),
+      ]);
+      const idx2 = make_index('file-two', [
+        make_version({ parent_path: '/Archive', file_name: 'report.docx' }),
+      ]);
+      vi.mocked(mocks.indexes.list_by_site).mockResolvedValue([idx1, idx2]);
+
+      await expect(
+        service.list_sharepoint_file_versions(TENANT_ID, SITE_ID, 'report.docx'),
+      ).rejects.toThrow(/matches 2 files.*\/Archive\/report\.docx.*\/Docs\/report\.docx/);
+    });
+
+    it('returns empty when a bare filename matches nothing', async () => {
+      vi.mocked(mocks.indexes.list_by_site).mockResolvedValue([]);
+
+      const result = await service.list_sharepoint_file_versions(
+        TENANT_ID,
+        SITE_ID,
+        'unknown.docx',
+      );
+
+      expect(result).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
Fixes #94

Four output-correctness fixes from the E2E bundle:

1. **Wide tables fragment** - `DataTable` now enforces a terminal-width budget: columns shrink widest-first (never below header length or 8 chars) so `sharepoint list-sites`, `replicate`, `replicate --status`, and `list-versions` render one line per row with `~` truncation markers instead of wrapping.
2. **`outlook read --raw` not pipeable** - the `--raw` check is hoisted above the banner render (and covers the not-found path), so `... --raw | jq .` works. Both MIME and JSON payloads short-circuit before any decorative output.
3. **Bare-filename `list-versions`** - when the ref is not a path and no Graph item id matches, both catalog services fall back to a basename match across the owner's/site's indexes. Multiple hits throw with the candidate paths; zero hits still returns empty.
4. **Zeroed `rehydrate -s` counters** - `build_skip_result` takes the present object count and reports it as `objects_total`/`objects_skipped`, so an already-present snapshot shows e.g. `35 skipped` like the mailbox-scoped path.

### Verification
- `pnpm run build` clean (10/10)
- New tests: DataTable terminal-budget case, OneDrive + SharePoint basename fallback (unique/ambiguous/none), `build_skip_result` counts. All pass; full suite green except one pre-existing flaky timing test (`sliding-window-limiter`, passes in isolation, untouched by this change).
- Lint: no new findings (1 pre-existing warning in `graph-sharepoint-download-helpers.ts`).

No CLI flags or SDK contracts changed, so no docs updates required.