### PR TITLE
fix(drive): skip malware-quarantined files instead of stalling the backup

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -143,6 +143,23 @@ Once the underlying problem clears, the next run picks the file up automatically
 `UNHEALTHY` with `will retry` is a warning: the backup is progressing, one file is behind. `PERMANENTLY SKIPPED after 5 attempts` means the file needs a human. Check its permissions, sensitivity label, or whether it is corrupt in the source. Either way the rest of the drive keeps being protected, and the exit code stays non-zero so schedulers can alert on it.
 :::
 
+### Content the service refuses to serve
+
+Malware-quarantined files are a separate case, and they are detected rather than retried. Atlas selects the Graph `malware` facet in its delta query, so a quarantined item is recognised before any download is attempted:
+
+```
+[!] Not backed up: infected.docx (01STBDHIPIY7N3OWY...) -- Quarantined by Microsoft 365 malware
+    policy: infected.docx (01STBDHIPIY7N3OWY...); PERMANENTLY SKIPPED by service policy, not
+    retried, first failed 2026-08-11T07:58:43.224Z
+[x] Status: UNHEALTHY
+```
+
+These records never consume the 5-attempt budget, because the budget exists for failures that might still succeed. A quarantine is a policy decision, and no number of retries changes it.
+
+Attempting the download is not merely wasteful, it is actively harmful. Graph refuses quarantined content by aborting the transfer rather than returning a clean 403, and an aborted transfer is indistinguishable from a network fault, so it engages the full Graph retry budget of 12 attempts over roughly 23 minutes. A single quarantined file could hold up an entire drive backup for that long, per run. Detecting the facet up front removes that stall.
+
+The file stays reported on every run until it is removed or cleaned in the source, and the run stays `UNHEALTHY`, so an operator can always answer which files are not in the backup and why.
+
 ## Snapshot Health Status
 
 Every backup prints a health status at the end:

--- a/docs/security.md
+++ b/docs/security.md
@@ -156,6 +156,21 @@ Atlas does **not** import archived MIME back into Exchange. Live testing establi
 
 The archived object keeps full fidelity either way. When an operator needs the original bytes -- for a legal hold, a forensic review, or DKIM verification -- `atlas outlook save` is the path that delivers them, and it never touches the live mailbox.
 
+### Content Microsoft 365 refuses to release
+
+Some drive content cannot be archived at all, because the service will not serve it. Malware-quarantined files are the clear case: Microsoft blocks the download by policy, so no backup tool can capture the bytes.
+
+Atlas selects the Graph `malware` facet during delta enumeration and skips a quarantined item without attempting the download. The item is then recorded in the drive's failed-item ledger, reported on every run, and the run is marked `UNHEALTHY` with a non-zero exit code. An operator can always answer which files are absent from a backup and why, which is the property that matters for an audit.
+
+Two consequences worth stating plainly:
+
+- **The quarantined file is not in your backup.** Atlas reports it rather than silently omitting it, but a restore cannot produce a file the service never released. If the content matters, it has to be cleaned or released in Microsoft 365 first.
+- **Retrying is not a workaround.** A quarantine is a policy state, so quarantined items do not consume the 5-attempt retry budget that transient failures use. Attempting the download is worse than useless: Graph aborts the transfer instead of returning a clean 403, an aborted transfer is indistinguishable from a network fault, and the request therefore inherits the full Graph retry budget of 12 attempts across roughly 23 minutes. One quarantined file could stall a whole drive backup for that long on every run.
+
+::: warning Sensitivity labels are not captured
+Atlas does not currently capture Microsoft Purview sensitivity labels or IRM protection state for drive items. Labelled files whose content Graph does serve are backed up as ciphertext like any other file, but the label itself is not recorded, so a restored copy does not carry its original classification. Treat restored content as unclassified until it is relabelled. Capturing label metadata is tracked separately; it is a metered Graph surface and is deliberately out of scope for the quarantine handling described above.
+:::
+
 ## Integrity Validation
 
 Atlas validates data integrity at three independent layers. Each layer catches a different class of failure:

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -130,6 +130,23 @@ Once the underlying problem clears, the next run picks the file up automatically
 `UNHEALTHY` with `will retry` is a warning: the backup is progressing, one file is behind. `PERMANENTLY SKIPPED after 5 attempts` means the file needs a human. Check its permissions, sensitivity label, or whether it is corrupt in the source. Either way the rest of the library keeps being protected, and the exit code stays non-zero so schedulers can alert on it.
 :::
 
