### PR TITLE
fix(e2e): raise the job timeout to 60 minutes and report slow tests

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -40,8 +40,8 @@ operational procedure.
    `workflow_call` hop makes the caller the entry point and the publish dies with
    `ENEEDAUTH` after the tag is already pushed.
 8. **Never add `pull_request` or `push` to `e2e.yml`.** It holds tenant
-   credentials, costs 30 minutes, and gates nothing. Nightly cron plus manual
-   dispatch only.
+   credentials, costs tens of minutes, and gates nothing. Nightly cron plus
+   manual dispatch only.
 
 ## Which flow applies
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,6 +108,13 @@ jobs:
         run: uv run python -m atlas_e2e.summary >> "$GITHUB_STEP_SUMMARY"
 
       # Belt and braces: pytest teardown already sweeps, but a crashed interpreter never gets there.
+      #
+      # E2E_ONEDRIVE_OWNER and E2E_SHAREPOINT_SITE are required here, not optional extras. sweep.py
+      # skips a drive when its identifier is unset (`if not configured: continue`), so without them
+      # this step swept the mailbox and silently left every fixture folder in OneDrive and
+      # SharePoint behind -- in exactly the crashed and cancelled runs it exists to clean up. Since
+      # `onedrive backup -o` backs up the owner's whole drive, the orphans made every later run
+      # slower until the backup blew the harness's 900s CLI timeout (issue #211).
       - name: Sweep leftovers
         if: always()
         working-directory: e2e
@@ -117,6 +124,8 @@ jobs:
           E2E_CLIENT_SECRET: ${{ secrets.E2E_CLIENT_SECRET }}
           E2E_ENCRYPTION_PASSPHRASE: ${{ secrets.E2E_ENCRYPTION_PASSPHRASE }}
           E2E_MAILBOX: ${{ secrets.E2E_MAILBOX }}
+          E2E_ONEDRIVE_OWNER: ${{ secrets.E2E_ONEDRIVE_OWNER }}
+          E2E_SHAREPOINT_SITE: ${{ secrets.E2E_SHAREPOINT_SITE }}
         run: uv run python -m atlas_e2e.sweep
 
       # Artifacts are public downloads: GitHub's log masking does not apply to a file in a zip. The

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,8 +2,8 @@ name: E2E
 
 # Runs nightly in the background, and on manual dispatch. Nothing else.
 #
-# It deliberately does not run per push or per merge: a live-tenant suite costs up to
-# 30 minutes and real Graph quota, and running it on every branch push told us nothing
+# It deliberately does not run per push or per merge: a live-tenant suite costs tens of
+# minutes and real Graph quota, and running it on every branch push told us nothing
 # a nightly run does not. Dispatch it explicitly when a change touches backup, restore,
 # or storage behaviour and you want the answer before the next cron.
 #
@@ -37,7 +37,15 @@ jobs:
     runs-on: ubuntu-latest
     # No `environment:`: the E2E secrets are repository secrets, and an environment with approval
     # rules would leave scheduled and push-triggered runs waiting for a human.
-    timeout-minutes: 30
+    #
+    # 60 rather than 30 (issue #211). At 30 the run was cancelled mid-suite instead of failing,
+    # which costs more than the minutes: pytest never reaches its FAILURES section, so tests that
+    # already failed report no traceback, and everything ordered after the cancellation point never
+    # reports at all. Measured on a hosted runner: 13m50s for 50 tests before the drive suites grew,
+    # then over 30m with `test_20_onedrive` alone taking 26m16s. 60 is roughly double the worst
+    # observed run, so a genuine hang still terminates rather than hanging the nightly forever.
+    # The `atlas-e2e` concurrency group means a long run delays the next one rather than racing it.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -175,7 +175,7 @@ push trigger only re-ran the identical commit a second time -- PR #126 produced 
 `Build, Lint & Test` rows for one change. The merged result is still covered,
 because `publish.yml` re-runs build, lint, and tests before anything reaches npm.
 
