### PR TITLE
cli: reject --lock-mode without --retention-days, validate the mode eagerly

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,8 +49,10 @@ atlas outlook backup -t <tenant-id> -m user@company.com        # explicit tenant
 | `--full`                 | Ignore saved delta links, run full enumeration                            |
 | `-P, --page-size <n>`    | Graph API page size per delta request (1--100, default 10)                |
 | `--retention-days <n>`   | Apply Object Lock retention for `n` days                                  |
-| `--lock-mode <mode>`     | Object Lock mode (`governance` or `compliance`)                           |
+| `--lock-mode <mode>`     | Object Lock mode (`governance` or `compliance`); requires `--retention-days` |
 | `-t, --tenant <id>`      | Override tenant ID from config                                            |
+
+`--lock-mode` only means something alongside `--retention-days`: the mode selects how retention is enforced, it does not request retention on its own. Passing it alone is rejected rather than ignored, so a run that was meant to be immutable cannot exit `0` with unprotected data. Retention without a mode defaults to `governance`.
 
 Requesting retention is fail-closed: when the bucket has versioning or Object Lock disabled, or cannot honour the requested mode, the run aborts instead of writing unprotected data.
 
@@ -359,7 +361,7 @@ atlas onedrive verify -o user@company.com -s od-snap-1735689600000-a1b2c3
 | `-o, --owner <id>`     | User email or Entra object ID (required)                              |
 | `--full`               | Force full crawl ignoring saved delta links                           |
 | `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (see note below) |
-| `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`) |
+| `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`); requires `--retention-days` |
 | `-t, --tenant <id>`    | Override tenant ID from config                                        |
 
 While the backup runs, a live dashboard shows one row per drive: delta fetch (`fetching changes...`), then per-item progress with rate and ETA, finishing as `[ok]` with stored/dedup/version counts or `[==] up to date` when an incremental delta has no changes. Non-interactive runs (cron/CI) print one plain log line per finished drive instead. Service messages (version syncs, warnings) print above the live region.
@@ -476,7 +478,7 @@ atlas sharepoint verify --site https://contoso.sharepoint.com/sites/Engineering 
 | `--full`               | Force full crawl ignoring saved delta links                                       |
 | `--include-subsites`   | Also back up every subsite beneath the site, one snapshot per subsite             |
 | `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (same semantics as OneDrive) |
-| `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`)             |
+| `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`); requires `--retention-days` |
 | `-t, --tenant <id>`    | Override tenant ID from config                                                    |
 
 :::: tip Subsites are separate sites

--- a/packages/cli/src/command-object-lock.ts
+++ b/packages/cli/src/command-object-lock.ts
@@ -2,9 +2,11 @@ import type {
   ObjectLockPolicy,
   ObjectLockRequest,
 } from '@wisecom/atlas-types/ports/backup/use-case.port';
+import type { ObjectLockSettings } from '@wisecom/atlas-core/services/shared/object-lock-policy';
 import {
   build_object_lock_policy as build_policy,
   build_object_lock_request as build_request,
+  parse_object_lock_mode,
 } from '@wisecom/atlas-core/services/shared/object-lock-policy';
 
 /** CLI flags shared by every command that accepts Object Lock options. */
@@ -13,24 +15,37 @@ export interface ObjectLockFlagOptions {
   lockMode?: string;
 }
 
