### PR TITLE
cli: require the tenant ID to be typed before a purge

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -302,7 +302,7 @@ atlas onedrive verify -o user@company.com -s od-snap-1735689600000-a1b2c3
 
 ## Status Checking
 
-Check whether a OneDrive backup is up to date by peeking at Graph delta state. This queries the delta endpoint with the saved delta links from the latest cursor without advancing them, so it does not interfere with the next backup.
+Check whether a OneDrive backup is up to date by peeking at Graph delta state. This queries the delta endpoint with the saved delta links from the latest cursor without advancing them, so it does not interfere with the next backup. On the CLI this is `atlas onedrive status -o <owner>`.
 
 ```typescript
 const status = await atlas.onedrive.checkStatus('owner-id');
@@ -330,7 +330,7 @@ for (const drive of status.drives) {
 
 ## Deletion
 
-Per-owner and per-snapshot deletion of OneDrive data is available through the SDK. The CLI uses the tenant-level `atlas outlook delete --purge` for full tenant cleanup.
+Per-owner and per-snapshot deletion of OneDrive data is available from both adapters: `atlas onedrive delete -o <owner>`, optionally with `-s <snapshot>`, or the SDK methods below. For a tenant-wide wipe across every workload, use `atlas delete --purge`.
 
 ```typescript
 // Erases manifests, blobs, indexes, cursors and staging -- every version of each

--- a/docs/operations/immutability.md
+++ b/docs/operations/immutability.md
@@ -71,11 +71,11 @@ Run `atlas storage-check` to validate readiness before your first immutable back
 
 Atlas uses content-addressed storage (`data/{mailbox}/{sha256}`). Deduplication behaves identically with or without Object Lock: if the object already exists, Atlas skips the upload. No extra storage cost, no extra S3 versions.
 
-Object Lock **prevents deletion** during the retention window but does **not auto-delete** objects after retention expires. Since Atlas never selectively deletes individual data objects (only bulk via `delete --mailbox` or `delete --purge`), no manifest can end up referencing a deleted object.
+Object Lock **prevents deletion** during the retention window but does **not auto-delete** objects after retention expires. Since Atlas never selectively deletes individual data objects (only bulk via `outlook delete --mailbox`, a workload delete, or `atlas delete --purge`), no manifest can end up referencing a deleted object.
 
 ## Deletion behavior under Object Lock
 
-`atlas outlook delete` removes objects in a fixed order:
+`atlas outlook delete`, the workload deletes, and `atlas delete --purge` all remove objects in a fixed order:
 
 1. **Manifests first.** This removes the index that references data objects.
 2. **Data objects second.** These are the actual encrypted messages and attachments.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -240,22 +240,20 @@ If the output file already exists, Atlas prompts `Overwrite? [Y/n]` before proce
 
 ### `atlas outlook delete`
 
-Delete backed-up data with confirmation prompt.
+Delete backed-up mail data with a confirmation prompt. Mail-scoped only: the tenant-wide purge is [`atlas delete`](#atlas-delete).
 
 ```bash
 atlas outlook delete -m user@company.com        # delete all data + manifests for a mailbox
 atlas outlook delete -s <snapshot-id>           # delete one snapshot manifest (data retained)
-atlas outlook delete --purge                    # delete EVERYTHING in the tenant bucket
-atlas outlook delete --purge -y                 # skip confirmation prompt
+atlas outlook delete -m user@company.com -y     # skip confirmation prompt
 ```
 
-| Option                  | Description                                                    |
-| ----------------------- | -------------------------------------------------------------- |
-| `-m, --mailbox <email>` | Delete all data, attachments, and manifests for a mailbox      |
-| `-s, --snapshot <id>`   | Delete a single snapshot manifest (data objects retained)      |
-| `--purge`               | Delete all data, manifests, and encryption keys (irreversible) |
-| `-y, --yes`             | Skip confirmation prompt                                       |
-| `-t, --tenant <id>`     | Override tenant ID                                             |
+| Option                  | Description                                               |
+| ----------------------- | --------------------------------------------------------- |
+| `-m, --mailbox <email>` | Delete all data, attachments, and manifests for a mailbox |
+| `-s, --snapshot <id>`   | Delete a single snapshot manifest (data objects retained) |
+| `-y, --yes`             | Skip confirmation prompt                                  |
+| `-t, --tenant <id>`     | Override tenant ID                                        |
 
 When Object Lock retention protects objects, delete commands return non-zero and report retained items separately from generic failures. "Retained" means a backend named Object Lock as the reason and the object becomes deletable when retention expires. Anything else, such as an IAM denial or an unreachable endpoint, is reported as a failure, because it will not resolve on its own.
 
@@ -263,14 +261,10 @@ When Object Lock retention protects objects, delete commands return non-zero and
 Atlas deletes **manifests first**, then data objects. This ordering is safe: if deletion is interrupted mid-way, you are left with orphan data blobs (harmless, can be cleaned up later) rather than dangling manifest references that point to missing data.
 
 When using `--snapshot`, only the manifest file is removed. The underlying data objects are retained because they may be referenced by other snapshots (content-addressed deduplication).
-
-When using `--purge`, **everything** is deleted including the encrypted DEK at `_meta/dek.enc`. This is irreversible. All data for the tenant becomes permanently inaccessible.
 :::
 
 ::: details Erasure in versioned buckets
 Every delete removes the object **and all of its noncurrent versions**. This matters wherever bucket versioning is on, which is everywhere Object Lock is used, since versioning is its prerequisite. Deleting a key without naming a version writes a delete marker: the object disappears from listings while every byte stays retrievable, so a deletion that reports success would not have erased anything.
-
-`--purge` sweeps the whole bucket rather than a fixed list of prefixes, so Outlook, OneDrive, SharePoint, the identity registry, and any tree a later release adds all go. The encrypted DEK is deleted last, and only if nothing survived: dropping the key while its ciphertext is still retained would leave data that can neither be restored nor be claimed erased.
 :::
 
 ### `atlas outlook status`
@@ -327,6 +321,27 @@ Mailbox size requires the `Reports.Read.All` Graph API permission. If the permis
 The `Type` column shows the Graph `mailboxSettings.userPurpose` value (`user`, `shared`, `room`, `equipment`, ...). To keep discovery fast, it is only resolved for unlicensed mailboxes; `--` means the purpose was not resolved. Note that `--licensed-only` excludes shared mailboxes, which are typically unlicensed.
 :::
 
+## `atlas delete`
+
+Tenant-wide deletion, across every workload. This is a top-level command rather than a subcommand of `outlook`, because the purge sweeps the whole bucket and nothing about it is mail-scoped.
+
+```bash
+atlas delete --purge        # delete EVERYTHING in the tenant bucket
+atlas delete --purge -y     # skip confirmation prompt
+```
+
+| Option              | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| `--purge`           | Delete all data, manifests, and encryption keys (irreversible) |
+| `-y, --yes`         | Skip confirmation prompt                                       |
+| `-t, --tenant <id>` | Override tenant ID                                             |
+
+`atlas delete` without `--purge` exits non-zero and deletes nothing: a tenant wipe is never the default reading of an incomplete command. For scoped deletes use `atlas outlook delete`, `atlas onedrive delete`, or `atlas sharepoint delete`.
+
+`--purge` sweeps the whole bucket rather than a fixed list of prefixes, so Outlook, OneDrive, SharePoint, the identity registry, and any tree a later release adds all go. **Everything** is deleted including the encrypted DEK at `_meta/dek.enc`. The DEK is deleted last, and only if nothing survived: dropping the key while its ciphertext is still retained would leave data that can neither be restored nor be claimed erased. This is irreversible. All data for the tenant becomes permanently inaccessible.
+
+Before v2.2.0 this was `atlas outlook delete --purge`. That flag is gone; scripts must call `atlas delete --purge`.
+
 ## `atlas onedrive`
 
 Back up and verify OneDrive files per user using Graph delta sync. Blobs and manifests live under the `onedrive/` prefix in the tenant bucket (see [OneDrive Backup](/onedrive-backup)). When `-o` contains `@`, Atlas resolves the mailbox to an Entra object ID via `GET /users/{email}` before touching storage keys.
@@ -342,6 +357,9 @@ atlas onedrive restore -o user@company.com -s od-snap-123 --conflict replace
 atlas onedrive list-snapshots -o user@company.com
 atlas onedrive list-versions -o user@company.com -f "Documents/report.docx"
 atlas onedrive verify -o user@company.com -s od-snap-1735689600000-a1b2c3
+atlas onedrive status -o user@company.com
+atlas onedrive delete -o user@company.com -s od-snap-123
+atlas onedrive delete -o user@company.com -y
 ```
 
 | Option           | Description                                                              |
@@ -351,6 +369,8 @@ atlas onedrive verify -o user@company.com -s od-snap-1735689600000-a1b2c3
 | `list-snapshots` | List snapshot IDs and timestamps for the owner                           |
 | `list-versions`  | List indexed versions for one file (`-f` file ID or path)                |
 | `verify`         | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows    |
+| `status`         | Report pending Graph changes per drive without backing up                |
+| `delete`         | Delete the owner's OneDrive backups, or a single snapshot                |
 
 **`atlas onedrive backup`**
 
@@ -439,6 +459,26 @@ Files larger than 4 MiB use streaming decryption to avoid buffering the full cip
 | `-s, --snapshot <id>` | OneDrive snapshot id (required)          |
 | `-t, --tenant <id>`   | Override tenant ID from config           |
 
+**`atlas onedrive status`**
+
+Reports pending Graph changes per drive by replaying the saved delta links from the latest manifest chain. Reads only: no backup runs and nothing is written.
+
+| Option              | Description                              |
+| ------------------- | ---------------------------------------- |
+| `-o, --owner <id>`  | User email or Entra object ID (required) |
+| `-t, --tenant <id>` | Override tenant ID from config           |
+
+**`atlas onedrive delete`**
+
+Deletes the owner's OneDrive backups behind the same confirmation prompt as the Outlook delete. Without `-s` it sweeps the owner's `manifests`, `data`, `index`, `_meta` and `staging` prefixes, staging included so an interrupted large-file upload does not leave file content parked in the bucket. With `-s` only that snapshot's manifest is removed; the content-addressed blobs stay, because other snapshots may reference them.
+
+| Option                | Description                                          |
+| --------------------- | ---------------------------------------------------- |
+| `-o, --owner <id>`    | User email or Entra object ID (required)             |
+| `-s, --snapshot <id>` | Delete only this snapshot instead of every backup    |
+| `-y, --yes`           | Skip confirmation prompt                             |
+| `-t, --tenant <id>`   | Override tenant ID from config                       |
+
 ::: tip Permissions
 Application permissions `Files.Read.All` and `User.Read.All` are required for backup and read operations; `Files.ReadWrite.All` is additionally required for restore. See Details and storage layout are documented on the [OneDrive Backup](/onedrive-backup) page.
 :::
@@ -457,6 +497,9 @@ atlas sharepoint list-versions --site https://contoso.sharepoint.com/sites/Engin
 atlas sharepoint restore --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-1735689600000-a1b2c3
 atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-1735689600000-a1b2c3
 atlas sharepoint verify --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-1735689600000-a1b2c3
+atlas sharepoint status --site https://contoso.sharepoint.com/sites/Engineering
+atlas sharepoint delete --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123
+atlas sharepoint delete --site https://contoso.sharepoint.com/sites/Engineering -y
 ```
 
 | Subcommand       | Description                                                           |
@@ -467,6 +510,8 @@ atlas sharepoint verify --site https://contoso.sharepoint.com/sites/Engineering 
 | `restore`        | Restore files from a snapshot back to the site's document libraries   |
 | `save`           | Decrypt and save files from a snapshot to a local zip archive         |
 | `verify`         | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows |
+| `status`         | Report pending Graph changes per document library without backing up  |
+| `delete`         | Delete the site's SharePoint backups, or a single snapshot            |
 
 **`atlas sharepoint backup`**
 
@@ -547,6 +592,26 @@ atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s
 | `--site <url-or-id>`  | SharePoint site URL or Graph site ID (required) |
 | `-s, --snapshot <id>` | SharePoint snapshot ID (required)               |
 | `-t, --tenant <id>`   | Override tenant ID from config                  |
+
+**`atlas sharepoint status`**
+
+Reports pending Graph changes per document library from the saved delta links. Reads only.
+
+| Option               | Description                                     |
+| -------------------- | ----------------------------------------------- |
+| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) |
+| `-t, --tenant <id>`  | Override tenant ID from config                  |
+
+**`atlas sharepoint delete`**
+
+Deletes the site's SharePoint backups behind a confirmation prompt. Without `-s` it sweeps the site's `manifests`, `data`, `index`, `_meta` and `staging` prefixes. With `-s` only that snapshot's manifest is removed and the shared blobs stay.
+
+| Option                | Description                                       |
+| --------------------- | ------------------------------------------------- |
+| `--site <url-or-id>`  | SharePoint site URL or Graph site ID (required)   |
+| `-s, --snapshot <id>` | Delete only this snapshot instead of every backup |
+| `-y, --yes`           | Skip confirmation prompt                          |
+| `-t, --tenant <id>`   | Override tenant ID from config                    |
 
 ::: tip Permissions
 Application permissions `Sites.Read.All` and `Files.Read.All` are required for SharePoint backup and verification. Restore additionally requires `Sites.ReadWrite.All`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -327,16 +327,25 @@ Tenant-wide deletion, across every workload. This is a top-level command rather 
 
 ```bash
 atlas delete --purge        # delete EVERYTHING in the tenant bucket
-atlas delete --purge -y     # skip confirmation prompt
+atlas delete --purge -y     # skip the typed confirmation
 ```
 