+### Content the service refuses to serve
+
+Malware-quarantined files are a separate case, and they are detected rather than retried. Atlas selects the Graph `malware` facet in its delta query, so a quarantined item is recognised before any download is attempted:
+
+```
+[!] Not backed up: infected.docx (01STBDHIPIY7N3OWY...) -- Quarantined by Microsoft 365 malware
+    policy: infected.docx (01STBDHIPIY7N3OWY...); PERMANENTLY SKIPPED by service policy, not
+    retried, first failed 2026-08-11T07:58:43.224Z
+[x] Status: UNHEALTHY
+```
+
+These records never consume the 5-attempt budget, because the budget exists for failures that might still succeed. A quarantine is a policy decision, and no number of retries changes it.
+
+Attempting the download is not merely wasteful, it is actively harmful. Graph refuses quarantined content by aborting the transfer rather than returning a clean 403, and an aborted transfer is indistinguishable from a network fault, so it engages the full Graph retry budget of 12 attempts over roughly 23 minutes. A single quarantined file could hold up an entire library backup for that long, per run. Detecting the facet up front removes that stall.
+
+The file stays reported on every run until it is removed or cleaned in the source, and the run stays `UNHEALTHY`, so an operator can always answer which files are not in the backup and why.
+
 ## Snapshot Health Status
 
 Every backup prints a health status at the end:

--- a/packages/core/src/services/shared/failed-item-ledger.ts
+++ b/packages/core/src/services/shared/failed-item-ledger.ts
@@ -26,7 +26,14 @@ export const MAX_FAILED_ITEM_ATTEMPTS = 5;
 /** Returns the ledger with this failure recorded, incrementing the item's attempt count. */
 export function record_item_failure(
   ledger: FailedItemLedger,
-  failure: { item_id: string; drive_id: string; name: string; reason: string },
+  failure: {
+    item_id: string;
+    drive_id: string;
+    name: string;
+    reason: string;
+    /** The service refuses this content by policy; retrying cannot help. */
+    permanent?: boolean;
+  },
 ): FailedItemLedger {
   const now = new Date().toISOString();
   const previous = ledger[failure.item_id];
@@ -39,6 +46,7 @@ export function record_item_failure(
       name: failure.name,
       reason: failure.reason,
       attempts: (previous?.attempts ?? 0) + 1,
+      ...(failure.permanent === true ? { permanent: true } : {}),
       first_failed_at: previous?.first_failed_at ?? now,
       last_failed_at: now,
     },
@@ -52,28 +60,34 @@ export function clear_item_failure(ledger: FailedItemLedger, item_id: string): F
   return rest;
 }
 
-/** Items belonging to one drive that still have retry budget left. */
+/** Items belonging to one drive that are still worth re-fetching. */
 export function retryable_items(ledger: FailedItemLedger, drive_id: string): FailedItemRecord[] {
   return Object.values(ledger).filter(
-    (record) => record.drive_id === drive_id && record.attempts < MAX_FAILED_ITEM_ATTEMPTS,
+    (record) => record.drive_id === drive_id && !is_retry_exhausted(record),
   );
 }
 