+/**
+ * Parses and validates the Object Lock flag pair.
+ *
+ * The core builders return early when no retention was requested, so they never see an invalid
+ * mode and never notice a mode that cannot be applied. Both checks therefore belong here, at the
+ * flag boundary: an operator who passes `--lock-mode` alone believes the backup is immutable, and
+ * silently dropping the flag hands them an unprotected snapshot with a zero exit code (#186).
+ */
+function parse_object_lock_flags(options: ObjectLockFlagOptions): ObjectLockSettings {
+  parse_object_lock_mode(options.lockMode);
+  const retention_days = parse_retention_days(options.retentionDays);
+  if (options.lockMode && retention_days === undefined) {
+    throw new Error(
+      '--lock-mode requires --retention-days. Object Lock mode alone applies no retention.',
+    );
+  }
+  return { retention_days, lock_mode: options.lockMode };
+}
+
 /** Builds an ObjectLockRequest from CLI flags; undefined when no retention requested. */
 export function build_object_lock_request(
   options: ObjectLockFlagOptions,
 ): ObjectLockRequest | undefined {
-  return build_request({
-    retention_days: parse_retention_days(options.retentionDays),
-    lock_mode: options.lockMode,
-  });
+  return build_request(parse_object_lock_flags(options));
 }
 
 /** Builds an ObjectLockPolicy from CLI flags; undefined when no retention requested. */
 export function build_object_lock_policy(
   options: ObjectLockFlagOptions,
 ): ObjectLockPolicy | undefined {
-  return build_policy({
-    retention_days: parse_retention_days(options.retentionDays),
-    lock_mode: options.lockMode,
-  });
+  return build_policy(parse_object_lock_flags(options));
 }
 
 /** Parses --retention-days into a positive integer. */

--- a/packages/cli/src/commands/onedrive-command.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-command.handlers.tsx
@@ -91,6 +91,8 @@ export async function execute_onedrive_backup(
   options: OneDriveBackupOptions,
 ): Promise<void> {
   const tenant_id = resolve_tenant_id(container, options);
+  // Built before the Graph lookup: invalid Object Lock flags must fail without a network call.
+  const object_lock_request = build_object_lock_request(options);
   const owner = await resolve_owner(container, tenant_id, options.owner);
   const backup = container.get<OneDriveBackupUseCase>(ONEDRIVE_BACKUP_USE_CASE_TOKEN);
 
@@ -114,7 +116,7 @@ export async function execute_onedrive_backup(
     force_full: options.full ?? false,
     owner_email: owner.email,
     owner_display_name: owner.display_name,
-    object_lock_request: build_object_lock_request(options),
+    object_lock_request,
     create_progress: create_backup_progress({ rate: 'files/s', extra: 'ver', row_noun: 'drive' }),
   });
 

--- a/packages/cli/src/commands/sharepoint-command.handlers.tsx
+++ b/packages/cli/src/commands/sharepoint-command.handlers.tsx
@@ -123,6 +123,8 @@ export async function execute_sharepoint_backup(
   options: SharePointBackupOptions,
 ): Promise<void> {
   const tenant_id = resolve_tenant_id(container, options);
+  // Built before the Graph lookup: invalid Object Lock flags must fail without a network call.
+  const object_lock_request = build_object_lock_request(options);
   const connector = container.get<SharePointSiteConnector>(SHAREPOINT_CONNECTOR_TOKEN);
   const site = await connector.resolve_site(tenant_id, options.site);
   logger.info(`Resolved site: ${site.display_name} (${site.site_id})`);
@@ -135,7 +137,7 @@ export async function execute_sharepoint_backup(
     include_subsites: options.includeSubsites ?? false,
     site_url: site.site_url,
     site_display_name: site.display_name,
-    object_lock_request: build_object_lock_request(options),
+    object_lock_request,
   });
 
   await render_static_view(<Banner title="Atlas SharePoint Backup" />);

