### PR TITLE
fix(e2e): replicate every workload so the drive suites survive the DR drill

### DIFF
--- a/e2e/atlas_e2e/config.py
+++ b/e2e/atlas_e2e/config.py
@@ -52,6 +52,21 @@ class Settings:
         """Atlas derives the bucket from the tenant id; the suite must not guess a different name."""
         return f"atlas-{self.tenant_id}"
 
+    @property
+    def configured_workloads(self) -> list[str]:
+        """Workloads this run actually backs up, in storage-prefix terms.
+
+        A workload whose identifier is unset is skipped by its own suite, so no later suite may
+        demand its objects. Shared so replication, per-workload deletion and the tenant purge all
+        assert against the same set instead of each hardcoding one prefix (issue #210).
+        """
+        workloads = ["outlook"]
+        if self.onedrive_owner:
+            workloads.append("onedrive")
+        if self.sharepoint_site:
+            workloads.append("sharepoint")
+        return workloads
+
     def cli_env(self) -> dict[str, str]:
         """ATLAS_* variables for a CLI subprocess. Env wins over the secure store, so no config file is needed."""
         return {

--- a/e2e/tests/test_40_replication.py
+++ b/e2e/tests/test_40_replication.py
@@ -26,39 +26,51 @@ def test_01_replica_endpoint_is_reachable(settings: Settings, s3_replica: Any) -
     )
 
 