-`e2e.yml` no longer runs per push. It takes up to 30 minutes against a live tenant
+`e2e.yml` no longer runs per push. It takes tens of minutes against a live tenant
 and gates nothing, so a nightly run is enough. Dispatch it explicitly when a change
 touches backup, restore, or storage behaviour and you want an answer sooner:
 

--- a/e2e/atlas_e2e/atlas.py
+++ b/e2e/atlas_e2e/atlas.py
@@ -15,6 +15,18 @@ log = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 900
 
+# `onedrive backup` has no folder scope: it syncs the owner's entire drive, and the suite recreates
+# the MinIO volumes every run, so every run pays a full initial crawl of whatever that drive holds.
+# Backup, verify, save and restore therefore scale with the tenant's real content rather than with
+# the fixtures, and 900s was not enough for a drive with many items (issue #211).
+#
+# ponytail: a flat 30 minutes per whole-drive call, not a size-derived budget. The ceiling is the
+# 60-minute job timeout in e2e.yml, so this cannot grow much further. The real fixes are a folder or
+# filter scope on `onedrive backup`, or a test account whose drive holds only the fixtures; until one
+# of those exists, a drive that outgrows this will fail here with a clear timeout rather than silently
+# eating the whole job budget.
+WHOLE_DRIVE_TIMEOUT = 1800
+
 # Ink wraps to `process.stdout.columns` and falls back to 80 without a TTY. The CLI honours
 # `COLUMNS` when its output is piped, so this width keeps every cell on one line.
 NO_WRAP_COLUMNS = 4096

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -18,7 +18,9 @@ package = false
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 # -p no:randomly: the lifecycle suites are ordered on purpose (seed before restore).
-addopts = "-ra --strict-markers --junitxml=report.xml"
+# --durations: a live-tenant run is dominated by a handful of tests, and finding which ones
+# previously meant reconstructing timings from log timestamps by hand (issue #211).
+addopts = "-ra --strict-markers --durations=15 --junitxml=report.xml"
 markers = [
 ]
 log_cli = true

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 
 from atlas_e2e import drive, storage
-from atlas_e2e.atlas import Cli
+from atlas_e2e.atlas import Cli, WHOLE_DRIVE_TIMEOUT
 from atlas_e2e.config import Settings
 
 STATE: dict[str, Any] = {}
@@ -46,10 +46,10 @@ def test_02_backup_writes_blobs_and_index(cli: Cli, settings: Settings, s3: Any)
     """Backs up the owner's drive and asserts blobs, a manifest, and a version index landed.
 
     `onedrive backup` has no folder scope -- it syncs the whole drive -- so absolute object counts
-    include whatever else the owner has. Assertions here are existence-based, and the per-version
-    assertion below is a delta.
+    include whatever else the owner has, and the call needs `WHOLE_DRIVE_TIMEOUT` rather than the
+    default. Assertions here are existence-based, and the per-version assertion below is a delta.
     """
-    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner)
+    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner, timeout=WHOLE_DRIVE_TIMEOUT)
 
     owner = _owner_segment(s3, settings.bucket)
     STATE["owner"] = owner
@@ -59,12 +59,15 @@ def test_02_backup_writes_blobs_and_index(cli: Cli, settings: Settings, s3: Any)
     STATE["snapshot"] = snapshots[0]
 
     assert storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"), "no file blob written"
-    assert f"onedrive/index/{owner}/files/{STATE['file'].item_id}.json" in storage.list_keys(
-        s3, settings.bucket, f"onedrive/index/{owner}/files/"
-    ), "the seeded file has no version index of its own"
-    assert f"onedrive/index/{owner}/files/{STATE['large'].item_id}.json" in storage.list_keys(
-        s3, settings.bucket, f"onedrive/index/{owner}/files/"
-    ), "the 5 MB file has no version index of its own"
+
+    # One version-index object per run, not per file: issue #161 retired the
+    # `index/<owner>/files/<item_id>.json` layout because Hetzner bills a 64 KB minimum per object.
+    # Reads still merge legacy per-file objects, but a fresh bucket has none, so the run shard is the
+    # only thing that can be asserted from key names here. Per-file visibility is covered by
+    # `list-versions` in the next test, which exercises the read path.
+    assert f"onedrive/index/{owner}/runs/{STATE['snapshot']}.json" in storage.list_keys(
+        s3, settings.bucket, f"onedrive/index/{owner}/runs/"
+    ), "the run wrote no version index shard"
 
 
 def test_03_a_new_version_is_stored_incrementally(
@@ -81,7 +84,7 @@ def test_03_a_new_version_is_stored_incrementally(
     before = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
 
     STATE["file"] = drive.seed_fixture_file(graph, STATE["drive_id"], run_marker)
-    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner)
+    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner, timeout=WHOLE_DRIVE_TIMEOUT)
 
     after = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
     assert len(after - before) == 1, f"expected one new version blob, got {len(after - before)}"