--- a/packages/cli/tests/unit/object-lock-flags.test.ts
+++ b/packages/cli/tests/unit/object-lock-flags.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import {
+  ONEDRIVE_BACKUP_USE_CASE_TOKEN,
+  SHAREPOINT_SITE_TREE_BACKUP_USE_CASE_TOKEN,
+  SHAREPOINT_CONNECTOR_TOKEN,
+  USER_IDENTITY_RESOLVER_TOKEN,
+} from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
+import { build_object_lock_policy, build_object_lock_request } from '@/command-object-lock';
+import { register_onedrive_command } from '@/commands/onedrive.command';
+import { register_sharepoint_command } from '@/commands/sharepoint.command';
+
+const TENANT_ID = 'test-tenant';
+const OWNER_EMAIL = 'john.doe@example.com';
+const OWNER_OBJECT_ID = '00000000-0000-0000-0000-000000000000';
+const SITE_URL = 'https://contoso.sharepoint.com/sites/Example';
+
+const PAIRING_ERROR = /--lock-mode requires --retention-days/;
+const INVALID_MODE_ERROR = /Invalid object lock mode "bogus"/;
+
+describe('Object Lock flag validation (issue #186)', () => {
+  it('rejects --lock-mode without --retention-days', () => {
+    expect(() => build_object_lock_request({ lockMode: 'compliance' })).toThrow(PAIRING_ERROR);
+    expect(() => build_object_lock_policy({ lockMode: 'compliance' })).toThrow(PAIRING_ERROR);
+  });
+
+  it('rejects an invalid --lock-mode whether or not retention was requested', () => {
+    expect(() => build_object_lock_request({ lockMode: 'bogus' })).toThrow(INVALID_MODE_ERROR);
+    expect(() => build_object_lock_request({ lockMode: 'bogus', retentionDays: '30' })).toThrow(
+      INVALID_MODE_ERROR,
+    );
+    expect(() => build_object_lock_policy({ lockMode: 'bogus' })).toThrow(INVALID_MODE_ERROR);
+  });
+
+  it('keeps defaulting to GOVERNANCE when only --retention-days is given', () => {
+    expect(build_object_lock_request({ retentionDays: '30' })).toEqual({
+      mode: 'GOVERNANCE',
+      retention_days: 30,
+    });
+    expect(build_object_lock_policy({ retentionDays: '30' })?.mode).toBe('GOVERNANCE');
+  });
+
+  it('still builds nothing when neither flag is given', () => {
+    expect(build_object_lock_request({})).toBeUndefined();
+    expect(build_object_lock_policy({})).toBeUndefined();
+  });
+
+  it('accepts a valid mode paired with retention', () => {
+    expect(build_object_lock_request({ lockMode: 'compliance', retentionDays: '7' })).toEqual({
+      mode: 'COMPLIANCE',
+      retention_days: 7,
+    });
+  });
+});
+
+interface Harness {
+  program: Command;
+  backup_onedrive: Mock;
+  backup_site_tree: Mock;
+  resolve_user: Mock;
+  resolve_site: Mock;
+}
+
+function harness(): Harness {
+  const container = new Container();
+  const backup_onedrive = vi.fn().mockResolvedValue({ summary: { errors: [], warnings: [] } });
+  const backup_site_tree = vi.fn().mockResolvedValue([]);
+  const resolve_user = vi.fn().mockResolvedValue({
+    object_id: OWNER_OBJECT_ID,
+    email: OWNER_EMAIL,
+    display_name: 'John Doe',
+  });
+  const resolve_site = vi.fn().mockResolvedValue({
+    site_id: `contoso.sharepoint.com,${OWNER_OBJECT_ID},${OWNER_OBJECT_ID}`,
+    site_url: SITE_URL,
+    display_name: 'Example',
+  });
+
+  container.bind(ONEDRIVE_BACKUP_USE_CASE_TOKEN).toConstantValue({ backup_onedrive });
+  container.bind(SHAREPOINT_SITE_TREE_BACKUP_USE_CASE_TOKEN).toConstantValue({ backup_site_tree });
+  container.bind(USER_IDENTITY_RESOLVER_TOKEN).toConstantValue({ resolve_user });
+  container.bind(SHAREPOINT_CONNECTOR_TOKEN).toConstantValue({ resolve_site });
+  container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({ tenant_id: TENANT_ID });
+
+  const program = new Command();
+  program.exitOverride();
+  register_onedrive_command(program, () => container);
+  register_sharepoint_command(program, () => container);
+  return { program, backup_onedrive, backup_site_tree, resolve_user, resolve_site };
+}
+
+describe('drive backups reject bad Object Lock flags before reaching Graph (issue #186)', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    h = harness();
+  });
+
+  it('fails a OneDrive backup without resolving the owner', async () => {
+    await expect(
+      h.program.parseAsync(['onedrive', 'backup', '-o', OWNER_EMAIL, '--lock-mode', 'compliance'], {
+        from: 'user',
+      }),
+    ).rejects.toThrow(PAIRING_ERROR);
+
+    expect(h.resolve_user).not.toHaveBeenCalled();
+    expect(h.backup_onedrive).not.toHaveBeenCalled();
+  });
+
+  it('fails a SharePoint backup without resolving the site', async () => {
+    await expect(
+      h.program.parseAsync(['sharepoint', 'backup', '--site', SITE_URL, '--lock-mode', 'bogus'], {
+        from: 'user',
+      }),
+    ).rejects.toThrow(INVALID_MODE_ERROR);
+
+    expect(h.resolve_site).not.toHaveBeenCalled();
+    expect(h.backup_site_tree).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid flag pair to the OneDrive use case', async () => {
+    await h.program.parseAsync(
+      [
+        'onedrive',
+        'backup',
+        '-o',
+        OWNER_EMAIL,
+        '--retention-days',
+        '30',
+        '--lock-mode',
+        'compliance',
+      ],
+      { from: 'user' },
+    );
+
+    expect(h.backup_onedrive.mock.calls[0]![2].object_lock_request).toEqual({
+      mode: 'COMPLIANCE',
+      retention_days: 30,
+    });
+  });
+});