-/** True once an item has exhausted its retry budget and is only reported. */
+/** True once an item will no longer be re-fetched, whether by budget or by policy. */
 export function is_retry_exhausted(record: FailedItemRecord): boolean {
-  return record.attempts >= MAX_FAILED_ITEM_ATTEMPTS;
+  return record.permanent === true || record.attempts >= MAX_FAILED_ITEM_ATTEMPTS;
 }
 
 /**
- * One operator-facing line per outstanding failure. Items past the budget are
- * called out as permanent, so a transient blip reads differently from a file
- * that will never back up without intervention.
+ * One operator-facing line per outstanding failure, so a transient blip reads
+ * differently from a file that will never back up without intervention.
+ *
+ * Three states, not two: a policy block is called out separately from a burned
+ * attempt budget, because "5 attempts failed" invites the operator to retry
+ * while "the service refuses this content" tells them not to bother.
  */
 export function describe_failed_items(ledger: FailedItemLedger): string[] {
   return Object.values(ledger).map((record) => {
-    const status = is_retry_exhausted(record)
-      ? `PERMANENTLY SKIPPED after ${record.attempts} attempts`
-      : `will retry (attempt ${record.attempts} of ${MAX_FAILED_ITEM_ATTEMPTS})`;
+    const status =
+      record.permanent === true
+        ? 'PERMANENTLY SKIPPED by service policy, not retried'
+        : record.attempts >= MAX_FAILED_ITEM_ATTEMPTS
+          ? `PERMANENTLY SKIPPED after ${record.attempts} attempts`
+          : `will retry (attempt ${record.attempts} of ${MAX_FAILED_ITEM_ATTEMPTS})`;
     return (
       `Not backed up: ${record.name} (${record.item_id}) -- ${record.reason}; ` +
       `${status}, first failed ${record.first_failed_at}`

--- a/packages/core/tests/unit/services/shared/failed-item-ledger.test.ts
+++ b/packages/core/tests/unit/services/shared/failed-item-ledger.test.ts
@@ -124,3 +124,35 @@ describe('describe_failed_items', () => {
     expect(describe_failed_items({})).toEqual([]);
   });
 });
+
+describe('policy-blocked items (issue #53)', () => {
+  const BLOCKED = { ...FAILURE, name: 'infected.docx', reason: 'quarantined', permanent: true };
+
+  it('marks the record permanent on the first failure', () => {
+    expect(record_item_failure({}, BLOCKED)['item-1']).toMatchObject({
+      attempts: 1,
+      permanent: true,
+    });
+  });
+
+  it('is never offered for retry, even on its first attempt', () => {
+    const ledger = record_item_failure({}, BLOCKED);
+
+    expect(ledger['item-1']!.attempts).toBe(1);
+    expect(retryable_items(ledger, 'drive-a')).toEqual([]);
+    expect(is_retry_exhausted(ledger['item-1']!)).toBe(true);
+  });
+
+  it('reports a policy refusal rather than a spent attempt budget', () => {
+    const [line] = describe_failed_items(record_item_failure({}, BLOCKED));
+
+    expect(line).toContain('infected.docx');
+    expect(line).toContain('service policy');
+    expect(line).not.toContain('will retry');
+    expect(line).not.toContain(`after 1 attempts`);
+  });
+
+  it('leaves transient failures retryable', () => {
+    expect(retryable_items(record_item_failure({}, FAILURE), 'drive-a')).toHaveLength(1);
+  });
+});

--- a/packages/onedrive/src/adapters/graph-onedrive-delta-mapper.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-delta-mapper.ts
@@ -21,6 +21,14 @@ export interface GraphDeltaDriveItem {
    * requested explicitly: `$select` strips it otherwise.
    */
   deleted?: { state?: string };
+  /**
+   * Non-null when Microsoft 365 has quarantined the item. Graph then refuses to
+   * serve its content, and the refusal surfaces as an aborted transfer rather
+   * than a clean 403, which `is_network_error` reads as retryable. Selecting the
+   * facet lets the pipeline skip the item instead of spending the full Graph
+   * retry budget on content that will never be served (issue #53).
+   */
+  malware?: Record<string, unknown>;
   '@removed'?: { reason: string };
   '@microsoft.graph.downloadUrl'?: string;
 }
@@ -42,6 +50,7 @@ export const DRIVE_DELTA_SELECT_FIELDS = [
   'folder',
   'package',
   'deleted',
+  'malware',
   '@microsoft.graph.downloadUrl',
 ].join(',');
 
@@ -93,6 +102,7 @@ export function map_delta_item(raw: GraphDeltaDriveItem, drive_id: string): OneD
     parent_path,
     size_bytes: raw.size ?? 0,
     deleted: is_deleted,
+    ...(raw.malware ? { quarantined: true } : {}),
     ...(raw.package ? { package_type: raw.package.type ?? 'unknown' } : {}),
     ...(raw.webUrl ? { web_url: raw.webUrl } : {}),
     ...(raw.eTag ? { etag: raw.eTag } : {}),

--- a/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
+++ b/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
@@ -311,6 +311,7 @@ export async function process_single_drive(
         drive_id: drive.drive_id,
         name: item.file_name,
         reason: outcome.error,
+        ...(outcome.permanent === true ? { permanent: true } : {}),
       });
       continue;
     }

