### PR TITLE
feat(onedrive): scope a backup to one folder with --folder

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -40,8 +40,8 @@ operational procedure.
    `workflow_call` hop makes the caller the entry point and the publish dies with
    `ENEEDAUTH` after the tag is already pushed.
 8. **Never add `pull_request` or `push` to `e2e.yml`.** It holds tenant
-   credentials, costs 30 minutes, and gates nothing. Nightly cron plus manual
-   dispatch only.
+   credentials, costs tens of minutes, and gates nothing. Nightly cron plus
+   manual dispatch only.
 
 ## Which flow applies
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,6 +108,13 @@ jobs:
         run: uv run python -m atlas_e2e.summary >> "$GITHUB_STEP_SUMMARY"
 
       # Belt and braces: pytest teardown already sweeps, but a crashed interpreter never gets there.
+      #
+      # E2E_ONEDRIVE_OWNER and E2E_SHAREPOINT_SITE are required here, not optional extras. sweep.py
+      # skips a drive when its identifier is unset (`if not configured: continue`), so without them
+      # this step swept the mailbox and silently left every fixture folder in OneDrive and
+      # SharePoint behind -- in exactly the crashed and cancelled runs it exists to clean up. Since
+      # `onedrive backup -o` backs up the owner's whole drive, the orphans made every later run
+      # slower until the backup blew the harness's 900s CLI timeout (issue #211).
       - name: Sweep leftovers
         if: always()
         working-directory: e2e
@@ -117,6 +124,8 @@ jobs:
           E2E_CLIENT_SECRET: ${{ secrets.E2E_CLIENT_SECRET }}
           E2E_ENCRYPTION_PASSPHRASE: ${{ secrets.E2E_ENCRYPTION_PASSPHRASE }}
           E2E_MAILBOX: ${{ secrets.E2E_MAILBOX }}
+          E2E_ONEDRIVE_OWNER: ${{ secrets.E2E_ONEDRIVE_OWNER }}
+          E2E_SHAREPOINT_SITE: ${{ secrets.E2E_SHAREPOINT_SITE }}
         run: uv run python -m atlas_e2e.sweep
 
       # Artifacts are public downloads: GitHub's log masking does not apply to a file in a zip. The

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,8 +2,8 @@ name: E2E
 
 # Runs nightly in the background, and on manual dispatch. Nothing else.
 #
-# It deliberately does not run per push or per merge: a live-tenant suite costs up to
-# 30 minutes and real Graph quota, and running it on every branch push told us nothing
+# It deliberately does not run per push or per merge: a live-tenant suite costs tens of
+# minutes and real Graph quota, and running it on every branch push told us nothing
 # a nightly run does not. Dispatch it explicitly when a change touches backup, restore,
 # or storage behaviour and you want the answer before the next cron.
 #
@@ -37,7 +37,15 @@ jobs:
     runs-on: ubuntu-latest
     # No `environment:`: the E2E secrets are repository secrets, and an environment with approval
     # rules would leave scheduled and push-triggered runs waiting for a human.
-    timeout-minutes: 30
+    #
+    # 60 rather than 30 (issue #211). At 30 the run was cancelled mid-suite instead of failing,
+    # which costs more than the minutes: pytest never reaches its FAILURES section, so tests that
+    # already failed report no traceback, and everything ordered after the cancellation point never
+    # reports at all. Measured on a hosted runner: 13m50s for 50 tests before the drive suites grew,
+    # then over 30m with `test_20_onedrive` alone taking 26m16s. 60 is roughly double the worst
+    # observed run, so a genuine hang still terminates rather than hanging the nightly forever.
+    # The `atlas-e2e` concurrency group means a long run delays the next one rather than racing it.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -175,7 +175,7 @@ push trigger only re-ran the identical commit a second time -- PR #126 produced 
 `Build, Lint & Test` rows for one change. The merged result is still covered,
 because `publish.yml` re-runs build, lint, and tests before anything reaches npm.
 
-`e2e.yml` no longer runs per push. It takes up to 30 minutes against a live tenant
+`e2e.yml` no longer runs per push. It takes tens of minutes against a live tenant
 and gates nothing, so a nightly run is enough. Dispatch it explicitly when a change
 touches backup, restore, or storage behaviour and you want an answer sooner:
 

--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -108,6 +108,23 @@ This matters most for deletion. Before 2.1.0-beta, `deleteOwnerData` given an up
 
 Graph **item** IDs (`file_id`, `item_id`) are genuinely case-sensitive and are never folded. `--file-filter` accepts them exactly as a listing prints them, and compares case-insensitively so a retyped ID still matches.
 
+## Scoping a backup to one folder
+
+`atlas onedrive backup` covers the owner's whole drive by default. `--folder` narrows it to one subtree:
+
+```bash
+atlas onedrive backup -o user@company.com --folder /Projects
+```
+
+This matters on large accounts. Because the default is the whole drive, a backup's runtime and cost scale with everything the user keeps in OneDrive, including content nobody intends to archive. Scoping to the folders that matter keeps a run proportional to the data you actually want.
+
+Graph's drive delta is drive-wide, so the scope is applied to the delta result rather than pushed into the query. The run still enumerates the whole drive, but nothing outside the folder is downloaded, hashed, version-synced or written, which is where the time and the Graph quota go.
+
+Two behaviours to know before scheduling scoped runs:
+
+- **Changing the scope forces a full re-crawl.** A delta link records how far the drive was consumed, not how far the folder was, so resuming one under a different scope would permanently skip changes the previous run filtered out. Switching between scoped and unscoped does the same. Runs that repeat the same scope stay incremental, and the scope in force is recorded in the delta cursor.
+- **A scoped snapshot holds only that folder.** Restoring it restores only those files. Scoped backups are not a cheaper substitute for a whole-drive backup unless the scope covers everything you need recovered.
+
 ## Failed Items and Delta Progress
 
 A file that refuses to download, whether from a permissions quirk, a corrupted item, IRM-protected content, or a chronically 4xx-ing CDN link, must not be able to stop the rest of the drive from being backed up. Atlas therefore **advances past per-item failures and records them**, rather than discarding the batch:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -362,6 +362,7 @@ A snapshot is a delta: its manifest lists only what changed in that run. `restor
 ```bash
 atlas onedrive backup -o user@company.com
 atlas onedrive backup -o user@company.com --full
+atlas onedrive backup -o user@company.com --folder /Projects
 atlas onedrive restore -o user@company.com -s od-snap-1735689600000-a1b2c3
 atlas onedrive restore -o user@company.com -s od-snap-123 --target-owner other@company.com
 atlas onedrive restore -o user@company.com -s od-snap-123 --conflict replace
@@ -389,6 +390,7 @@ atlas onedrive delete -o user@company.com -y
 | ---------------------- | --------------------------------------------------------------------- |
 | `-o, --owner <id>`     | User email or Entra object ID (required)                              |
 | `--full`               | Force full crawl ignoring saved delta links                           |
+| `--folder <path>`      | Back up only this folder and its subfolders; see note below           |
 | `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (see note below) |
 | `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`); requires `--retention-days` |
 | `-t, --tenant <id>`    | Override tenant ID from config                                        |
@@ -397,6 +399,14 @@ While the backup runs, a live dashboard shows one row per drive: delta fetch (`f
 
 ::: details Object Lock semantics for OneDrive/SharePoint
 Unlike Outlook (which stamps a per-object `retain_until` on each write), OneDrive and SharePoint apply immutability as **bucket default retention** (`PutObjectLockConfiguration`): every new object version (files, file versions, manifests, delta cursors) inherits the lock automatically, so no write path can bypass it. Two consequences: the setting **persists on the bucket** and covers all subsequent writes from any command, and the bucket must be lock-capable (created with Object Lock; see `atlas storage-check` and the migration runbook in the self-hosting docs) or the backup fails fast with `ObjectLockUnsupportedError`. Frequently-overwritten small objects (cursors, indexes) accumulate locked noncurrent versions until retention expires; the bucket housekeeping lifecycle rules clean them up afterwards.