### PR DESCRIPTION
Closes #186.

## What was wrong

`build_object_lock_request` and `build_object_lock_policy` delegate to the core builders, which return early when `retention_days` is absent:

```ts
if (!settings.retention_days) {
  return undefined;          // parse_object_lock_mode never runs
}
```

So `--lock-mode` passed without `--retention-days` was never parsed and never applied. A misspelled mode was accepted, and, worse, a correctly spelled one was too: the operator asked for compliance retention, got exit `0`, and got an unprotected snapshot. Before #178 the CLI parsed the mode above the retention guard, so this was a regression rather than long-standing behaviour.

## Fix

Validation moved to the flag boundary in `packages/cli/src/command-object-lock.ts`, in one helper both builders call:

1. Parse the mode first, so `bogus` is rejected with the existing specific message whether or not retention was requested.
2. Then enforce the pairing: `--lock-mode` without `--retention-days` fails with `--lock-mode requires --retention-days. Object Lock mode alone applies no retention.`

The order matters for the diagnostic: a typo'd mode gets told it is a typo, not that a different flag is missing.

The drive backup handlers now build the request before their Graph lookup (`resolve_owner`, `resolve_site`), so an invalid flag pair fails without a network call. Outlook already built its sync options before any Graph work.

`atlas storage-check` is deliberately untouched: it parses the mode itself, and there `--lock-mode` alone is a readiness probe ("could this bucket honour compliance mode?") rather than a request to lock anything. Verified still working.

## Verification

Smoke against the built bundle:

| Invocation | Result |
| --- | --- |
| `--lock-mode bogus` | `Invalid object lock mode "bogus"` |
| `--lock-mode compliance` | `--lock-mode requires --retention-days` |
| `--retention-days 30 --lock-mode bogus` | `Invalid object lock mode "bogus"` |
| `--retention-days 30` | proceeds, defaults to `GOVERNANCE` |
| `storage-check --lock-mode governance` | `Status: ready`, unchanged |

- New `packages/cli/tests/unit/object-lock-flags.test.ts` (8 cases): both builders reject the unpaired flag, both reject an invalid value with and without retention, retention-only still defaults to `GOVERNANCE`, neither flag still builds nothing, a valid pair round-trips, and both drive backup commands reject before their resolver is called.
- The ordering assertion has teeth: moving the OneDrive build back below `resolve_owner` fails exactly the "without resolving the owner" case, and it passes again when restored.
- `pnpm run build` 10/10, `pnpm run typecheck` 17/17, `pnpm run lint` 0 errors, `pnpm run docs:build` clean, `pnpm run test` 1061 passed with CLI at 70.

## Docs

`docs/reference/cli.md`: the `--lock-mode` rows for `outlook backup`, `onedrive backup` and `sharepoint backup` now state the dependency, with a short paragraph explaining that the mode selects how retention is enforced and does not request retention on its own. The `storage-check` row is unchanged, since its behaviour is unchanged.