--- a/packages/onedrive/src/services/onedrive-delta-item-processor.ts
+++ b/packages/onedrive/src/services/onedrive-delta-item-processor.ts
@@ -36,6 +36,8 @@ export interface DeltaItemOutcome {
   files_deduplicated: number;
   deleted_items: number;
   error?: string;
+  /** The error is a policy refusal, so retrying it on later runs is pointless. */
+  permanent?: boolean;
 }
 
 /** Clears file tracking maps when Graph signals a delta reset. */
@@ -90,6 +92,20 @@ export async function process_delta_item(
       files_stored: 0,
       files_deduplicated: 0,
       deleted_items: 1,
+    };
+  }
+
+  // Quarantined content is never served, so attempting the download only burns
+  // the Graph retry budget: the refusal arrives as an aborted transfer, which
+  // `is_network_error` classifies as retryable, and a single blocked file can
+  // then hold a backup for the full ~23 minute budget (issue #53).
+  if (item.quarantined === true) {
+    return {
+      files_stored: 0,
+      files_deduplicated: 0,
+      deleted_items: 0,
+      error: `Quarantined by Microsoft 365 malware policy: ${item.file_name} (${item.item_id})`,
+      permanent: true,
     };
   }
 

--- a/packages/onedrive/tests/unit/services/onedrive-quarantined-items.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-quarantined-items.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Issue #53: a malware-quarantined file must not stall the backup.
+ *
+ * Graph never serves quarantined content, and it refuses in a way that looks
+ * retryable: the transfer aborts rather than returning a clean 403, so
+ * `is_network_error` matches on the message and `with_graph_retry` spends its
+ * full ~23 minute budget on content that will never arrive. The pipeline
+ * therefore has to skip the item on the `malware` facet, before any download.
+ */
+
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import type { OneDriveConnector, OneDriveDeltaItem, TenantContext } from '@wisecom/atlas-types';
+import {
+  process_delta_item,
+  type DriveTrackingState,
+  type VersionStats,
+} from '@/services/onedrive-delta-item-processor';
+import type { RunVersionCollector } from '@/services/onedrive-version-sync';
+
+function make_item(overrides: Partial<OneDriveDeltaItem> = {}): OneDriveDeltaItem {
+  return {
+    item_id: 'item-1',
+    drive_id: 'drive-1',
+    kind: 'file',
+    file_name: 'infected.docx',
+    parent_path: '/',
+    size_bytes: 68,
+    deleted: false,
+    etag: 'etag-1',
+    ...overrides,
+  };
+}
+
+function make_state(): DriveTrackingState {
+  return {
+    previous_path_by_file_id: {},
+    previous_name_by_file_id: {},
+    previous_etag_by_file_id: {},
+    previous_kind_by_file_id: {},
+  };
+}
+
+function make_connector(): { connector: OneDriveConnector; download: Mock } {
+  const download = vi.fn(async () => Buffer.from('content'));
+  const connector = {
+    download_file_content: download,
+    list_file_versions: vi.fn(async () => []),
+  } as unknown as OneDriveConnector;
+  return { connector, download };
+}
+
+function make_context(): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: {
+      exists: vi.fn(async () => false),
+      put: vi.fn(async () => undefined),
+    },
+    encrypt: (buffer: Buffer) => buffer,
+  } as unknown as TenantContext;
+}
+
+async function run(item: OneDriveDeltaItem) {
+  const { connector, download } = make_connector();
+  const versions: RunVersionCollector = { watermarks: {}, rows: new Map() };
+  const version_stats: VersionStats = {
+    total_versions_stored: 0,
+    total_versions_unavailable: 0,
+    total_versions_failed: 0,
+  };
+
+  const outcome = await process_delta_item(
+    connector,
+    item,
+    'owner-1',
+    'snap-1',
+    make_context(),
+    make_state(),
+    version_stats,
+    () => undefined,
+    versions,
+  );
+
+  return { outcome, download };
+}
+
+describe('process_delta_item with a quarantined file (#53)', () => {
+  it('never attempts the download', async () => {
+    const { download } = await run(make_item({ quarantined: true }));
+
+    expect(download).not.toHaveBeenCalled();
+  });
+
+  it('reports the block as permanent so later runs stop re-fetching it', async () => {
+    const { outcome } = await run(make_item({ quarantined: true }));
+
+    expect(outcome.permanent).toBe(true);
+    expect(outcome.error).toContain('Quarantined');
+    expect(outcome.error).toContain('infected.docx');
+  });
+
+  it('stores no entry and counts no file', async () => {
+    const { outcome } = await run(make_item({ quarantined: true }));
+
+    expect(outcome.entry).toBeUndefined();
+    expect(outcome.files_stored).toBe(0);
+    expect(outcome.files_deduplicated).toBe(0);
+    expect(outcome.deleted_items).toBe(0);
+  });
+
+  it('still downloads a file that is not quarantined', async () => {
+    const { outcome, download } = await run(make_item());
+
+    expect(download).toHaveBeenCalledTimes(1);
+    expect(outcome.error).toBeUndefined();
+    expect(outcome.entry?.file_id).toBe('item-1');
+  });
+
+  it('treats a deleted quarantined item as a deletion, not a block', async () => {
+    const { outcome, download } = await run(make_item({ quarantined: true, deleted: true }));
+
+    expect(download).not.toHaveBeenCalled();
+    expect(outcome.deleted_items).toBe(1);
+    expect(outcome.error).toBeUndefined();
+  });
+});