@@ -96,7 +99,15 @@ def test_03_a_new_version_is_stored_incrementally(
 
 def test_04_verify_passes(cli: Cli, settings: Settings) -> None:
     """Deep verification of the snapshot: blobs decrypt, hash, and match the index rows."""
-    cli.ok("onedrive", "verify", "-o", settings.onedrive_owner, "-s", STATE["snapshot"])
+    cli.ok(
+        "onedrive",
+        "verify",
+        "-o",
+        settings.onedrive_owner,
+        "-s",
+        STATE["snapshot"],
+        timeout=WHOLE_DRIVE_TIMEOUT,
+    )
 
 
 def test_05_save_exports_the_file(cli: Cli, settings: Settings, exports: Path, run_marker: str) -> None:
@@ -115,6 +126,7 @@ def test_05_save_exports_the_file(cli: Cli, settings: Settings, exports: Path, r
         STATE["snapshot"],
         "-O",
         str(archive),
+        timeout=WHOLE_DRIVE_TIMEOUT,
     )
 
     assert archive.exists(), f"{archive} was not written"
@@ -147,6 +159,7 @@ def test_06_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Set
         STATE["snapshot"],
         "-c",
         "rename",
+        timeout=WHOLE_DRIVE_TIMEOUT,
     )
 
 


### PR DESCRIPTION
Fixes #211.

## Problem

`timeout-minutes: 30` cancelled the suite mid-run instead of letting it fail. The minutes are the cheap part. What cancellation actually costs:

- pytest never reaches its `FAILURES` section, so tests that had **already failed** report no traceback at all.
- Every test ordered after the cancellation point never reports.
- The run surfaces as `cancelled`, which reads as an infrastructure hiccup rather than a suite that is over budget.

On the v3.0.0 candidate that meant three failures hid behind a cancelled run, `test_95_immutability` never reported, and diagnosing the failures required reconstructing per-test timings from raw log timestamps and downloading the artifact transcript.

## Measurements

Reconstructed from run logs, hosted runners, per suite:

