### PR TITLE
chore(release): 2.1.3

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,6 +68,12 @@ jobs:
           docker compose -f e2e/docker-compose.e2e.yml down -v --remove-orphans
           docker compose -f e2e/docker-compose.e2e.yml up -d --wait
 
+      # Redaction is what makes a public artifact safe, so it is proved before the first Graph call
+      # rather than after an upload. Uses stand-in values only and needs no secrets.
+      - name: Prove the redaction boundary holds
+        working-directory: e2e
+        run: uv run python -m atlas_e2e.self_check
+
       - name: Mask derived values
         env:
           E2E_TENANT_ID: ${{ secrets.E2E_TENANT_ID }}
@@ -107,7 +113,9 @@ jobs:
 
       # Artifacts are public downloads: GitHub's log masking does not apply to a file in a zip. The
       # transcript is written scrubbed, and this step refuses to publish it if that failed. It
-      # compares against the secrets without ever echoing them.
+      # compares against the secrets without ever echoing them. Each artifact is checked twice: as
+      # written, and with all whitespace stripped, because the CLI used to wrap long cells and a
+      # value split across two lines is not a contiguous match (issue #175).
       - name: Verify artifacts carry no tenant data
         id: leakcheck
         if: always()
@@ -121,6 +129,9 @@ jobs:
           E2E_ENCRYPTION_PASSPHRASE: ${{ secrets.E2E_ENCRYPTION_PASSPHRASE }}
         run: |
           status=0
+          strip() { tr -d '[:space:]'; }
+          flat="$(mktemp)"
+          find e2e/report.xml e2e/logs -type f 2>/dev/null -exec cat {} + | strip > "$flat"
           for name in E2E_TENANT_ID E2E_MAILBOX E2E_ONEDRIVE_OWNER E2E_SHAREPOINT_SITE \
                       E2E_CLIENT_ID E2E_CLIENT_SECRET E2E_ENCRYPTION_PASSPHRASE; do
             value="${!name}"
@@ -128,8 +139,12 @@ jobs:
             if grep -rqF -- "$value" e2e/report.xml e2e/logs 2>/dev/null; then
               echo "$name appears in an artifact; refusing to upload" >&2
               status=1
+            elif printf '%s' "$value" | strip | grep -qFf /dev/stdin "$flat"; then
+              echo "$name appears in an artifact across a line break; refusing to upload" >&2
+              status=1
             fi
           done
+          rm -f "$flat"
           [ "$status" -eq 0 ] && echo "Artifacts checked: no secret value present."
           exit "$status"
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,6 +14,16 @@ With a **local** (non-global) install, a postinstall hook links `atlas` into `/u
 
 For programmatic use in Node.js applications (custom schedulers, multi-tenant SaaS, portals), use **`@wisecom/atlas-sdk`** instead. See [Programmatic SDK](/reference/sdk). The SDK uses explicit config at construction time (no `.env` dependency) and exposes the same operations as typed methods.
 
+## Output width
+
+Tables and dashboards are laid out for the terminal width. When output is piped or redirected there is no terminal to measure, so Atlas falls back to 80 columns and long cells such as site URLs and object ids wrap onto a second line. Set `COLUMNS` to keep each row intact:
+
+```bash
+COLUMNS=200 atlas sharepoint list-sites > sites.txt
+```
+
+This matters beyond readability. Anything that post-processes the output, a log scrubber, a grep for an id, a parser, sees a wrapped value as two unrelated fragments and misses it.
+
 ## `atlas outlook`
 
 Outlook mailbox backup, restore, and management commands. All mailbox operations live under this group; cross-cutting storage and replication commands remain at the root level.
@@ -335,6 +345,8 @@ The `Type` column shows the Graph `mailboxSettings.userPurpose` value (`user`, `
 
 Back up and verify OneDrive files per user using Graph delta sync. Blobs and manifests live under the `onedrive/` prefix in the tenant bucket (see [OneDrive Backup](/onedrive-backup)). When `-o` contains `@`, Atlas resolves the mailbox to an Entra object ID via `GET /users/{email}` before touching storage keys.
 
+A snapshot is a delta: its manifest lists only what changed in that run. `restore`, `save` and `verify` therefore resolve the snapshot's **manifest chain**, the target manifest plus every older manifest for the same owner, merged newest-first and deduplicated by drive item. Restoring the newest snapshot gives the whole drive as it stood at that moment, not just the last few changed files. A file whose newest entry is a deletion stays deleted: the tombstone wins over the older stored version, so a restore never resurrects a file the user removed.
+
 ```bash
 atlas onedrive backup -o user@company.com
 atlas onedrive backup -o user@company.com --full
@@ -448,6 +460,8 @@ Application permissions `Files.Read.All` and `User.Read.All` are required for ba
 ## `atlas sharepoint`
 
 Back up, restore, and verify SharePoint document library files per site using Graph delta sync. Blobs and manifests live under the `sharepoint/` prefix in the tenant bucket. SharePoint backup is site-targeted (not user-targeted like OneDrive). The site can be specified as a full URL or a Graph site ID.
+
+As with OneDrive, a snapshot is a delta and `restore`, `save` and `verify` resolve the full manifest chain for the site. See the note under [`atlas onedrive`](#atlas-onedrive) for how tombstones and superseded versions are merged.
 
 ```bash
 atlas sharepoint backup --site https://contoso.sharepoint.com/sites/Engineering

--- a/e2e/atlas_e2e/atlas.py
+++ b/e2e/atlas_e2e/atlas.py
@@ -15,10 +15,19 @@ log = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 900
 
+# Ink wraps to `process.stdout.columns` and falls back to 80 without a TTY. The CLI honours
+# `COLUMNS` when its output is piped, so this width keeps every cell on one line.
+NO_WRAP_COLUMNS = 4096
+
 
 @dataclass(frozen=True)
 class Result:
-    """One CLI invocation: what was asked, what came back."""
+    """One CLI invocation: what was asked, what came back.
+
+    Every field is already scrubbed. `run` redacts both streams before constructing this, so no
+    consumer can reach raw CLI output: not an assertion message, not the transcript, not a future
+    code path someone adds without reading this module.
+    """
 
     argv: tuple[str, ...]
     code: int
@@ -44,8 +53,7 @@ class Cli:
         # must depend on the env vars it sets, not on whatever a developer configured locally.
         self._home = home
         home.mkdir(parents=True, exist_ok=True)
-        # Uploaded as an artifact, so it is written scrubbed rather than scrubbed later: a file that
-        # was never allowed to hold a secret cannot leak one through a forgotten code path.
+        # Commands and exit codes only, never CLI output: see `_record`.
         self._transcript = transcript
         if transcript:
             transcript.parent.mkdir(parents=True, exist_ok=True)
@@ -64,6 +72,10 @@ class Cli:
             # Non-TTY output: Ink renders a static view, which is what we want in CI logs.
             "CI": "1",
             "NO_COLOR": "1",
+            # Without a TTY Ink lays out at 80 columns and wraps long cells mid-value. Every rule in
+            # `scrub` needs the value contiguous, so a wrapped address or site URL survives
+            # redaction. A width nothing reaches keeps values on one line.
+            "COLUMNS": str(NO_WRAP_COLUMNS),
             **self._settings.cli_env(),
         }
         log.info("atlas %s", " ".join(display_argv))
@@ -75,15 +87,27 @@ class Cli:
             cwd=self._home,  # no repo-root atlas.config.json in scope
             env=env,
         )