--- a/packages/sharepoint/src/adapters/graph-sharepoint-delta-fetch.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-delta-fetch.ts
@@ -21,6 +21,7 @@ const DRIVE_DELTA_SELECT_FIELDS = [
   'folder',
   'package',
   'deleted',
+  'malware',
   '@microsoft.graph.downloadUrl',
 ].join(',');
 

--- a/packages/sharepoint/src/adapters/graph-sharepoint-delta-mapper.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-delta-mapper.ts
@@ -17,6 +17,14 @@ export interface GraphDeltaDriveItem {
    * requested explicitly: `$select` strips it otherwise.
    */
   deleted?: { state?: string };
+  /**
+   * Non-null when Microsoft 365 has quarantined the item. Graph then refuses to
+   * serve its content, and the refusal surfaces as an aborted transfer rather
+   * than a clean 403, which `is_network_error` reads as retryable. Selecting the
+   * facet lets the pipeline skip the item instead of spending the full Graph
+   * retry budget on content that will never be served (issue #53).
+   */
+  malware?: Record<string, unknown>;
   '@removed'?: { reason: string };
   '@microsoft.graph.downloadUrl'?: string;
 }
@@ -54,6 +62,7 @@ export function map_delta_item(raw: GraphDeltaDriveItem, drive_id: string): Shar
     parent_path,
     size_bytes: raw.size ?? 0,
     deleted: is_deleted,
+    ...(raw.malware ? { quarantined: true } : {}),
     ...(raw.package ? { package_type: raw.package.type ?? 'unknown' } : {}),
     ...(raw.webUrl ? { web_url: raw.webUrl } : {}),
     ...(raw.eTag ? { etag: raw.eTag } : {}),

--- a/packages/sharepoint/src/services/sharepoint-library-item-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-library-item-processor.ts
@@ -94,6 +94,22 @@ export async function process_delta_item(
     return;
   }
 