-def test_02_replicate_copies_ciphertext_and_the_key(
+def test_02_replicate_copies_every_workload_and_the_key(
     cli: Cli, settings: Settings, s3: Any, s3_replica: Any
 ) -> None:
-    """Replication copies manifests, blobs and the wrapped DEK to the target endpoint.
+    """Replication copies manifests, blobs and the wrapped DEK for every configured workload.
 
     The DEK matters more than the data: without `_meta/dek.enc` the replica is a pile of ciphertext
     nobody can open, so a "successful" replication that omitted it would be worthless.
+
+    Every workload is replicated explicitly because `replicate` has no tenant-wide scope: its
+    selectors are `-s`, `-m`, `--site` and `-o`. Replicating only the mailbox left the drives out of
+    the replica, and since `test_04` purges the whole bucket, `test_05` could not bring them back.
+    That is what silently emptied the drive prefixes before `test_85` asserted on them (issue #210).
     """
     primary_keys = storage.list_keys(s3, settings.bucket)
     assert primary_keys, "nothing on primary to replicate; earlier suites stored no objects"
     STATE["snapshot"] = storage.snapshot_ids(s3, settings.bucket, _owner(s3, settings.bucket))[0]
 
-    cli.ok(
-        "replicate",
-        "-m",
-        settings.mailbox,
-        "--target-endpoint",
-        settings.s3_replica_endpoint,
-        "--target-access-key",
-        settings.s3_access_key,
-        "--target-secret-key",
-        settings.s3_secret_key,
-    )
+    _replicate(cli, settings, "-m", settings.mailbox)
+    if settings.onedrive_owner:
+        _replicate(cli, settings, "-o", settings.onedrive_owner)
+    if settings.sharepoint_site:
+        _replicate(cli, settings, "--site", settings.sharepoint_site)
 
     replica_keys = storage.list_keys(s3_replica, settings.bucket)
     assert "_meta/dek.enc" in replica_keys, "the wrapped DEK was not replicated"
-    assert [k for k in replica_keys if k.startswith("manifests/")], "no manifest reached the replica"
-    assert [k for k in replica_keys if k.startswith("data/")], "no message blob reached the replica"
 
-    # Ciphertext is copied as-is, so the replicated keys must be byte-identical addresses.
-    outlook_primary = {k for k in primary_keys if k.startswith(("manifests/", "data/", "attachments/"))}
-    outlook_replica = {k for k in replica_keys if k.startswith(("manifests/", "data/", "attachments/"))}
-    assert outlook_primary <= outlook_replica, sorted(outlook_primary - outlook_replica)[:5]
+    # Ciphertext is copied as-is, so the replicated keys must be byte-identical addresses. Asserted
+    # per workload and per prefix: one bucket-wide subset check passes while a whole workload, or a
+    # workload's blobs, are missing.
+    for workload in settings.configured_workloads:
+        for prefix in (storage.MANIFEST_PREFIXES[workload], storage.DATA_PREFIXES[workload]):
+            primary = {k for k in primary_keys if k.startswith(prefix)}
+            replica = {k for k in replica_keys if k.startswith(prefix)}
+            assert primary, f"{workload} stored nothing under {prefix}; its suite did not run"
+            assert primary <= replica, (
+                f"{workload} objects missing from the replica under {prefix}: "
+                f"{sorted(primary - replica)[:5]}"
+            )
+
+    # Attachments are only their own objects in pre-MIME snapshots (issue #138), so this asserts
+    # they replicate when present rather than requiring them.
+    attachments = {k for k in primary_keys if k.startswith("attachments/")}
+    assert attachments <= {k for k in replica_keys if k.startswith("attachments/")}, (
+        "attachment objects did not reach the replica"
+    )
 
 
 def test_03_status_records_the_replication(cli: Cli, settings: Settings, s3: Any) -> None:
@@ -78,9 +90,10 @@ def test_05_rehydrate_recovers_from_the_replica(
 ) -> None:
     """Recovers every workload from the replica into the emptied primary bucket.
 
-    `--all` rather than `-m`: the replica also holds whatever OneDrive and SharePoint objects the
-    earlier suites replicated, and a drill that recovers one workload while reporting success for the
-    tenant is the failure mode this asserts against.
+    `--all` rather than `-m`: a drill that recovers one workload while reporting success for the
+    tenant is the failure mode this asserts against. The per-workload check below is what makes that
+    real. Comparing only the Outlook `manifests/` prefix passed while both drives were absent, which
+    is how the gap behind issue #210 stayed invisible here.
     """
     cli.ok(
         "rehydrate",
@@ -93,11 +106,17 @@ def test_05_rehydrate_recovers_from_the_replica(
         settings.s3_secret_key,
     )
 
-    recovered = storage.list_keys(s3, settings.bucket)
+    recovered = set(storage.list_keys(s3, settings.bucket))
     assert "_meta/dek.enc" in recovered, "the DEK was not copied back; the data cannot be decrypted"
 
-    replicated = {k for k in storage.list_keys(s3_replica, settings.bucket) if k.startswith("manifests/")}
-    assert replicated <= set(recovered), "not every replicated manifest came back"
+    replica_keys = storage.list_keys(s3_replica, settings.bucket)
+    for workload in settings.configured_workloads:
+        prefix = storage.MANIFEST_PREFIXES[workload]
+        replicated = {k for k in replica_keys if k.startswith(prefix)}
+        assert replicated, f"{workload} has no manifest on the replica to recover"
+        assert replicated <= recovered, (
+            f"{workload} manifests did not come back: {sorted(replicated - recovered)[:5]}"
+        )
 
 
 def test_06_verify_passes_on_rehydrated_data(cli: Cli, settings: Settings) -> None:
@@ -114,3 +133,17 @@ def _owner(s3: Any, bucket: str) -> str:
     owners = {key.split("/")[1] for key in storage.list_keys(s3, bucket, "manifests/")}
     assert len(owners) == 1, f"expected exactly one backed-up owner, found {sorted(owners)}"
     return owners.pop()
+
+
+def _replicate(cli: Cli, settings: Settings, *scope: str) -> None:
+    """Replicates one scope to the replica endpoint."""
+    cli.ok(
+        "replicate",
+        *scope,
+        "--target-endpoint",
+        settings.s3_replica_endpoint,
+        "--target-access-key",
+        settings.s3_access_key,
+        "--target-secret-key",
+        settings.s3_secret_key,
+    )

--- a/e2e/tests/test_85_workload_delete.py
+++ b/e2e/tests/test_85_workload_delete.py
@@ -9,7 +9,11 @@ and it leaves the drive prefixes populated so `test_90_purge` still proves the c
 it claims to. The owner and site scopes are covered by the CLI unit suite, which can assert the
 use-case call without erasing a live tenant's backup.
 
-Runs after replication (`test_40`) because that suite reads the drive snapshots this one touches.
+Runs after replication (`test_40`), which destroys the primary bucket and rehydrates it from the
+replica. The drive snapshots asserted here are therefore the rehydrated copies, which makes this a
+stronger check than it looks: it only passes if the drives survived the whole replicate, purge and
+rehydrate loop. That is exactly what failed before issue #210, when `test_40` replicated the mailbox
+alone and the drives never came back.
 """
 
 from __future__ import annotations

--- a/e2e/tests/test_90_purge.py
+++ b/e2e/tests/test_90_purge.py
@@ -30,8 +30,12 @@ def test_purge_empties_the_whole_bucket(cli: Cli, settings: Settings, s3: Any) -
     # The cross-workload claim in this module's docstring has to be checked, not assumed. Before
     # issue #210 the bucket held Outlook objects alone by this point, so the sweep was proven
     # against one prefix while reading as though it covered three.
+    #
+    # Asserted on the data prefix, not the manifest one: `test_85` deletes a snapshot per drive and
+    # a snapshot delete deliberately retains the content-addressed blobs, so a workload whose only
+    # manifest was the deleted one still has objects the purge must sweep.
     for workload in settings.configured_workloads:
-        prefix = storage.MANIFEST_PREFIXES[workload]
+        prefix = storage.DATA_PREFIXES[workload]
         assert [k for k in before if k.startswith(prefix)], (
             f"{workload} has no objects to purge; the sweep would not be proven across workloads"
         )

--- a/e2e/tests/test_90_purge.py
+++ b/e2e/tests/test_90_purge.py
@@ -27,6 +27,15 @@ def test_purge_empties_the_whole_bucket(cli: Cli, settings: Settings, s3: Any) -
     before = storage.list_keys(s3, settings.bucket)
     assert before, "nothing to purge: the workload suites stored no objects"
 
+    # The cross-workload claim in this module's docstring has to be checked, not assumed. Before
+    # issue #210 the bucket held Outlook objects alone by this point, so the sweep was proven
+    # against one prefix while reading as though it covered three.
+    for workload in settings.configured_workloads:
+        prefix = storage.MANIFEST_PREFIXES[workload]
+        assert [k for k in before if k.startswith(prefix)], (
+            f"{workload} has no objects to purge; the sweep would not be proven across workloads"
+        )
+
     cli.ok("delete", "--purge", "-y")
 
     remaining = storage.list_keys(s3, settings.bucket)


### PR DESCRIPTION
Fixes #210.

## Problem

`test_85_workload_delete` has never passed. It was added in #185, and E2E only runs nightly on the default branch, so nothing ever executed it against `dev`.

It asserts on OneDrive and SharePoint manifests. By the time it runs, they are gone:

1. `test_02` replicated `-m <mailbox>` only. `replicate` has **no tenant-wide scope**, its selectors are `-s`, `-m`, `--site` and `-o`, so nothing under `onedrive/` or `sharepoint/` ever reached the replica.
2. `test_04_primary_is_destroyed` runs `delete --purge`, which wipes every workload.
3. `test_05` rehydrates `--all`, but a rehydrate can only restore what the replica holds.

Both drive tests then failed in `_single_segment` with `expected exactly one segment under onedrive/manifests/, found []`, in about 20 ms, before either reached the CLI.

Three claims in the suite were false, and each one is why the next stayed hidden:

- `test_05`'s docstring: "the replica also holds whatever OneDrive and SharePoint objects the earlier suites replicated". It held none.
- `test_05`'s assertion compared only the Outlook `manifests/` prefix, so two entirely missing workloads passed it.
- `test_90_purge`'s docstring claimed to prove a cross-workload sweep. By that point the bucket held Outlook objects alone, so the sweep was proven against one prefix while reading as though it covered three.

## Fix

Replicate what the drill claims to replicate, rather than reordering the tests around the gap. Reordering would have unbroken `test_85` while leaving all three claims false.

- `test_02` replicates each configured workload explicitly, via a small `_replicate` helper, and is renamed to `test_02_replicate_copies_every_workload_and_the_key`.
- Assertions are now **per workload and per prefix**. The old bucket-wide subset check is exactly what let two missing workloads through. Attachments are asserted only when present, since post-#138 snapshots keep them inside the message object.
- `test_05` asserts each workload's manifests came back, not just Outlook's.
- `test_90_purge` asserts each configured workload has objects **before** purging, converting its docstring claim into a check.
- The workload set moves to `Settings.configured_workloads`, so replication, per-workload deletion and the purge assert against one shared set, and a workload whose identifier is unset is never demanded downstream. This also avoids a cross-test-module import, which would not have resolved reliably.

`test_85` itself needs no change. Its docstring now records that it asserts on **rehydrated** copies, which makes it a stronger check than it looks: it passes only if the drives survive replicate, purge and rehydrate intact.

## Verification

`pytest --collect-only -q` collects 54 tests, and `Settings.configured_workloads` is checked across all four identifier combinations:

```
configured_workloads: all 4 cases OK
```

`ruff` is not installed in the e2e environment, which is #160, so no lint gate ran there.

The real verification is a live run, dispatched on an integration branch carrying this PR plus #214 and #215, because the three are entangled: without #214's timeout the run is cancelled before `test_85` reports, and without #215 the OneDrive suite dies on a quarantined file and never produces the drive snapshots this suite depends on. Result posted in a comment.

## Note on scope

This PR does not touch product code. It fixes the harness so the drive delete, replication and rehydration paths are actually exercised. The corresponding coverage gap in unit tests is #191.