-        result = Result(argv=display_argv, code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+        result = Result(
+            argv=display_argv,
+            code=proc.returncode,
+            stdout=scrub(proc.stdout, self._settings),
+            stderr=scrub(proc.stderr, self._settings),
+        )
         self._record(result)
         return result
 
     def _record(self, result: Result) -> None:
-        """Appends one scrubbed invocation to the transcript, when one is configured."""
+        """Appends one invocation to the transcript: the command and its exit code, no output.
+
+        The transcript is a public artifact and the CLI prints live tenant content -- owner display
+        names, document names, the tenant's site inventory. None of that is a secret value or a
+        recognisable shape, so no redaction rule can catch it, and pattern matching is the wrong
+        tool for "everything except our own fixtures". So the output is simply never written.
+        Assertions still carry the scrubbed output through `describe`.
+        """
         if not self._transcript:
             return
-        entry = f"$ atlas {' '.join(result.argv)}\n{result.out.strip()}\n[exit {result.code}]\n\n"
+        entry = f"$ atlas {' '.join(result.argv)}\n[exit {result.code}]\n\n"
         with self._transcript.open("a", encoding="utf-8") as handle:
             handle.write(scrub(entry, self._settings))
 

--- a/e2e/atlas_e2e/config.py
+++ b/e2e/atlas_e2e/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -24,21 +24,28 @@ _DEFAULTS = {
 
 @dataclass(frozen=True)
 class Settings:
-    """Everything the suite needs to talk to Graph, S3, and the CLI."""
+    """Everything the suite needs to talk to Graph, S3, and the CLI.
 
-    tenant_id: str
-    client_id: str
-    client_secret: str
-    passphrase: str
-    mailbox: str
+    Secret and tenant-identifying fields are `repr=False`: pytest prints the repr of every fixture
+    argument in a failing test's traceback, and that traceback is written verbatim into
+    `report.xml`, which is uploaded as a public artifact. GitHub masks secrets in *logs*, never in
+    a file. Non-identifying fields stay visible so a failure header still says how the run was
+    configured.
+    """
+
+    tenant_id: str = field(repr=False)
+    client_id: str = field(repr=False)
+    client_secret: str = field(repr=False)
+    passphrase: str = field(repr=False)
+    mailbox: str = field(repr=False)
     s3_endpoint: str
     s3_replica_endpoint: str
-    s3_access_key: str
-    s3_secret_key: str
+    s3_access_key: str = field(repr=False)
+    s3_secret_key: str = field(repr=False)
     s3_region: str
     cli: Path
-    onedrive_owner: str
-    sharepoint_site: str
+    onedrive_owner: str = field(repr=False)
+    sharepoint_site: str = field(repr=False)
 
     @property
     def bucket(self) -> str:

--- a/e2e/atlas_e2e/scrub.py
+++ b/e2e/atlas_e2e/scrub.py
@@ -1,8 +1,8 @@
 """Redaction for every byte this suite logs or uploads.
 
 Two audiences, one rule. GitHub masks registered secrets in *workflow logs*, but only the exact
-values it was given: a tenant id also appears as `wisecomfi-my.sharepoint.com`, a mailbox also
-appears as `/personal/miika_wisecom_fi`, and neither is masked. Artifacts get no masking at all --
+values it was given: a tenant id also appears as `contoso-my.sharepoint.com`, a mailbox also
+appears as `/personal/john_doe_example_com`, and neither is masked. Artifacts get no masking at all --
 they are raw files in a public repository.
 
 So everything passes through here, in two deliberately overlapping layers:

--- a/e2e/atlas_e2e/self_check.py
+++ b/e2e/atlas_e2e/self_check.py
@@ -1,0 +1,128 @@
+"""Proves the redaction boundary holds, before the suite is allowed near a real tenant.
+
+Everything this suite publishes is a public artifact of a public repository, so redaction is not a
+nicety. These checks run first in CI: if any of them fails the job stops before a single Graph call,
+rather than discovering the hole in an uploaded file (issues #174, #175).
+
+Run with `uv run python -m atlas_e2e.self_check`.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from atlas_e2e.atlas import Cli, Result
+from atlas_e2e.config import Settings
+from atlas_e2e.scrub import scrub
+
+# Recognisable stand-ins, none of them a real value. Each is long enough to pass the eight-character
+# floor in `scrub._literals`.
+_FAKE = Settings(
+    tenant_id="tenant-11111111",
+    client_id="client-22222222",
+    client_secret="secret-33333333",
+    passphrase="passphrase-44444444",
+    mailbox="john.doe@example.com",
+    s3_endpoint="http://127.0.0.1:9000",
+    s3_replica_endpoint="http://127.0.0.1:9002",
+    s3_access_key="access-55555555",
+    s3_secret_key="secretkey-66666666",
+    s3_region="us-east-1",
+    cli=Path("/nonexistent/cli.mjs"),
+    onedrive_owner="jane.roe@example.com",
+    sharepoint_site="contoso.sharepoint.com,00000000-0000-0000-0000-000000000000",
+)
+
+_SECRET_VALUES = (
+    _FAKE.tenant_id,
+    _FAKE.client_id,
+    _FAKE.client_secret,
+    _FAKE.passphrase,
+    _FAKE.mailbox,
+    _FAKE.onedrive_owner,
+    _FAKE.sharepoint_site,
+    _FAKE.s3_access_key,
+    _FAKE.s3_secret_key,
+)
+
+
+def check_settings_repr_hides_secrets() -> None:
+    """pytest prints fixture reprs into `report.xml`; none of them may carry a secret (#174)."""
+    rendered = repr(_FAKE)
+    leaked = [value for value in _SECRET_VALUES if value in rendered]
+    assert not leaked, f"Settings repr exposes {len(leaked)} secret field(s)"
+    assert "s3_region" in rendered, "the repr lost every field; failure headers say nothing now"
+
+
+def check_scrub_redacts_every_secret() -> None:
+    """Each configured value, and the shapes derived from it, must not survive `scrub`."""
+    text = " ".join(_SECRET_VALUES) + " https://contoso.sharepoint.com/sites/Example"
+    cleaned = scrub(text, _FAKE)
+    leaked = [value for value in _SECRET_VALUES if value in cleaned]
+    assert not leaked, f"scrub left {len(leaked)} secret value(s) intact"
+    assert "sharepoint.com" not in cleaned, "scrub left a tenant hostname intact"
+
+
+def check_result_streams_are_scrubbed() -> None:
+    """`Cli.run` must redact both streams, so no consumer can reach raw CLI output (#175)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        stub = root / "stub.mjs"
+        stub.write_text(
+            "process.stdout.write(process.env.ATLAS_TENANT_ID + ' out\\n');\n"
+            "process.stderr.write(process.env.ATLAS_CLIENT_SECRET + ' err\\n');\n",
+            encoding="utf-8",
+        )
+        transcript = root / "logs" / "cli.log"
+        settings = Settings(**{**_FAKE.__dict__, "cli": stub})
+        cli = Cli(settings, root / "home", transcript)
+
+        result = cli.run("anything")
+
+        assert _FAKE.tenant_id not in result.out, "stdout reached the caller unscrubbed"
+        assert _FAKE.client_secret not in result.out, "stderr reached the caller unscrubbed"
+        assert _FAKE.tenant_id not in result.describe(), "describe() exposed stdout"
+        assert _FAKE.client_secret not in result.describe(), "describe() exposed stderr"
+
+        written = transcript.read_text(encoding="utf-8")
+        assert "anything" in written, "the transcript lost the command it recorded"
+        assert "[exit 0]" in written, "the transcript lost the exit code"
+        assert " out" not in written, "the transcript recorded CLI stdout"
+        assert " err" not in written, "the transcript recorded CLI stderr"
+
+
+def check_transcript_never_holds_output() -> None:
+    """Even a hand-built Result must not put CLI output in the transcript."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        transcript = root / "logs" / "cli.log"
+        cli = Cli(_FAKE, root / "home", transcript)
+        noisy = Result(argv=("status",), code=2, stdout="Report.docx stored", stderr="John Doe")
+
+        cli._record(noisy)  # noqa: SLF001 - the guarantee under test is internal
+
+        written = transcript.read_text(encoding="utf-8")
+        assert "Report.docx" not in written, "a file name reached the transcript"
+        assert "John Doe" not in written, "a display name reached the transcript"
+        assert "[exit 2]" in written, "the transcript lost the exit code"
+
+
+CHECKS = (
+    check_settings_repr_hides_secrets,
+    check_scrub_redacts_every_secret,
+    check_result_streams_are_scrubbed,
+    check_transcript_never_holds_output,
+)
+
+
+def main() -> None:
+    """Runs every check, reporting the first failure by name."""
+    for check in CHECKS:
+        check()
+        print(f"ok  {check.__name__}")
+    print(f"{len(CHECKS)} redaction check(s) passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-cli",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "CLI for Atlas — secure Microsoft 365 backup and restore to S3-compatible storage.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",

--- a/packages/cli/src/ui/render.ts
+++ b/packages/cli/src/ui/render.ts
@@ -3,6 +3,28 @@ import type { Instance, RenderOptions } from 'ink';
 import type { ReactElement } from 'react';
 
 /**
+ * Ink and the `DataTable` width budget both read `process.stdout.columns`, which Node populates
+ * only for a TTY. Piped or redirected output therefore falls back to 80 columns and truncates long
+ * cells such as site URLs. Honouring `COLUMNS` is the POSIX convention and lets
+ * `atlas ... > out.txt` keep rows intact.
+ *
+ * This runs at module load, so it must never throw: on some stdout implementations `columns` is a
+ * read-only accessor, and an exception here would take down every command before it starts.
+ */
+function apply_columns_override(): void {
+  if (process.stdout.isTTY) return;
+  const columns = Number(process.env['COLUMNS']);
+  if (!Number.isInteger(columns) || columns <= 0) return;
+  try {
+    Object.defineProperty(process.stdout, 'columns', { value: columns, configurable: true });
+  } catch {
+    // A stdout that refuses the override keeps its own width; layout is cosmetic, crashing is not.
+  }
+}
+
+apply_columns_override();
+
+/**
  * Renders a one-shot view (banner, table, summary) and resolves once the
  * final frame is flushed. Safe in non-TTY environments: Ink writes plain
  * lines without ANSI redraw sequences.

--- a/packages/cli/tests/unit/ui/components/data-table.test.tsx
+++ b/packages/cli/tests/unit/ui/components/data-table.test.tsx
@@ -74,4 +74,24 @@ describe('DataTable', () => {
       });
     }
   });
+
+  // #175: at the 80-column fallback a site URL is cut to `https://contoso.sharepoint~`, which no
+  // longer matches a hostname pattern, so anything scrubbing the output misses the tenant name.
+  it('keeps a long cell intact when the width budget is wide', () => {
+    const original_columns = process.stdout.columns;
+    Object.defineProperty(process.stdout, 'columns', { value: 4096, configurable: true });
+    try {
+      const wide: TableColumn<{ url: string }>[] = [{ key: 'url', header: 'Url' }];
+      const url = 'https://contoso.sharepoint.com/sites/ExampleLongSiteName';
+      const { lastFrame } = render(<DataTable columns={wide} rows={[{ url }]} />);
+
+      expect(lastFrame()).toContain(url);
+      expect(lastFrame()).not.toContain('~');
+    } finally {
+      Object.defineProperty(process.stdout, 'columns', {
+        value: original_columns,
+        configurable: true,
+      });
+    }
+  });
 });

--- a/packages/cli/tests/unit/ui/render-columns.test.ts
+++ b/packages/cli/tests/unit/ui/render-columns.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+
+/**
+ * Exercises the module-load side effect in `@/ui/render`: the override runs once on import, so each
+ * case needs the registry reset and the module imported again. A static import would apply it once
+ * for the whole file and test nothing (issue #175).
+ */
+async function load_render_module(): Promise<void> {
+  vi.resetModules();
+  await import('@/ui/render');
+}
+
+describe('render column override', () => {
+  const original_columns = process.stdout.columns;
+  const original_is_tty = process.stdout.isTTY;
+  const original_env = process.env['COLUMNS'];
+
+  function set_stdout(columns: number | undefined, is_tty: boolean): void {
+    Object.defineProperty(process.stdout, 'columns', { value: columns, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: is_tty, configurable: true });
+  }
+
+  beforeEach(() => {
+    delete process.env['COLUMNS'];
+  });
+
+  afterEach(() => {
+    set_stdout(original_columns, original_is_tty);
+    if (original_env === undefined) delete process.env['COLUMNS'];
+    else process.env['COLUMNS'] = original_env;
+  });
+
+  it('adopts COLUMNS when stdout is piped', async () => {
+    set_stdout(undefined, false);
+    process.env['COLUMNS'] = '4096';
+
+    await load_render_module();
+
+    expect(process.stdout.columns).toBe(4096);
+  });
+
+  it('leaves a real terminal alone', async () => {
+    set_stdout(120, true);
+    process.env['COLUMNS'] = '4096';
+
+    await load_render_module();
+
+    expect(process.stdout.columns).toBe(120);
+  });
+
+  it('ignores a COLUMNS value that is not a positive integer', async () => {
+    set_stdout(undefined, false);
+    process.env['COLUMNS'] = 'wide';
+
+    await load_render_module();
+
+    expect(process.stdout.columns).toBeUndefined();
+  });
+
+  it('ignores a zero or negative COLUMNS', async () => {
+    set_stdout(undefined, false);
+    process.env['COLUMNS'] = '0';
+
+    await load_render_module();
+
+    expect(process.stdout.columns).toBeUndefined();
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-core",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/services/shared/drive-snapshot-chain.ts
+++ b/packages/core/src/services/shared/drive-snapshot-chain.ts
@@ -1,0 +1,63 @@
+/**
+ * Folds a chain of drive delta manifests into one point-in-time view.
+ *
+ * OneDrive and SharePoint back up incrementally: a snapshot manifest lists only the items that
+ * changed in that run. Restoring, exporting or verifying a single manifest therefore covers only
+ * the last delta and silently ignores everything carried over from earlier runs (issue #173).
+ * Outlook has always folded its chain; these helpers give the drive workloads the same semantics.
+ */
+
+/** The shape both drive manifests share: entries keyed by drive item id. */
+export interface DriveChainManifest<Entry> {
+  readonly snapshot_id: string;
+  readonly entries: readonly Entry[];
+}
+
+/** One folded entry, tagged with the snapshot that actually recorded it. */
+export interface DriveChainEntry<Entry> {
+  readonly snapshot_id: string;
+  readonly entry: Entry;
+}
+
+/**
+ * Reduces a newest-first chain to the newest state of every file.
+ *
+ * A file keeps the first entry seen, which is its newest version. Tombstones are entries like any
+ * other: a file whose newest entry is a deletion stays in the result carrying `change_type:
+ * 'deleted'`, so the existing restore and export filters skip it instead of resurrecting a file the
+ * user removed. Callers that need only the entries map over `.entry`.
+ */
+export function fold_drive_snapshot_chain<Entry extends { readonly file_id: string }>(
+  manifests: readonly DriveChainManifest<Entry>[],
+): DriveChainEntry<Entry>[] {
+  const seen = new Set<string>();
+  const folded: DriveChainEntry<Entry>[] = [];
+
+  for (const manifest of manifests) {
+    for (const entry of manifest.entries) {
+      if (seen.has(entry.file_id)) continue;
+      seen.add(entry.file_id);
+      folded.push({ snapshot_id: manifest.snapshot_id, entry });
+    }
+  }
+
+  return folded;
+}
+
+/**
+ * Selects the target manifest and every older one for the same scope, newest-first.
+ *
+ * `created_at` ties are broken by keeping the target first, so a chain never depends on the order
+ * the storage listing happened to return.
+ */
+export function select_drive_manifest_chain<
+  Manifest extends { readonly snapshot_id: string; readonly created_at: Date },
+>(all: readonly Manifest[], target: Manifest): Manifest[] {
+  const cutoff = target.created_at.getTime();
+  const older = all.filter(
+    (candidate) =>
+      candidate.snapshot_id !== target.snapshot_id && candidate.created_at.getTime() <= cutoff,
+  );
+  older.sort((a, b) => b.created_at.getTime() - a.created_at.getTime());
+  return [target, ...older];
+}

--- a/packages/core/src/services/shared/index.ts
+++ b/packages/core/src/services/shared/index.ts
@@ -9,5 +9,10 @@ export {
   filter_manifests_by_date,
   merge_snapshot_entries,
 } from '@/services/shared/manifest-entry-merger';
+export {
+  fold_drive_snapshot_chain,
+  select_drive_manifest_chain,
+} from '@/services/shared/drive-snapshot-chain';
+export type { DriveChainEntry, DriveChainManifest } from '@/services/shared/drive-snapshot-chain';
 export { stream_decrypt_from_storage } from '@/services/shared/stream-decrypt';
 export type { StreamDecryptResult } from '@/services/shared/stream-decrypt';

--- a/packages/core/tests/unit/services/shared/drive-snapshot-chain.test.ts
+++ b/packages/core/tests/unit/services/shared/drive-snapshot-chain.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fold_drive_snapshot_chain,
+  select_drive_manifest_chain,
+} from '@/services/shared/drive-snapshot-chain';
+
+interface TestEntry {
+  readonly file_id: string;
+  readonly change_type: 'created' | 'updated' | 'deleted';
+  readonly checksum?: string;
+}
+
+function manifest(
+  snapshot_id: string,
+  created_at: string,
+  entries: TestEntry[],
+): { snapshot_id: string; created_at: Date; entries: TestEntry[] } {
+  return { snapshot_id, created_at: new Date(created_at), entries };
+}
+
+const CREATED = (file_id: string, checksum: string): TestEntry => ({
+  file_id,
+  change_type: 'created',
+  checksum,
+});
+const UPDATED = (file_id: string, checksum: string): TestEntry => ({
+  file_id,
+  change_type: 'updated',
+  checksum,
+});
+const DELETED = (file_id: string): TestEntry => ({ file_id, change_type: 'deleted' });
+
+describe('fold_drive_snapshot_chain', () => {
+  it('carries forward a file that changed only in an older snapshot', () => {
+    const chain = [
+      manifest('snap-2', '2026-02-01', [UPDATED('small', 'v2')]),
+      manifest('snap-1', '2026-01-01', [CREATED('small', 'v1'), CREATED('large', 'big')]),
+    ];
+
+    const folded = fold_drive_snapshot_chain(chain);
+
+    expect(folded.map((f) => f.entry.file_id).sort()).toEqual(['large', 'small']);
+  });
+
+  it('keeps the newest version of a file that changed more than once', () => {
+    const chain = [
+      manifest('snap-3', '2026-03-01', [UPDATED('doc', 'v3')]),
+      manifest('snap-2', '2026-02-01', [UPDATED('doc', 'v2')]),
+      manifest('snap-1', '2026-01-01', [CREATED('doc', 'v1')]),
+    ];
+
+    const folded = fold_drive_snapshot_chain(chain);
+
+    expect(folded).toHaveLength(1);
+    expect(folded[0]?.entry.checksum).toBe('v3');
+  });
+
+  it('tags each entry with the snapshot that recorded it, not the target', () => {
+    const chain = [
+      manifest('snap-2', '2026-02-01', [UPDATED('small', 'v2')]),
+      manifest('snap-1', '2026-01-01', [CREATED('large', 'big')]),
+    ];
+
+    const by_file = Object.fromEntries(
+      fold_drive_snapshot_chain(chain).map((f) => [f.entry.file_id, f.snapshot_id]),
+    );
+
+    expect(by_file['small']).toBe('snap-2');
+    expect(by_file['large']).toBe('snap-1');
+  });
+
+  it('lets a newer tombstone win over an older stored version', () => {
+    const chain = [
+      manifest('snap-2', '2026-02-01', [DELETED('gone')]),
+      manifest('snap-1', '2026-01-01', [CREATED('gone', 'v1')]),
+    ];
+
+    const folded = fold_drive_snapshot_chain(chain);
+
+    expect(folded).toHaveLength(1);
+    expect(folded[0]?.entry.change_type).toBe('deleted');
+  });
+
+  it('restores a file that was deleted and then re-created', () => {
+    const chain = [
+      manifest('snap-3', '2026-03-01', [CREATED('again', 'v2')]),
+      manifest('snap-2', '2026-02-01', [DELETED('again')]),
+      manifest('snap-1', '2026-01-01', [CREATED('again', 'v1')]),
+    ];
+
+    const folded = fold_drive_snapshot_chain(chain);
+
+    expect(folded).toHaveLength(1);
+    expect(folded[0]?.entry.change_type).toBe('created');
+    expect(folded[0]?.entry.checksum).toBe('v2');
+  });
+
+  it('returns nothing for an empty chain', () => {
+    expect(fold_drive_snapshot_chain([])).toEqual([]);
+  });
+});
+
+describe('select_drive_manifest_chain', () => {
+  const snap1 = manifest('snap-1', '2026-01-01', []);
+  const snap2 = manifest('snap-2', '2026-02-01', []);
+  const snap3 = manifest('snap-3', '2026-03-01', []);
+
+  it('puts the target first and every older manifest after it, newest-first', () => {
+    const chain = select_drive_manifest_chain([snap1, snap3, snap2], snap3);
+
+    expect(chain.map((m) => m.snapshot_id)).toEqual(['snap-3', 'snap-2', 'snap-1']);
+  });
+
+  it('excludes manifests newer than the target, so an old snapshot stays a point in time', () => {
+    const chain = select_drive_manifest_chain([snap1, snap2, snap3], snap2);
+
+    expect(chain.map((m) => m.snapshot_id)).toEqual(['snap-2', 'snap-1']);
+  });
+
+  it('never repeats the target when the listing already contains it', () => {
+    const chain = select_drive_manifest_chain([snap1, snap2], snap2);
+
+    expect(chain.filter((m) => m.snapshot_id === 'snap-2')).toHaveLength(1);
+  });
+
+  it('keeps the target ahead of another manifest sharing its timestamp', () => {
+    const tie = manifest('snap-tie', '2026-02-01', []);
+
+    const chain = select_drive_manifest_chain([tie, snap2], snap2);
+
+    expect(chain[0]?.snapshot_id).toBe('snap-2');
+    expect(chain.map((m) => m.snapshot_id)).toContain('snap-tie');
+  });
+});

--- a/packages/m365-graph/package.json
+++ b/packages/m365-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-m365-graph",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/onedrive/package.json
+++ b/packages/onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-onedrive",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/onedrive/src/services/onedrive-manifest-chain.ts
+++ b/packages/onedrive/src/services/onedrive-manifest-chain.ts
@@ -1,0 +1,45 @@
+import {
+  fold_drive_snapshot_chain,
+  select_drive_manifest_chain,
+} from '@wisecom/atlas-core/services/shared/drive-snapshot-chain';
+import type { DriveChainEntry } from '@wisecom/atlas-core/services/shared/drive-snapshot-chain';
+import type {
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  TenantContext,
+} from '@wisecom/atlas-types';
+
+export type OneDriveChainEntry = DriveChainEntry<OneDriveManifestEntry>;
+
+/**
+ * Resolves a snapshot to the newest state of every file the owner had at that point.
+ *
+ * A OneDrive manifest holds one delta, so reading it alone loses every file that last changed in an
+ * earlier run (issue #173). This loads the target manifest plus every older manifest for the same
+ * owner and folds them newest-first.
+ */
+export async function load_onedrive_chain_entries(
+  manifests: OneDriveManifestRepository,
+  ctx: TenantContext,
+  owner_id: string,
+  snapshot_id: string,
+): Promise<{ manifest: OneDriveSnapshotManifest; entries: OneDriveChainEntry[] }> {
+  const target = await manifests.find_by_snapshot(ctx, owner_id, snapshot_id);
+  if (!target) {
+    throw new Error(`No OneDrive manifest found for snapshot ${snapshot_id}`);
+  }
+
+  const all = await manifests.list_snapshots_by_owner(ctx, owner_id);
+  const chain = select_drive_manifest_chain(all, target);
+  return { manifest: target, entries: fold_drive_snapshot_chain(chain) };
+}
+
+/** Drops tombstones and entries with no stored blob: what a restore or export can actually write. */
+export function restorable_entries(
+  entries: readonly OneDriveChainEntry[],
+): OneDriveManifestEntry[] {
+  return entries
+    .filter(({ entry }) => entry.change_type !== 'deleted' && entry.storage_key)
+    .map(({ entry }) => entry);
+}

--- a/packages/onedrive/src/services/onedrive-restore.service.ts
+++ b/packages/onedrive/src/services/onedrive-restore.service.ts
@@ -32,6 +32,10 @@ import {
   plaintext_sha256_equals_expected,
 } from '@/services/onedrive-restore-integrity';
 import { filter_onedrive_entries } from '@/services/onedrive-entry-filter';
+import {
+  load_onedrive_chain_entries,
+  restorable_entries,
+} from '@/services/onedrive-manifest-chain';
 import { empty_restore_result } from '@/services/onedrive-restore-result';
 
 const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
@@ -58,10 +62,12 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
     }
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
-      const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, options.snapshot_id);
-      if (!manifest) {
-        throw new Error(`Snapshot ${options.snapshot_id} not found`);
-      }
+      const chain = await load_onedrive_chain_entries(
+        this._manifests,
+        ctx,
+        owner_id,
+        options.snapshot_id,
+      );
 
       const target_owner = options.target_owner_id ?? owner_id;
       const drives = await this._connector.list_drives(tenant_id, target_owner);
@@ -72,7 +78,10 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       const drive_id = primary_drive.drive_id;
 
       const conflict = options.conflict_behavior ?? 'rename';
-      const entries = filter_onedrive_entries(manifest.entries, options.file_filter);
+      const restorable = filter_onedrive_entries(
+        restorable_entries(chain.entries),
+        options.file_filter,
+      );
       const folder_ids = new Map<string, string>();
       folder_ids.set('/', 'root');
 
@@ -80,18 +89,15 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       let files_skipped = 0;
       const errors: string[] = [];
 
-      const sorted_entries = [...entries].filter(
-        (e) => e.change_type !== 'deleted' && e.storage_key,
-      );
       emit_operation_progress(options, {
         operation: 'restore',
         workload: 'onedrive',
         phase: 'processing',
         processed: 0,
-        total: sorted_entries.length,
+        total: restorable.length,
       });
 
-      for (const entry of sorted_entries) {
+      for (const entry of restorable) {
         if (options.should_interrupt?.() === true) break;
         const result = await this.restore_single_entry(
           tenant_id,
@@ -113,7 +119,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
           workload: 'onedrive',
           phase: 'processing',
           processed: files_restored + files_skipped,
-          total: sorted_entries.length,
+          total: restorable.length,
           current: entry.file_name,
         });
       }
@@ -124,8 +130,8 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
         'restore',
         'onedrive',
         files_restored + files_skipped,
-        sorted_entries.length,
-        files_restored + files_skipped < sorted_entries.length,
+        restorable.length,
+        files_restored + files_skipped < restorable.length,
       );
 
       return {

--- a/packages/onedrive/src/services/onedrive-save.service.ts
+++ b/packages/onedrive/src/services/onedrive-save.service.ts
@@ -31,6 +31,10 @@ import {
   verify_streaming_checksum,
 } from '@/services/onedrive-restore-streaming';
 import { filter_onedrive_entries } from '@/services/onedrive-entry-filter';
+import {
+  load_onedrive_chain_entries,
+  restorable_entries,
+} from '@/services/onedrive-manifest-chain';
 
 @injectable()
 export class OneDriveSaveService implements OneDriveSaveUseCase {
@@ -53,13 +57,16 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
     }
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
-      const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, options.snapshot_id);
-      if (!manifest) {
-        throw new Error(`Snapshot ${options.snapshot_id} not found for owner ${owner_id}`);
-      }
-
-      const entries = filter_onedrive_entries(manifest.entries, options.file_filter);
-      const restorable = entries.filter((e) => e.change_type !== 'deleted' && e.storage_key);
+      const chain = await load_onedrive_chain_entries(
+        this._manifests,
+        ctx,
+        owner_id,
+        options.snapshot_id,
+      );
+      const restorable = filter_onedrive_entries(
+        restorable_entries(chain.entries),
+        options.file_filter,
+      );
 
       if (restorable.length === 0) {
         const interrupted = finish_operation_progress(options, 'save', 'onedrive', 0, 0);

--- a/packages/onedrive/src/services/onedrive-verification.service.ts
+++ b/packages/onedrive/src/services/onedrive-verification.service.ts
@@ -21,6 +21,7 @@ import {
   ONEDRIVE_MANIFEST_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
+import { load_onedrive_chain_entries } from '@/services/onedrive-manifest-chain';
 
 const HASH_CHUNK_SIZE = 64 * 1024 * 1024;
 
@@ -56,10 +57,15 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
     }
     const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
-      const manifest = await this._manifests.find_by_snapshot(ctx, owner_id, snapshot_id);
-      if (!manifest) {
-        throw new Error(`No OneDrive manifest found for snapshot ${snapshot_id}`);
-      }
+      // The chain, not the single manifest: a snapshot inherits every file that last changed in an
+      // earlier run, and verifying only the target would report those as checked when they were
+      // never looked at (issue #173).
+      const { manifest, entries } = await load_onedrive_chain_entries(
+        this._manifests,
+        ctx,
+        owner_id,
+        snapshot_id,
+      );
 
       const failed_file_ids: string[] = [];
       const index_issues: string[] = [];
@@ -70,16 +76,18 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
         workload: 'onedrive',
         phase: 'processing',
         processed: 0,
-        total: manifest.entries.length,
+        total: entries.length,
       });
 
-      for (const entry of manifest.entries) {
+      for (const { snapshot_id: source_snapshot, entry } of entries) {
         if (options.should_interrupt?.() === true) break;
         const idx = await this._indexes.find_by_file_id(ctx, manifest.owner_id, entry.file_id);
-        const has_version = idx?.versions.some((v) => v.snapshot_id === snapshot_id);
+        // Against the snapshot that recorded the entry, not the one being verified: a carried-over
+        // file has its index row under the older snapshot.
+        const has_version = idx?.versions.some((v) => v.snapshot_id === source_snapshot);
         if (!has_version) {
           index_issues.push(
-            `missing index version for file ${entry.file_id} snapshot ${snapshot_id}`,
+            `missing index version for file ${entry.file_id} snapshot ${source_snapshot}`,
           );
         }
 
@@ -94,7 +102,7 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
           workload: 'onedrive',
           phase: 'processing',
           processed,
-          total: manifest.entries.length,
+          total: entries.length,
           current: entry.file_name,
         });
       }
@@ -103,8 +111,8 @@ export class OneDriveVerificationService implements OneDriveVerificationUseCase 
         'verify',
         'onedrive',
         processed,
-        manifest.entries.length,
-        processed < manifest.entries.length,
+        entries.length,
+        processed < entries.length,
       );
 
       return {

--- a/packages/onedrive/tests/unit/services/onedrive-save.service.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-save.service.test.ts
@@ -108,6 +108,7 @@ describe('OneDriveSaveService', () => {
 
     mock_manifests = {
       find_by_snapshot: vi.fn(),
+      list_snapshots_by_owner: vi.fn().mockResolvedValue([]),
       list_manifests: vi.fn().mockResolvedValue([]),
       save_manifest: vi.fn(),
     } as unknown as OneDriveManifestRepository;
@@ -137,6 +138,59 @@ describe('OneDriveSaveService', () => {
       expect(result.output_path).toBe('/tmp/test-save.zip');
     });
 
+    // #173: a delta snapshot lists only what changed, so an export that reads one manifest loses
+    // every file whose last change was an earlier run.
+    it('exports a file carried over from an older snapshot', async () => {
+      const newest = make_manifest([make_entry({ file_id: 'file-1', file_name: 'report.docx' })], {
+        snapshot_id: 'od-snap-2',
+        created_at: new Date('2025-03-16T10:00:00Z'),
+      });
+      const older = make_manifest([make_entry({ file_id: 'file-2', file_name: 'budget.xlsx' })]);
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(newest);
+      vi.mocked(mock_manifests.list_snapshots_by_owner).mockResolvedValue([newest, older]);
+
+      const result = await service.save_snapshot('test-tenant', 'owner-1', {
+        snapshot_id: 'od-snap-2',
+        output_path: '/tmp/test-save.zip',
+      });
+
+      expect(result.files_saved).toBe(2);
+    });
+
+    it('does not export a file the newest snapshot records as deleted', async () => {
+      const newest = make_manifest(
+        [make_entry({ file_id: 'file-2', change_type: 'deleted', storage_key: undefined })],
+        { snapshot_id: 'od-snap-2', created_at: new Date('2025-03-16T10:00:00Z') },
+      );
+      const older = make_manifest([make_entry({ file_id: 'file-2', file_name: 'budget.xlsx' })]);
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(newest);
+      vi.mocked(mock_manifests.list_snapshots_by_owner).mockResolvedValue([newest, older]);
+
+      const result = await service.save_snapshot('test-tenant', 'owner-1', {
+        snapshot_id: 'od-snap-2',
+        output_path: '/tmp/test-save.zip',
+      });
+
+      expect(result.files_saved).toBe(0);
+    });
+
+    it('ignores snapshots newer than the one being exported', async () => {
+      const target = make_manifest([make_entry({ file_id: 'file-1' })]);
+      const newer = make_manifest([make_entry({ file_id: 'file-9', file_name: 'later.docx' })], {
+        snapshot_id: 'od-snap-9',
+        created_at: new Date('2025-04-01T10:00:00Z'),
+      });
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(target);
+      vi.mocked(mock_manifests.list_snapshots_by_owner).mockResolvedValue([newer, target]);
+
+      const result = await service.save_snapshot('test-tenant', 'owner-1', {
+        snapshot_id: 'od-snap-1',
+        output_path: '/tmp/test-save.zip',
+      });
+
+      expect(result.files_saved).toBe(1);
+    });
+
     it('returns empty result when no restorable entries', async () => {
       const entries = [make_entry({ change_type: 'deleted', storage_key: undefined })];
       const manifest = make_manifest(entries);
@@ -155,7 +209,7 @@ describe('OneDriveSaveService', () => {
 
       await expect(
         service.save_snapshot('test-tenant', 'owner-1', { snapshot_id: 'od-snap-bad' }),
-      ).rejects.toThrow('Snapshot od-snap-bad not found');
+      ).rejects.toThrow('No OneDrive manifest found for snapshot od-snap-bad');
     });
 
     it('filters entries by file_filter', async () => {

--- a/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
+++ b/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
@@ -60,6 +60,7 @@ function make_context(storage: TenantContext['storage']): TenantContext {
 function make_manifest_repository(manifest: OneDriveSnapshotManifest): OneDriveManifestRepository {
   return {
     find_by_snapshot: vi.fn().mockResolvedValue(manifest),
+    list_snapshots_by_owner: vi.fn().mockResolvedValue([]),
   } as unknown as OneDriveManifestRepository;
 }
 

--- a/packages/outlook/package.json
+++ b/packages/outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-outlook",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-s3",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-sdk",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Programmatic API for embedding Atlas M365 backup and restore in Node.js applications.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",

--- a/packages/sharepoint/package.json
+++ b/packages/sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-sharepoint",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sharepoint/src/services/sharepoint-manifest-chain.ts
+++ b/packages/sharepoint/src/services/sharepoint-manifest-chain.ts
@@ -1,0 +1,45 @@
+import {
+  fold_drive_snapshot_chain,
+  select_drive_manifest_chain,
+} from '@wisecom/atlas-core/services/shared/drive-snapshot-chain';
+import type { DriveChainEntry } from '@wisecom/atlas-core/services/shared/drive-snapshot-chain';
+import type {
+  SharePointManifestEntry,
+  SharePointManifestRepository,
+  SharePointSnapshotManifest,
+  TenantContext,
+} from '@wisecom/atlas-types';
+
+export type SharePointChainEntry = DriveChainEntry<SharePointManifestEntry>;
+
+/**
+ * Resolves a snapshot to the newest state of every file the site had at that point.
+ *
+ * A SharePoint manifest holds one delta, so reading it alone loses every file that last changed in
+ * an earlier run (issue #173). This loads the target manifest plus every older manifest for the
+ * same site and folds them newest-first.
+ */
+export async function load_sharepoint_chain_entries(
+  manifests: SharePointManifestRepository,
+  ctx: TenantContext,
+  site_id: string,
+  snapshot_id: string,
+): Promise<{ manifest: SharePointSnapshotManifest; entries: SharePointChainEntry[] }> {
+  const target = await manifests.find_by_snapshot(ctx, site_id, snapshot_id);
+  if (!target) {
+    throw new Error(`No SharePoint manifest found for snapshot ${snapshot_id}`);
+  }
+
+  const all = await manifests.list_snapshots_by_site(ctx, site_id);
+  const chain = select_drive_manifest_chain(all, target);
+  return { manifest: target, entries: fold_drive_snapshot_chain(chain) };
+}
+
+/** Drops tombstones and entries with no stored blob: what a restore or export can actually write. */
+export function restorable_entries(
+  entries: readonly SharePointChainEntry[],
+): SharePointManifestEntry[] {
+  return entries
+    .filter(({ entry }) => entry.change_type !== 'deleted' && entry.storage_key)
+    .map(({ entry }) => entry);
+}

--- a/packages/sharepoint/src/services/sharepoint-restore-folder-path.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore-folder-path.ts
@@ -1,0 +1,61 @@
+import type { SharePointSiteConnector } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+/**
+ * Resolves a manifest `parent_path` to a drive item id, creating the folders that are missing.
+ *
+ * `folder_ids` is the per-restore memo. Keys are `drive_id:path` because one snapshot spans several
+ * document libraries and the same path means a different folder in each. Returns undefined when a
+ * segment could not be created; the caller reports the entry as skipped.
+ */
+export async function ensure_sharepoint_folder_path(
+  connector: SharePointSiteConnector,
+  tenant_id: string,
+  site_id: string,
+  drive_id: string,
+  path: string,
+  folder_ids: Map<string, string>,
+): Promise<string | undefined> {
+  const normalized = path.length === 0 || path === '.' ? '/' : path;
+  const cache_key = `${drive_id}:${normalized}`;
+  const cached = folder_ids.get(cache_key);
+  if (cached !== undefined) return cached;
+
+  if (normalized === '/') {
+    folder_ids.set(cache_key, 'root');
+    return 'root';
+  }
+
+  const segments = normalized.split('/').filter(Boolean);
+  let current_path = '';
+  let parent_id = 'root';
+
+  for (const segment of segments) {
+    current_path = current_path ? `${current_path}/${segment}` : `/${segment}`;
+    const segment_key = `${drive_id}:${current_path}`;
+    const known = folder_ids.get(segment_key);
+    if (known !== undefined) {
+      parent_id = known;
+      continue;
+    }
+
+    try {
+      const folder_id = await connector.create_folder(
+        tenant_id,
+        site_id,
+        drive_id,
+        parent_id,
+        segment,
+      );
+      folder_ids.set(segment_key, folder_id);
+      parent_id = folder_id;
+    } catch (err) {
+      logger.warn(
+        `Failed to create folder ${current_path} in drive ${drive_id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  return parent_id;
+}

--- a/packages/sharepoint/src/services/sharepoint-restore.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore.service.ts
@@ -31,6 +31,11 @@ import {
   resolve_destination_library,
 } from '@/services/sharepoint-restore-target';
 import { filter_sharepoint_entries } from '@/services/sharepoint-entry-filter';
+import {
+  load_sharepoint_chain_entries,
+  restorable_entries,
+} from '@/services/sharepoint-manifest-chain';
+import { ensure_sharepoint_folder_path } from '@/services/sharepoint-restore-folder-path';
 
 const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
 
@@ -65,14 +70,15 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
     }
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
-      const manifest = await this._manifests.find_by_snapshot(ctx, site_id, options.snapshot_id);
-      if (!manifest) {
-        throw new Error(`Snapshot ${options.snapshot_id} not found for site ${site_id}`);
-      }
+      const chain = await load_sharepoint_chain_entries(
+        this._manifests,
+        ctx,
+        site_id,
+        options.snapshot_id,
+      );
 
       const target_site = options.target_site_id ?? site_id;
       const conflict = options.conflict_behavior ?? 'rename';
-      const entries = filter_sharepoint_entries(manifest.entries, options.file_filter);
 
       // Entry drive ids belong to the source site, so a cross-site restore has to
       // re-point every upload at a library of the target site.
@@ -93,7 +99,10 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
       let files_skipped = 0;
       const errors: string[] = [];
 
-      const restorable = [...entries].filter((e) => e.change_type !== 'deleted' && e.storage_key);
+      const restorable = filter_sharepoint_entries(
+        restorable_entries(chain.entries),
+        options.file_filter,
+      );
       const routing: EntryRouting = {
         cross_site,
         target_libraries,
@@ -215,7 +224,8 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
     errors: string[],
   ): Promise<'restored' | 'skipped'> {
     try {
-      const parent_id = await this.ensure_folder_path(
+      const parent_id = await ensure_sharepoint_folder_path(
+        this._connector,
         tenant_id,
         target_site,
         destination_drive_id,
@@ -273,56 +283,6 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
       logger.warn(`Skipped ${entry.file_name}: ${msg}`);
       return 'skipped';
     }
-  }
-
-  private async ensure_folder_path(
-    tenant_id: string,
-    site_id: string,
-    drive_id: string,
-    path: string,
-    folder_ids: Map<string, string>,
-  ): Promise<string | undefined> {
-    const normalized = path.length === 0 || path === '.' ? '/' : path;
-    const cache_key = `${drive_id}:${normalized}`;
-    if (folder_ids.has(cache_key)) return folder_ids.get(cache_key)!;
-
-    // Root always resolves to 'root'
-    if (normalized === '/') {
-      folder_ids.set(cache_key, 'root');
-      return 'root';
-    }
-
-    const segments = normalized.split('/').filter(Boolean);
-    let current_path = '';
-    let parent_id = 'root';
-
-    for (const segment of segments) {
-      current_path = current_path ? `${current_path}/${segment}` : `/${segment}`;
-      const segment_key = `${drive_id}:${current_path}`;
-      if (folder_ids.has(segment_key)) {
-        parent_id = folder_ids.get(segment_key)!;
-        continue;
-      }
-
-      try {
-        const folder_id = await this._connector.create_folder(
-          tenant_id,
-          site_id,
-          drive_id,
-          parent_id,
-          segment,
-        );
-        folder_ids.set(segment_key, folder_id);
-        parent_id = folder_id;
-      } catch (err) {
-        logger.warn(
-          `Failed to create folder ${current_path} in drive ${drive_id}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        return undefined;
-      }
-    }
-
-    return parent_id;
   }
 }
 

--- a/packages/sharepoint/src/services/sharepoint-save.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-save.service.ts
@@ -31,6 +31,10 @@ import {
   verify_streaming_checksum,
 } from '@/services/sharepoint-restore-streaming';
 import { filter_sharepoint_entries } from '@/services/sharepoint-entry-filter';
+import {
+  load_sharepoint_chain_entries,
+  restorable_entries,
+} from '@/services/sharepoint-manifest-chain';
 
 @injectable()
 export class SharePointSaveService implements SharePointSaveUseCase {
@@ -53,13 +57,16 @@ export class SharePointSaveService implements SharePointSaveUseCase {
     }
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
-      const manifest = await this._manifests.find_by_snapshot(ctx, site_id, options.snapshot_id);
-      if (!manifest) {
-        throw new Error(`Snapshot ${options.snapshot_id} not found for site ${site_id}`);
-      }
-
-      const entries = filter_sharepoint_entries(manifest.entries, options.file_filter);
-      const restorable = entries.filter((e) => e.change_type !== 'deleted' && e.storage_key);
+      const chain = await load_sharepoint_chain_entries(
+        this._manifests,
+        ctx,
+        site_id,
+        options.snapshot_id,
+      );
+      const restorable = filter_sharepoint_entries(
+        restorable_entries(chain.entries),
+        options.file_filter,
+      );
 
       if (restorable.length === 0) {
         const interrupted = finish_operation_progress(options, 'save', 'sharepoint', 0, 0);

--- a/packages/sharepoint/src/services/sharepoint-verification.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-verification.service.ts
@@ -21,6 +21,7 @@ import {
   SHAREPOINT_MANIFEST_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
+import { load_sharepoint_chain_entries } from '@/services/sharepoint-manifest-chain';
 
 const HASH_CHUNK_SIZE = 64 * 1024 * 1024;
 
@@ -56,10 +57,15 @@ export class SharePointVerificationService implements SharePointVerificationUseC
     }
     const ctx = await this._tenant_factory.create_readonly(tenant_id);
     try {
-      const manifest = await this._manifests.find_by_snapshot(ctx, site_id, snapshot_id);
-      if (!manifest) {
-        throw new Error(`No SharePoint manifest found for snapshot ${snapshot_id}`);
-      }
+      // The chain, not the single manifest: a snapshot inherits every file that last changed in an
+      // earlier run, and verifying only the target would report those as checked when they were
+      // never looked at (issue #173).
+      const { manifest, entries } = await load_sharepoint_chain_entries(
+        this._manifests,
+        ctx,
+        site_id,
+        snapshot_id,
+      );
 
       const failed_file_ids: string[] = [];
       const index_issues: string[] = [];
@@ -70,16 +76,18 @@ export class SharePointVerificationService implements SharePointVerificationUseC
         workload: 'sharepoint',
         phase: 'processing',
         processed: 0,
-        total: manifest.entries.length,
+        total: entries.length,
       });
 
-      for (const entry of manifest.entries) {
+      for (const { snapshot_id: source_snapshot, entry } of entries) {
         if (options.should_interrupt?.() === true) break;
         const idx = await this._indexes.find_by_file_id(ctx, manifest.site_id, entry.file_id);
-        const has_version = idx?.versions.some((v) => v.snapshot_id === snapshot_id);
+        // Against the snapshot that recorded the entry, not the one being verified: a carried-over
+        // file has its index row under the older snapshot.
+        const has_version = idx?.versions.some((v) => v.snapshot_id === source_snapshot);
         if (!has_version) {
           index_issues.push(
-            `missing index version for file ${entry.file_id} snapshot ${snapshot_id}`,
+            `missing index version for file ${entry.file_id} snapshot ${source_snapshot}`,
           );
         }
 
@@ -94,7 +102,7 @@ export class SharePointVerificationService implements SharePointVerificationUseC
           workload: 'sharepoint',
           phase: 'processing',
           processed,
-          total: manifest.entries.length,
+          total: entries.length,
           current: entry.file_name,
         });
       }
@@ -104,8 +112,8 @@ export class SharePointVerificationService implements SharePointVerificationUseC
         'verify',
         'sharepoint',
         processed,
-        manifest.entries.length,
-        processed < manifest.entries.length,
+        entries.length,
+        processed < entries.length,
       );
 
       return {

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-cancellation.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-cancellation.test.ts
@@ -106,6 +106,7 @@ describe('SharePoint restore cancellation', () => {
         total_files: 2,
         entries: [make_entry('f1'), make_entry('f2')],
       }),
+      list_snapshots_by_site: vi.fn().mockResolvedValue([]),
     } as unknown as SharePointManifestRepository;
     const service = new SharePointRestoreService(factory, connector, manifests);
     const on_progress = vi.fn((event: { phase: string; processed: number }) => {

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-cross-site.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-cross-site.test.ts
@@ -79,6 +79,7 @@ describe('SharePointRestoreService cross-site routing', () => {
         total_files: 1,
         entries: [make_entry()],
       }),
+      list_snapshots_by_site: vi.fn().mockResolvedValue([]),
     } as unknown as SharePointManifestRepository;
 
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(factory);

--- a/packages/sharepoint/tests/unit/services/sharepoint-save.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-save.service.test.ts
@@ -108,6 +108,7 @@ describe('SharePointSaveService', () => {
 
     mock_manifests = {
       find_by_snapshot: vi.fn(),
+      list_snapshots_by_site: vi.fn().mockResolvedValue([]),
       list_manifests: vi.fn().mockResolvedValue([]),
       save_manifest: vi.fn(),
     } as unknown as SharePointManifestRepository;
@@ -140,6 +141,42 @@ describe('SharePointSaveService', () => {
       expect(result.output_path).toBe('/tmp/sp-test-save.zip');
     });
 
+    // #173: a delta snapshot lists only what changed, so an export that reads one manifest loses
+    // every file whose last change was an earlier run.
+    it('exports a file carried over from an older snapshot', async () => {
+      const newest = make_manifest([make_entry({ file_id: 'sp-file-1' })], {
+        snapshot_id: 'sp-snap-2',
+        created_at: new Date('2025-03-16T10:00:00Z'),
+      });
+      const older = make_manifest([make_entry({ file_id: 'sp-file-2', file_name: 'report.docx' })]);
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(newest);
+      vi.mocked(mock_manifests.list_snapshots_by_site).mockResolvedValue([newest, older]);
+
+      const result = await service.save_snapshot('test-tenant', 'site-1', {
+        snapshot_id: 'sp-snap-2',
+        output_path: '/tmp/sp-test-save.zip',
+      });
+
+      expect(result.files_saved).toBe(2);
+    });
+
+    it('does not export a file the newest snapshot records as deleted', async () => {
+      const newest = make_manifest(
+        [make_entry({ file_id: 'sp-file-2', change_type: 'deleted', storage_key: undefined })],
+        { snapshot_id: 'sp-snap-2', created_at: new Date('2025-03-16T10:00:00Z') },
+      );
+      const older = make_manifest([make_entry({ file_id: 'sp-file-2', file_name: 'report.docx' })]);
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(newest);
+      vi.mocked(mock_manifests.list_snapshots_by_site).mockResolvedValue([newest, older]);
+
+      const result = await service.save_snapshot('test-tenant', 'site-1', {
+        snapshot_id: 'sp-snap-2',
+        output_path: '/tmp/sp-test-save.zip',
+      });
+
+      expect(result.files_saved).toBe(0);
+    });
+
     it('returns empty result when no restorable entries', async () => {
       const entries = [make_entry({ change_type: 'deleted', storage_key: undefined })];
       const manifest = make_manifest(entries);
@@ -158,7 +195,7 @@ describe('SharePointSaveService', () => {
 
       await expect(
         service.save_snapshot('test-tenant', 'site-1', { snapshot_id: 'sp-snap-bad' }),
-      ).rejects.toThrow('Snapshot sp-snap-bad not found');
+      ).rejects.toThrow('No SharePoint manifest found for snapshot sp-snap-bad');
     });
 
     it('filters entries by file_filter (file ID)', async () => {

--- a/packages/sharepoint/tests/unit/services/sharepoint-verification.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-verification.service.test.ts
@@ -110,7 +110,7 @@ function create_mocks() {
     save: vi.fn(),
     find_by_snapshot: vi.fn(),
     find_latest_by_site: vi.fn(),
-    list_snapshots_by_site: vi.fn(),
+    list_snapshots_by_site: vi.fn().mockResolvedValue([]),
   } as unknown as SharePointManifestRepository;
 
   const indexes: SharePointFileVersionIndexRepository = {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-types",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Releases `v2.1.3`. Merging this PR tags `v2.1.3` on `main` and publishes @wisecom/atlas-sdk and @wisecom/atlas-cli to npm.

Cut as a hotfix from `main`: one of these is silent data loss in the published 2.1.2, and two are active leak vectors in a public repository. `dev` is level with `main`, so nothing unreleased is held back and `sync-dev` will fast-forward `dev` onto `main` after publish.

## What is fixed

**#173: OneDrive and SharePoint restore, save and verify only read one delta manifest.** A snapshot manifest lists only the items that changed in that run, so every file whose last change was an earlier run was silently missing from an export and never recreated by a restore. Verification passed because it checked the same truncated entry set. All six services now fold the manifest chain, as Outlook has always done. Tombstones win over older stored versions, so a restore never resurrects a deleted file.

**#174: a failing test wrote the whole `Settings` dataclass into `report.xml`.** pytest prints fixture reprs in the traceback header. Secret and identifying fields are now `repr=False`.

**#175: the scrubber was defeated by column wrapping and covered no display or file names.** Every `e2e-report` artifact this repository published carried real tenant data. Those artifacts have been deleted. `Result` now scrubs both streams at construction, the transcript records commands and exit codes only, the CLI honours `COLUMNS` off-TTY so values are never split or truncated mid-value, and the leak check greps a whitespace-stripped copy as a backstop.

## Verification

- `pnpm run test` 15/15 packages, `lint` 0 errors, `typecheck` 17/17, `format:check` clean, `docs:build` clean.
- 10 unit tests for chain folding, 5 service-level tests proving a file from snapshot 1 is exported from snapshot 2, 4 CLI tests for the `COLUMNS` override, 4 redaction self-checks.
- Mutation tested: stubbing the chain to `[target]` fails the carry-forward test; disabling `scrub` fails the redaction check.
- E2E dispatched against the live tenant on this branch, since the release changes restore, save and verify behaviour.

## Docs

`docs/reference/cli.md` gains chain semantics under `atlas onedrive` and `atlas sharepoint`, and a new "Output width" section for `COLUMNS`.