+  // Quarantined content is never served, so attempting the download only burns
+  // the Graph retry budget: the refusal arrives as an aborted transfer, which
+  // `is_network_error` classifies as retryable, and a single blocked file can
+  // then hold a backup for the full ~23 minute budget (issue #53).
+  if (item.quarantined === true) {
+    library_state.failed_item_ids.add(item.item_id);
+    library_state.failed_items = record_item_failure(library_state.failed_items, {
+      item_id: item.item_id,
+      drive_id: item.drive_id,
+      name: item.file_name,
+      reason: `Quarantined by Microsoft 365 malware policy: ${item.file_name} (${item.item_id})`,
+      permanent: true,
+    });
+    return;
+  }
+
   const result = await process_backup_file(connector, item, site_id, ctx);
   if (!result) {
     library_state.failed_item_ids.add(item.item_id);

--- a/packages/sharepoint/tests/unit/services/sharepoint-quarantined-items.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-quarantined-items.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Issue #53: a malware-quarantined file must not stall the backup.
+ *
+ * Graph never serves quarantined content, and it refuses in a way that looks
+ * retryable: the transfer aborts rather than returning a clean 403, so
+ * `is_network_error` matches on the message and `with_graph_retry` spends its
+ * full ~23 minute budget on content that will never arrive. The pipeline
+ * therefore has to skip the item on the `malware` facet, before any download.
+ */
+
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import type {
+  SharePointDeltaItem,
+  SharePointSiteConnector,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import {
+  process_delta_item,
+  type FileTrackingState,
+  type LibraryProcessingState,
+  type VersionStatsState,
+} from '@/services/sharepoint-library-item-processor';
+import type { RunVersionCollector } from '@/services/sharepoint-version-sync';
+
+function make_item(overrides: Partial<SharePointDeltaItem> = {}): SharePointDeltaItem {
+  return {
+    item_id: 'item-1',
+    drive_id: 'drive-1',
+    kind: 'file',
+    file_name: 'infected.docx',
+    parent_path: '/',
+    size_bytes: 68,
+    deleted: false,
+    etag: 'etag-1',
+    ...overrides,
+  };
+}
+
+function make_tracking(): FileTrackingState {
+  return {
+    previous_path_by_file_id: {},
+    previous_name_by_file_id: {},
+    previous_etag_by_file_id: {},
+    previous_kind_by_file_id: {},
+  };
+}
+
+function make_library_state(): LibraryProcessingState {
+  return {
+    library_entries: [],
+    library_name: 'Documents',
+    library_files_stored: 0,
+    library_files_deduplicated: 0,
+    library_deleted_items: 0,
+    failed_items: {},
+    failed_item_ids: new Set<string>(),
+  };
+}
+
+function make_connector(): { connector: SharePointSiteConnector; download: Mock } {
+  const download = vi.fn(async () => Buffer.from('content'));
+  const connector = {
+    download_file_content: download,
+    list_file_versions: vi.fn(async () => []),
+  } as unknown as SharePointSiteConnector;
+  return { connector, download };
+}
+
+function make_context(): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: {
+      exists: vi.fn(async () => false),
+      put: vi.fn(async () => undefined),
+    },
+    encrypt: (buffer: Buffer) => buffer,
+  } as unknown as TenantContext;
+}
+
+async function run(item: SharePointDeltaItem) {
+  const { connector, download } = make_connector();
+  const library_state = make_library_state();
+  const versions: RunVersionCollector = { watermarks: {}, rows: new Map() };
+  const version_stats: VersionStatsState = {
+    total_versions_stored: 0,
+    total_versions_unavailable: 0,
+    total_versions_failed: 0,
+  };
+
+  await process_delta_item(
+    connector,
+    item,
+    'site-1',
+    'snap-1',
+    make_context(),
+    make_tracking(),
+    library_state,
+    versions,
+    version_stats,
+  );
+
+  return { library_state, download };
+}
+
+describe('process_delta_item with a quarantined file (#53)', () => {
+  it('never attempts the download', async () => {
+    const { download } = await run(make_item({ quarantined: true }));
+
+    expect(download).not.toHaveBeenCalled();
+  });
+
+  it('records the block as permanent so later runs stop re-fetching it', async () => {
+    const { library_state } = await run(make_item({ quarantined: true }));
+
+    const record = library_state.failed_items['item-1'];
+    expect(record?.permanent).toBe(true);
+    expect(record?.reason).toContain('Quarantined');
+    expect(library_state.failed_item_ids.has('item-1')).toBe(true);
+  });
+
+  it('stores no entry and counts no file', async () => {
+    const { library_state } = await run(make_item({ quarantined: true }));
+
+    expect(library_state.library_entries).toEqual([]);
+    expect(library_state.library_files_stored).toBe(0);
+    expect(library_state.library_files_deduplicated).toBe(0);
+  });
+
+  it('still downloads a file that is not quarantined', async () => {
+    const { library_state, download } = await run(make_item());
+
+    expect(download).toHaveBeenCalledTimes(1);
+    expect(library_state.failed_items).toEqual({});
+    expect(library_state.library_entries).toHaveLength(1);
+  });
+
+  it('treats a deleted quarantined item as a deletion, not a block', async () => {
+    const { library_state, download } = await run(make_item({ quarantined: true, deleted: true }));
+
+    expect(download).not.toHaveBeenCalled();
+    expect(library_state.library_deleted_items).toBe(1);
+    expect(library_state.failed_items).toEqual({});
+  });
+});