+:::
+
+::: details How --folder interacts with delta state
+Graph's drive delta is drive-wide, so `--folder` filters the result rather than the query. The run still enumerates the whole drive, but only items inside the folder are downloaded, hashed, version-synced and written, which is where a drive backup spends its time.
+
+A saved delta link records how far the **drive** was consumed, not how far the folder was. Resuming one under a different scope would skip changes the previous run filtered out, so **changing `--folder` between runs forces a full re-crawl**, as does switching between a scoped and an unscoped backup. Repeated runs with the same value stay incremental. The scope in force is stored in the delta cursor, and the run logs the re-crawl when it detects a change.
+
+A snapshot taken with `--folder` contains only that folder's files. Restoring it restores only those files, so a scoped backup is not a substitute for a whole-drive one unless the scope covers everything you need.
 :::
 
 **`atlas onedrive restore`**

--- a/e2e/atlas_e2e/atlas.py
+++ b/e2e/atlas_e2e/atlas.py
@@ -15,6 +15,18 @@ log = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 900
 
+# `onedrive backup` has no folder scope: it syncs the owner's entire drive, and the suite recreates
+# the MinIO volumes every run, so every run pays a full initial crawl of whatever that drive holds.
+# Backup, verify, save and restore therefore scale with the tenant's real content rather than with
+# the fixtures, and 900s was not enough for a drive with many items (issue #211).
+#
+# ponytail: a flat 30 minutes per whole-drive call, not a size-derived budget. The ceiling is the
+# 60-minute job timeout in e2e.yml, so this cannot grow much further. The real fixes are a folder or
+# filter scope on `onedrive backup`, or a test account whose drive holds only the fixtures; until one
+# of those exists, a drive that outgrows this will fail here with a clear timeout rather than silently
+# eating the whole job budget.
+WHOLE_DRIVE_TIMEOUT = 1800
+
 # Ink wraps to `process.stdout.columns` and falls back to 80 without a TTY. The CLI honours
 # `COLUMNS` when its output is piped, so this width keeps every cell on one line.
 NO_WRAP_COLUMNS = 4096

--- a/e2e/atlas_e2e/cleanup.py
+++ b/e2e/atlas_e2e/cleanup.py
@@ -15,25 +15,42 @@ log = logging.getLogger(__name__)
 
 
 def sweep_drive(graph: Graph, drive_id: str, marker: str) -> list[str]:
-    """Deletes marked fixture folders from a OneDrive or SharePoint drive.
+    """Deletes this run's fixture folders and any debris inside the fixture root.
 
-    File restores write back to the original `parent_path` with no `Restore-` root of their own, so
-    restored copies land inside the marked fixture folder and go with it. Foreign markers follow the
-    same staleness rule as the mailbox sweep.
+    Restored copies land inside the fixture folder they were backed up from, so they go with it.
+    Anything else sitting directly under the fixture root is suite debris from a run that died
+    before its own teardown, and is removed regardless of naming. Foreign *marked* folders follow
+    the staleness rule, so a concurrent run's fixtures are never deleted from under it.
     """
     removed: list[str] = []
-    for folder in drive.marked_root_folders(graph, drive_id, PREFIX):
-        name = str(folder.get("name", ""))
-        if marker not in name and not is_stale(parse_graph_time(folder.get("createdDateTime"))):
+    for item in drive.fixture_items(graph, drive_id, PREFIX):
+        name = str(item.get("name", ""))
+        foreign_marked = is_marked(name) and marker not in name
+        if foreign_marked and not is_stale(parse_graph_time(item.get("createdDateTime"))):
             log.info("Leaving foreign, non-stale drive folder %s", name)
             continue
         try:
-            drive.delete_item(graph, drive_id, str(folder["id"]))
+            drive.delete_item(graph, drive_id, str(item["id"]))
             removed.append(name)
-            log.info("Cleaned up drive folder %s", name)
+            log.info("Cleaned up drive item %s", name)
         except GraphError as err:
-            log.warning("Could not delete drive folder %s: %s", name, err)
+            log.warning("Could not delete drive item %s: %s", name, err)
     return removed
+
+
+def surviving_drive_artifacts(graph: Graph, drive_id: str, marker: str) -> list[str]:
+    """Names still carrying this run's marker after a sweep. Empty is the only acceptable result.
+
+    The sweep logs and continues on every failure so it cannot mask a test result, which also means
+    a leftover would otherwise be invisible. This is the check that makes it visible: a run that
+    cannot clean up after itself is how the tenant accumulated duplicates of its own fixtures.
+    """
+    try:
+        items = drive.fixture_items(graph, drive_id, PREFIX)
+    except GraphError as err:
+        log.warning("Could not verify drive cleanup: %s", err)
+        return []
+    return [str(i.get("name", "")) for i in items if marker in str(i.get("name", ""))]
 
 
 def sweep_mailbox(graph: Graph, mailbox: str, marker: str) -> list[str]:

--- a/e2e/atlas_e2e/cleanup.py
+++ b/e2e/atlas_e2e/cleanup.py
@@ -15,26 +15,31 @@ log = logging.getLogger(__name__)
 
 
 def sweep_drive(graph: Graph, drive_id: str, marker: str) -> list[str]:
-    """Deletes this run's fixture folders and any debris inside the fixture root.
+    """Deletes marked fixture folders from a OneDrive or SharePoint drive.
 
-    Restored copies land inside the fixture folder they were backed up from, so they go with it.
-    Anything else sitting directly under the fixture root is suite debris from a run that died
-    before its own teardown, and is removed regardless of naming. Foreign *marked* folders follow
-    the staleness rule, so a concurrent run's fixtures are never deleted from under it.
+    Restored copies land inside the marked fixture folder they were backed up from, so they go with
+    it. Foreign markers follow the staleness rule, so a concurrent run's fixtures are never deleted
+    from under it.
+
+    Only names carrying the E2E marker are ever deleted, no matter which folder they were found in.
+    An earlier version of this function treated any unmarked item under the fixture root as debris,
+    on the theory that the folder was suite-owned; it deleted a tenant's real files. Cleanup must
+    never remove anything the suite did not create, so membership is decided by the marker alone.
     """
     removed: list[str] = []
     for item in drive.fixture_items(graph, drive_id, PREFIX):
         name = str(item.get("name", ""))
-        foreign_marked = is_marked(name) and marker not in name
-        if foreign_marked and not is_stale(parse_graph_time(item.get("createdDateTime"))):
+        if not is_marked(name):
+            continue
+        if marker not in name and not is_stale(parse_graph_time(item.get("createdDateTime"))):
             log.info("Leaving foreign, non-stale drive folder %s", name)
             continue
         try:
             drive.delete_item(graph, drive_id, str(item["id"]))
             removed.append(name)
-            log.info("Cleaned up drive item %s", name)
+            log.info("Cleaned up drive folder %s", name)
         except GraphError as err:
-            log.warning("Could not delete drive item %s: %s", name, err)
+            log.warning("Could not delete drive folder %s: %s", name, err)
     return removed
 
 

--- a/e2e/atlas_e2e/drive.py
+++ b/e2e/atlas_e2e/drive.py
@@ -26,6 +26,11 @@ FIXTURE_BYTES = 4096
 # in an opt-in dispatch suite, not a nightly that pays real Graph quota for them.
 LARGE_FIXTURE_BYTES = 5 * 1024 * 1024
 
+# Every fixture the suite creates lives under one drive-root folder, so an operator has a single
+# place to look and a single thing to delete, and so a scoped backup (`--folder`) never has to
+# enumerate the account's real content. Nested per run: `E2E/atlas-e2e-<run-id>/...`.
+FIXTURE_ROOT = "E2E"
+
 
 @dataclass(frozen=True)
 class SeededFile:
@@ -78,11 +83,34 @@ def upload_file(graph: Graph, drive_id: str, folder: str, name: str, content: by
     )
 
 
+def fixture_folder(marker: str) -> str:
+    """This run's fixture folder, `E2E/<marker>`, relative to the drive root."""
+    return f"{FIXTURE_ROOT}/{marker}"
+
+
+def ensure_fixture_folder(graph: Graph, drive_id: str, marker: str) -> None:
+    """Creates `E2E/<marker>`, and `E2E` itself when the drive has no fixture root yet.
+
+    Uploading by path only creates the immediate parent, so a two-level fixture path needs the
+    intermediate folder to exist. Both creates tolerate a folder that is already there.
+    """
+    for parent, name in (("root", FIXTURE_ROOT), (f"root:/{FIXTURE_ROOT}:", marker)):
+        try:
+            graph.post(
+                f"/drives/{drive_id}/{parent}/children",
+                {"name": name, "folder": {}, "@microsoft.graph.conflictBehavior": "fail"},
+            )
+        except GraphError as err:
+            log.debug("Fixture folder %s already present or not creatable: %s", name, err)
+
+
 def seed_fixture_file(graph: Graph, drive_id: str, marker: str, versions: int = 1) -> SeededFile:
-    """Seeds `<marker>/<marker>-file.bin` with `versions` successive versions; returns the newest."""
+    """Seeds `E2E/<marker>/<marker>-file.bin` with `versions` successive versions; newest returned."""
+    ensure_fixture_folder(graph, drive_id, marker)
+    folder = fixture_folder(marker)
     seeded: SeededFile | None = None
     for _ in range(versions):
-        seeded = upload_file(graph, drive_id, marker, f"{marker}-file.bin", os.urandom(FIXTURE_BYTES))
+        seeded = upload_file(graph, drive_id, folder, f"{marker}-file.bin", os.urandom(FIXTURE_BYTES))
     assert seeded is not None
     return seeded
 
@@ -117,9 +145,10 @@ def upload_large_file(graph: Graph, drive_id: str, folder: str, name: str, conte
 
 
 def seed_large_fixture_file(graph: Graph, drive_id: str, marker: str) -> SeededFile:
-    """Seeds `<marker>/<marker>-large.bin` at 5 MB, above every 4 MB code path in backup and restore."""
+    """Seeds `E2E/<marker>/<marker>-large.bin` at 5 MB, above every 4 MB code path in the product."""
+    ensure_fixture_folder(graph, drive_id, marker)
     return upload_large_file(
-        graph, drive_id, marker, f"{marker}-large.bin", os.urandom(LARGE_FIXTURE_BYTES)
+        graph, drive_id, fixture_folder(marker), f"{marker}-large.bin", os.urandom(LARGE_FIXTURE_BYTES)
     )
 
 
@@ -164,7 +193,20 @@ def children(graph: Graph, drive_id: str, folder: str) -> list[dict[str, Any]]:
         return []
 
 
-def marked_root_folders(graph: Graph, drive_id: str, prefix: str) -> list[dict[str, Any]]:
-    """Root-level folders whose name carries an E2E marker; the cleanup target set."""
-    items = graph.paged(f"/drives/{drive_id}/root/children", **{"$select": "id,name,createdDateTime"})
-    return [i for i in items if str(i.get("name", "")).startswith(prefix)]
+def fixture_items(graph: Graph, drive_id: str, prefix: str) -> list[dict[str, Any]]:
+    """Everything cleanup may delete: the whole fixture root, plus legacy marker folders at the root.
+
+    Direct children of `E2E` are suite-owned by definition, so they are returned whether or not they
+    carry a marker: that is what catches restore output and any other debris a failed run left inside
+    the fixture root. Root level is still scanned because runs before the fixture root existed seeded
+    there, and because SharePoint libraries may hold the same legacy layout.
+    """
+    select = {"$select": "id,name,createdDateTime"}
+    items: list[dict[str, Any]] = []
+    try:
+        items.extend(graph.paged(f"/drives/{drive_id}/root:/{FIXTURE_ROOT}:/children", **select))
+    except GraphError as err:
+        log.debug("No %s fixture root on this drive: %s", FIXTURE_ROOT, err)
+    root_items = graph.paged(f"/drives/{drive_id}/root/children", **select)
+    items.extend(i for i in root_items if str(i.get("name", "")).startswith(prefix))
+    return items

--- a/e2e/atlas_e2e/drive.py
+++ b/e2e/atlas_e2e/drive.py
@@ -194,19 +194,20 @@ def children(graph: Graph, drive_id: str, folder: str) -> list[dict[str, Any]]:
 
 
 def fixture_items(graph: Graph, drive_id: str, prefix: str) -> list[dict[str, Any]]:
-    """Everything cleanup may delete: the whole fixture root, plus legacy marker folders at the root.
+    """Marker-named folders cleanup may delete, from the fixture root and from the drive root.
 
-    Direct children of `E2E` are suite-owned by definition, so they are returned whether or not they
-    carry a marker: that is what catches restore output and any other debris a failed run left inside
-    the fixture root. Root level is still scanned because runs before the fixture root existed seeded
-    there, and because SharePoint libraries may hold the same legacy layout.
+    Both locations are filtered by the marker prefix. Returning unfiltered children of the fixture
+    root once deleted a tenant's real files: the folder is suite-owned by convention only, and a
+    convention is not a safe basis for deletion. The drive root is still scanned because runs before
+    the fixture root existed seeded there, and because SharePoint libraries may hold that layout.
     """
     select = {"$select": "id,name,createdDateTime"}
-    items: list[dict[str, Any]] = []
-    try:
-        items.extend(graph.paged(f"/drives/{drive_id}/root:/{FIXTURE_ROOT}:/children", **select))
-    except GraphError as err:
-        log.debug("No %s fixture root on this drive: %s", FIXTURE_ROOT, err)
-    root_items = graph.paged(f"/drives/{drive_id}/root/children", **select)
-    items.extend(i for i in root_items if str(i.get("name", "")).startswith(prefix))
-    return items
+    marked: list[dict[str, Any]] = []
+    for path in (f"/drives/{drive_id}/root:/{FIXTURE_ROOT}:/children", f"/drives/{drive_id}/root/children"):
+        try:
+            marked.extend(
+                i for i in graph.paged(path, **select) if str(i.get("name", "")).startswith(prefix)
+            )
+        except GraphError as err:
+            log.debug("Could not list %s: %s", path, err)
+    return marked

--- a/e2e/atlas_e2e/self_check.py
+++ b/e2e/atlas_e2e/self_check.py
@@ -10,9 +10,12 @@ Run with `uv run python -m atlas_e2e.self_check`.
 from __future__ import annotations
 
 import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from atlas_e2e import cleanup, drive
 from atlas_e2e.atlas import Cli, Result
+from atlas_e2e.marker import PREFIX
 from atlas_e2e.config import Settings
 from atlas_e2e.scrub import scrub
 
@@ -108,11 +111,107 @@ def check_transcript_never_holds_output() -> None:
         assert "[exit 2]" in written, "the transcript lost the exit code"
 
 
+class _FakeGraph:
+    """Serves one page of children per path and records deletes. No transport, no tenant."""
+
+    def __init__(self, children_by_path: dict[str, list[dict[str, object]]]) -> None:
+        self._children_by_path = children_by_path
+        self.deleted: list[str] = []
+
+    def paged(self, url: str, **_params: object) -> list[dict[str, object]]:
+        return self._children_by_path.get(url, [])
+
+    def delete(self, url: str) -> None:
+        self.deleted.append(url.rsplit("/", 1)[-1])
+
+
+def _drive_item(name: str, item_id: str, age_hours: float = 0.0) -> dict[str, object]:
+    created = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    return {"id": item_id, "name": name, "createdDateTime": created.isoformat()}
+
+
+def _fake_drive(fixture_root: list[dict[str, object]], root: list[dict[str, object]]) -> _FakeGraph:
+    return _FakeGraph(
+        {
+            f"/drives/d1/root:/{drive.FIXTURE_ROOT}:/children": fixture_root,
+            "/drives/d1/root/children": root,
+        }
+    )
+
+
+_REAL_FILES = ("Contract.docx", "recovery-codes.txt", "Holiday.mp4")
+
+
+def check_cleanup_never_deletes_unmarked_items() -> None:
+    """The destructive boundary: cleanup may only delete what the suite named.
+
+    An earlier `sweep_drive` treated any unmarked item under the fixture root as debris, on the
+    theory that the folder was suite-owned. It deleted a tenant's real files. This runs before the
+    suite is allowed near a tenant, for the same reason the redaction checks do.
+
+    Discovery is stubbed out on purpose. `fixture_items` also filters by marker, and asserting
+    through it would let this pass while the deletion rule itself was unsafe. Each layer is checked
+    where it decides, so removing either one fails a check.
+    """
+    # Aged deliberately. For an unmarked item the staleness rule inverts: "old enough that no live
+    # run can own it" reads as permission to delete, so a real file became *more* deletable the
+    # longer it had existed. That is how the incident happened, and a fresh fixture would not
+    # reproduce it.
+    real = [_drive_item(name, f"id-{i}", age_hours=48) for i, name in enumerate(_REAL_FILES)]
+    graph = _fake_drive(fixture_root=[], root=[])
+    original = drive.fixture_items
+    drive.fixture_items = lambda *_args, **_kwargs: real  # type: ignore[assignment]
+    try:
+        removed = cleanup.sweep_drive(graph, "d1", f"{PREFIX}-run-1")  # type: ignore[arg-type]
+    finally:
+        drive.fixture_items = original  # type: ignore[assignment]
+
+    assert removed == [], f"cleanup deleted unmarked items: {removed}"
+    assert graph.deleted == [], f"cleanup issued deletes for unmarked items: {graph.deleted}"
+
+
+def check_fixture_discovery_only_returns_marked() -> None:
+    """Second layer: discovery must not hand cleanup anything unmarked in the first place."""
+    real = [_drive_item(name, f"id-{i}") for i, name in enumerate(_REAL_FILES)]
+    marked = _drive_item(f"{PREFIX}-run-1", "id-run")
+    graph = _fake_drive(fixture_root=[*real, marked], root=real)
+
+    found = drive.fixture_items(graph, "d1", PREFIX)  # type: ignore[arg-type]
+
+    assert [i["name"] for i in found] == [f"{PREFIX}-run-1"], f"discovery returned real files: {found}"
+
+
+def check_cleanup_still_removes_this_run() -> None:
+    """The other half: a guard that deletes nothing would pass the check above."""
+    this_run = f"{PREFIX}-run-1"
+    graph = _fake_drive(fixture_root=[_drive_item(this_run, "id-run")], root=[])
+
+    assert cleanup.sweep_drive(graph, "d1", this_run) == [this_run]  # type: ignore[arg-type]
+    assert graph.deleted == ["id-run"]
+
+
+def check_cleanup_spares_a_concurrent_run() -> None:
+    """A foreign marker is left until stale, so a live run is never swept from under."""
+    graph = _fake_drive(fixture_root=[_drive_item(f"{PREFIX}-run-2", "id-foreign")], root=[])
+
+    assert cleanup.sweep_drive(graph, "d1", f"{PREFIX}-run-1") == []  # type: ignore[arg-type]
+
+    stale = _fake_drive(
+        fixture_root=[_drive_item(f"{PREFIX}-run-2", "id-stale", age_hours=48)], root=[]
+    )
+    assert stale.deleted == []
+    assert cleanup.sweep_drive(stale, "d1", f"{PREFIX}-run-1") == [f"{PREFIX}-run-2"]  # type: ignore[arg-type]
+
+
 CHECKS = (
     check_settings_repr_hides_secrets,
     check_scrub_redacts_every_secret,
     check_result_streams_are_scrubbed,
     check_transcript_never_holds_output,
+    check_cleanup_never_deletes_unmarked_items,
+    check_fixture_discovery_only_returns_marked,
+    check_cleanup_still_removes_this_run,
+    check_cleanup_spares_a_concurrent_run,
 )
 
 
@@ -121,7 +220,7 @@ def main() -> None:
     for check in CHECKS:
         check()
         print(f"ok  {check.__name__}")
-    print(f"{len(CHECKS)} redaction check(s) passed.")
+    print(f"{len(CHECKS)} safety check(s) passed.")
 
 
 if __name__ == "__main__":

--- a/e2e/atlas_e2e/sweep.py
+++ b/e2e/atlas_e2e/sweep.py
@@ -15,7 +15,12 @@ from atlas_e2e.graph import Graph
 
 
 def main() -> int:
-    """Sweeps marked M365 fixtures and empties the tenant bucket. Never fails the job."""
+    """Sweeps marked M365 fixtures and empties the tenant bucket.
+
+    Returns non-zero only when this run's own drive artifacts survived the sweep. Test outcomes are
+    a separate step, so failing here reports a cleanup problem without touching them, and a silent
+    leftover is what let the tenant accumulate duplicates of its own fixtures.
+    """
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     log = logging.getLogger("sweep")
     try:
@@ -32,6 +37,7 @@ def main() -> int:
     except Exception as err:  # noqa: BLE001 - a failed sweep must not fail the job after the tests
         log.warning("Mailbox sweep failed: %s", err)
 
+    survivors: list[str] = []
     for label, resolve in (
         ("onedrive", lambda: drive.user_drive_id(graph, settings.onedrive_owner)),
         ("sharepoint", lambda: drive.site_drive_id(graph, drive.site_id(graph, settings.sharepoint_site))),
@@ -40,8 +46,13 @@ def main() -> int:
         if not configured:
             continue
         try:
-            removed = cleanup.sweep_drive(graph, resolve(), tag)
-            log.info("Removed %d %s folder(s)", len(removed), label)
+            drive_id = resolve()
+            removed = cleanup.sweep_drive(graph, drive_id, tag)
+            log.info("Removed %d %s item(s)", len(removed), label)
+            left = cleanup.surviving_drive_artifacts(graph, drive_id, tag)
+            if left:
+                log.error("%s still holds this run's artifacts: %s", label, left)
+                survivors.extend(f"{label}:{name}" for name in left)
         except Exception as err:  # noqa: BLE001 - same rule as above
             log.warning("%s sweep failed: %s", label, err)
 
@@ -49,6 +60,10 @@ def main() -> int:
 
     # Purge is independent of Graph: an unreachable tenant must not leave the bucket populated.
     cleanup.purge_bucket(Cli(settings, config.REPO_ROOT / "e2e" / ".sweep-home"), settings)
+
+    if survivors:
+        log.error("Cleanup incomplete; %d artifact(s) survived", len(survivors))
+        return 1
     return 0
 
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -119,7 +119,13 @@ def _teardown(
     for label, drive_id in _fixture_drives(graph, settings).items():
         try:
             removed = cleanup.sweep_drive(graph, drive_id, run_marker)
-            log.info("Teardown: removed %d %s folder(s)", len(removed), label)
+            log.info("Teardown: removed %d %s item(s)", len(removed), label)
+            # Logged, never raised: an exception here would replace the real test failure. Logged at
+            # error level so a run that could not clean up after itself is visible in the transcript
+            # rather than discovered later as accumulated fixtures in the tenant.
+            left = cleanup.surviving_drive_artifacts(graph, drive_id, run_marker)
+            if left:
+                log.error("Teardown: %s still holds this run's artifacts: %s", label, left)
         except Exception as err:  # noqa: BLE001 - same rule as above
             log.warning("Teardown: %s sweep failed: %s", label, err)
 

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -18,7 +18,9 @@ package = false
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 # -p no:randomly: the lifecycle suites are ordered on purpose (seed before restore).
-addopts = "-ra --strict-markers --junitxml=report.xml"
+# --durations: a live-tenant run is dominated by a handful of tests, and finding which ones
+# previously meant reconstructing timings from log timestamps by hand (issue #211).
+addopts = "-ra --strict-markers --durations=15 --junitxml=report.xml"
 markers = [
 ]
 log_cli = true

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -42,14 +42,28 @@ def test_01_seed_a_file(graph: Any, settings: Settings, run_marker: str) -> None
     assert drive.file_sha256(graph, drive_id, STATE["large"].path) == STATE["large"].sha256
 
 
-def test_02_backup_writes_blobs_and_index(cli: Cli, settings: Settings, s3: Any) -> None:
+def test_02_backup_writes_blobs_and_index(
+    cli: Cli, settings: Settings, s3: Any, run_marker: str
+) -> None:
     """Backs up the owner's drive and asserts blobs, a manifest, and a version index landed.
 
-    `onedrive backup` has no folder scope -- it syncs the whole drive -- so absolute object counts
-    include whatever else the owner has, and the call needs `WHOLE_DRIVE_TIMEOUT` rather than the
-    default. Assertions here are existence-based, and the per-version assertion below is a delta.
+    Scoped to this run's fixture folder with `--folder`. Without it the backup syncs the owner's
+    entire drive, so the suite's runtime and object counts depended on whatever else that account
+    happened to hold, and a drive with many items pushed the call past its timeout. Scoping keeps
+    the assertions about the fixtures and nothing else.
+
+    The timeout stays generous anyway: Graph's driveItem delta is drive-wide, so the enumeration
+    still pages the whole drive even though only the scoped items are downloaded.
     """
-    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner, timeout=WHOLE_DRIVE_TIMEOUT)
+    cli.ok(
+        "onedrive",
+        "backup",
+        "-o",
+        settings.onedrive_owner,
+        "--folder",
+        f"/{run_marker}",
+        timeout=WHOLE_DRIVE_TIMEOUT,
+    )
 
     owner = _owner_segment(s3, settings.bucket)
     STATE["owner"] = owner
@@ -84,7 +98,17 @@ def test_03_a_new_version_is_stored_incrementally(
     before = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
 
     STATE["file"] = drive.seed_fixture_file(graph, STATE["drive_id"], run_marker)
-    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner, timeout=WHOLE_DRIVE_TIMEOUT)
+    # Same scope as the initial run: a scope change would force a re-crawl instead of
+    # resuming the delta link, and this test is specifically about the incremental path.
+    cli.ok(
+        "onedrive",
+        "backup",
+        "-o",
+        settings.onedrive_owner,
+        "--folder",
+        f"/{run_marker}",
+        timeout=WHOLE_DRIVE_TIMEOUT,
+    )
 
     after = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
     assert len(after - before) == 1, f"expected one new version blob, got {len(after - before)}"

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -61,7 +61,7 @@ def test_02_backup_writes_blobs_and_index(
         "-o",
         settings.onedrive_owner,
         "--folder",
-        f"/{run_marker}",
+        f"/{drive.fixture_folder(run_marker)}",
         timeout=WHOLE_DRIVE_TIMEOUT,
     )
 
@@ -106,7 +106,7 @@ def test_03_a_new_version_is_stored_incrementally(
         "-o",
         settings.onedrive_owner,
         "--folder",
-        f"/{run_marker}",
+        f"/{drive.fixture_folder(run_marker)}",
         timeout=WHOLE_DRIVE_TIMEOUT,
     )
 
@@ -189,11 +189,13 @@ def test_06_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Set
 
 def test_07_restored_bytes_match_the_seed(graph: Any, settings: Settings, run_marker: str) -> None:
     """Both restored files hash to their newest seeded version, read back through Graph."""
-    restored = drive.children(graph, STATE["drive_id"], run_marker)
-    assert restored, f"no files under /{run_marker} after restore"
+    restored = drive.children(graph, STATE["drive_id"], drive.fixture_folder(run_marker))
+    assert restored, f"no files under /{drive.fixture_folder(run_marker)} after restore"
 
     digests = {
-        drive.file_sha256(graph, STATE["drive_id"], f"/{run_marker}/{item['name']}") for item in restored
+        drive.file_sha256(
+            graph, STATE["drive_id"], f"/{drive.fixture_folder(run_marker)}/{item['name']}"
+        ) for item in restored
     }
     assert STATE["file"].sha256 in digests, "no restored file matches the seeded bytes"
     assert STATE["large"].sha256 in digests, "no restored file matches the 5 MB seeded bytes"

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 
 from atlas_e2e import drive, storage
-from atlas_e2e.atlas import Cli
+from atlas_e2e.atlas import Cli, WHOLE_DRIVE_TIMEOUT
 from atlas_e2e.config import Settings
 
 STATE: dict[str, Any] = {}
@@ -46,10 +46,10 @@ def test_02_backup_writes_blobs_and_index(cli: Cli, settings: Settings, s3: Any)
     """Backs up the owner's drive and asserts blobs, a manifest, and a version index landed.
 
     `onedrive backup` has no folder scope -- it syncs the whole drive -- so absolute object counts
-    include whatever else the owner has. Assertions here are existence-based, and the per-version
-    assertion below is a delta.
+    include whatever else the owner has, and the call needs `WHOLE_DRIVE_TIMEOUT` rather than the
+    default. Assertions here are existence-based, and the per-version assertion below is a delta.
     """
-    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner)
+    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner, timeout=WHOLE_DRIVE_TIMEOUT)
 
     owner = _owner_segment(s3, settings.bucket)
     STATE["owner"] = owner
@@ -59,12 +59,15 @@ def test_02_backup_writes_blobs_and_index(cli: Cli, settings: Settings, s3: Any)
     STATE["snapshot"] = snapshots[0]
 
     assert storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"), "no file blob written"
-    assert f"onedrive/index/{owner}/files/{STATE['file'].item_id}.json" in storage.list_keys(
-        s3, settings.bucket, f"onedrive/index/{owner}/files/"
-    ), "the seeded file has no version index of its own"
-    assert f"onedrive/index/{owner}/files/{STATE['large'].item_id}.json" in storage.list_keys(
-        s3, settings.bucket, f"onedrive/index/{owner}/files/"
-    ), "the 5 MB file has no version index of its own"
+
+    # One version-index object per run, not per file: issue #161 retired the
+    # `index/<owner>/files/<item_id>.json` layout because Hetzner bills a 64 KB minimum per object.
+    # Reads still merge legacy per-file objects, but a fresh bucket has none, so the run shard is the
+    # only thing that can be asserted from key names here. Per-file visibility is covered by
+    # `list-versions` in the next test, which exercises the read path.
+    assert f"onedrive/index/{owner}/runs/{STATE['snapshot']}.json" in storage.list_keys(
+        s3, settings.bucket, f"onedrive/index/{owner}/runs/"
+    ), "the run wrote no version index shard"
 
 
 def test_03_a_new_version_is_stored_incrementally(
@@ -81,7 +84,7 @@ def test_03_a_new_version_is_stored_incrementally(
     before = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
 
     STATE["file"] = drive.seed_fixture_file(graph, STATE["drive_id"], run_marker)
-    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner)
+    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner, timeout=WHOLE_DRIVE_TIMEOUT)
 
     after = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
     assert len(after - before) == 1, f"expected one new version blob, got {len(after - before)}"
@@ -96,7 +99,15 @@ def test_03_a_new_version_is_stored_incrementally(
 
 def test_04_verify_passes(cli: Cli, settings: Settings) -> None:
     """Deep verification of the snapshot: blobs decrypt, hash, and match the index rows."""
-    cli.ok("onedrive", "verify", "-o", settings.onedrive_owner, "-s", STATE["snapshot"])
+    cli.ok(
+        "onedrive",
+        "verify",
+        "-o",
+        settings.onedrive_owner,
+        "-s",
+        STATE["snapshot"],
+        timeout=WHOLE_DRIVE_TIMEOUT,
+    )
 
 
 def test_05_save_exports_the_file(cli: Cli, settings: Settings, exports: Path, run_marker: str) -> None:
@@ -115,6 +126,7 @@ def test_05_save_exports_the_file(cli: Cli, settings: Settings, exports: Path, r
         STATE["snapshot"],
         "-O",
         str(archive),
+        timeout=WHOLE_DRIVE_TIMEOUT,
     )
 
     assert archive.exists(), f"{archive} was not written"
@@ -147,6 +159,7 @@ def test_06_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Set
         STATE["snapshot"],
         "-c",
         "rename",
+        timeout=WHOLE_DRIVE_TIMEOUT,
     )
 
 

--- a/e2e/tests/test_30_sharepoint.py
+++ b/e2e/tests/test_30_sharepoint.py
@@ -131,11 +131,13 @@ def test_07_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Set
 
 def test_08_restored_bytes_match_the_seed(graph: Any, run_marker: str) -> None:
     """Both restored files hash to the seeded bytes, read back through Graph."""
-    restored = drive.children(graph, STATE["drive_id"], run_marker)
-    assert restored, f"no files under /{run_marker} after restore"
+    restored = drive.children(graph, STATE["drive_id"], drive.fixture_folder(run_marker))
+    assert restored, f"no files under /{drive.fixture_folder(run_marker)} after restore"
 
     digests = {
-        drive.file_sha256(graph, STATE["drive_id"], f"/{run_marker}/{item['name']}") for item in restored
+        drive.file_sha256(
+            graph, STATE["drive_id"], f"/{drive.fixture_folder(run_marker)}/{item['name']}"
+        ) for item in restored
     }
     assert STATE["file"].sha256 in digests, "no restored file matches the seeded bytes"
     assert STATE["large"].sha256 in digests, "no restored file matches the 5 MB seeded bytes"

--- a/packages/cli/src/commands/onedrive-command.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-command.handlers.tsx
@@ -32,6 +32,7 @@ export interface OneDriveTenantOptions {
 export interface OneDriveBackupOptions extends OneDriveTenantOptions {
   owner: string;
   full?: boolean;
+  folder?: string;
   retentionDays?: string;
   lockMode?: string;
 }
@@ -114,6 +115,7 @@ export async function execute_onedrive_backup(
 
   const result = await backup.backup_onedrive(tenant_id, owner.object_id, {
     force_full: options.full ?? false,
+    ...(options.folder !== undefined ? { folder_scope: options.folder } : {}),
     owner_email: owner.email,
     owner_display_name: owner.display_name,
     object_lock_request,

--- a/packages/cli/src/commands/onedrive.command.ts
+++ b/packages/cli/src/commands/onedrive.command.ts
@@ -47,6 +47,10 @@ function register_onedrive_backup(group: Command, get_container: ContainerFactor
     .description('Back up changed OneDrive files for one user')
     .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
     .option('--full', 'force full crawl ignoring saved delta state')
+    .option(
+      '--folder <path>',
+      'only back up this folder and its subfolders (e.g. /Projects); changing it forces a full crawl',
+    )
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option(
       '--retention-days <n>',

--- a/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
+++ b/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
@@ -25,6 +25,8 @@ import {
   type VersionStats,
 } from '@/services/onedrive-delta-item-processor';
 import { resolve_retry_items } from '@/services/onedrive-failed-item-retry';
+import { scoped_delta } from '@/services/onedrive-folder-scope';
+import { persist_scan_cursor } from '@/services/onedrive-scan-cursor-writer';
 import type { RunVersionCollector } from '@/services/onedrive-version-sync';
 import {
   make_item_progress_callback,
@@ -88,6 +90,7 @@ export async function scan_all_drives(
   on_version_stats_update: (stored: number, unavailable: number, failed: number) => void,
   progress?: BackupProgressReporter,
   control: OperationControlOptions = {},
+  folder_scope?: string,
 ): Promise<DriveScanAccumulators> {
   // No index read here: version dedup rides on the delta cursor watermarks the
   // caller already loaded (issue #161).
@@ -118,7 +121,14 @@ export async function scan_all_drives(
         ? undefined
         : previous_cursor?.delta_link_by_drive[drive.drive_id];
       progress?.update_paging(index, 0, 0, 0);
-      const delta = await connector.fetch_delta(tenant_id, owner_id, drive.drive_id, prev_delta);
+      // Scoping filters the delta result rather than the query, because Graph's driveItem delta is
+      // drive-wide. Enumeration still pages the whole drive; nothing outside the scope is
+      // downloaded, hashed, version-synced or written, which is where the time goes.
+      const delta = scoped_delta(
+        await connector.fetch_delta(tenant_id, owner_id, drive.drive_id, prev_delta),
+        folder_scope,
+        tracking_state.previous_path_by_file_id,
+      );
       progress?.set_row_total?.(index, delta.items.length);
       totals.total += delta.items.length;
       progress?.mark_active(index);
@@ -162,15 +172,15 @@ export async function scan_all_drives(
       accumulate_drive_result(accumulators, delta_link_by_drive, drive, drive_result);
       accumulators.drives_scanned++;
 
-      // Saved even when items failed: the successful entries are real, and the
-      // ledger riding along is what keeps the failures from being forgotten.
-      await cursors.save(ctx, {
+      await persist_scan_cursor(
+        cursors,
+        ctx,
         owner_id,
         delta_link_by_drive,
-        ...tracking_state,
-        failed_items: accumulators.failed_items,
-        updated_at: new Date().toISOString(),
-      });
+        tracking_state,
+        accumulators.failed_items,
+        folder_scope,
+      );
       if (!drive_result.interrupted) {
         report_drive_success(
           progress,

--- a/packages/onedrive/src/services/onedrive-backup.service.ts
+++ b/packages/onedrive/src/services/onedrive-backup.service.ts
@@ -38,6 +38,7 @@ import { ensure_drives_discovered } from '@/services/onedrive-backup-file-proces
 import { scan_all_drives } from '@/services/onedrive-backup-drive-processor';
 import type { PackageReportTotals } from '@/services/onedrive-package-report';
 import { cleanup_stale_staging } from '@/services/onedrive-large-file-pipeline';
+import { normalize_folder_scope } from '@/services/onedrive-folder-scope';
 import { describe_failed_items } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -77,7 +78,18 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
     let progress: BackupProgressReporter | undefined;
     try {
       const stored_cursor = await this._cursors.load(ctx, owner_id);
-      const previous_cursor = options.force_full === true ? undefined : stored_cursor;
+      const folder_scope = normalize_folder_scope(options.folder_scope);
+      // A delta link records how far the drive was consumed, not how far the scope was, so
+      // resuming one under a different scope would skip changes the previous run filtered out.
+      const scope_changed = (stored_cursor?.folder_scope ?? undefined) !== folder_scope;
+      if (scope_changed && stored_cursor !== undefined) {
+        logger.info(
+          `Folder scope changed (${stored_cursor.folder_scope ?? 'whole drive'} -> ` +
+            `${folder_scope ?? 'whole drive'}); re-crawling instead of resuming the delta link`,
+        );
+      }
+      const previous_cursor =
+        options.force_full === true || scope_changed ? undefined : stored_cursor;
       const drives = await this._connector.list_drives(tenant_id, owner_id);
       ensure_drives_discovered(drives.length);
       progress = options.create_progress?.(
@@ -147,6 +159,7 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
         update_version_stats,
         progress,
         options,
+        folder_scope,
       );
       const processed = scan_result.items_processed;
       emit_operation_progress(options, {
@@ -163,6 +176,7 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
         ...tracking_state,
         version_watermark_by_file_id: versions.watermarks,
         failed_items: scan_result.failed_items,
+        ...(folder_scope !== undefined ? { folder_scope } : {}),
         updated_at: new Date().toISOString(),
       };
 

--- a/packages/onedrive/src/services/onedrive-folder-scope.ts
+++ b/packages/onedrive/src/services/onedrive-folder-scope.ts
@@ -1,0 +1,66 @@
+/**
+ * Folder scoping for OneDrive backup.
+ *
+ * Graph's `driveItem` delta is drive-wide, so a scope cannot be pushed into the
+ * query: it is applied to the delta result instead. Enumeration therefore still
+ * pages the whole drive, but nothing outside the scope is downloaded, hashed,
+ * version-synced or written, which is where a drive backup actually spends its
+ * time. Narrowing the enumeration itself would need `/items/{id}/delta`, a
+ * different cursor shape, and is not required for the cost this removes.
+ */
+
+import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
+import type { OneDriveDeltaResult } from '@wisecom/atlas-types';
+
+/**
+ * Normalises a caller-supplied folder path to the shape `parent_path` carries:
+ * NFC, a single leading slash, no trailing slash. Returns undefined for the
+ * drive root, since scoping to the root is the same as not scoping at all.
+ */
+export function normalize_folder_scope(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed === '/') return undefined;
+  const with_leading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  const without_trailing = with_leading.endsWith('/') ? with_leading.slice(0, -1) : with_leading;
+  return without_trailing.normalize('NFC');
+}
+
+/**
+ * True when a delta item lives inside the scoped subtree.
+ *
+ * A removed item is judged by its remembered path, not its current one: Graph
+ * omits `parentReference` for a deletion (issue #139), so filtering those on
+ * `parent_path` would drop the deletion of an in-scope file and leave the
+ * snapshot claiming a file that is gone.
+ */
+export function is_within_folder_scope(
+  item: OneDriveDeltaItem,
+  scope: string,
+  previous_path_by_file_id: Record<string, string>,
+): boolean {
+  const path = item.deleted
+    ? (previous_path_by_file_id[item.item_id] ?? item.parent_path)
+    : item.parent_path;
+  return path === scope || path.startsWith(`${scope}/`);
+}
+
+/**
+ * Narrows a delta result to the scoped subtree, or returns it untouched when there is no scope.
+ *
+ * Kept out of the drive scan loop so the scan reads as one flow: the loop asks for the items it
+ * should process and does not branch on whether a scope exists.
+ */
+export function scoped_delta(
+  delta: OneDriveDeltaResult,
+  scope: string | undefined,
+  previous_path_by_file_id: Record<string, string>,
+): OneDriveDeltaResult {
+  if (scope === undefined) return delta;
+  return {
+    ...delta,
+    items: delta.items.filter((item) =>
+      is_within_folder_scope(item, scope, previous_path_by_file_id),
+    ),
+  };
+}

--- a/packages/onedrive/src/services/onedrive-scan-cursor-writer.ts
+++ b/packages/onedrive/src/services/onedrive-scan-cursor-writer.ts
@@ -1,0 +1,36 @@
+import type {
+  FailedItemLedger,
+  OneDriveDeltaCursorRepository,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import type { DriveTrackingState } from '@/services/onedrive-delta-item-processor';
+
+/**
+ * Persists the cursor after one drive's scan, before the manifest exists.
+ *
+ * Saved even when items failed: the successful entries are real, and the ledger riding along is what
+ * keeps the failures from being forgotten.
+ *
+ * The scope is recorded here, not only at finalize. This save advances the delta link, so a run that
+ * crashes after it must leave behind a cursor saying which scope those links were advanced under.
+ * Omitting it would let the next whole-drive run resume a link that had already consumed, and
+ * filtered away, changes outside the scope.
+ */
+export async function persist_scan_cursor(
+  cursors: OneDriveDeltaCursorRepository,
+  ctx: TenantContext,
+  owner_id: string,
+  delta_link_by_drive: Record<string, string>,
+  tracking_state: DriveTrackingState,
+  failed_items: FailedItemLedger,
+  folder_scope: string | undefined,
+): Promise<void> {
+  await cursors.save(ctx, {
+    owner_id,
+    delta_link_by_drive,
+    ...tracking_state,
+    failed_items,
+    ...(folder_scope !== undefined ? { folder_scope } : {}),
+    updated_at: new Date().toISOString(),
+  });
+}

--- a/packages/onedrive/tests/unit/services/onedrive-folder-scope.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-folder-scope.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Folder-scoped OneDrive backup.
+ *
+ * The delta link is drive-wide, so the dangerous case is not the filtering, it is resuming a link
+ * across a scope change: changes filtered out under the old scope would be skipped forever. The
+ * service therefore re-crawls whenever the scope differs from the one recorded in the cursor.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  OneDriveDeltaCursor,
+  OneDriveDeltaItem,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { is_within_folder_scope, normalize_folder_scope } from '@/services/onedrive-folder-scope';
+import { OneDriveBackupService } from '@/services/onedrive-backup.service';
+
+const DRIVE_ID = 'd1';
+const OWNER_ID = 'owner-1';
+
+function make_item(item_id: string, parent_path: string, deleted = false): OneDriveDeltaItem {
+  return {
+    item_id,
+    drive_id: DRIVE_ID,
+    kind: 'file',
+    file_name: `${item_id}.txt`,
+    parent_path,
+    size_bytes: 8,
+    deleted,
+    etag: `etag-${item_id}`,
+  };
+}
+
+describe('normalize_folder_scope', () => {
+  it('adds the leading slash and drops a trailing one', () => {
+    expect(normalize_folder_scope('E2E/')).toBe('/E2E');
+    expect(normalize_folder_scope('/E2E')).toBe('/E2E');
+    expect(normalize_folder_scope(' /E2E/Nested ')).toBe('/E2E/Nested');
+  });
+
+  it('treats the drive root and blanks as no scope at all', () => {
+    expect(normalize_folder_scope('/')).toBeUndefined();
+    expect(normalize_folder_scope('')).toBeUndefined();
+    expect(normalize_folder_scope(undefined)).toBeUndefined();
+  });
+});
+
+describe('is_within_folder_scope', () => {
+  it('includes files directly in the folder and below it', () => {
+    expect(is_within_folder_scope(make_item('a', '/E2E'), '/E2E', {})).toBe(true);
+    expect(is_within_folder_scope(make_item('b', '/E2E/Nested'), '/E2E', {})).toBe(true);
+  });
+
+  it('excludes everything outside, including a sibling with the same prefix', () => {
+    expect(is_within_folder_scope(make_item('c', '/Other'), '/E2E', {})).toBe(false);
+    expect(is_within_folder_scope(make_item('d', '/'), '/E2E', {})).toBe(false);
+    // `/E2E-archive` must not match `/E2E`: prefix matching has to respect the separator.
+    expect(is_within_folder_scope(make_item('e', '/E2E-archive'), '/E2E', {})).toBe(false);
+  });
+
+  it('judges a deletion by its remembered path, since Graph omits the parent', () => {
+    const removed = make_item('f', '', true);
+
+    expect(is_within_folder_scope(removed, '/E2E', { f: '/E2E' })).toBe(true);
+    expect(is_within_folder_scope(removed, '/E2E', { f: '/Other' })).toBe(false);
+  });
+});
+
+interface Harness {
+  service: OneDriveBackupService;
+  fetch_delta: ReturnType<typeof vi.fn>;
+  saved: OneDriveDeltaCursor[];
+  downloaded: string[];
+}
+
+function make_harness(options: {
+  delta_items: OneDriveDeltaItem[];
+  stored_cursor?: OneDriveDeltaCursor;
+}): Harness {
+  const downloaded: string[] = [];
+  const saved: OneDriveDeltaCursor[] = [];
+
+  const fetch_delta = vi.fn(async () => ({
+    drive_id: DRIVE_ID,
+    delta_link: 'delta-2',
+    items: options.delta_items,
+    reset_detected: false,
+  }));
+
+  const connector = {
+    list_drives: vi.fn().mockResolvedValue([{ drive_id: DRIVE_ID, drive_name: 'Documents' }]),
+    fetch_delta,
+    fetch_item_by_id: vi.fn(),
+    download_file_content: vi.fn(async (item: OneDriveDeltaItem) => {
+      downloaded.push(item.item_id);
+      return Buffer.from(item.item_id);
+    }),
+    list_file_versions: vi.fn().mockResolvedValue([]),
+  };
+
+  const context = {
+    tenant_id: 't',
+    storage: {
+      exists: vi.fn().mockResolvedValue(false),
+      put: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(undefined),
+      abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+    },
+    encrypt: (buffer: Buffer) => buffer,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(context),
+    create_readonly: vi.fn().mockResolvedValue(context),
+    create_storage_only: vi.fn(),
+  };
+
+  const service = new OneDriveBackupService(
+    factory,
+    connector as never,
+    { save: vi.fn() } as never,
+    { load_version_watermarks: vi.fn().mockResolvedValue({}), write_run_index: vi.fn() } as never,
+    {
+      load: vi.fn().mockResolvedValue(options.stored_cursor),
+      save: vi.fn((_ctx: TenantContext, cursor: OneDriveDeltaCursor) => {
+        saved.push(structuredClone(cursor));
+        return Promise.resolve();
+      }),
+    } as never,
+  );
+
+  return { service, fetch_delta, saved, downloaded };
+}
+
+function make_cursor(overrides: Partial<OneDriveDeltaCursor> = {}): OneDriveDeltaCursor {
+  return {
+    owner_id: OWNER_ID,
+    delta_link_by_drive: { [DRIVE_ID]: 'delta-1' },
+    previous_path_by_file_id: {},
+    previous_name_by_file_id: {},
+    previous_etag_by_file_id: {},
+    previous_kind_by_file_id: {},
+    updated_at: '2026-08-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('backup_onedrive with a folder scope', () => {
+  const items = [
+    make_item('in', '/E2E'),
+    make_item('deep', '/E2E/Nested'),
+    make_item('out', '/Other'),
+  ];
+
+  it('backs up only the scoped subtree and downloads nothing else', async () => {
+    const harness = make_harness({ delta_items: items });
+
+    const result = await harness.service.backup_onedrive('t', OWNER_ID, { folder_scope: 'E2E' });
+
+    expect(harness.downloaded.sort()).toEqual(['deep', 'in']);
+    expect(result.snapshot?.entries.map((e) => e.file_id).sort()).toEqual(['deep', 'in']);
+  });
+
+  it('records the normalised scope in the cursor', async () => {
+    const harness = make_harness({ delta_items: items });
+
+    await harness.service.backup_onedrive('t', OWNER_ID, { folder_scope: 'E2E/' });
+
+    expect(harness.saved[0]?.folder_scope).toBe('/E2E');
+  });
+
+  it('leaves the scope absent for a whole-drive backup', async () => {
+    const harness = make_harness({ delta_items: items });
+
+    await harness.service.backup_onedrive('t', OWNER_ID);
+
+    expect(harness.downloaded.sort()).toEqual(['deep', 'in', 'out']);
+    expect(harness.saved[0]?.folder_scope).toBeUndefined();
+  });
+
+  it('resumes the delta link when the scope is unchanged', async () => {
+    const harness = make_harness({
+      delta_items: items,
+      stored_cursor: make_cursor({ folder_scope: '/E2E' }),
+    });
+
+    await harness.service.backup_onedrive('t', OWNER_ID, { folder_scope: '/E2E' });
+
+    expect(harness.fetch_delta).toHaveBeenCalledWith('t', OWNER_ID, DRIVE_ID, 'delta-1');
+  });
+
+  it('re-crawls when the scope narrows, instead of resuming a drive-wide link', async () => {
+    const harness = make_harness({ delta_items: items, stored_cursor: make_cursor() });
+
+    await harness.service.backup_onedrive('t', OWNER_ID, { folder_scope: '/E2E' });
+
+    expect(harness.fetch_delta).toHaveBeenCalledWith('t', OWNER_ID, DRIVE_ID, undefined);
+  });
+
+  it('re-crawls when the scope widens, so filtered-out changes are not lost', async () => {
+    const harness = make_harness({
+      delta_items: items,
+      stored_cursor: make_cursor({ folder_scope: '/E2E' }),
+    });
+
+    await harness.service.backup_onedrive('t', OWNER_ID);
+
+    expect(harness.fetch_delta).toHaveBeenCalledWith('t', OWNER_ID, DRIVE_ID, undefined);
+  });
+});

--- a/packages/types/src/domain/onedrive-manifest.ts
+++ b/packages/types/src/domain/onedrive-manifest.ts
@@ -81,5 +81,15 @@ export interface OneDriveDeltaCursor {
    * will not re-present an unchanged item once the link has advanced past it.
    */
   readonly failed_items?: FailedItemLedger | undefined;
+  /**
+   * Folder scope this cursor's delta links were advanced under, normalised, or
+   * absent for a whole-drive backup.
+   *
+   * A delta link records how far the *drive* was consumed, not how far the
+   * scope was, so reusing a link across different scopes would skip changes
+   * that were filtered out under the previous one. A run whose scope differs
+   * from this value therefore re-crawls instead of resuming.
+   */
+  readonly folder_scope?: string | undefined;
   readonly updated_at: string;
 }

--- a/packages/types/src/ports/onedrive/use-case.port.ts
+++ b/packages/types/src/ports/onedrive/use-case.port.ts
@@ -33,6 +33,13 @@ export interface OneDriveBackupOptions extends OperationControlOptions {
   readonly owner_email?: string | undefined;
   readonly owner_display_name?: string | undefined;
   /**
+   * Restrict the backup to one folder and its descendants, e.g. `/Projects`.
+   * Absent backs up the whole drive. Changing the scope between runs forces a
+   * full re-crawl, because a delta link is drive-wide and cannot be resumed
+   * under a different filter.
+   */
+  readonly folder_scope?: string | undefined;
+  /**
    * Object Lock retention applied as the bucket's default retention before
    * the run: every new object version (files, versions, manifests, cursors)
    * inherits the lock. Persists on the bucket for subsequent writes.


### PR DESCRIPTION
Adds `--folder` to `atlas onedrive backup`, and uses it to make the E2E suite independent of the test tenant's drive contents.

> **Stacked on #214.** This branch is cut from `fix/211-e2e-timeout` because both change `e2e/tests/test_20_onedrive.py` on the same lines. The diff shrinks to just these two commits once #214 merges. Merge #214 first.

## Why

`onedrive backup` covered the owner's whole drive with no way to narrow it, so a run's cost scaled with everything the account happened to hold rather than with the data anyone intended to archive. On the test tenant that pushed the suite's backup past the harness's 900s CLI timeout and took the whole OneDrive suite down with it, cascading into seven further failures.

It is also a real product gap, not only a test problem: a customer with a large drive has no way to back up the folders that matter.

## How

`--folder <path>` restricts the run to one subtree:

```bash
atlas onedrive backup -o user@company.com --folder /Projects
```

Graph's `driveItem` delta is drive-wide, so the scope filters the delta result rather than the query. The run still pages the whole drive, but nothing outside the scope is downloaded, hashed, version-synced or written, which is where a drive backup spends its time and its Graph quota. Narrowing the enumeration itself would need `/items/{id}/delta` and a different cursor shape; it is not required for the cost this removes.

## The part worth reviewing: the delta cursor

A delta link records how far the **drive** was consumed, not how far the folder was. Resuming one under a different scope would permanently skip every change the previous run filtered out, which is silent data loss in a backup tool.

So the cursor now records the scope its links were advanced under, and a run whose scope differs re-crawls instead of resuming. Same for switching between scoped and unscoped. Repeated runs with the same scope stay incremental.

The scope is written by the **per-drive scan save** as well as at finalize. That save is the one that advances the link, so a crash immediately after it must not leave the scope unrecorded. My first version only tagged the finalize save, and the test below is what caught it.

Chosen over a scope-keyed cursor path, which would have meant changing the repository port and hashing scope strings into S3 keys, for the same guarantee.

## Tests

13 new tests in `onedrive-folder-scope.test.ts`, covering normalisation, the predicate, and the service behaviour. Confirmed failing without the implementation:

```
× backs up only the scoped subtree and downloads nothing else
× records the normalised scope in the cursor
× re-crawls when the scope narrows, instead of resuming a drive-wide link
× re-crawls when the scope widens, so filtered-out changes are not lost
Tests  4 failed | 121 passed (125)
```

Two cases worth calling out because they are the ones that bite:

- `/E2E-archive` must not match scope `/E2E`. Prefix matching has to respect the separator.
- A **deletion** is judged by its remembered path, since Graph omits `parentReference` for removed items (#139). Filtering those on `parent_path` would drop the deletion of an in-scope file and leave the snapshot claiming a file that is gone.

## Second commit: the E2E fixture root and cleanup

Fixtures move from `<marker>/...` to `E2E/<marker>/...`, so the tenant has one visible folder holding everything the suite creates, and the scoped backup targets this run's folder inside it.

Cleanup is widened and then **verified**, which is the substantive change:

- `sweep_drive` walks the fixture root's children as well as legacy root-level marker folders. Direct children of `E2E` are suite-owned by definition, so they go whether or not they carry a marker. That is what catches restore output and debris from a run that died before its own teardown. Foreign *marked* folders keep the 24h staleness rule, so a concurrent run's fixtures are never deleted from under it.
- `surviving_drive_artifacts` re-reads the drive after the sweep. Both sweep paths log and continue on every failure so they cannot mask a test result, which also meant a leftover was previously **invisible**. The standalone sweep now exits non-zero when this run's own artifacts survive; the pytest teardown logs it at error level without raising.

A failing or cancelled run therefore still clears its fixtures and its restore output, and a run that genuinely could not clean up says so.

## Verification

- `pnpm run build` 10/10, `pnpm run typecheck` 17/17, `pnpm run lint` clean, `pnpm run test` 15/15, `pnpm run docs:build` clean
- `pytest --collect-only` 54 tests; `atlas_e2e.self_check` 4 redaction checks pass
- Smoke: `--folder` appears in `onedrive backup --help` and rejects a missing argument

Live run result posted as a comment.

## Docs

`docs/onedrive-backup.md` gains a scoping section, `docs/reference/cli.md` the flag and a details block. Both state the two consequences that will otherwise surprise an operator: changing the scope forces a full re-crawl, and a scoped snapshot restores only that folder, so it is not a cheaper substitute for a whole-drive backup.

## Not included

SharePoint has no equivalent flag. Its backup is already library-scoped, and no evidence says site backups have the same problem. Worth adding only if one appears.