-| Option              | Description                                                    |
-| ------------------- | -------------------------------------------------------------- |
-| `--purge`           | Delete all data, manifests, and encryption keys (irreversible) |
-| `-y, --yes`         | Skip confirmation prompt                                       |
-| `-t, --tenant <id>` | Override tenant ID                                             |
+| Option              | Description                                                       |
+| ------------------- | ----------------------------------------------------------------- |
+| `--purge`           | Delete all data, manifests, and encryption keys (irreversible)    |
+| `-y, --yes`         | Skip the typed confirmation, for scheduled and scripted runs      |
+| `-t, --tenant <id>` | Override tenant ID; the typed confirmation checks against this ID |
 
 `atlas delete` without `--purge` exits non-zero and deletes nothing: a tenant wipe is never the default reading of an incomplete command. For scoped deletes use `atlas outlook delete`, `atlas onedrive delete`, or `atlas sharepoint delete`.
+
+Interactively, the purge asks for the tenant ID to be typed back and aborts on anything else:
+
+```
+[!] This will delete ALL data for tenant <tenant-id> across Outlook, OneDrive and SharePoint (data, manifests, encryption keys)
+Type the tenant ID to confirm:
+```
+
+A keypress is not enough here. The mistake this catches is not a mistyped `y` but a purge aimed at the wrong tenant, which typing the target is the only prompt that can catch. Workload-scoped deletes keep the single-keypress `y/n` prompt, deliberately: making every delete laborious trains operators to pass `-y` everywhere, which would remove the guard that matters. `-y` still bypasses the prompt entirely, so scheduled jobs and the E2E suite are unaffected.
 
 `--purge` sweeps the whole bucket rather than a fixed list of prefixes, so Outlook, OneDrive, SharePoint, the identity registry, and any tree a later release adds all go. **Everything** is deleted including the encrypted DEK at `_meta/dek.enc`. The DEK is deleted last, and only if nothing survived: dropping the key while its ciphertext is still retained would leave data that can neither be restored nor be claimed erased. This is irreversible. All data for the tenant becomes permanently inaccessible.
 

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -175,7 +175,7 @@ The callback is optional and runs inline with the operation. Keep it fast; move 
 | `listAvailableMailboxes(options?)`    | _(discovery)_                  | List all tenant mailboxes via Graph                                                                |
 | `deleteMailboxData(mailboxId)`        | `atlas outlook delete -m`      | Delete all data for a mailbox                                                                      |
 | `deleteSnapshot(snapshotId)`          | `atlas outlook delete -s`      | Delete a single snapshot manifest                                                                  |
-| `purgeTenantData()`                   | `atlas outlook delete --purge` | Purge entire tenant bucket                                                                         |
+| `purgeTenantData()`                   | `atlas delete --purge`         | Purge entire tenant bucket                                                                         |
 | `getMailboxStats(mailboxId)`          | `atlas stats -m`               | Mailbox-level statistics                                                                           |
 
 OneDrive and SharePoint expose parallel methods on `atlas.onedrive` and `atlas.sharepoint` (including workload-specific replication). See [OneDrive Backup](/onedrive-backup) and [SharePoint Backup](/sharepoint-backup) for full SDK examples per workload.

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -316,7 +316,7 @@ Exit code is `0` when all checked entries pass, `1` when any blob mismatch or in
 
 ## Status Checking
 
-Check whether a SharePoint site backup is up to date by peeking at Graph delta state. This queries the delta endpoint with the saved delta links from the latest cursor without advancing them, so it does not interfere with the next backup.
+Check whether a SharePoint site backup is up to date by peeking at Graph delta state. This queries the delta endpoint with the saved delta links from the latest cursor without advancing them, so it does not interfere with the next backup. On the CLI this is `atlas sharepoint status --site <site>`.
 
 ```typescript
 const status = await atlas.sharepoint.checkStatus('site-id');
@@ -344,7 +344,7 @@ for (const lib of status.libraries) {
 
 ## Deletion
 
-Per-site and per-snapshot deletion of SharePoint data is available through the SDK.
+Per-site and per-snapshot deletion of SharePoint data is available from both adapters: `atlas sharepoint delete --site <site>`, optionally with `-s <snapshot>`, or the SDK methods below.
 
 ```typescript
 // Erases manifests, blobs, indexes, cursors and staging -- every version of each

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -19,6 +19,8 @@ Each suite is a lifecycle — every step depends on the previous one:
   infrastructure.
 - **Disaster recovery** (`test_40`): replicate to the replica MinIO → purge primary → rehydrate →
   verify the recovered data decrypts.
+- **Workload deletion** (`test_85`): `onedrive delete` and `sharepoint delete` drop one snapshot
+  manifest, keep the shared blobs, and leave the other workloads' objects untouched.
 - **Purge** (`test_90`): `delete --purge` must leave an empty bucket.
 - **Immutability** (`test_95`): backup with Object Lock → S3 reports the retention → deleting the
   locked object fails. Runs last on purpose: a locked object would make the purge assertion

