### PR TITLE
fix(replicate): leave no drive manifest when object copies failed

### DIFF
--- a/docs/operations/replication.md
+++ b/docs/operations/replication.md
@@ -47,6 +47,8 @@ Objects are always copied in this order:
 
 If replication crashes at any point, the target is left in a safe state: orphan data blobs exist (harmless, reclaimable), but no manifest ever references missing objects. Rerunning replication picks up where it left off.
 
+The same guarantee covers a run that completes with failures instead of crashing. If any object fails to copy, the manifest is not written at all, so the snapshot still counts as unreplicated and the next run retries it. This applies to Outlook, OneDrive and SharePoint alike. Whether a snapshot needs replicating is decided by manifest presence on the target, so a manifest written after a partial copy would make the failure permanent: the retry would report nothing to do while the missing objects stayed missing.
+
 ## Safety model
 
 ### Primary is authoritative

--- a/packages/core/src/services/replication/onedrive-snapshot-replicator.ts
+++ b/packages/core/src/services/replication/onedrive-snapshot-replicator.ts
@@ -48,6 +48,14 @@ export async function replicate_onedrive_snapshot(
   const all_keys = [...storage_keys, ...(options.ancillary_keys ?? [])];
   const tally = await copy_keys_with_tally(source_ctx, target_ctx, all_keys);
 
+  // A manifest is what makes a snapshot reachable, so a partial copy must leave none behind.
+  // diff_od_manifests decides "already replicated" from manifest presence alone, so writing one
+  // after a failed blob copy makes the failure sticky: the next run skips the snapshot and never
+  // retries the missing objects. Mirrors the Outlook gate in replicate_snapshot_to_target.
+  if (tally.objects_failed > 0) {
+    return { ...tally, source_manifest_checksum: '', replicated_manifest_checksum: '' };
+  }
+
   const source_manifest_blob = await source_ctx.storage.get(manifest_key);
   const source_manifest_checksum = sha256_hex(source_manifest_blob);
   await target_ctx.storage.put(manifest_key, source_manifest_blob);

--- a/packages/core/src/services/replication/sharepoint-snapshot-replicator.ts
+++ b/packages/core/src/services/replication/sharepoint-snapshot-replicator.ts
@@ -48,6 +48,14 @@ export async function replicate_sharepoint_snapshot(
   const all_keys = [...storage_keys, ...(options.ancillary_keys ?? [])];
   const tally = await copy_keys_with_tally(source_ctx, target_ctx, all_keys);
 
+  // A manifest is what makes a snapshot reachable, so a partial copy must leave none behind.
+  // diff_sp_manifests decides "already replicated" from manifest presence alone, so writing one
+  // after a failed blob copy makes the failure sticky: the next run skips the snapshot and never
+  // retries the missing objects. Mirrors the Outlook gate in replicate_snapshot_to_target.
+  if (tally.objects_failed > 0) {
+    return { ...tally, source_manifest_checksum: '', replicated_manifest_checksum: '' };
+  }
+
   const source_manifest_blob = await source_ctx.storage.get(manifest_key);
   const source_manifest_checksum = sha256_hex(source_manifest_blob);
   await target_ctx.storage.put(manifest_key, source_manifest_blob);

--- a/packages/core/tests/unit/services/replication/drive-snapshot-replicator.test.ts
+++ b/packages/core/tests/unit/services/replication/drive-snapshot-replicator.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Issue #190: a drive snapshot whose blobs did not all copy must leave no manifest on the target.
+ *
+ * The storage fakes are Map-backed rather than assertion-only mocks on purpose. What makes the bug
+ * sticky is the interaction between the manifest write and the presence check that decides whether a
+ * snapshot still needs replicating, so the diff assertions here read the target the replicator
+ * actually wrote instead of a hardcoded list.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  ObjectStorage,
+  OneDriveSnapshotManifest,
+  SharePointSnapshotManifest,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+import { stub_tenant_create_decipher } from '@wisecom/atlas-types/testing/stub-tenant-create-decipher';
+import { replicate_onedrive_snapshot } from '@/services/replication/onedrive-snapshot-replicator';
+import { replicate_sharepoint_snapshot } from '@/services/replication/sharepoint-snapshot-replicator';
+import { diff_od_manifests } from '@/services/replication/onedrive-replication-helpers';
+import { diff_sp_manifests } from '@/services/replication/sharepoint-replication-helpers';
+
+const OD_MANIFEST_KEY = 'onedrive/manifests/owner-1/snapshot-1.json';
+const SP_MANIFEST_KEY = 'sharepoint/manifests/site-1/snapshot-1.json';
+const OD_DATA_KEY = 'onedrive/data/owner-1/hash-1';
+const SP_DATA_KEY = 'sharepoint/data/site-1/hash-1';
+
+function make_storage(
+  objects: Map<string, Buffer>,
+  reject_put: readonly string[] = [],
+): ObjectStorage {
+  return {
+    put: vi.fn(async (key: string, data: Buffer) => {
+      if (reject_put.includes(key)) throw new Error('AccessDenied');
+      objects.set(key, data);
+    }),
+    get: vi.fn(async (key: string) => {
+      const value = objects.get(key);
+      if (!value) throw new Error(`NoSuchKey: ${key}`);
+      return value;
+    }),
+    exists: vi.fn(async (key: string) => objects.has(key)),
+    list: vi.fn(async (prefix: string) =>
+      [...objects.keys()].filter((key) => key.startsWith(prefix)),
+    ),
+    delete: vi.fn(),
+    delete_version: vi.fn(),
+    list_versions: vi.fn(),
+    begin_multipart_upload: vi.fn(),
+    copy: vi.fn(),
+    get_with_etag: vi.fn(),
+    get_stream: vi.fn(),
+    apply_default_retention: vi.fn(),
+    abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+    probe_immutability: vi.fn(),
+  };
+}
+
+function make_context(storage: ObjectStorage, tenant_id = 'tenant-1'): TenantContext {
+  return {
+    tenant_id,
+    storage,
+    encrypt: vi.fn((data: Buffer) => data),
+    decrypt: vi.fn((data: Buffer) => data),
+    create_cipher: stub_tenant_create_cipher,
+    create_decipher: stub_tenant_create_decipher,
+    destroy: vi.fn(),
+  };
+}
+
+/** A source holding the DEK, one data blob and the snapshot manifest. */
+function make_source(manifest_key: string, data_key: string): Map<string, Buffer> {
+  return new Map([
+    ['_meta/dek.enc', Buffer.from('wrapped-dek')],
+    [data_key, Buffer.from('ciphertext')],
+    [manifest_key, Buffer.from('encrypted-manifest')],
+  ]);
+}
+
+function make_od_manifest(): OneDriveSnapshotManifest {
+  return {
+    id: 'manifest-1',
+    tenant_id: 'tenant-1',
+    owner_id: 'owner-1',
+    snapshot_id: 'snapshot-1',
+    created_at: new Date('2026-01-01'),
+    total_files: 1,
+    total_size_bytes: 10,
+    entries: [
+      {
+        file_id: 'file-1',
+        drive_id: 'drive-1',
+        file_name: 'Report.docx',
+        parent_path: '/',
+        size_bytes: 10,
+        storage_key: OD_DATA_KEY,
+        backup_at: '2026-01-01T00:00:00.000Z',
+        change_type: 'created',
+      },
+    ],
+  };
+}
+
+function make_sp_manifest(): SharePointSnapshotManifest {
+  return {
+    id: 'manifest-1',
+    tenant_id: 'tenant-1',
+    site_id: 'site-1',
+    snapshot_id: 'snapshot-1',
+    created_at: new Date('2026-01-01'),
+    total_files: 1,
+    total_size_bytes: 10,
+    entries: [
+      {
+        file_id: 'file-1',
+        drive_id: 'drive-1',
+        file_name: 'Budget.xlsx',
+        parent_path: '/',
+        size_bytes: 10,
+        storage_key: SP_DATA_KEY,
+        backup_at: '2026-01-01T00:00:00.000Z',
+        change_type: 'created',
+      },
+    ],
+  };
+}
+
+describe('replicate_onedrive_snapshot manifest gate (#190)', () => {
+  it('writes no manifest when a data blob fails to copy, and still reports the tally', async () => {
+    const target_objects = new Map<string, Buffer>();
+    const source_ctx = make_context(make_storage(make_source(OD_MANIFEST_KEY, OD_DATA_KEY)));
+    const target_ctx = make_context(make_storage(target_objects, [OD_DATA_KEY]));
+
+    const result = await replicate_onedrive_snapshot(
+      source_ctx,
+      target_ctx,
+      make_od_manifest(),
+      OD_MANIFEST_KEY,
+    );
+
+    expect(result.objects_failed).toBe(1);
+    expect(result.objects_copied).toBe(0);
+    expect(result.errors[0]).toContain('AccessDenied');
+    expect(result.source_manifest_checksum).toBe('');
+    expect(result.replicated_manifest_checksum).toBe('');
+    expect(target_objects.has(OD_MANIFEST_KEY)).toBe(false);
+  });
+
+  it('leaves the snapshot unreplicated so the next run retries it', async () => {
+    const target_objects = new Map<string, Buffer>();
+    const source_ctx = make_context(make_storage(make_source(OD_MANIFEST_KEY, OD_DATA_KEY)));
+    const target_ctx = make_context(make_storage(target_objects, [OD_DATA_KEY]));
+    const manifest = make_od_manifest();
+
+    await replicate_onedrive_snapshot(source_ctx, target_ctx, manifest, OD_MANIFEST_KEY);
+
+    const pending = await diff_od_manifests([manifest], target_ctx, 'owner-1');
+    expect(pending.map((m) => m.snapshot_id)).toEqual(['snapshot-1']);
+  });
+
+  it('writes no manifest when an ancillary object fails to copy', async () => {
+    const index_key = 'onedrive/index/owner-1/runs/snapshot-1.json';
+    const source_objects = make_source(OD_MANIFEST_KEY, OD_DATA_KEY);
+    source_objects.set(index_key, Buffer.from('version-index'));
+    const target_objects = new Map<string, Buffer>();
+    const source_ctx = make_context(make_storage(source_objects));
+    const target_ctx = make_context(make_storage(target_objects, [index_key]));
+
+    const result = await replicate_onedrive_snapshot(
+      source_ctx,
+      target_ctx,
+      make_od_manifest(),
+      OD_MANIFEST_KEY,
+      { ancillary_keys: [index_key] },
+    );
+
+    expect(result.objects_failed).toBe(1);
+    expect(target_objects.has(OD_MANIFEST_KEY)).toBe(false);
+  });
+
+  it('still writes the manifest when every object copies', async () => {
+    const target_objects = new Map<string, Buffer>();
+    const source_ctx = make_context(make_storage(make_source(OD_MANIFEST_KEY, OD_DATA_KEY)));
+    const target_ctx = make_context(make_storage(target_objects));
+    const manifest = make_od_manifest();
+
+    const result = await replicate_onedrive_snapshot(
+      source_ctx,
+      target_ctx,
+      manifest,
+      OD_MANIFEST_KEY,
+    );
+
+    expect(result.objects_failed).toBe(0);
+    expect(result.objects_copied).toBe(1);
+    expect(result.source_manifest_checksum).toBe(result.replicated_manifest_checksum);
+    expect(target_objects.has(OD_MANIFEST_KEY)).toBe(true);
+    expect(await diff_od_manifests([manifest], target_ctx, 'owner-1')).toEqual([]);
+  });
+});
+
+describe('replicate_sharepoint_snapshot manifest gate (#190)', () => {
+  it('writes no manifest when a data blob fails to copy, and still reports the tally', async () => {
+    const target_objects = new Map<string, Buffer>();
+    const source_ctx = make_context(make_storage(make_source(SP_MANIFEST_KEY, SP_DATA_KEY)));
+    const target_ctx = make_context(make_storage(target_objects, [SP_DATA_KEY]));
+
+    const result = await replicate_sharepoint_snapshot(
+      source_ctx,
+      target_ctx,
+      make_sp_manifest(),
+      SP_MANIFEST_KEY,
+    );
+
+    expect(result.objects_failed).toBe(1);
+    expect(result.objects_copied).toBe(0);
+    expect(result.errors[0]).toContain('AccessDenied');
+    expect(result.source_manifest_checksum).toBe('');
+    expect(result.replicated_manifest_checksum).toBe('');
+    expect(target_objects.has(SP_MANIFEST_KEY)).toBe(false);
+  });
+
+  it('leaves the snapshot unreplicated so the next run retries it', async () => {
+    const target_objects = new Map<string, Buffer>();
+    const source_ctx = make_context(make_storage(make_source(SP_MANIFEST_KEY, SP_DATA_KEY)));
+    const target_ctx = make_context(make_storage(target_objects, [SP_DATA_KEY]));
+    const manifest = make_sp_manifest();
+
+    await replicate_sharepoint_snapshot(source_ctx, target_ctx, manifest, SP_MANIFEST_KEY);
+
+    const pending = await diff_sp_manifests([manifest], target_ctx, 'site-1');
+    expect(pending.map((m) => m.snapshot_id)).toEqual(['snapshot-1']);
+  });
+
+  it('still writes the manifest when every object copies', async () => {
+    const target_objects = new Map<string, Buffer>();
+    const source_ctx = make_context(make_storage(make_source(SP_MANIFEST_KEY, SP_DATA_KEY)));
+    const target_ctx = make_context(make_storage(target_objects));
+    const manifest = make_sp_manifest();
+
+    const result = await replicate_sharepoint_snapshot(
+      source_ctx,
+      target_ctx,
+      manifest,
+      SP_MANIFEST_KEY,
+    );
+
+    expect(result.objects_failed).toBe(0);
+    expect(result.source_manifest_checksum).toBe(result.replicated_manifest_checksum);
+    expect(target_objects.has(SP_MANIFEST_KEY)).toBe(true);
+    expect(await diff_sp_manifests([manifest], target_ctx, 'site-1')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #190.

## Problem

`replicate_onedrive_snapshot` and `replicate_sharepoint_snapshot` wrote the snapshot manifest to the target regardless of the copy tally. `replicate_snapshot_to_target` (Outlook) has gated on this since it was written, the two drive twins never did.

That makes a partial copy permanent rather than transient. `diff_od_manifests` and `diff_sp_manifests` decide whether a snapshot still needs replicating from manifest presence alone:

```ts
return source.filter((m) => !ids.has(m.snapshot_id));
```

So a manifest written after a failed blob copy means the next run reports nothing to do, the missing objects are never retried, and `rehydrate` from that replica yields a snapshot whose manifest references objects that are not there. The operator watching the first run does see `objects_failed`, but the operator who fixes the storage problem and re-runs replication gets a clean no-op.

## Fix

The same early return the Outlook path already uses, in both drive replicators:

```ts
if (tally.objects_failed > 0) {
  return { ...tally, source_manifest_checksum: '', replicated_manifest_checksum: '' };
}
```

Placed after `copy_keys_with_tally` and before the manifest read, so nothing is written when the tally is dirty. The result still carries `objects_copied`, `objects_skipped`, `objects_failed`, `bytes_copied` and `errors`, so reporting and the status sidecar are unchanged.

Ancillary objects (version indexes, delta cursors) needed no separate handling: `all_keys` already concatenates them into the same tally, so a failed index copy also suppresses the manifest. That is the behaviour the issue asked for, since a manifest is what makes those objects reachable.

No caller changes. Every call site routes through `build_replication_result`, which already coalesces absent checksums with `?? ''`.

## Tests

New file, `packages/core/tests/unit/services/replication/drive-snapshot-replicator.test.ts`, 7 tests covering both drives. The storage fakes are `Map`-backed rather than assertion-only mocks, so the diff assertions read the target the replicator actually wrote instead of a hardcoded list. That matters here: the bug is the interaction between the manifest write and the presence check, and a mocked `list` would let the regression pass.

Confirmed the tests fail without the source change. Reverting only the two replicators:

```
× writes no manifest when a data blob fails to copy, and still reports the tally
× leaves the snapshot unreplicated so the next run retries it
× writes no manifest when an ancillary object fails to copy
× writes no manifest when a data blob fails to copy, and still reports the tally   (sharepoint)
× leaves the snapshot unreplicated so the next run retries it                      (sharepoint)

AssertionError: expected [] to deeply equal [ 'snapshot-1' ]
Tests  5 failed | 304 passed (309)
```

`expected [] to deeply equal ['snapshot-1']` is the data-loss symptom itself: the snapshot no longer appears as pending. The two happy-path tests pass with and without the gate on purpose, so an over-broad gate that suppressed healthy manifests would fail them.

This also lifts the two replicators off the 0.0% and 3.9% statement coverage that hid the divergence, which is part of what #191 tracks.

## Verification

- `pnpm run build` 10/10
- `pnpm run typecheck` 17/17
- `pnpm run lint` clean
- `pnpm run test` 15/15 tasks, core 309 passed (was 302)
- `pnpm run docs:build` clean

## Docs

`docs/operations/replication.md` already promised this ("no manifest ever references missing objects"), but only for a crash. A run that completes with failures is a different path and was undocumented, so the guarantee is now stated explicitly along with why manifest presence makes a partial write permanent.

## Not in scope

The E2E suite does not cover replication failure injection, and #210 has to land before the drive suites past `test_40` run at all. Left alone deliberately.