--- a/packages/types/src/domain/failed-item.ts
+++ b/packages/types/src/domain/failed-item.ts
@@ -14,6 +14,14 @@ export interface FailedItemRecord {
   readonly reason: string;
   /** Backup runs that have tried and failed on this item. */
   readonly attempts: number;
+  /**
+   * Set when the service refuses the content by policy rather than failing
+   * transiently, so no number of retries can change the outcome. A
+   * malware-quarantined item is the canonical case. Permanent records are
+   * reported on every run but never re-fetched, and they do not consume the
+   * attempt budget, which exists for failures that might still succeed.
+   */
+  readonly permanent?: boolean;
   readonly first_failed_at: string;
   readonly last_failed_at: string;
 }

--- a/packages/types/src/ports/onedrive/connector.port.ts
+++ b/packages/types/src/ports/onedrive/connector.port.ts
@@ -18,6 +18,11 @@ export interface OneDriveDeltaItem {
   readonly etag?: string;
   readonly last_modified_at?: string;
   readonly deleted: boolean;
+  /**
+   * Graph reports a non-null `malware` facet for this item, so the service will
+   * not serve its content. Requires `malware` in the delta `$select`.
+   */
+  readonly quarantined?: boolean;
   readonly download_url?: string;
 }
 

--- a/packages/types/src/ports/sharepoint/connector.port.ts
+++ b/packages/types/src/ports/sharepoint/connector.port.ts
@@ -35,6 +35,11 @@ export interface SharePointDeltaItem {
   readonly etag?: string;
   readonly last_modified_at?: string;
   readonly deleted: boolean;
+  /**
+   * Graph reports a non-null `malware` facet for this item, so the service will
+   * not serve its content. Requires `malware` in the delta `$select`.
+   */
+  readonly quarantined?: boolean;
   readonly download_url?: string;
 }
 


### PR DESCRIPTION
Fixes #53.

## Problem