--- a/e2e/atlas_e2e/cleanup.py
+++ b/e2e/atlas_e2e/cleanup.py
@@ -68,7 +68,7 @@ def purge_bucket(cli: Cli, settings: Settings) -> None:
     logged rather than raised -- the workflow's volume teardown owns those bytes. The output is
     scrubbed before logging: purge output can carry object keys, and keys carry owner ids.
     """
-    result = cli.run("outlook", "delete", "--purge", "-y")
+    result = cli.run("delete", "--purge", "-y")
     if result.code != 0:
         log.warning("Purge exited %s: %s", result.code, scrub(result.out, settings).strip()[:400])
 

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -162,6 +162,16 @@ def test_07_restored_bytes_match_the_seed(graph: Any, settings: Settings, run_ma
     assert STATE["large"].sha256 in digests, "no restored file matches the 5 MB seeded bytes"
 
 
+def test_08_status_reports_the_stored_snapshot(cli: Cli, settings: Settings) -> None:
+    """`onedrive status` reaches Graph and the manifest chain, and names the last snapshot.
+
+    Wired to the CLI by #163: the status use case existed and only the SDK could reach it.
+    """
+    result = cli.ok("onedrive", "status", "-o", settings.onedrive_owner)
+
+    assert STATE["snapshot"] in result.out, result.describe()
+
+
 def _owner_segment(s3: Any, bucket: str) -> str:
     """Reads the owner segment Atlas used, rather than assuming how the email was normalised."""
     keys = storage.list_keys(s3, bucket, "onedrive/manifests/")

--- a/e2e/tests/test_30_sharepoint.py
+++ b/e2e/tests/test_30_sharepoint.py
@@ -141,6 +141,13 @@ def test_08_restored_bytes_match_the_seed(graph: Any, run_marker: str) -> None:
     assert STATE["large"].sha256 in digests, "no restored file matches the 5 MB seeded bytes"
 
 
+def test_09_status_reports_the_stored_snapshot(cli: Cli, settings: Settings) -> None:
+    """`sharepoint status` resolves the site and names the last snapshot (wired by #163)."""
+    result = cli.ok("sharepoint", "status", "--site", settings.sharepoint_site)
+
+    assert STATE["snapshot"] in result.out, result.describe()
+
+
 def _site_segment(s3: Any, bucket: str) -> str:
     """Reads the site segment Atlas used, rather than assuming how the composite id was normalised."""
     keys = storage.list_keys(s3, bucket, "sharepoint/manifests/")

--- a/e2e/tests/test_40_replication.py
+++ b/e2e/tests/test_40_replication.py
@@ -69,7 +69,7 @@ def test_03_status_records_the_replication(cli: Cli, settings: Settings, s3: Any
 
 def test_04_primary_is_destroyed(cli: Cli, settings: Settings, s3: Any) -> None:
     """Wipes primary, including the DEK. Without this the rehydrate below proves nothing."""
-    cli.ok("outlook", "delete", "--purge", "-y")
+    cli.ok("delete", "--purge", "-y")
     assert storage.list_keys(s3, settings.bucket) == [], "primary still holds objects after purge"
 
 

--- a/e2e/tests/test_85_workload_delete.py
+++ b/e2e/tests/test_85_workload_delete.py
@@ -1,0 +1,90 @@
+"""Per-workload deletion, asserted after every workload suite and before the tenant purge.
+
+Wired to the CLI by issue #163: the OneDrive and SharePoint deletion services existed, were tested,
+and only the SDK could reach them.
+
+Deliberately snapshot-scoped rather than owner- or site-scoped. A snapshot delete removes exactly
+one manifest and retains the content-addressed blobs, which is the property worth asserting here,
+and it leaves the drive prefixes populated so `test_90_purge` still proves the cross-workload sweep
+it claims to. The owner and site scopes are covered by the CLI unit suite, which can assert the
+use-case call without erasing a live tenant's backup.
+
+Runs after replication (`test_40`) because that suite reads the drive snapshots this one touches.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from atlas_e2e import storage
+from atlas_e2e.atlas import Cli
+from atlas_e2e.config import Settings
+
+
+def test_01_onedrive_snapshot_delete_keeps_the_blobs(
+    cli: Cli, settings: Settings, s3: Any
+) -> None:
+    """`onedrive delete -o -s` drops one manifest, retains data objects, spares other workloads."""
+    if not settings.onedrive_owner:
+        pytest.skip("E2E_ONEDRIVE_OWNER not set")
+
+    owner = _single_segment(s3, settings.bucket, "onedrive/manifests/")
+    snapshots = storage.snapshot_ids(s3, settings.bucket, owner, "onedrive")
+    assert snapshots, "no OneDrive snapshot to delete"
+
+    data_before = storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/")
+    sharepoint_before = storage.list_keys(s3, settings.bucket, "sharepoint/")
+    outlook_before = storage.list_keys(s3, settings.bucket, "outlook/")
+
+    cli.ok("onedrive", "delete", "-o", settings.onedrive_owner, "-s", snapshots[0], "-y")
+
+    remaining = storage.snapshot_ids(s3, settings.bucket, owner, "onedrive")
+    assert snapshots[0] not in remaining, "the deleted OneDrive snapshot is still listed"
+    assert storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/") == data_before, (
+        "a snapshot delete removed content-addressed blobs other snapshots may reference"
+    )
+    assert storage.list_keys(s3, settings.bucket, "sharepoint/") == sharepoint_before, (
+        "a OneDrive-scoped delete touched SharePoint objects"
+    )
+    assert storage.list_keys(s3, settings.bucket, "outlook/") == outlook_before, (
+        "a OneDrive-scoped delete touched Outlook objects"
+    )
+
+
+def test_02_sharepoint_snapshot_delete_keeps_the_blobs(
+    cli: Cli, settings: Settings, s3: Any
+) -> None:
+    """`sharepoint delete --site -s` drops one manifest and spares the other workloads."""
+    if not settings.sharepoint_site:
+        pytest.skip("E2E_SHAREPOINT_SITE not set")
+
+    site = _single_segment(s3, settings.bucket, "sharepoint/manifests/")
+    snapshots = storage.snapshot_ids(s3, settings.bucket, site, "sharepoint")
+    assert snapshots, "no SharePoint snapshot to delete"
+
+    data_before = storage.list_keys(s3, settings.bucket, f"sharepoint/data/{site}/")
+    onedrive_before = storage.list_keys(s3, settings.bucket, "onedrive/")
+    outlook_before = storage.list_keys(s3, settings.bucket, "outlook/")
+
+    cli.ok("sharepoint", "delete", "--site", settings.sharepoint_site, "-s", snapshots[0], "-y")
+
+    remaining = storage.snapshot_ids(s3, settings.bucket, site, "sharepoint")
+    assert snapshots[0] not in remaining, "the deleted SharePoint snapshot is still listed"
+    assert storage.list_keys(s3, settings.bucket, f"sharepoint/data/{site}/") == data_before, (
+        "a snapshot delete removed content-addressed blobs other snapshots may reference"
+    )
+    assert storage.list_keys(s3, settings.bucket, "onedrive/") == onedrive_before, (
+        "a SharePoint-scoped delete touched OneDrive objects"
+    )
+    assert storage.list_keys(s3, settings.bucket, "outlook/") == outlook_before, (
+        "a SharePoint-scoped delete touched Outlook objects"
+    )
+
+
+def _single_segment(s3: Any, bucket: str, prefix: str) -> str:
+    """Reads the one owner or site segment Atlas wrote under a manifests prefix."""
+    segments = {key.split("/")[2] for key in storage.list_keys(s3, bucket, prefix)}
+    assert len(segments) == 1, f"expected exactly one segment under {prefix}, found {sorted(segments)}"
+    return segments.pop()

--- a/e2e/tests/test_90_purge.py
+++ b/e2e/tests/test_90_purge.py
@@ -27,7 +27,7 @@ def test_purge_empties_the_whole_bucket(cli: Cli, settings: Settings, s3: Any) -
     before = storage.list_keys(s3, settings.bucket)
     assert before, "nothing to purge: the workload suites stored no objects"
 
-    cli.ok("outlook", "delete", "--purge", "-y")
+    cli.ok("delete", "--purge", "-y")
 
     remaining = storage.list_keys(s3, settings.bucket)
     assert remaining == [], f"purge left {len(remaining)} object(s) behind: {remaining[:5]}"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,6 +6,7 @@ import { compose_container } from '@/container';
 import { register_outlook_command } from '@/commands/outlook.command';
 import { register_onedrive_command } from '@/commands/onedrive.command';
 import { register_sharepoint_command } from '@/commands/sharepoint.command';
+import { register_tenant_delete_command } from '@/commands/tenant-delete.command';
 import { register_stats_command } from '@/commands/stats.command';
 import { register_storage_check_command } from '@/commands/storage-check.command';
 import { register_replicate_command } from '@/commands/replicate.command';
@@ -42,6 +43,7 @@ function register_commands(program: Command): void {
   register_outlook_command(program, get_container);
   register_onedrive_command(program, get_container);
   register_sharepoint_command(program, get_container);
+  register_tenant_delete_command(program, get_container);
   register_stats_command(program, get_container);
   register_storage_check_command(program, get_container);
   register_replicate_command(program, get_container);

--- a/packages/cli/src/commands/deletion-presenter.tsx
+++ b/packages/cli/src/commands/deletion-presenter.tsx
@@ -1,0 +1,51 @@
+import type { DeletionResult } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core';
+import { Banner } from '@/ui/components/banner';
+import { ask_confirmation } from '@/ui/components/confirm-prompt';
+import { render_static_view } from '@/ui/render';
+
+/** Renders the shared delete banner every deletion command starts with. */
+export async function render_delete_banner(): Promise<void> {
+  await render_static_view(<Banner title="Atlas Delete" />);
+}
+
+/**
+ * Warns what is about to be erased and asks for confirmation unless `skip_prompt` is set.
+ * Returns false when the operator declines, so callers return without touching storage.
+ */
+export async function confirm_deletion(description: string, skip_prompt = false): Promise<boolean> {
+  logger.warn(description);
+  if (skip_prompt) return true;
+
+  const confirmed = await ask_confirmation('Continue?', false);
+  if (!confirmed) logger.info('Aborted');
+  return confirmed;
+}
+
+/** Prints a summary of what was deleted, and fails the run on retained or failed objects. */
+export function print_delete_result(result: DeletionResult): void {
+  const no_deleted = result.deleted_objects === 0 && result.deleted_manifests === 0;
+  const no_retained = result.retained_objects === 0 && result.retained_manifests === 0;
+  const no_failed = result.failed_objects === 0 && result.failed_manifests === 0;
+
+  if (no_deleted && no_retained && no_failed) {
+    logger.warn('Nothing to delete');
+    return;
+  }
+
+  logger.success(
+    `Deleted ${result.deleted_objects} object(s), ${result.deleted_manifests} manifest(s)`,
+  );
+  logger.info(
+    `Retained and not deleted: ${result.retained_objects} object(s), ` +
+      `${result.retained_manifests} manifest(s)`,
+  );
+  logger.info(
+    `Failed for other reasons: ${result.failed_objects} object(s), ` +
+      `${result.failed_manifests} manifest(s)`,
+  );
+
+  if (!no_retained || !no_failed) {
+    process.exitCode = 1;
+  }
+}

--- a/packages/cli/src/commands/drive-status-presenter.tsx
+++ b/packages/cli/src/commands/drive-status-presenter.tsx
@@ -1,0 +1,93 @@
+import { logger } from '@wisecom/atlas-core';
+import { DataTable, type TableColumn } from '@/ui/components/data-table';
+import { render_static_view } from '@/ui/render';
+
+/** One drive or document library in a status report. */
+export interface DriveStatusItem {
+  readonly drive_name: string;
+  readonly has_backup: boolean;
+  readonly pending_changes: number;
+  readonly is_up_to_date: boolean;
+}
+
+/** Workload-agnostic shape of a OneDrive or SharePoint status result. */
+export interface DriveStatusReport {
+  readonly scope_label: string;
+  readonly item_label: string;
+  readonly last_backup_at: Date | undefined;
+  readonly last_snapshot_id: string | undefined;
+  readonly is_up_to_date: boolean;
+  readonly total_pending_changes: number;
+  readonly items: readonly DriveStatusItem[];
+}
+
+interface DriveStatusRow {
+  name: string;
+  status: string;
+  status_color: string;
+  pending: string;
+  pending_color: string;
+}
+
+/** Prints the last backup, a per-drive table, and an overall verdict. */
+export async function print_drive_status(report: DriveStatusReport): Promise<void> {
+  if (report.last_backup_at) {
+    const ts = report.last_backup_at.toISOString().replace('T', ' ').slice(0, 16);
+    logger.info(`Last backup: ${ts} (${report.last_snapshot_id ?? 'unknown'})\n`);
+  } else {
+    logger.warn(`No previous backup found for this ${report.scope_label}.\n`);
+  }
+
+  const columns: TableColumn<DriveStatusRow>[] = [
+    { key: 'name', header: report.item_label, max_width: 30 },
+    { key: 'status', header: 'Status', color: (row) => row.status_color },
+    { key: 'pending', header: 'Pending', color: (row) => row.pending_color },
+  ];
+  await render_static_view(
+    <DataTable columns={columns} rows={report.items.map(build_drive_status_row)} />,
+  );
+
+  print_verdict(report);
+}
+
+/** Derives the status and pending cells, and their colors, for one drive. */
+function build_drive_status_row(item: DriveStatusItem): DriveStatusRow {
+  if (!item.has_backup) {
+    return {
+      name: item.drive_name,
+      status: 'never backed up',
+      status_color: 'yellow',
+      pending: '-',
+      pending_color: 'gray',
+    };
+  }
+  return {
+    name: item.drive_name,
+    status: item.is_up_to_date ? 'up-to-date' : `${item.pending_changes} change(s)`,
+    status_color: item.is_up_to_date ? 'green' : 'red',
+    pending: String(item.pending_changes),
+    pending_color: item.pending_changes === 0 ? 'green' : 'red',
+  };
+}
+
+function print_verdict(report: DriveStatusReport): void {
+  if (report.is_up_to_date) {
+    const scope = report.scope_label;
+    logger.success(
+      `${scope.charAt(0).toUpperCase()}${scope.slice(1)} is up to date -- no pending changes.`,
+    );
+    return;
+  }
+
+  const never_backed_up = report.items.filter((item) => !item.has_backup).length;
+  const parts: string[] = [];
+  if (report.total_pending_changes > 0) {
+    parts.push(`${report.total_pending_changes} pending change(s)`);
+  }
+  if (never_backed_up > 0) {
+    parts.push(`${never_backed_up} ${report.item_label.toLowerCase()}(s) never backed up`);
+  }
+  logger.info(
+    `Overall: ${parts.join(', ')} across ${report.items.length} ${report.item_label.toLowerCase()}(s)`,
+  );
+}

--- a/packages/cli/src/commands/onedrive-data-ops.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-data-ops.handlers.tsx
@@ -1,0 +1,87 @@
+import { Box } from 'ink';
+import type { Container } from 'inversify';
+import type { OneDriveDeletionUseCase, OneDriveStatusUseCase } from '@wisecom/atlas-types';
+import {
+  ONEDRIVE_DELETION_USE_CASE_TOKEN,
+  ONEDRIVE_STATUS_USE_CASE_TOKEN,
+} from '@wisecom/atlas-types';
+import { Banner } from '@/ui/components/banner';
+import { KeyValueList } from '@/ui/components/key-value-list';
+import { render_static_view } from '@/ui/render';
+import {
+  confirm_deletion,
+  print_delete_result,
+  render_delete_banner,
+} from '@/commands/deletion-presenter';
+import { print_drive_status } from '@/commands/drive-status-presenter';
+import {
+  resolve_owner,
+  resolve_tenant_id,
+  type OneDriveTenantOptions,
+} from '@/commands/onedrive-command.handlers';
+
+export interface OneDriveDeleteOptions extends OneDriveTenantOptions {
+  owner: string;
+  snapshot?: string;
+  yes?: boolean;
+}
+
+export interface OneDriveStatusCommandOptions extends OneDriveTenantOptions {
+  owner: string;
+}
+
+/** Deletes one OneDrive snapshot, or every backup for an owner, after confirmation. */
+export async function execute_onedrive_delete(
+  container: Container,
+  options: OneDriveDeleteOptions,
+): Promise<void> {
+  const tenant_id = resolve_tenant_id(container, options);
+  await render_delete_banner();
+
+  const owner = await resolve_owner(container, tenant_id, options.owner);
+  const description = options.snapshot
+    ? `This will delete OneDrive snapshot ${options.snapshot} for ${owner.object_id} ` +
+      `(data objects are retained for other snapshots)`
+    : `This will delete all OneDrive data and manifests for ${owner.object_id}`;
+
+  if (!(await confirm_deletion(description, options.yes))) return;
+
+  const deletion = container.get<OneDriveDeletionUseCase>(ONEDRIVE_DELETION_USE_CASE_TOKEN);
+  const result = options.snapshot
+    ? await deletion.delete_snapshot(tenant_id, owner.object_id, options.snapshot)
+    : await deletion.delete_owner_data(tenant_id, owner.object_id);
+  print_delete_result(result);
+}
+
+/** Reports whether an owner's OneDrive backup is current, drive by drive. */
+export async function execute_onedrive_status(
+  container: Container,
+  options: OneDriveStatusCommandOptions,
+): Promise<void> {
+  const tenant_id = resolve_tenant_id(container, options);
+  const owner = await resolve_owner(container, tenant_id, options.owner);
+
+  await render_static_view(
+    <Box flexDirection="column">
+      <Banner title="Atlas OneDrive Status" />
+      <KeyValueList
+        items={[
+          { label: 'Tenant', value: tenant_id },
+          { label: 'Owner', value: owner.object_id },
+        ]}
+      />
+    </Box>,
+  );
+
+  const status = container.get<OneDriveStatusUseCase>(ONEDRIVE_STATUS_USE_CASE_TOKEN);
+  const result = await status.check_onedrive_status(tenant_id, owner.object_id);
+  await print_drive_status({
+    scope_label: 'owner',
+    item_label: 'Drive',
+    last_backup_at: result.last_backup_at,
+    last_snapshot_id: result.last_snapshot_id,
+    is_up_to_date: result.is_up_to_date,
+    total_pending_changes: result.total_pending_changes,
+    items: result.drives,
+  });
+}

--- a/packages/cli/src/commands/onedrive.command.ts
+++ b/packages/cli/src/commands/onedrive.command.ts
@@ -17,6 +17,12 @@ import {
   type OneDriveListSnapshotsOptions,
   type OneDriveListVersionsOptions,
 } from '@/commands/onedrive-catalog-command.handlers';
+import {
+  execute_onedrive_delete,
+  execute_onedrive_status,
+  type OneDriveDeleteOptions,
+  type OneDriveStatusCommandOptions,
+} from '@/commands/onedrive-data-ops.handlers';
 
 type ContainerFactory = () => Container;
 
@@ -31,6 +37,8 @@ export function register_onedrive_command(program: Command, get_container: Conta
   register_onedrive_list_snapshots(group, get_container);
   register_onedrive_list_versions(group, get_container);
   register_onedrive_verify(group, get_container);
+  register_onedrive_status(group, get_container);
+  register_onedrive_delete(group, get_container);
 }
 
 function register_onedrive_backup(group: Command, get_container: ContainerFactory): void {
@@ -115,4 +123,26 @@ function register_onedrive_verify(group: Command, get_container: ContainerFactor
     .requiredOption('-s, --snapshot <id>', 'snapshot identifier')
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .action((options: OneDriveVerifyOptions) => execute_onedrive_verify(get_container(), options));
+}
+
+function register_onedrive_status(group: Command, get_container: ContainerFactory): void {
+  group
+    .command('status')
+    .description('Check whether an owner OneDrive backup is up to date')
+    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
+    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .action((options: OneDriveStatusCommandOptions) =>
+      execute_onedrive_status(get_container(), options),
+    );
+}
+
+function register_onedrive_delete(group: Command, get_container: ContainerFactory): void {
+  group
+    .command('delete')
+    .description('Delete OneDrive backups for one owner, or a single snapshot')
+    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
+    .option('-s, --snapshot <id>', 'delete a single snapshot instead of every backup')
+    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .option('-y, --yes', 'skip confirmation prompt')
+    .action((options: OneDriveDeleteOptions) => execute_onedrive_delete(get_container(), options));
 }

--- a/packages/cli/src/commands/outlook-data-ops.handler.tsx
+++ b/packages/cli/src/commands/outlook-data-ops.handler.tsx
@@ -3,15 +3,14 @@ import { Box } from 'ink';
 import type { Container } from 'inversify';
 import type { AtlasConfig } from '@wisecom/atlas-core';
 import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
-import type {
-  SaveUseCase,
-  SaveResult,
-  SaveOptions,
-  DeletionUseCase,
-  DeletionResult,
-} from '@wisecom/atlas-types';
+import type { SaveUseCase, SaveResult, SaveOptions, DeletionUseCase } from '@wisecom/atlas-types';
 import { SAVE_USE_CASE_TOKEN, DELETION_USE_CASE_TOKEN } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core';
+import {
+  confirm_deletion,
+  print_delete_result,
+  render_delete_banner,
+} from '@/commands/deletion-presenter';
 import { Banner } from '@/ui/components/banner';
 import { ask_confirmation } from '@/ui/components/confirm-prompt';
 import { ErrorList } from '@/ui/components/error-list';
@@ -36,11 +35,8 @@ export interface OutlookDeleteOptions {
   tenant?: string;
   mailbox?: string;
   snapshot?: string;
-  purge?: boolean;
   yes?: boolean;
 }
-
-type DeleteScope = 'mailbox' | 'snapshot' | 'purge';
 
 /** Saves backed-up emails as EML files in a compressed zip archive. */
 export async function execute_outlook_save(
@@ -79,33 +75,29 @@ export async function execute_outlook_save(
   return execute_mailbox_save(save_service, tenant_id, options, save_options);
 }
 
-/** Routes to the correct deletion scope and asks for confirmation. */
+/** Routes to the correct mail deletion scope and asks for confirmation. */
 export async function execute_outlook_delete(
   container: Container,
   options: OutlookDeleteOptions,
 ): Promise<void> {
   const tenant_id = options.tenant ?? container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
-  await render_static_view(<Banner title="Atlas Delete" />);
+  await render_delete_banner();
 
-  const { scope, description } = determine_scope(options, tenant_id);
-  if (!scope) {
-    logger.error('Specify one of: --mailbox, --snapshot, or --purge');
+  if (!options.mailbox && !options.snapshot) {
+    logger.error('Specify one of: --mailbox or --snapshot. Tenant-wide purge is `atlas delete`');
     process.exitCode = 1;
     return;
   }
 
-  logger.warn(description);
-
-  if (!options.yes) {
-    const confirmed = await ask_confirmation('Continue?', false);
-    if (!confirmed) {
-      logger.info('Aborted');
-      return;
-    }
-  }
+  const description = options.mailbox
+    ? `This will delete all data and manifests for ${options.mailbox}`
+    : `This will delete snapshot ${options.snapshot} (data objects are retained for other snapshots)`;
+  if (!(await confirm_deletion(description, options.yes))) return;
 
   const deletion = container.get<DeletionUseCase>(DELETION_USE_CASE_TOKEN);
-  const result = await dispatch_deletion(deletion, scope, tenant_id, options);
+  const result = options.mailbox
+    ? await deletion.delete_mailbox_data(tenant_id, options.mailbox)
+    : await deletion.delete_snapshot(tenant_id, options.snapshot!);
   print_delete_result(result);
 }
 
@@ -196,77 +188,6 @@ async function report_save_result(result: SaveResult): Promise<void> {
   if (result.error_count > 0) {
     logger.warn(`Saved ${result.saved_count} messages with ${result.error_count} errors`);
     await render_static_view(<ErrorList errors={result.errors} />);
-    process.exitCode = 1;
-  }
-}
-
-/** Determines which deletion path to take and builds a human-readable warning. */
-function determine_scope(
-  options: OutlookDeleteOptions,
-  tenant_id: string,
-): { scope: DeleteScope | undefined; description: string } {
-  if (options.purge) {
-    return {
-      scope: 'purge',
-      description: `This will delete ALL data for tenant ${tenant_id} (data, manifests, encryption keys)`,
-    };
-  }
-  if (options.mailbox) {
-    return {
-      scope: 'mailbox',
-      description: `This will delete all data and manifests for ${options.mailbox}`,
-    };
-  }
-  if (options.snapshot) {
-    return {
-      scope: 'snapshot',
-      description: `This will delete snapshot ${options.snapshot} (data objects are retained for other snapshots)`,
-    };
-  }
-  return { scope: undefined, description: '' };
-}
-
-/** Dispatches to the correct DeletionService method. */
-async function dispatch_deletion(
-  deletion: DeletionUseCase,
-  scope: DeleteScope,
-  tenant_id: string,
-  options: OutlookDeleteOptions,
-): Promise<DeletionResult> {
-  switch (scope) {
-    case 'mailbox':
-      return deletion.delete_mailbox_data(tenant_id, options.mailbox!);
-    case 'snapshot':
-      return deletion.delete_snapshot(tenant_id, options.snapshot!);
-    case 'purge':
-      return deletion.purge_tenant(tenant_id);
-  }
-}
-
-/** Prints a summary of what was deleted. */
-function print_delete_result(result: DeletionResult): void {
-  const no_deleted = result.deleted_objects === 0 && result.deleted_manifests === 0;
-  const no_retained = result.retained_objects === 0 && result.retained_manifests === 0;
-  const no_failed = result.failed_objects === 0 && result.failed_manifests === 0;
-
-  if (no_deleted && no_retained && no_failed) {
-    logger.warn('Nothing to delete');
-    return;
-  }
-
-  logger.success(
-    `Deleted ${result.deleted_objects} object(s), ${result.deleted_manifests} manifest(s)`,
-  );
-  logger.info(
-    `Retained and not deleted: ${result.retained_objects} object(s), ` +
-      `${result.retained_manifests} manifest(s)`,
-  );
-  logger.info(
-    `Failed for other reasons: ${result.failed_objects} object(s), ` +
-      `${result.failed_manifests} manifest(s)`,
-  );
-
-  if (!no_retained || !no_failed) {
     process.exitCode = 1;
   }
 }

--- a/packages/cli/src/commands/outlook.command.ts
+++ b/packages/cli/src/commands/outlook.command.ts
@@ -132,11 +132,10 @@ function register_outlook_save(group: Command, get_container: ContainerFactory):
 function register_outlook_delete(group: Command, get_container: ContainerFactory): void {
   group
     .command('delete')
-    .description('Delete backed-up data (mailbox, snapshot, or entire tenant)')
+    .description('Delete backed-up mail data (one mailbox or one snapshot)')
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option('-m, --mailbox <email>', 'delete all data and manifests for a mailbox')
     .option('-s, --snapshot <id>', 'delete a single snapshot manifest')
-    .option('--purge', 'delete ALL data in the tenant bucket (irreversible)')
     .option('-y, --yes', 'skip confirmation prompt')
     .action((options: OutlookDeleteOptions) => execute_outlook_delete(get_container(), options));
 }

--- a/packages/cli/src/commands/sharepoint-command.handlers.tsx
+++ b/packages/cli/src/commands/sharepoint-command.handlers.tsx
@@ -59,7 +59,8 @@ export interface SharePointSaveCommandOptions extends SharePointTenantOptions {
   skipVerify?: boolean;
 }
 
-function resolve_tenant_id(container: Container, options: SharePointTenantOptions): string {
+/** Resolves the tenant id from CLI options, falling back to the configured tenant. */
+export function resolve_tenant_id(container: Container, options: SharePointTenantOptions): string {
   if (options.tenant) return options.tenant;
   return container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
 }

--- a/packages/cli/src/commands/sharepoint-data-ops.handlers.tsx
+++ b/packages/cli/src/commands/sharepoint-data-ops.handlers.tsx
@@ -1,0 +1,87 @@
+import { Box } from 'ink';
+import type { Container } from 'inversify';
+import type { SharePointDeletionUseCase, SharePointStatusUseCase } from '@wisecom/atlas-types';
+import {
+  SHAREPOINT_DELETION_USE_CASE_TOKEN,
+  SHAREPOINT_STATUS_USE_CASE_TOKEN,
+} from '@wisecom/atlas-types';
+import { Banner } from '@/ui/components/banner';
+import { KeyValueList } from '@/ui/components/key-value-list';
+import { render_static_view } from '@/ui/render';
+import {
+  confirm_deletion,
+  print_delete_result,
+  render_delete_banner,
+} from '@/commands/deletion-presenter';
+import { print_drive_status } from '@/commands/drive-status-presenter';
+import {
+  resolve_site_id,
+  resolve_tenant_id,
+  type SharePointTenantOptions,
+} from '@/commands/sharepoint-command.handlers';
+
+export interface SharePointDeleteOptions extends SharePointTenantOptions {
+  site: string;
+  snapshot?: string;
+  yes?: boolean;
+}
+
+export interface SharePointStatusCommandOptions extends SharePointTenantOptions {
+  site: string;
+}
+
+/** Deletes one SharePoint snapshot, or every backup for a site, after confirmation. */
+export async function execute_sharepoint_delete(
+  container: Container,
+  options: SharePointDeleteOptions,
+): Promise<void> {
+  const tenant_id = resolve_tenant_id(container, options);
+  await render_delete_banner();
+
+  const site_id = await resolve_site_id(container, tenant_id, options.site);
+  const description = options.snapshot
+    ? `This will delete SharePoint snapshot ${options.snapshot} for ${site_id} ` +
+      `(data objects are retained for other snapshots)`
+    : `This will delete all SharePoint data and manifests for ${site_id}`;
+
+  if (!(await confirm_deletion(description, options.yes))) return;
+
+  const deletion = container.get<SharePointDeletionUseCase>(SHAREPOINT_DELETION_USE_CASE_TOKEN);
+  const result = options.snapshot
+    ? await deletion.delete_snapshot(tenant_id, site_id, options.snapshot)
+    : await deletion.delete_site_data(tenant_id, site_id);
+  print_delete_result(result);
+}
+
+/** Reports whether a site's SharePoint backup is current, library by library. */
+export async function execute_sharepoint_status(
+  container: Container,
+  options: SharePointStatusCommandOptions,
+): Promise<void> {
+  const tenant_id = resolve_tenant_id(container, options);
+  const site_id = await resolve_site_id(container, tenant_id, options.site);
+
+  await render_static_view(
+    <Box flexDirection="column">
+      <Banner title="Atlas SharePoint Status" />
+      <KeyValueList
+        items={[
+          { label: 'Tenant', value: tenant_id },
+          { label: 'Site', value: site_id },
+        ]}
+      />
+    </Box>,
+  );
+
+  const status = container.get<SharePointStatusUseCase>(SHAREPOINT_STATUS_USE_CASE_TOKEN);
+  const result = await status.check_sharepoint_status(tenant_id, site_id);
+  await print_drive_status({
+    scope_label: 'site',
+    item_label: 'Library',
+    last_backup_at: result.last_backup_at,
+    last_snapshot_id: result.last_snapshot_id,
+    is_up_to_date: result.is_up_to_date,
+    total_pending_changes: result.total_pending_changes,
+    items: result.libraries,
+  });
+}

--- a/packages/cli/src/commands/sharepoint.command.ts
+++ b/packages/cli/src/commands/sharepoint.command.ts
@@ -17,6 +17,12 @@ import {
   register_sharepoint_list_snapshots,
   register_sharepoint_list_versions,
 } from '@/commands/sharepoint-catalog.command';
+import {
+  execute_sharepoint_delete,
+  execute_sharepoint_status,
+  type SharePointDeleteOptions,
+  type SharePointStatusCommandOptions,
+} from '@/commands/sharepoint-data-ops.handlers';
 
 type ContainerFactory = () => Container;
 
@@ -35,6 +41,8 @@ export function register_sharepoint_command(
   register_sharepoint_restore(group, get_container);
   register_sharepoint_save(group, get_container);
   register_sharepoint_verify(group, get_container);
+  register_sharepoint_status(group, get_container);
+  register_sharepoint_delete(group, get_container);
 }
 
 function register_sharepoint_list_sites(group: Command, get_container: ContainerFactory): void {
@@ -113,5 +121,29 @@ function register_sharepoint_verify(group: Command, get_container: ContainerFact
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .action((options: SharePointVerifyOptions) =>
       execute_sharepoint_verify(get_container(), options),
+    );
+}
+
+function register_sharepoint_status(group: Command, get_container: ContainerFactory): void {
+  group
+    .command('status')
+    .description('Check whether a site SharePoint backup is up to date')
+    .requiredOption('--site <site>', 'site URL, hostname, or composite site ID')
+    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .action((options: SharePointStatusCommandOptions) =>
+      execute_sharepoint_status(get_container(), options),
+    );
+}
+
+function register_sharepoint_delete(group: Command, get_container: ContainerFactory): void {
+  group
+    .command('delete')
+    .description('Delete SharePoint backups for one site, or a single snapshot')
+    .requiredOption('--site <site>', 'site URL, hostname, or composite site ID')
+    .option('-s, --snapshot <id>', 'delete a single snapshot instead of every backup')
+    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .option('-y, --yes', 'skip confirmation prompt')
+    .action((options: SharePointDeleteOptions) =>
+      execute_sharepoint_delete(get_container(), options),
     );
 }

--- a/packages/cli/src/commands/tenant-delete.command.tsx
+++ b/packages/cli/src/commands/tenant-delete.command.tsx
@@ -1,0 +1,59 @@
+import type { Command } from 'commander';
+import type { Container } from 'inversify';
+import type { AtlasConfig } from '@wisecom/atlas-core';
+import { ATLAS_CONFIG_TOKEN, logger } from '@wisecom/atlas-core';
+import type { DeletionUseCase } from '@wisecom/atlas-types';
+import { DELETION_USE_CASE_TOKEN } from '@wisecom/atlas-types';
+import {
+  confirm_deletion,
+  print_delete_result,
+  render_delete_banner,
+} from '@/commands/deletion-presenter';
+
+type ContainerFactory = () => Container;
+
+export interface TenantDeleteOptions {
+  tenant?: string;
+  purge?: boolean;
+  yes?: boolean;
+}
+
+/**
+ * Registers the tenant-wide `atlas delete`. The purge sweeps the whole bucket across every
+ * workload, so it lives at the top level rather than under a workload group (issue #163).
+ */
+export function register_tenant_delete_command(
+  program: Command,
+  get_container: ContainerFactory,
+): void {
+  program
+    .command('delete')
+    .description('Delete tenant-wide data across every workload')
+    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .option('--purge', 'delete ALL data in the tenant bucket, every workload (irreversible)')
+    .option('-y, --yes', 'skip confirmation prompt')
+    .action((options: TenantDeleteOptions) => execute_tenant_delete(get_container(), options));
+}
+
+/** Purges every object in the tenant bucket after confirmation. */
+export async function execute_tenant_delete(
+  container: Container,
+  options: TenantDeleteOptions,
+): Promise<void> {
+  if (!options.purge) {
+    logger.error('Specify --purge to delete all tenant data, or use a workload delete command');
+    process.exitCode = 1;
+    return;
+  }
+
+  const tenant_id = options.tenant ?? container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
+  await render_delete_banner();
+
+  const description =
+    `This will delete ALL data for tenant ${tenant_id} across Outlook, OneDrive and ` +
+    `SharePoint (data, manifests, encryption keys)`;
+  if (!(await confirm_deletion(description, options.yes))) return;
+
+  const deletion = container.get<DeletionUseCase>(DELETION_USE_CASE_TOKEN);
+  print_delete_result(await deletion.purge_tenant(tenant_id));
+}

--- a/packages/cli/src/commands/tenant-delete.command.tsx
+++ b/packages/cli/src/commands/tenant-delete.command.tsx
@@ -4,11 +4,8 @@ import type { AtlasConfig } from '@wisecom/atlas-core';
 import { ATLAS_CONFIG_TOKEN, logger } from '@wisecom/atlas-core';
 import type { DeletionUseCase } from '@wisecom/atlas-types';
 import { DELETION_USE_CASE_TOKEN } from '@wisecom/atlas-types';
-import {
-  confirm_deletion,
-  print_delete_result,
-  render_delete_banner,
-} from '@/commands/deletion-presenter';
+import { print_delete_result, render_delete_banner } from '@/commands/deletion-presenter';
+import { ask_exact_match } from '@/ui/components/confirm-prompt';
 
 type ContainerFactory = () => Container;
 
@@ -49,11 +46,27 @@ export async function execute_tenant_delete(
   const tenant_id = options.tenant ?? container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
   await render_delete_banner();
 
-  const description =
+  logger.warn(
     `This will delete ALL data for tenant ${tenant_id} across Outlook, OneDrive and ` +
-    `SharePoint (data, manifests, encryption keys)`;
-  if (!(await confirm_deletion(description, options.yes))) return;
+      `SharePoint (data, manifests, encryption keys)`,
+  );
+  if (!(await confirm_purge_target(tenant_id, options.yes))) {
+    logger.info('Aborted');
+    return;
+  }
 
   const deletion = container.get<DeletionUseCase>(DELETION_USE_CASE_TOKEN);
   print_delete_result(await deletion.purge_tenant(tenant_id));
+}
+
+/**
+ * Confirms the purge by having the tenant ID typed back, rather than accepting a keypress.
+ *
+ * A purge deletes every workload's objects and then the encryption key, so the mistake worth
+ * guarding is not "meant to type n" but "purged the wrong tenant" (issue #187). Typing the target
+ * is the only confirmation that catches it. `-y` remains a full bypass for scheduled runs.
+ */
+async function confirm_purge_target(tenant_id: string, skip_prompt = false): Promise<boolean> {
+  if (skip_prompt) return true;
+  return await ask_exact_match('Type the tenant ID to confirm:', tenant_id);
 }

--- a/packages/cli/src/ui/components/confirm-prompt.tsx
+++ b/packages/cli/src/ui/components/confirm-prompt.tsx
@@ -55,3 +55,20 @@ export async function ask_confirmation(message: string, default_yes = false): Pr
   instance.unmount();
   return confirmed;
 }
+
+/**
+ * Asks the operator to type a value back and reports whether it matched exactly.
+ *
+ * Readline on a TTY as well as on piped stdin: a typed answer needs echo and line editing, which
+ * the single-keypress Ink prompt above deliberately does not provide. Trailing whitespace is
+ * forgiven because terminals and `echo` add it; nothing else is.
+ */
+export async function ask_exact_match(message: string, expected: string): Promise<boolean> {
+  const { promise, resolve } = Promise.withResolvers<boolean>();
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  rl.question(`${message} `, (answer) => {
+    rl.close();
+    resolve(answer.trim() === expected);
+  });
+  return await promise;
+}

--- a/packages/cli/tests/unit/drive-delete-command.test.ts
+++ b/packages/cli/tests/unit/drive-delete-command.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import {
+  ONEDRIVE_DELETION_USE_CASE_TOKEN,
+  SHAREPOINT_DELETION_USE_CASE_TOKEN,
+  SHAREPOINT_CONNECTOR_TOKEN,
+  DELETION_USE_CASE_TOKEN,
+  USER_IDENTITY_RESOLVER_TOKEN,
+} from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
+import type { DeletionResult } from '@wisecom/atlas-types';
+import { register_onedrive_command } from '@/commands/onedrive.command';
+import { register_sharepoint_command } from '@/commands/sharepoint.command';
+import { register_tenant_delete_command } from '@/commands/tenant-delete.command';
+import { register_outlook_command } from '@/commands/outlook.command';
+import { ask_confirmation } from '@/ui/components/confirm-prompt';
+
+vi.mock('@/ui/components/confirm-prompt', () => ({
+  ask_confirmation: vi.fn().mockResolvedValue(true),
+}));
+
+const TENANT_ID = 'test-tenant';
+const OWNER_EMAIL = 'user@example.com';
+const OWNER_OBJECT_ID = '75a21b57-4d82-4f42-9ccc-7c231c30f78c';
+const SITE_URL = 'https://contoso.sharepoint.com/sites/Example';
+const SITE_ID = `contoso.sharepoint.com,${OWNER_OBJECT_ID},11111111-1111-1111-1111-111111111111`;
+
+const RESULT: DeletionResult = {
+  deleted_objects: 3,
+  deleted_manifests: 1,
+  retained_objects: 0,
+  retained_manifests: 0,
+  failed_objects: 0,
+  failed_manifests: 0,
+};
+
+interface Harness {
+  program: Command;
+  onedrive: { delete_owner_data: Mock; delete_snapshot: Mock };
+  sharepoint: { delete_site_data: Mock; delete_snapshot: Mock };
+  outlook: { purge_tenant: Mock; delete_mailbox_data: Mock; delete_snapshot: Mock };
+  resolve_user: Mock;
+  resolve_site: Mock;
+}
+
+function harness(): Harness {
+  const container = new Container();
+  const onedrive = {
+    delete_owner_data: vi.fn().mockResolvedValue(RESULT),
+    delete_snapshot: vi.fn().mockResolvedValue(RESULT),
+  };
+  const sharepoint = {
+    delete_site_data: vi.fn().mockResolvedValue(RESULT),
+    delete_snapshot: vi.fn().mockResolvedValue(RESULT),
+  };
+  const outlook = {
+    purge_tenant: vi.fn().mockResolvedValue(RESULT),
+    delete_mailbox_data: vi.fn().mockResolvedValue(RESULT),
+    delete_snapshot: vi.fn().mockResolvedValue(RESULT),
+  };
+  const resolve_user = vi.fn().mockResolvedValue({
+    object_id: OWNER_OBJECT_ID,
+    email: OWNER_EMAIL,
+    display_name: 'Example User',
+  });
+  const resolve_site = vi.fn().mockResolvedValue({
+    site_id: SITE_ID,
+    site_url: SITE_URL,
+    display_name: 'Example',
+  });
+
+  container.bind(ONEDRIVE_DELETION_USE_CASE_TOKEN).toConstantValue(onedrive);
+  container.bind(SHAREPOINT_DELETION_USE_CASE_TOKEN).toConstantValue(sharepoint);
+  container.bind(DELETION_USE_CASE_TOKEN).toConstantValue(outlook);
+  container.bind(USER_IDENTITY_RESOLVER_TOKEN).toConstantValue({ resolve_user });
+  container.bind(SHAREPOINT_CONNECTOR_TOKEN).toConstantValue({ resolve_site });
+  container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({ tenant_id: TENANT_ID });
+
+  const program = new Command();
+  program.exitOverride();
+  register_onedrive_command(program, () => container);
+  register_sharepoint_command(program, () => container);
+  register_tenant_delete_command(program, () => container);
+  register_outlook_command(program, () => container);
+  return { program, onedrive, sharepoint, outlook, resolve_user, resolve_site };
+}
+
+describe('drive deletion commands (issue #163)', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.mocked(ask_confirmation).mockClear();
+    vi.mocked(ask_confirmation).mockResolvedValue(true);
+    process.exitCode = undefined;
+    h = harness();
+  });
+
+  it('deletes every OneDrive backup for the resolved owner object id, not the raw email', async () => {
+    await h.program.parseAsync(['onedrive', 'delete', '-o', OWNER_EMAIL, '-y'], { from: 'user' });
+
+    expect(h.resolve_user).toHaveBeenCalledWith(TENANT_ID, OWNER_EMAIL);
+    expect(h.onedrive.delete_owner_data).toHaveBeenCalledWith(TENANT_ID, OWNER_OBJECT_ID);
+    expect(h.onedrive.delete_snapshot).not.toHaveBeenCalled();
+  });
+
+  it('scopes OneDrive deletion to one snapshot when -s is given', async () => {
+    await h.program.parseAsync(
+      ['onedrive', 'delete', '-o', OWNER_OBJECT_ID, '-s', 'od-snap-1', '-y'],
+      { from: 'user' },
+    );
+
+    expect(h.onedrive.delete_snapshot).toHaveBeenCalledWith(
+      TENANT_ID,
+      OWNER_OBJECT_ID,
+      'od-snap-1',
+    );
+    expect(h.onedrive.delete_owner_data).not.toHaveBeenCalled();
+  });
+
+  it('deletes SharePoint data under the resolved composite site id', async () => {
+    await h.program.parseAsync(['sharepoint', 'delete', '--site', SITE_URL, '-y'], {
+      from: 'user',
+    });
+
+    expect(h.resolve_site).toHaveBeenCalledWith(TENANT_ID, SITE_URL);
+    expect(h.sharepoint.delete_site_data).toHaveBeenCalledWith(TENANT_ID, SITE_ID);
+  });
+
+  it('scopes SharePoint deletion to one snapshot when -s is given', async () => {
+    await h.program.parseAsync(
+      ['sharepoint', 'delete', '--site', SITE_ID, '-s', 'sp-snap-1', '-y'],
+      { from: 'user' },
+    );
+
+    expect(h.resolve_site).not.toHaveBeenCalled();
+    expect(h.sharepoint.delete_snapshot).toHaveBeenCalledWith(TENANT_ID, SITE_ID, 'sp-snap-1');
+  });
+
+  it('deletes nothing when the operator declines the confirmation', async () => {
+    vi.mocked(ask_confirmation).mockResolvedValue(false);
+
+    await h.program.parseAsync(['onedrive', 'delete', '-o', OWNER_OBJECT_ID], { from: 'user' });
+    await h.program.parseAsync(['sharepoint', 'delete', '--site', SITE_ID], { from: 'user' });
+    await h.program.parseAsync(['delete', '--purge'], { from: 'user' });
+
+    expect(h.onedrive.delete_owner_data).not.toHaveBeenCalled();
+    expect(h.sharepoint.delete_site_data).not.toHaveBeenCalled();
+    expect(h.outlook.purge_tenant).not.toHaveBeenCalled();
+  });
+
+  it('asks for confirmation before deleting when -y is absent', async () => {
+    await h.program.parseAsync(['onedrive', 'delete', '-o', OWNER_OBJECT_ID], { from: 'user' });
+
+    expect(ask_confirmation).toHaveBeenCalledTimes(1);
+    expect(h.onedrive.delete_owner_data).toHaveBeenCalledWith(TENANT_ID, OWNER_OBJECT_ID);
+  });
+});
+
+describe('tenant-wide purge moved out of the outlook group (issue #163)', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.mocked(ask_confirmation).mockResolvedValue(true);
+    process.exitCode = undefined;
+    h = harness();
+  });
+
+  it('purges the whole tenant from the top-level delete command', async () => {
+    await h.program.parseAsync(['delete', '--purge', '-y'], { from: 'user' });
+
+    expect(h.outlook.purge_tenant).toHaveBeenCalledWith(TENANT_ID);
+  });
+
+  it('refuses a bare delete rather than guessing a scope', async () => {
+    await h.program.parseAsync(['delete'], { from: 'user' });
+
+    expect(h.outlook.purge_tenant).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('no longer accepts --purge under outlook delete', async () => {
+    await expect(
+      h.program.parseAsync(['outlook', 'delete', '--purge', '-y'], { from: 'user' }),
+    ).rejects.toThrow(/unknown option/);
+    expect(h.outlook.purge_tenant).not.toHaveBeenCalled();
+  });
+
+  it('still deletes a single mailbox through outlook delete', async () => {
+    await h.program.parseAsync(['outlook', 'delete', '-m', OWNER_EMAIL, '-y'], { from: 'user' });
+
+    expect(h.outlook.delete_mailbox_data).toHaveBeenCalledWith(TENANT_ID, OWNER_EMAIL);
+  });
+});

--- a/packages/cli/tests/unit/drive-delete-command.test.ts
+++ b/packages/cli/tests/unit/drive-delete-command.test.ts
@@ -15,10 +15,11 @@ import { register_onedrive_command } from '@/commands/onedrive.command';
 import { register_sharepoint_command } from '@/commands/sharepoint.command';
 import { register_tenant_delete_command } from '@/commands/tenant-delete.command';
 import { register_outlook_command } from '@/commands/outlook.command';
-import { ask_confirmation } from '@/ui/components/confirm-prompt';
+import { ask_confirmation, ask_exact_match } from '@/ui/components/confirm-prompt';
 
 vi.mock('@/ui/components/confirm-prompt', () => ({
   ask_confirmation: vi.fn().mockResolvedValue(true),
+  ask_exact_match: vi.fn().mockResolvedValue(true),
 }));
 
 const TENANT_ID = 'test-tenant';
@@ -141,6 +142,7 @@ describe('drive deletion commands (issue #163)', () => {
 
   it('deletes nothing when the operator declines the confirmation', async () => {
     vi.mocked(ask_confirmation).mockResolvedValue(false);
+    vi.mocked(ask_exact_match).mockResolvedValue(false);
 
     await h.program.parseAsync(['onedrive', 'delete', '-o', OWNER_OBJECT_ID], { from: 'user' });
     await h.program.parseAsync(['sharepoint', 'delete', '--site', SITE_ID], { from: 'user' });
@@ -164,7 +166,10 @@ describe('tenant-wide purge moved out of the outlook group (issue #163)', () => 
 
   beforeEach(() => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.mocked(ask_confirmation).mockClear();
     vi.mocked(ask_confirmation).mockResolvedValue(true);
+    vi.mocked(ask_exact_match).mockClear();
+    vi.mocked(ask_exact_match).mockResolvedValue(true);
     process.exitCode = undefined;
     h = harness();
   });
@@ -193,5 +198,32 @@ describe('tenant-wide purge moved out of the outlook group (issue #163)', () => 
     await h.program.parseAsync(['outlook', 'delete', '-m', OWNER_EMAIL, '-y'], { from: 'user' });
 
     expect(h.outlook.delete_mailbox_data).toHaveBeenCalledWith(TENANT_ID, OWNER_EMAIL);
+  });
+
+  it('purges only when the tenant ID is typed back exactly', async () => {
+    vi.mocked(ask_exact_match).mockResolvedValue(false);
+    await h.program.parseAsync(['delete', '--purge'], { from: 'user' });
+    expect(h.outlook.purge_tenant).not.toHaveBeenCalled();
+
+    vi.mocked(ask_exact_match).mockResolvedValue(true);
+    await h.program.parseAsync(['delete', '--purge'], { from: 'user' });
+
+    expect(ask_exact_match).toHaveBeenLastCalledWith(expect.any(String), TENANT_ID);
+    expect(h.outlook.purge_tenant).toHaveBeenCalledWith(TENANT_ID);
+  });
+
+  it('never asks the operator to type anything when -y is given', async () => {
+    await h.program.parseAsync(['delete', '--purge', '-y'], { from: 'user' });
+
+    expect(ask_exact_match).not.toHaveBeenCalled();
+    expect(ask_confirmation).not.toHaveBeenCalled();
+    expect(h.outlook.purge_tenant).toHaveBeenCalledWith(TENANT_ID);
+  });
+
+  it('asks for the tenant ID against --tenant, not the configured tenant', async () => {
+    await h.program.parseAsync(['delete', '--purge', '-t', 'other-tenant'], { from: 'user' });
+
+    expect(ask_exact_match).toHaveBeenLastCalledWith(expect.any(String), 'other-tenant');
+    expect(h.outlook.purge_tenant).toHaveBeenCalledWith('other-tenant');
   });
 });

--- a/packages/cli/tests/unit/drive-status-command.test.ts
+++ b/packages/cli/tests/unit/drive-status-command.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import {
+  ONEDRIVE_STATUS_USE_CASE_TOKEN,
+  SHAREPOINT_STATUS_USE_CASE_TOKEN,
+  SHAREPOINT_CONNECTOR_TOKEN,
+  USER_IDENTITY_RESOLVER_TOKEN,
+} from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
+import { register_onedrive_command } from '@/commands/onedrive.command';
+import { register_sharepoint_command } from '@/commands/sharepoint.command';
+
+const TENANT_ID = 'test-tenant';
+const OWNER_EMAIL = 'user@example.com';
+const OWNER_OBJECT_ID = '75a21b57-4d82-4f42-9ccc-7c231c30f78c';
+const SITE_URL = 'https://contoso.sharepoint.com/sites/Example';
+const SITE_ID = `contoso.sharepoint.com,${OWNER_OBJECT_ID},11111111-1111-1111-1111-111111111111`;
+
+const ONEDRIVE_STATUS = {
+  owner_id: OWNER_OBJECT_ID,
+  last_backup_at: new Date('2026-08-01T10:00:00Z'),
+  last_snapshot_id: 'od-snap-1',
+  total_drives: 2,
+  drives: [
+    {
+      drive_id: 'd1',
+      drive_name: 'OneDrive',
+      has_backup: true,
+      pending_changes: 4,
+      is_up_to_date: false,
+    },
+    {
+      drive_id: 'd2',
+      drive_name: 'Archive',
+      has_backup: false,
+      pending_changes: 0,
+      is_up_to_date: false,
+    },
+  ],
+  is_up_to_date: false,
+  total_pending_changes: 4,
+};
+
+const SHAREPOINT_STATUS = {
+  site_id: SITE_ID,
+  last_backup_at: undefined,
+  last_snapshot_id: undefined,
+  total_libraries: 1,
+  libraries: [
+    {
+      drive_id: 'l1',
+      drive_name: 'Documents',
+      has_backup: false,
+      pending_changes: 0,
+      is_up_to_date: false,
+    },
+  ],
+  is_up_to_date: false,
+  total_pending_changes: 0,
+};
+
+interface Harness {
+  program: Command;
+  check_onedrive_status: Mock;
+  check_sharepoint_status: Mock;
+  resolve_user: Mock;
+  resolve_site: Mock;
+}
+
+function harness(): Harness {
+  const container = new Container();
+  const check_onedrive_status = vi.fn().mockResolvedValue(ONEDRIVE_STATUS);
+  const check_sharepoint_status = vi.fn().mockResolvedValue(SHAREPOINT_STATUS);
+  const resolve_user = vi.fn().mockResolvedValue({
+    object_id: OWNER_OBJECT_ID,
+    email: OWNER_EMAIL,
+    display_name: 'Example User',
+  });
+  const resolve_site = vi.fn().mockResolvedValue({
+    site_id: SITE_ID,
+    site_url: SITE_URL,
+    display_name: 'Example',
+  });
+
+  container.bind(ONEDRIVE_STATUS_USE_CASE_TOKEN).toConstantValue({ check_onedrive_status });
+  container.bind(SHAREPOINT_STATUS_USE_CASE_TOKEN).toConstantValue({ check_sharepoint_status });
+  container.bind(USER_IDENTITY_RESOLVER_TOKEN).toConstantValue({ resolve_user });
+  container.bind(SHAREPOINT_CONNECTOR_TOKEN).toConstantValue({ resolve_site });
+  container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({ tenant_id: TENANT_ID });
+
+  const program = new Command();
+  program.exitOverride();
+  register_onedrive_command(program, () => container);
+  register_sharepoint_command(program, () => container);
+  return { program, check_onedrive_status, check_sharepoint_status, resolve_user, resolve_site };
+}
+
+describe('drive status commands (issue #163)', () => {
+  let h: Harness;
+  let output: string[];
+
+  beforeEach(() => {
+    output = [];
+    const capture = (...args: unknown[]): void => {
+      output.push(args.join(' '));
+    };
+    vi.spyOn(console, 'log').mockImplementation(capture);
+    vi.spyOn(console, 'warn').mockImplementation(capture);
+    h = harness();
+  });
+
+  it('checks OneDrive status under the resolved owner object id', async () => {
+    await h.program.parseAsync(['onedrive', 'status', '-o', OWNER_EMAIL], { from: 'user' });
+
+    expect(h.resolve_user).toHaveBeenCalledWith(TENANT_ID, OWNER_EMAIL);
+    expect(h.check_onedrive_status).toHaveBeenCalledWith(TENANT_ID, OWNER_OBJECT_ID);
+  });
+
+  it('reports the last snapshot and the overall pending verdict', async () => {
+    await h.program.parseAsync(['onedrive', 'status', '-o', OWNER_OBJECT_ID], { from: 'user' });
+
+    const text = output.join('\n');
+    expect(text).toContain('od-snap-1');
+    expect(text).toContain('4 pending change(s)');
+    expect(text).toContain('1 drive(s) never backed up');
+  });
+
+  it('checks SharePoint status under the resolved composite site id', async () => {
+    await h.program.parseAsync(['sharepoint', 'status', '--site', SITE_URL], { from: 'user' });
+
+    expect(h.resolve_site).toHaveBeenCalledWith(TENANT_ID, SITE_URL);
+    expect(h.check_sharepoint_status).toHaveBeenCalledWith(TENANT_ID, SITE_ID);
+  });
+
+  it('warns when a site has never been backed up', async () => {
+    await h.program.parseAsync(['sharepoint', 'status', '--site', SITE_ID], { from: 'user' });
+
+    expect(h.resolve_site).not.toHaveBeenCalled();
+    expect(output.join('\n')).toContain('No previous backup found for this site.');
+  });
+});


### PR DESCRIPTION
Closes #187.

> **Stacked on #185.** `atlas delete --purge` is introduced by #185, so this branch is cut from `fix/163-drive-delete-status` and its diff will show that commit until #185 merges. Merge #185 first; this PR then reduces to the one commit `6a7889f`. The alternative was implementing the guard on `atlas outlook delete --purge`, which #185 deletes, so it would have been thrown away on merge.

## What changed

The purge asked for one keypress. It now asks for the tenant ID:

```
[!] This will delete ALL data for tenant <tenant-id> across Outlook, OneDrive and SharePoint (data, manifests, encryption keys)
Type the tenant ID to confirm:
```

Anything else aborts, exits zero, and deletes nothing, matching the existing declined-confirmation behaviour.

New `ask_exact_match` in `packages/cli/src/ui/components/confirm-prompt.tsx`, on readline for both a TTY and piped stdin. The existing single-keypress Ink prompt is not usable for a typed answer: it has no echo and no line editing. Trailing whitespace is trimmed, since terminals and `echo` add it; nothing else is forgiven.

It validates against the *effective* tenant, so when `-t` is passed that is the ID which has to be typed. Purging the wrong tenant is the mistake this guards, and the guard would be pointless if it checked the config default while the flag pointed elsewhere.

## Why not a keypress, and why only here

A `y/n` prompt confirms the verb. The failure mode worth guarding is not "meant to type n", it is a purge aimed at the wrong tenant on a workstation that has several in `~/.atlas/config.enc`. Typing the target is the only prompt that catches that.

Workload-scoped deletes (`outlook delete -m/-s`, `onedrive delete`, `sharepoint delete`) deliberately keep `y/n`. Making every delete laborious is how operators learn to pass `-y` to everything, which would remove the guard that actually matters.

`-y` remains a complete bypass. `test_90_purge`, `test_40_replication` and `atlas_e2e/cleanup.py` all purge non-interactively and are untouched.

## Verification

Against the built bundle, through real piped stdin rather than a mock:

| Input | Result |
| --- | --- |
| `echo wrong-tenant \| atlas delete --purge` | `Type the tenant ID to confirm:` then `Aborted`, nothing deleted |
| `echo <tenant> \| atlas delete --purge -t <tenant>` | prompt accepted, purge proceeds |

Run against the all-zeros placeholder tenant for the accepting case, so nothing real was in scope.

- Three new cases in `drive-delete-command.test.ts`: purge only on an exact match (`purge_tenant` not called on a mismatch), no prompt at all under `-y`, and the prompt validating against `--tenant` rather than the configured tenant. The existing declined-confirmation case now covers both prompt types.
- `pnpm run build` 10/10, `pnpm run typecheck` 17/17, `pnpm run lint` 0 errors, `pnpm run docs:build` clean, `pnpm run test` 1070 passed with CLI at 79.

## Docs

`docs/reference/cli.md` under `atlas delete`: the prompt is shown, `-y` is described as skipping the typed confirmation, `-t` notes that it is the ID being checked, and the paragraph states why scoped deletes keep `y/n`.