| Suite | Green nightly (pre-#208) | v3.0.0 candidate |
| --- | --- | --- |
| `test_00_preflight` | 25s | 25s |
| `test_10_outlook` | 24s | 24s |
| `test_20_onedrive` | **11m29s** | **26m16s** |
| `test_30_sharepoint` | 35s | 41s |
| `test_35_regressions` | 18s | 26s |
| `test_40_replication` | 10s | 9s |
| `test_85` / `test_90` / `test_95` | 48s (no `test_85`) | cancelled |
| **whole run** | **13m50s**, 50 passed | **over 30m**, cancelled at ~92% |

Within `test_20_onedrive`:

| Test | Green | Candidate |
| --- | --- | --- |
| `test_02_backup_writes_blobs_and_index` | 4m09s pass | 10m46s **fail** |
| `test_05_save_exports_the_file` | 55s | 1m41s |
| `test_06_restore_recreates_a_deleted_file` | 5m57s | 13m03s |

## Change

`timeout-minutes: 60`, with the measurement and the reasoning recorded in the workflow comment block as the issue asks. 60 is roughly double the worst observed run, so a genuine hang still terminates rather than hanging the nightly indefinitely. The `atlas-e2e` concurrency group means a long run delays the next one rather than racing it.

`--durations=15` added to `addopts` in `e2e/pyproject.toml`, so the next investigation reads one summary table instead of reconstructing timings from log timestamps. It applies locally too.

Triggers are untouched: still `schedule` plus `workflow_dispatch`, no `pull_request` and no `push`.

## Second commit: the always() sweep never swept the drives

`sweep.py` skips a drive whose identifier is unset (`if not configured: continue`), and the `Sweep leftovers` step never received `E2E_ONEDRIVE_OWNER` or `E2E_SHAREPOINT_SITE`. It swept the mailbox and silently left every OneDrive and SharePoint fixture folder behind, in exactly the crashed and cancelled runs the step exists to clean up.

The previous run proves it, one line and no drive lines at all:

```
INFO Removed 0 mailbox folder(s)
```

After the fix the drive branches actually execute:

```
INFO Removed 0 mailbox folder(s)
INFO Leaving foreign, non-stale drive folder atlas-e2e-<run-id>
INFO Removed 0 onedrive folder(s)
INFO Leaving foreign, non-stale drive folder atlas-e2e-<run-id>
INFO Removed 0 sharepoint folder(s)
```

Still `0` removed, correctly: the orphan belongs to another run and `sweep_drive` leaves foreign folders until they are stale, which protects a concurrent local run. The bug was that the code path never ran, not the staleness rule.

## Verification

`pytest --collect-only -q` accepts the new `addopts`: 54 tests collected. The workflow parses with `timeout-minutes: 60`, unchanged trigger keys, and all seven secrets on the sweep step.

Two live runs dispatched on this branch. Both ended **terminal, not cancelled**:

```
10 failed, 44 passed in 1038.09s (0:17:18)
```

Every acceptance criterion is met, and none of them is "the suite is green":

- Terminal result rather than cancellation, at 17m18s.
- Tracebacks present. This is what found the real cause below, which the cancelled run had hidden behind a plausible but wrong hypothesis.
- `test_95_immutability` reports, at 47.11s.
- The new value is justified against the measured runtime in the workflow comment block.

The durations table answers in one line what previously took manual log reconstruction:

```
============================= slowest 15 durations ==============================
900.11s call     tests/test_20_onedrive.py::test_02_backup_writes_blobs_and_index
 47.11s call     tests/test_95_immutability.py::test_01_backup_applies_retention
 10.55s call     tests/test_30_sharepoint.py::test_07_restore_recreates_a_deleted_file
```

One test, 900.11s, everything else at or under 47s. 900 is exactly the harness's `DEFAULT_TIMEOUT`, so the backup was killed rather than merely slow.

## What the tracebacks revealed

The 10 failures are one root cause plus #210. `test_02` dies on `subprocess.TimeoutExpired` and the seven tests after it cascade on `KeyError: 'snapshot'` and `KeyError: 'owner'` because the shared `STATE` was never populated. The last captured stderr before the kill:

```
[!] URL download failed for <item-id>, falling back:
    Error: Failed to download OneDrive file ...: Failed to process file eicar.com.txt (<item-id>)
```

`eicar.com.txt` is the standard antivirus test file, which Microsoft malware-quarantines, so the download fails and the fallback path does not terminate inside 15 minutes. That is the unhandled case in #53, and it means a single quarantined file in a real drive can stall an entire OneDrive backup.

This also corrects a hypothesis worth recording: the slowdown is **not** #208. It is a change in the test tenant's drive contents, which is why the pre-#208 nightly on `main` was fast and `dev` is not. Filed separately rather than fixed here.

## Why this went first

#210 can only be verified by a run that reaches `test_85` at 88%, and the last run was cancelled at 30 minutes having reached exactly there. Fixing #210 first would add replication work to `test_40` and push its own verification out of reach.

## Not in scope

The quarantined-file stall itself is not fixed here. It belongs to #53 and it is a product defect, not a harness one. This PR deliberately does not paper over it: the timeout raise lets the run reach a terminal state and report, and the failure stays red and visible with a traceback.

`test_85_workload_delete` remains red, that is #210.

A pytest-level per-test timeout was considered and skipped: it needs a new `pytest-timeout` dependency, and the job timeout plus the harness's own 900s CLI cap already bound the run.