Found while diagnosing why the E2E suite blew its timeout (#211). The test tenant's OneDrive contains `eicar.com.txt`, the standard antivirus test file, which Microsoft 365 quarantines. `test_02_backup_writes_blobs_and_index` then died at exactly **900.11s** in two consecutive runs, which is the harness's `DEFAULT_TIMEOUT`, meaning the backup was killed rather than merely slow. Seven downstream tests cascaded on `KeyError: 'snapshot'`.

The mechanism is a misclassification, not slowness:

1. Neither drive delta selected the Graph `malware` facet, so the pipeline could not tell a quarantined item from a healthy one. It found out by attempting the download.
2. Graph refuses quarantined content by **aborting the transfer**, not by returning a clean 403.
3. `is_network_error` matches on message substrings including `aborted`, `terminated` and `fetch failed`, so the refusal is classified as a network fault.
4. `is_retryable_error` is therefore true, and `download_via_graph_content` wraps the call in `with_graph_retry`: **12 attempts, delays capped at 5 minutes, a ~23 minute budget**.
5. `download_with_retry` sits above that with up to 3 attempts of its own.

A single quarantined file could hold an entire drive backup for the length of that budget, on every run, for bytes that will never arrive.

Observed, with the item id truncated:

```
[!] URL download failed for 01URRJBN..., falling back:
    Error: Failed to download OneDrive file ...: Failed to process file eicar.com.txt
```

## Fix

Select the facet, then skip on it before any download:

```ts
if (item.quarantined === true) {
  return { ..., error: `Quarantined by Microsoft 365 malware policy: ...`, permanent: true };
}
```

`malware` is added to both delta `$select` field lists and mapped to `quarantined` in both delta mappers. The skip sits at the one choke point each pipeline already has, immediately before `process_backup_file`, so the retry tree is never entered.

Recording reuses the existing `FailedItemLedger` rather than adding a parallel mechanism, with one new field:

- `permanent?: boolean` on `FailedItemRecord`. Permanent records are reported every run but never re-fetched, and they do **not** consume the 5-attempt budget, which exists for failures that might still succeed.
- `retryable_items` now routes through `is_retry_exhausted` instead of duplicating the rule, so budget and policy exclusion cannot drift apart.
- `describe_failed_items` gained a third state. This is the part worth a second look: `PERMANENTLY SKIPPED after 5 attempts` invites an operator to retry, whereas `PERMANENTLY SKIPPED by service policy, not retried` tells them the answer will not change.

Both drives get identical treatment. The reporting path needed no new plumbing: both backup services already surface `describe_failed_items` as warnings, and the run is already `UNHEALTHY` with a non-zero exit while any record is outstanding.

## Tests

Two new files, 10 tests, unit-testing the choke point directly rather than duplicating the 145-line service harness.

Confirmed they fail without the source change. Reverting only the two item processors:

```
× never attempts the download
× reports the block as permanent so later runs stop re-fetching it
× stores no entry and counts no file
Tests  3 failed | 111 passed (114)     # onedrive
Tests  3 failed | 187 passed (190)     # sharepoint
```

`never attempts the download` is the guarantee this PR exists for. Two control tests per drive pass with and without the gate on purpose: a non-quarantined file must still download, and a **deleted** quarantined item must still be recorded as a deletion rather than a block. An over-broad guard fails those.

Plus 4 ledger tests in core covering the permanent flag, its exclusion from retry on the very first attempt, the distinct operator line, and that transient failures stay retryable.

## Verification

- `pnpm run build` 10/10
- `pnpm run typecheck` 17/17
- `pnpm run lint` clean
- `pnpm run test` 15/15 tasks. core 313 (was 309), onedrive 114, sharepoint 190
- `pnpm run docs:build` clean

### Verified against a live tenant, with one prediction corrected

Run on an integration branch carrying this PR plus #214 and #216. The skip fires exactly as designed, and the old `URL download failed ... falling back` warning is gone:

```
[!] Drive b!3Yh3...: Quarantined by Microsoft 365 malware policy: eicar.com.txt (01URRJBN...)
```

So the quarantined file is now detected from the facet and skipped with no download attempt, and it is reported as a permanent skip rather than a generic failure.

**The prediction in the first version of this PR description was wrong.** I expected this to stop `test_02_backup_writes_blobs_and_index` timing out. It did not: that test still consumed the harness's full 900s CLI timeout with the skip in place, so the quarantined file was not what was consuming the time. The retry-amplification analysis above is still accurate as a description of the code path, and removing it is still correct, but it was not the cause of the E2E stall.

The remaining OneDrive backup stall is therefore a separate, still-unexplained problem, and it is being tracked separately rather than folded in here. This PR should be judged on what it does do: a quarantined item no longer triggers a download attempt, no longer burns the Graph retry budget, no longer consumes the transient-failure retry budget across five runs, and is reported to the operator as a policy refusal.

## Docs

- `docs/onedrive-backup.md`, `docs/sharepoint-backup.md`: new subsection under the existing failed-items section, with the operator output and why retrying is harmful rather than merely wasteful.
- `docs/security.md`: what quarantine means for a backup's completeness, stated plainly. The quarantined file **is not in your backup**, Atlas reports it rather than silently omitting it, and a restore cannot produce bytes the service never released.

## Deliberately not included

**Sensitivity-label capture**, the third part of #53. It is a metered Graph surface and a separate compliance feature, and bundling it would mean shipping the stall fix behind a much larger change. The gap is now documented as a warning in `docs/security.md` instead of being implicit: labelled files are backed up, their classification is not, so restored content should be treated as unclassified until relabelled.

**Manifest entries for skipped items.** #53 suggests a manifest record with `skip_reason`. The ledger already gives an auditable per-item record with a reason, rides in the delta cursor, and drives the non-zero exit. A new manifest entry kind would ripple into restore, verify and save for no gain the operator can see today. Worth revisiting only if the audit requirement turns out to be per-snapshot rather than per-drive.

