### PR TITLE
feat(drive): restore under a Restore-<timestamp> root instead of over live files

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -40,8 +40,8 @@ operational procedure.
    `workflow_call` hop makes the caller the entry point and the publish dies with
    `ENEEDAUTH` after the tag is already pushed.
 8. **Never add `pull_request` or `push` to `e2e.yml`.** It holds tenant
-   credentials, costs 30 minutes, and gates nothing. Nightly cron plus manual
-   dispatch only.
+   credentials, costs tens of minutes, and gates nothing. Nightly cron plus
+   manual dispatch only.
 
 ## Which flow applies
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,6 +108,13 @@ jobs:
         run: uv run python -m atlas_e2e.summary >> "$GITHUB_STEP_SUMMARY"
 
       # Belt and braces: pytest teardown already sweeps, but a crashed interpreter never gets there.
+      #
+      # E2E_ONEDRIVE_OWNER and E2E_SHAREPOINT_SITE are required here, not optional extras. sweep.py
+      # skips a drive when its identifier is unset (`if not configured: continue`), so without them
+      # this step swept the mailbox and silently left every fixture folder in OneDrive and
+      # SharePoint behind -- in exactly the crashed and cancelled runs it exists to clean up. Since
+      # `onedrive backup -o` backs up the owner's whole drive, the orphans made every later run
+      # slower until the backup blew the harness's 900s CLI timeout (issue #211).
       - name: Sweep leftovers
         if: always()
         working-directory: e2e
@@ -117,6 +124,8 @@ jobs:
           E2E_CLIENT_SECRET: ${{ secrets.E2E_CLIENT_SECRET }}
           E2E_ENCRYPTION_PASSPHRASE: ${{ secrets.E2E_ENCRYPTION_PASSPHRASE }}
           E2E_MAILBOX: ${{ secrets.E2E_MAILBOX }}
+          E2E_ONEDRIVE_OWNER: ${{ secrets.E2E_ONEDRIVE_OWNER }}
+          E2E_SHAREPOINT_SITE: ${{ secrets.E2E_SHAREPOINT_SITE }}
         run: uv run python -m atlas_e2e.sweep
 
       # Artifacts are public downloads: GitHub's log masking does not apply to a file in a zip. The

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,8 +2,8 @@ name: E2E
 
 # Runs nightly in the background, and on manual dispatch. Nothing else.
 #
-# It deliberately does not run per push or per merge: a live-tenant suite costs up to
-# 30 minutes and real Graph quota, and running it on every branch push told us nothing
+# It deliberately does not run per push or per merge: a live-tenant suite costs tens of
+# minutes and real Graph quota, and running it on every branch push told us nothing
 # a nightly run does not. Dispatch it explicitly when a change touches backup, restore,
 # or storage behaviour and you want the answer before the next cron.
 #
@@ -37,7 +37,15 @@ jobs:
     runs-on: ubuntu-latest
     # No `environment:`: the E2E secrets are repository secrets, and an environment with approval
     # rules would leave scheduled and push-triggered runs waiting for a human.
-    timeout-minutes: 30
+    #
+    # 60 rather than 30 (issue #211). At 30 the run was cancelled mid-suite instead of failing,
+    # which costs more than the minutes: pytest never reaches its FAILURES section, so tests that
+    # already failed report no traceback, and everything ordered after the cancellation point never
+    # reports at all. Measured on a hosted runner: 13m50s for 50 tests before the drive suites grew,
+    # then over 30m with `test_20_onedrive` alone taking 26m16s. 60 is roughly double the worst
+    # observed run, so a genuine hang still terminates rather than hanging the nightly forever.
+    # The `atlas-e2e` concurrency group means a long run delays the next one rather than racing it.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -175,7 +175,7 @@ push trigger only re-ran the identical commit a second time -- PR #126 produced 
 `Build, Lint & Test` rows for one change. The merged result is still covered,
 because `publish.yml` re-runs build, lint, and tests before anything reaches npm.
 
-`e2e.yml` no longer runs per push. It takes up to 30 minutes against a live tenant
+`e2e.yml` no longer runs per push. It takes tens of minutes against a live tenant
 and gates nothing, so a nightly run is enough. Dispatch it explicitly when a change
 touches backup, restore, or storage behaviour and you want an answer sooner:
 

--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -226,14 +226,17 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 
 ### `atlas onedrive restore`
 
-| Flag                       | Description                                          | Default           |
-| -------------------------- | ---------------------------------------------------- | ----------------- |
-| `-o, --owner <id>`         | User email or Entra object ID                        | Required          |
-| `-s, --snapshot <id>`      | Snapshot to restore from                             | Required          |
-| `--target-owner <id>`      | Restore to a different user's OneDrive               | Same as `--owner` |
-| `--file-filter <paths...>` | Only restore specific files (by ID or path)          | All files         |
-| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` | `rename`          |
-| `-t, --tenant <id>`        | Tenant identifier                                    | Config default    |
+| Flag                       | Description                                          | Default                    |
+| -------------------------- | ---------------------------------------------------- | -------------------------- |
+| `-o, --owner <id>`         | User email or Entra object ID                        | Required                   |
+| `-s, --snapshot <id>`      | Snapshot to restore from                             | Required                   |
+| `--target-owner <id>`      | Restore to a different user's OneDrive               | Same as `--owner`          |
+| `--destination <path>`     | Folder to restore under, created when missing        | `/Restore-<timestamp>`     |
+| `--in-place`               | Restore to the original paths                        | `false`                    |
+| `--name <filename>`        | Rename the restored file; single-file restores only  | Original name              |
+| `--file-filter <paths...>` | Only restore specific files (by ID or path)          | All files                  |
+| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` | `rename`                   |
+| `-t, --tenant <id>`        | Tenant identifier                                    | Config default             |
 
 ### `atlas onedrive save`
 
@@ -272,16 +275,34 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 ## Restore
 
 ```bash
-# Restore a whole snapshot back to the same user
+# Restore a whole snapshot into a fresh Restore-<timestamp> folder
 atlas onedrive restore -o user@company.com -s od-snap-123
 
 # Restore into another user's OneDrive
 atlas onedrive restore -o user@company.com -s od-snap-123 --target-owner other@company.com
 
-# Restore specific files only, replacing what is already there
+# Restore into a folder you name
+atlas onedrive restore -o user@company.com -s od-snap-123 --destination /DR-drill
+
+# Put files back exactly where they came from, mixed into live content
+atlas onedrive restore -o user@company.com -s od-snap-123 --in-place
+
+# Restore one file under a new name
 atlas onedrive restore -o user@company.com -s od-snap-123 \
-  --file-filter "/Documents/report.docx" -c replace
+  --file-filter "/Documents/report.docx" --name report-2026-08.docx
 ```
+
+### Where restored files land
+
+A restore creates `/Restore-<timestamp>` at the target drive root and recreates the original folder structure beneath it. A file backed up from `/Projects/2026/Report.docx` restores to `/Restore-2026-08-27T10-15-30/Projects/2026/Report.docx`. The timestamp format matches the Outlook restore folder, so the two workloads read alike.
+
+This exists because the conflict policy is not a safety net. With the default `rename`, restoring a snapshot whose files still exist neither fails nor overwrites; it writes a suffixed copy next to every original. Repeated across a few DR rehearsals that leaves copies of the same file interleaved with real data, with nothing marking which is which. A restore root makes the result reviewable before it matters and reversible afterwards: delete the folder and the restore is undone.
+
+`--destination` replaces the generated root with one you name, created if missing. `--in-place` restores to the original paths, which was the behaviour before 3.1.0 and is now opt-in. `--conflict` keeps its meaning and applies inside whichever destination is chosen; under a fresh root there is normally nothing to collide with.
+
+`--name` renames a single restored file and is rejected when the restore resolves to more than one file, since renaming many files to one name would either collide or silently rename only the first. Pair it with `--file-filter`.
+
+Nesting the original structure under a restore root lengthens every path, and OneDrive enforces a path length limit. A file that exceeds it is reported as a skipped item with the reason and does not abort the run.
 
 Restored files are uploaded to the target user's primary drive. Folders are created as needed, and existing folders with the same name are reused rather than overwritten. Each file is decrypted, SHA-256 verified against the manifest checksum, and then uploaded using a small-file PUT (&le; 4 MiB) or a resumable upload session (> 4 MiB, with per-chunk retry on any transient Graph status: 429, 500, 502, 503, 504). A range PUT is addressed by its `Content-Range`, so a replayed chunk rewrites the same bytes rather than appending them twice.
 

--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -108,6 +108,23 @@ This matters most for deletion. Before 2.1.0-beta, `deleteOwnerData` given an up
 
 Graph **item** IDs (`file_id`, `item_id`) are genuinely case-sensitive and are never folded. `--file-filter` accepts them exactly as a listing prints them, and compares case-insensitively so a retyped ID still matches.
 
+## Scoping a backup to one folder
+
+`atlas onedrive backup` covers the owner's whole drive by default. `--folder` narrows it to one subtree:
+
+```bash
+atlas onedrive backup -o user@company.com --folder /Projects
+```
+
+This matters on large accounts. Because the default is the whole drive, a backup's runtime and cost scale with everything the user keeps in OneDrive, including content nobody intends to archive. Scoping to the folders that matter keeps a run proportional to the data you actually want.
+
+Graph's drive delta is drive-wide, so the scope is applied to the delta result rather than pushed into the query. The run still enumerates the whole drive, but nothing outside the folder is downloaded, hashed, version-synced or written, which is where the time and the Graph quota go.
+
+Two behaviours to know before scheduling scoped runs:
+
+- **Changing the scope forces a full re-crawl.** A delta link records how far the drive was consumed, not how far the folder was, so resuming one under a different scope would permanently skip changes the previous run filtered out. Switching between scoped and unscoped does the same. Runs that repeat the same scope stay incremental, and the scope in force is recorded in the delta cursor.
+- **A scoped snapshot holds only that folder.** Restoring it restores only those files. Scoped backups are not a cheaper substitute for a whole-drive backup unless the scope covers everything you need recovered.
+
 ## Failed Items and Delta Progress
 
 A file that refuses to download, whether from a permissions quirk, a corrupted item, IRM-protected content, or a chronically 4xx-ing CDN link, must not be able to stop the rest of the drive from being backed up. Atlas therefore **advances past per-item failures and records them**, rather than discarding the batch:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -364,6 +364,8 @@ atlas onedrive backup -o user@company.com
 atlas onedrive backup -o user@company.com --full
 atlas onedrive backup -o user@company.com --folder /Projects
 atlas onedrive restore -o user@company.com -s od-snap-1735689600000-a1b2c3
+atlas onedrive restore -o user@company.com -s od-snap-123 --destination /DR-drill
+atlas onedrive restore -o user@company.com -s od-snap-123 --in-place
 atlas onedrive restore -o user@company.com -s od-snap-123 --target-owner other@company.com
 atlas onedrive restore -o user@company.com -s od-snap-123 --conflict replace
 atlas onedrive list-snapshots -o user@company.com
@@ -411,14 +413,19 @@ A snapshot taken with `--folder` contains only that folder's files. Restoring it
 
 **`atlas onedrive restore`**
 
-| Option                     | Description                                                              |
-| -------------------------- | ------------------------------------------------------------------------ |
-| `-o, --owner <id>`         | User email or Entra object ID (required)                                 |
-| `-s, --snapshot <id>`      | Snapshot to restore from (required)                                      |
-| `--target-owner <id>`      | Restore to a different user's OneDrive (defaults to owner)               |
-| `--file-filter <paths...>` | Only restore specific files by ID or path                                |
-| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`) |
-| `-t, --tenant <id>`        | Override tenant ID from config                                           |
+| Option                     | Description                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------- |
+| `-o, --owner <id>`         | User email or Entra object ID (required)                                           |
+| `-s, --snapshot <id>`      | Snapshot to restore from (required)                                                |
+| `--target-owner <id>`      | Restore to a different user's OneDrive (defaults to owner)                         |
+| `--destination <path>`     | Folder to restore under, created when missing (default: `/Restore-<timestamp>`)    |
+| `--in-place`               | Restore to the original paths instead of a restore root                            |
+| `--name <filename>`        | Rename the restored file; rejected unless exactly one file matches                 |
+| `--file-filter <paths...>` | Only restore specific files by ID or path                                          |
+| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`)          |
+| `-t, --tenant <id>`        | Override tenant ID from config                                                     |
+
+A drive restore nests under `/Restore-<timestamp>` at the target drive root and recreates the original folder structure beneath it, matching how Outlook restores have always worked. `--in-place` reproduces the pre-3.1.0 behaviour of writing back over the original paths; it is never the default, because `--conflict rename` turns a repeated in-place restore into suffixed duplicates scattered through live content rather than a failure. See [Where restored files land](/onedrive-backup#where-restored-files-land).
 
 Identifiers are matched case-insensitively: `--owner`, `--site`, and `--file-filter` all accept whatever case a listing or portal shows. Owner and site IDs are lowercased before they become storage keys, so one identifier always addresses one tree. Earlier releases wrote a second tree for a second spelling and deleted from whichever one they were handed.
 
@@ -516,6 +523,7 @@ atlas sharepoint backup --site https://contoso.sharepoint.com/sites/Engineering 
 atlas sharepoint list-snapshots --site https://contoso.sharepoint.com/sites/Engineering
 atlas sharepoint list-versions --site https://contoso.sharepoint.com/sites/Engineering -f /Documents/report.docx
 atlas sharepoint restore --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-1735689600000-a1b2c3
+atlas sharepoint restore --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 --destination /DR-drill
 atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-1735689600000-a1b2c3
 atlas sharepoint verify --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-1735689600000-a1b2c3
 atlas sharepoint status --site https://contoso.sharepoint.com/sites/Engineering
@@ -570,14 +578,22 @@ Graph returns only the subsites the application can read. A subsite that cannot 
 
 **`atlas sharepoint restore`**
 
-| Option                      | Description                                                              |
-| --------------------------- | ------------------------------------------------------------------------ |
-| `--site <url-or-id>`        | SharePoint site URL or Graph site ID (required)                          |
-| `-s, --snapshot <id>`       | SharePoint snapshot ID (required)                                        |
-| `--target-site <url-or-id>` | Restore to a different site (defaults to original)                       |
-| `--file-filter <paths...>`  | Only restore specific files (by ID or path)                              |
-| `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`) |
-| `-t, --tenant <id>`         | Override tenant ID from config                                           |
+| Option                      | Description                                                                    |
+| --------------------------- | ------------------------------------------------------------------------------ |
+| `--site <url-or-id>`        | SharePoint site URL or Graph site ID (required)                                |
+| `-s, --snapshot <id>`       | SharePoint snapshot ID (required)                                              |
+| `--target-site <url-or-id>` | Restore to a different site (defaults to original)                             |
+| `--destination <path>`      | Folder to restore under, created when missing (default: `/Restore-<timestamp>`) |
+| `--in-place`                | Restore to the original paths instead of a restore root                         |
+| `--name <filename>`         | Rename the restored file; rejected unless exactly one file matches             |
+| `--file-filter <paths...>`  | Only restore specific files (by ID or path)                                    |
+| `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`)       |
+| `-t, --tenant <id>`         | Override tenant ID from config                                                  |
+
+Restored files nest under `Restore-<timestamp>` in each destination library, with the original
+structure recreated beneath it. `--in-place` restores over the original paths, which was the
+behaviour before 3.1.0. See
+[Where restored files land](../sharepoint-backup.md#where-restored-files-land).
 
 With `--target-site`, each file goes to the target library whose name matches the
 one it was backed up from, or, when the restore comes from a single library,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -362,6 +362,7 @@ A snapshot is a delta: its manifest lists only what changed in that run. `restor
 ```bash
 atlas onedrive backup -o user@company.com
 atlas onedrive backup -o user@company.com --full
+atlas onedrive backup -o user@company.com --folder /Projects
 atlas onedrive restore -o user@company.com -s od-snap-1735689600000-a1b2c3
 atlas onedrive restore -o user@company.com -s od-snap-123 --target-owner other@company.com
 atlas onedrive restore -o user@company.com -s od-snap-123 --conflict replace
@@ -389,6 +390,7 @@ atlas onedrive delete -o user@company.com -y
 | ---------------------- | --------------------------------------------------------------------- |
 | `-o, --owner <id>`     | User email or Entra object ID (required)                              |
 | `--full`               | Force full crawl ignoring saved delta links                           |
+| `--folder <path>`      | Back up only this folder and its subfolders; see note below           |
 | `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (see note below) |
 | `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`); requires `--retention-days` |
 | `-t, --tenant <id>`    | Override tenant ID from config                                        |
@@ -397,6 +399,14 @@ While the backup runs, a live dashboard shows one row per drive: delta fetch (`f
 
 ::: details Object Lock semantics for OneDrive/SharePoint
 Unlike Outlook (which stamps a per-object `retain_until` on each write), OneDrive and SharePoint apply immutability as **bucket default retention** (`PutObjectLockConfiguration`): every new object version (files, file versions, manifests, delta cursors) inherits the lock automatically, so no write path can bypass it. Two consequences: the setting **persists on the bucket** and covers all subsequent writes from any command, and the bucket must be lock-capable (created with Object Lock; see `atlas storage-check` and the migration runbook in the self-hosting docs) or the backup fails fast with `ObjectLockUnsupportedError`. Frequently-overwritten small objects (cursors, indexes) accumulate locked noncurrent versions until retention expires; the bucket housekeeping lifecycle rules clean them up afterwards.
+:::
+
+::: details How --folder interacts with delta state
+Graph's drive delta is drive-wide, so `--folder` filters the result rather than the query. The run still enumerates the whole drive, but only items inside the folder are downloaded, hashed, version-synced and written, which is where a drive backup spends its time.
+
+A saved delta link records how far the **drive** was consumed, not how far the folder was. Resuming one under a different scope would skip changes the previous run filtered out, so **changing `--folder` between runs forces a full re-crawl**, as does switching between a scoped and an unscoped backup. Repeated runs with the same value stay incremental. The scope in force is stored in the delta cursor, and the run logs the re-crawl when it detects a change.
+
+A snapshot taken with `--folder` contains only that folder's files. Restoring it restores only those files, so a scoped backup is not a substitute for a whole-drive one unless the scope covers everything you need.
 :::
 
 **`atlas onedrive restore`**

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -180,6 +180,15 @@ The callback is optional and runs inline with the operation. Keep it fast; move 
 
 OneDrive and SharePoint expose parallel methods on `atlas.onedrive` and `atlas.sharepoint` (including workload-specific replication). See [OneDrive Backup](/onedrive-backup) and [SharePoint Backup](/sharepoint-backup) for full SDK examples per workload.
 
+The drive restore methods take `destination`, `in_place` and `rename_to` alongside `conflict_behavior`. As of 3.1.0 they default to a generated `Restore-<timestamp>` root rather than writing back over the original paths, so an embedder that relied on the old behaviour has to pass `in_place: true`:
+
+```typescript
+const snapshot_id = 'od-snap-123';
+await atlas.onedrive.restore('owner-id', { snapshot_id }); // /Restore-2026-08-27T10-15-30/...
+await atlas.onedrive.restore('owner-id', { snapshot_id, destination: '/DR-drill' });
+await atlas.onedrive.restore('owner-id', { snapshot_id, in_place: true }); // pre-3.1.0 behaviour
+```
+
 Deletion methods erase every version of the objects they match. `purgeTenantData()` sweeps the whole bucket, every workload and not only Outlook. The returned `DeletionResult` separates `retained_*` (blocked by Object Lock, deletable once retention expires) from `failed_*` (everything else, which will not clear on its own). See [Erasure](/security#erasure).
 
 ### Shared mailbox identity

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -197,14 +197,17 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 
 ### `atlas sharepoint restore`
 
-| Flag                        | Description                                          | Default        |
-| --------------------------- | ---------------------------------------------------- | -------------- |
-| `--site <url-or-id>`        | SharePoint site URL or Graph site ID                 | Required       |
-| `-s, --snapshot <id>`       | SharePoint snapshot ID                               | Required       |
-| `--target-site <url-or-id>` | Restore to a different site                          | Original site  |
-| `--file-filter <paths...>`  | Only restore specific files (by ID or path)          | All files      |
-| `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` | `rename`       |
-| `-t, --tenant <id>`         | Tenant identifier                                    | Config default |
+| Flag                        | Description                                          | Default                |
+| --------------------------- | ---------------------------------------------------- | ---------------------- |
+| `--site <url-or-id>`        | SharePoint site URL or Graph site ID                 | Required               |
+| `-s, --snapshot <id>`       | SharePoint snapshot ID                               | Required               |
+| `--target-site <url-or-id>` | Restore to a different site                          | Original site          |
+| `--destination <path>`      | Folder to restore under, created when missing        | `/Restore-<timestamp>` |
+| `--in-place`                | Restore to the original paths                        | `false`                |
+| `--name <filename>`         | Rename the restored file; single-file restores only   | Original name          |
+| `--file-filter <paths...>`  | Only restore specific files (by ID or path)          | All files              |
+| `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` | `rename`               |
+| `-t, --tenant <id>`         | Tenant identifier                                    | Config default         |
 
 ### `atlas sharepoint save`
 
@@ -243,17 +246,33 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 ## Restore
 
 ```bash
-# Restore all files from a snapshot
+# Restore all files into a fresh Restore-<timestamp> folder in each library
 atlas sharepoint restore --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123
 
 # Restore to a different site
 atlas sharepoint restore --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 \
   --target-site https://contoso.sharepoint.com/sites/Staging
 
+# Restore into a folder you name
+atlas sharepoint restore --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 \
+  --destination /DR-drill
+
+# Put files back exactly where they came from, mixed into live content
+atlas sharepoint restore --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 \
+  --in-place
+
 # Restore specific files only, replacing existing
 atlas sharepoint restore --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 \
   --file-filter /Documents/report.docx /Documents/budget.xlsx -c replace
 ```
+
+### Where restored files land
+
+A restore creates `Restore-<timestamp>` in each destination library and recreates the original folder structure beneath it, so a file backed up from `/Reports/2026` returns to `/Restore-2026-08-27T10-15-30/Reports/2026`. Deleting that one folder undoes the whole restore.
+
+Before 3.1.0 a restore wrote every file back over its original path. With the default `rename` conflict policy that neither failed nor overwrote; it left a suffixed copy beside each original, scattered through live library content with nothing marking which copy came from a backup. `--in-place` still does exactly that, but it now has to be asked for.
+
+`--destination` names the folder instead of generating one, and is created when missing. `--name` renames a single restored file and is rejected when more than one file matches, so pair it with `--file-filter`. Path length limits apply to the deeper nesting: a file that exceeds one is reported as a skipped item and does not abort the run.
 
 Restore decrypts stored file blobs, verifies SHA-256 checksums, and uploads them back to a site's document libraries via the Graph API. Restoring in place uses each manifest entry's own `drive_id`, so files return to the library they came from. Restoring to another site with `--target-site` re-points every upload at a library of that site, described in [Where a cross-site restore lands](#where-a-cross-site-restore-lands).
 

--- a/e2e/atlas_e2e/atlas.py
+++ b/e2e/atlas_e2e/atlas.py
@@ -15,6 +15,18 @@ log = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 900
 
+# `onedrive backup` has no folder scope: it syncs the owner's entire drive, and the suite recreates
+# the MinIO volumes every run, so every run pays a full initial crawl of whatever that drive holds.
+# Backup, verify, save and restore therefore scale with the tenant's real content rather than with
+# the fixtures, and 900s was not enough for a drive with many items (issue #211).
+#
+# ponytail: a flat 30 minutes per whole-drive call, not a size-derived budget. The ceiling is the
+# 60-minute job timeout in e2e.yml, so this cannot grow much further. The real fixes are a folder or
+# filter scope on `onedrive backup`, or a test account whose drive holds only the fixtures; until one
+# of those exists, a drive that outgrows this will fail here with a clear timeout rather than silently
+# eating the whole job budget.
+WHOLE_DRIVE_TIMEOUT = 1800
+
 # Ink wraps to `process.stdout.columns` and falls back to 80 without a TTY. The CLI honours
 # `COLUMNS` when its output is piped, so this width keeps every cell on one line.
 NO_WRAP_COLUMNS = 4096

--- a/e2e/atlas_e2e/cleanup.py
+++ b/e2e/atlas_e2e/cleanup.py
@@ -15,25 +15,42 @@ log = logging.getLogger(__name__)
 
 
 def sweep_drive(graph: Graph, drive_id: str, marker: str) -> list[str]:
-    """Deletes marked fixture folders from a OneDrive or SharePoint drive.
+    """Deletes this run's fixture folders and any debris inside the fixture root.
 
-    File restores write back to the original `parent_path` with no `Restore-` root of their own, so
-    restored copies land inside the marked fixture folder and go with it. Foreign markers follow the
-    same staleness rule as the mailbox sweep.
+    Restored copies land inside the fixture folder they were backed up from, so they go with it.
+    Anything else sitting directly under the fixture root is suite debris from a run that died
+    before its own teardown, and is removed regardless of naming. Foreign *marked* folders follow
+    the staleness rule, so a concurrent run's fixtures are never deleted from under it.
     """
     removed: list[str] = []
-    for folder in drive.marked_root_folders(graph, drive_id, PREFIX):
-        name = str(folder.get("name", ""))
-        if marker not in name and not is_stale(parse_graph_time(folder.get("createdDateTime"))):
+    for item in drive.fixture_items(graph, drive_id, PREFIX):
+        name = str(item.get("name", ""))
+        foreign_marked = is_marked(name) and marker not in name
+        if foreign_marked and not is_stale(parse_graph_time(item.get("createdDateTime"))):
             log.info("Leaving foreign, non-stale drive folder %s", name)
             continue
         try:
-            drive.delete_item(graph, drive_id, str(folder["id"]))
+            drive.delete_item(graph, drive_id, str(item["id"]))
             removed.append(name)
-            log.info("Cleaned up drive folder %s", name)
+            log.info("Cleaned up drive item %s", name)
         except GraphError as err:
-            log.warning("Could not delete drive folder %s: %s", name, err)
+            log.warning("Could not delete drive item %s: %s", name, err)
     return removed
+
+
+def surviving_drive_artifacts(graph: Graph, drive_id: str, marker: str) -> list[str]:
+    """Names still carrying this run's marker after a sweep. Empty is the only acceptable result.
+
+    The sweep logs and continues on every failure so it cannot mask a test result, which also means
+    a leftover would otherwise be invisible. This is the check that makes it visible: a run that
+    cannot clean up after itself is how the tenant accumulated duplicates of its own fixtures.
+    """
+    try:
+        items = drive.fixture_items(graph, drive_id, PREFIX)
+    except GraphError as err:
+        log.warning("Could not verify drive cleanup: %s", err)
+        return []
+    return [str(i.get("name", "")) for i in items if marker in str(i.get("name", ""))]
 
 
 def sweep_mailbox(graph: Graph, mailbox: str, marker: str) -> list[str]:

--- a/e2e/atlas_e2e/cleanup.py
+++ b/e2e/atlas_e2e/cleanup.py
@@ -15,26 +15,31 @@ log = logging.getLogger(__name__)
 
 
 def sweep_drive(graph: Graph, drive_id: str, marker: str) -> list[str]:
-    """Deletes this run's fixture folders and any debris inside the fixture root.
+    """Deletes marked fixture folders from a OneDrive or SharePoint drive.
 
-    Restored copies land inside the fixture folder they were backed up from, so they go with it.
-    Anything else sitting directly under the fixture root is suite debris from a run that died
-    before its own teardown, and is removed regardless of naming. Foreign *marked* folders follow
-    the staleness rule, so a concurrent run's fixtures are never deleted from under it.
+    Restored copies land inside the marked fixture folder they were backed up from, so they go with
+    it. Foreign markers follow the staleness rule, so a concurrent run's fixtures are never deleted
+    from under it.
+
+    Only names carrying the E2E marker are ever deleted, no matter which folder they were found in.
+    An earlier version of this function treated any unmarked item under the fixture root as debris,
+    on the theory that the folder was suite-owned; it deleted a tenant's real files. Cleanup must
+    never remove anything the suite did not create, so membership is decided by the marker alone.
     """
     removed: list[str] = []
     for item in drive.fixture_items(graph, drive_id, PREFIX):
         name = str(item.get("name", ""))
-        foreign_marked = is_marked(name) and marker not in name
-        if foreign_marked and not is_stale(parse_graph_time(item.get("createdDateTime"))):
+        if not is_marked(name):
+            continue
+        if marker not in name and not is_stale(parse_graph_time(item.get("createdDateTime"))):
             log.info("Leaving foreign, non-stale drive folder %s", name)
             continue
         try:
             drive.delete_item(graph, drive_id, str(item["id"]))
             removed.append(name)
-            log.info("Cleaned up drive item %s", name)
+            log.info("Cleaned up drive folder %s", name)
         except GraphError as err:
-            log.warning("Could not delete drive item %s: %s", name, err)
+            log.warning("Could not delete drive folder %s: %s", name, err)
     return removed
 
 

--- a/e2e/atlas_e2e/drive.py
+++ b/e2e/atlas_e2e/drive.py
@@ -26,6 +26,11 @@ FIXTURE_BYTES = 4096
 # in an opt-in dispatch suite, not a nightly that pays real Graph quota for them.
 LARGE_FIXTURE_BYTES = 5 * 1024 * 1024
 
+# Every fixture the suite creates lives under one drive-root folder, so an operator has a single
+# place to look and a single thing to delete, and so a scoped backup (`--folder`) never has to
+# enumerate the account's real content. Nested per run: `E2E/atlas-e2e-<run-id>/...`.
+FIXTURE_ROOT = "E2E"
+
 
 @dataclass(frozen=True)
 class SeededFile:
@@ -78,11 +83,34 @@ def upload_file(graph: Graph, drive_id: str, folder: str, name: str, content: by
     )
 
 
+def fixture_folder(marker: str) -> str:
+    """This run's fixture folder, `E2E/<marker>`, relative to the drive root."""
+    return f"{FIXTURE_ROOT}/{marker}"
+
+
+def ensure_fixture_folder(graph: Graph, drive_id: str, marker: str) -> None:
+    """Creates `E2E/<marker>`, and `E2E` itself when the drive has no fixture root yet.
+
+    Uploading by path only creates the immediate parent, so a two-level fixture path needs the
+    intermediate folder to exist. Both creates tolerate a folder that is already there.
+    """
+    for parent, name in (("root", FIXTURE_ROOT), (f"root:/{FIXTURE_ROOT}:", marker)):
+        try:
+            graph.post(
+                f"/drives/{drive_id}/{parent}/children",
+                {"name": name, "folder": {}, "@microsoft.graph.conflictBehavior": "fail"},
+            )
+        except GraphError as err:
+            log.debug("Fixture folder %s already present or not creatable: %s", name, err)
+
+
 def seed_fixture_file(graph: Graph, drive_id: str, marker: str, versions: int = 1) -> SeededFile:
-    """Seeds `<marker>/<marker>-file.bin` with `versions` successive versions; returns the newest."""
+    """Seeds `E2E/<marker>/<marker>-file.bin` with `versions` successive versions; newest returned."""
+    ensure_fixture_folder(graph, drive_id, marker)
+    folder = fixture_folder(marker)
     seeded: SeededFile | None = None
     for _ in range(versions):
-        seeded = upload_file(graph, drive_id, marker, f"{marker}-file.bin", os.urandom(FIXTURE_BYTES))
+        seeded = upload_file(graph, drive_id, folder, f"{marker}-file.bin", os.urandom(FIXTURE_BYTES))
     assert seeded is not None
     return seeded
 
@@ -117,9 +145,10 @@ def upload_large_file(graph: Graph, drive_id: str, folder: str, name: str, conte
 
 
 def seed_large_fixture_file(graph: Graph, drive_id: str, marker: str) -> SeededFile:
-    """Seeds `<marker>/<marker>-large.bin` at 5 MB, above every 4 MB code path in backup and restore."""
+    """Seeds `E2E/<marker>/<marker>-large.bin` at 5 MB, above every 4 MB code path in the product."""
+    ensure_fixture_folder(graph, drive_id, marker)
     return upload_large_file(
-        graph, drive_id, marker, f"{marker}-large.bin", os.urandom(LARGE_FIXTURE_BYTES)
+        graph, drive_id, fixture_folder(marker), f"{marker}-large.bin", os.urandom(LARGE_FIXTURE_BYTES)
     )
 
 
@@ -164,7 +193,20 @@ def children(graph: Graph, drive_id: str, folder: str) -> list[dict[str, Any]]:
         return []
 
 
-def marked_root_folders(graph: Graph, drive_id: str, prefix: str) -> list[dict[str, Any]]:
-    """Root-level folders whose name carries an E2E marker; the cleanup target set."""
-    items = graph.paged(f"/drives/{drive_id}/root/children", **{"$select": "id,name,createdDateTime"})
-    return [i for i in items if str(i.get("name", "")).startswith(prefix)]
+def fixture_items(graph: Graph, drive_id: str, prefix: str) -> list[dict[str, Any]]:
+    """Everything cleanup may delete: the whole fixture root, plus legacy marker folders at the root.
+
+    Direct children of `E2E` are suite-owned by definition, so they are returned whether or not they
+    carry a marker: that is what catches restore output and any other debris a failed run left inside
+    the fixture root. Root level is still scanned because runs before the fixture root existed seeded
+    there, and because SharePoint libraries may hold the same legacy layout.
+    """
+    select = {"$select": "id,name,createdDateTime"}
+    items: list[dict[str, Any]] = []
+    try:
+        items.extend(graph.paged(f"/drives/{drive_id}/root:/{FIXTURE_ROOT}:/children", **select))
+    except GraphError as err:
+        log.debug("No %s fixture root on this drive: %s", FIXTURE_ROOT, err)
+    root_items = graph.paged(f"/drives/{drive_id}/root/children", **select)
+    items.extend(i for i in root_items if str(i.get("name", "")).startswith(prefix))
+    return items

--- a/e2e/atlas_e2e/drive.py
+++ b/e2e/atlas_e2e/drive.py
@@ -194,19 +194,20 @@ def children(graph: Graph, drive_id: str, folder: str) -> list[dict[str, Any]]:
 
 
 def fixture_items(graph: Graph, drive_id: str, prefix: str) -> list[dict[str, Any]]:
-    """Everything cleanup may delete: the whole fixture root, plus legacy marker folders at the root.
+    """Marker-named folders cleanup may delete, from the fixture root and from the drive root.
 
-    Direct children of `E2E` are suite-owned by definition, so they are returned whether or not they
-    carry a marker: that is what catches restore output and any other debris a failed run left inside
-    the fixture root. Root level is still scanned because runs before the fixture root existed seeded
-    there, and because SharePoint libraries may hold the same legacy layout.
+    Both locations are filtered by the marker prefix. Returning unfiltered children of the fixture
+    root once deleted a tenant's real files: the folder is suite-owned by convention only, and a
+    convention is not a safe basis for deletion. The drive root is still scanned because runs before
+    the fixture root existed seeded there, and because SharePoint libraries may hold that layout.
     """
     select = {"$select": "id,name,createdDateTime"}
-    items: list[dict[str, Any]] = []
-    try:
-        items.extend(graph.paged(f"/drives/{drive_id}/root:/{FIXTURE_ROOT}:/children", **select))
-    except GraphError as err:
-        log.debug("No %s fixture root on this drive: %s", FIXTURE_ROOT, err)
-    root_items = graph.paged(f"/drives/{drive_id}/root/children", **select)
-    items.extend(i for i in root_items if str(i.get("name", "")).startswith(prefix))
-    return items
+    marked: list[dict[str, Any]] = []
+    for path in (f"/drives/{drive_id}/root:/{FIXTURE_ROOT}:/children", f"/drives/{drive_id}/root/children"):
+        try:
+            marked.extend(
+                i for i in graph.paged(path, **select) if str(i.get("name", "")).startswith(prefix)
+            )
+        except GraphError as err:
+            log.debug("Could not list %s: %s", path, err)
+    return marked

--- a/e2e/atlas_e2e/drive.py
+++ b/e2e/atlas_e2e/drive.py
@@ -88,6 +88,22 @@ def fixture_folder(marker: str) -> str:
     return f"{FIXTURE_ROOT}/{marker}"
 
 
+def restore_destination(marker: str) -> str:
+    """Where this run sends restore output.
+
+    Issue #217 made a drive restore nest under a generated `Restore-<timestamp>` root at the drive
+    root. That is the right default for an operator, but it sits outside the marker namespace the
+    suite owns, and cleanup must never delete outside it, so the suite restores into its own fixture
+    folder instead and asserts the nesting there.
+    """
+    return f"/{fixture_folder(marker)}/restored"
+
+
+def restored_tree(marker: str) -> str:
+    """Restored files keep their original nesting beneath the destination."""
+    return f"{restore_destination(marker)}/{fixture_folder(marker)}"
+
+
 def ensure_fixture_folder(graph: Graph, drive_id: str, marker: str) -> None:
     """Creates `E2E/<marker>`, and `E2E` itself when the drive has no fixture root yet.
 

--- a/e2e/atlas_e2e/self_check.py
+++ b/e2e/atlas_e2e/self_check.py
@@ -10,9 +10,12 @@ Run with `uv run python -m atlas_e2e.self_check`.
 from __future__ import annotations
 
 import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from atlas_e2e import cleanup, drive
 from atlas_e2e.atlas import Cli, Result
+from atlas_e2e.marker import PREFIX
 from atlas_e2e.config import Settings
 from atlas_e2e.scrub import scrub
 
@@ -108,11 +111,107 @@ def check_transcript_never_holds_output() -> None:
         assert "[exit 2]" in written, "the transcript lost the exit code"
 
 
+class _FakeGraph:
+    """Serves one page of children per path and records deletes. No transport, no tenant."""
+
+    def __init__(self, children_by_path: dict[str, list[dict[str, object]]]) -> None:
+        self._children_by_path = children_by_path
+        self.deleted: list[str] = []
+
+    def paged(self, url: str, **_params: object) -> list[dict[str, object]]:
+        return self._children_by_path.get(url, [])
+
+    def delete(self, url: str) -> None:
+        self.deleted.append(url.rsplit("/", 1)[-1])
+
+
+def _drive_item(name: str, item_id: str, age_hours: float = 0.0) -> dict[str, object]:
+    created = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    return {"id": item_id, "name": name, "createdDateTime": created.isoformat()}
+
+
+def _fake_drive(fixture_root: list[dict[str, object]], root: list[dict[str, object]]) -> _FakeGraph:
+    return _FakeGraph(
+        {
+            f"/drives/d1/root:/{drive.FIXTURE_ROOT}:/children": fixture_root,
+            "/drives/d1/root/children": root,
+        }
+    )
+
+
+_REAL_FILES = ("Contract.docx", "recovery-codes.txt", "Holiday.mp4")
+
+
+def check_cleanup_never_deletes_unmarked_items() -> None:
+    """The destructive boundary: cleanup may only delete what the suite named.
+
+    An earlier `sweep_drive` treated any unmarked item under the fixture root as debris, on the
+    theory that the folder was suite-owned. It deleted a tenant's real files. This runs before the
+    suite is allowed near a tenant, for the same reason the redaction checks do.
+
+    Discovery is stubbed out on purpose. `fixture_items` also filters by marker, and asserting
+    through it would let this pass while the deletion rule itself was unsafe. Each layer is checked
+    where it decides, so removing either one fails a check.
+    """
+    # Aged deliberately. For an unmarked item the staleness rule inverts: "old enough that no live
+    # run can own it" reads as permission to delete, so a real file became *more* deletable the
+    # longer it had existed. That is how the incident happened, and a fresh fixture would not
+    # reproduce it.
+    real = [_drive_item(name, f"id-{i}", age_hours=48) for i, name in enumerate(_REAL_FILES)]
+    graph = _fake_drive(fixture_root=[], root=[])
+    original = drive.fixture_items
+    drive.fixture_items = lambda *_args, **_kwargs: real  # type: ignore[assignment]
+    try:
+        removed = cleanup.sweep_drive(graph, "d1", f"{PREFIX}-run-1")  # type: ignore[arg-type]
+    finally:
+        drive.fixture_items = original  # type: ignore[assignment]
+
+    assert removed == [], f"cleanup deleted unmarked items: {removed}"
+    assert graph.deleted == [], f"cleanup issued deletes for unmarked items: {graph.deleted}"
+
+
+def check_fixture_discovery_only_returns_marked() -> None:
+    """Second layer: discovery must not hand cleanup anything unmarked in the first place."""
+    real = [_drive_item(name, f"id-{i}") for i, name in enumerate(_REAL_FILES)]
+    marked = _drive_item(f"{PREFIX}-run-1", "id-run")
+    graph = _fake_drive(fixture_root=[*real, marked], root=real)
+
+    found = drive.fixture_items(graph, "d1", PREFIX)  # type: ignore[arg-type]
+
+    assert [i["name"] for i in found] == [f"{PREFIX}-run-1"], f"discovery returned real files: {found}"
+
+
+def check_cleanup_still_removes_this_run() -> None:
+    """The other half: a guard that deletes nothing would pass the check above."""
+    this_run = f"{PREFIX}-run-1"
+    graph = _fake_drive(fixture_root=[_drive_item(this_run, "id-run")], root=[])
+
+    assert cleanup.sweep_drive(graph, "d1", this_run) == [this_run]  # type: ignore[arg-type]
+    assert graph.deleted == ["id-run"]
+
+
+def check_cleanup_spares_a_concurrent_run() -> None:
+    """A foreign marker is left until stale, so a live run is never swept from under."""
+    graph = _fake_drive(fixture_root=[_drive_item(f"{PREFIX}-run-2", "id-foreign")], root=[])
+
+    assert cleanup.sweep_drive(graph, "d1", f"{PREFIX}-run-1") == []  # type: ignore[arg-type]
+
+    stale = _fake_drive(
+        fixture_root=[_drive_item(f"{PREFIX}-run-2", "id-stale", age_hours=48)], root=[]
+    )
+    assert stale.deleted == []
+    assert cleanup.sweep_drive(stale, "d1", f"{PREFIX}-run-1") == [f"{PREFIX}-run-2"]  # type: ignore[arg-type]
+
+
 CHECKS = (
     check_settings_repr_hides_secrets,
     check_scrub_redacts_every_secret,
     check_result_streams_are_scrubbed,
     check_transcript_never_holds_output,
+    check_cleanup_never_deletes_unmarked_items,
+    check_fixture_discovery_only_returns_marked,
+    check_cleanup_still_removes_this_run,
+    check_cleanup_spares_a_concurrent_run,
 )
 
 
@@ -121,7 +220,7 @@ def main() -> None:
     for check in CHECKS:
         check()
         print(f"ok  {check.__name__}")
-    print(f"{len(CHECKS)} redaction check(s) passed.")
+    print(f"{len(CHECKS)} safety check(s) passed.")
 
 
 if __name__ == "__main__":

--- a/e2e/atlas_e2e/sweep.py
+++ b/e2e/atlas_e2e/sweep.py
@@ -15,7 +15,12 @@ from atlas_e2e.graph import Graph
 
 
 def main() -> int:
-    """Sweeps marked M365 fixtures and empties the tenant bucket. Never fails the job."""
+    """Sweeps marked M365 fixtures and empties the tenant bucket.
+
+    Returns non-zero only when this run's own drive artifacts survived the sweep. Test outcomes are
+    a separate step, so failing here reports a cleanup problem without touching them, and a silent
+    leftover is what let the tenant accumulate duplicates of its own fixtures.
+    """
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     log = logging.getLogger("sweep")
     try:
@@ -32,6 +37,7 @@ def main() -> int:
     except Exception as err:  # noqa: BLE001 - a failed sweep must not fail the job after the tests
         log.warning("Mailbox sweep failed: %s", err)
 
+    survivors: list[str] = []
     for label, resolve in (
         ("onedrive", lambda: drive.user_drive_id(graph, settings.onedrive_owner)),
         ("sharepoint", lambda: drive.site_drive_id(graph, drive.site_id(graph, settings.sharepoint_site))),
@@ -40,8 +46,13 @@ def main() -> int:
         if not configured:
             continue
         try:
-            removed = cleanup.sweep_drive(graph, resolve(), tag)
-            log.info("Removed %d %s folder(s)", len(removed), label)
+            drive_id = resolve()
+            removed = cleanup.sweep_drive(graph, drive_id, tag)
+            log.info("Removed %d %s item(s)", len(removed), label)
+            left = cleanup.surviving_drive_artifacts(graph, drive_id, tag)
+            if left:
+                log.error("%s still holds this run's artifacts: %s", label, left)
+                survivors.extend(f"{label}:{name}" for name in left)
         except Exception as err:  # noqa: BLE001 - same rule as above
             log.warning("%s sweep failed: %s", label, err)
 
@@ -49,6 +60,10 @@ def main() -> int:
 
     # Purge is independent of Graph: an unreachable tenant must not leave the bucket populated.
     cleanup.purge_bucket(Cli(settings, config.REPO_ROOT / "e2e" / ".sweep-home"), settings)
+
+    if survivors:
+        log.error("Cleanup incomplete; %d artifact(s) survived", len(survivors))
+        return 1
     return 0
 
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -119,7 +119,13 @@ def _teardown(
     for label, drive_id in _fixture_drives(graph, settings).items():
         try:
             removed = cleanup.sweep_drive(graph, drive_id, run_marker)
-            log.info("Teardown: removed %d %s folder(s)", len(removed), label)
+            log.info("Teardown: removed %d %s item(s)", len(removed), label)
+            # Logged, never raised: an exception here would replace the real test failure. Logged at
+            # error level so a run that could not clean up after itself is visible in the transcript
+            # rather than discovered later as accumulated fixtures in the tenant.
+            left = cleanup.surviving_drive_artifacts(graph, drive_id, run_marker)
+            if left:
+                log.error("Teardown: %s still holds this run's artifacts: %s", label, left)
         except Exception as err:  # noqa: BLE001 - same rule as above
             log.warning("Teardown: %s sweep failed: %s", label, err)
 

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -18,7 +18,9 @@ package = false
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 # -p no:randomly: the lifecycle suites are ordered on purpose (seed before restore).
-addopts = "-ra --strict-markers --junitxml=report.xml"
+# --durations: a live-tenant run is dominated by a handful of tests, and finding which ones
+# previously meant reconstructing timings from log timestamps by hand (issue #211).
+addopts = "-ra --strict-markers --durations=15 --junitxml=report.xml"
 markers = [
 ]
 log_cli = true

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -163,12 +163,15 @@ def test_05_save_exports_the_file(cli: Cli, settings: Settings, exports: Path, r
         assert zf.getinfo(large).file_size == drive.LARGE_FIXTURE_BYTES
 
 
-def test_06_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Settings) -> None:
-    """Deletes the file from OneDrive and restores it from the snapshot.
+def test_06_restore_recreates_a_deleted_file(
+    cli: Cli, graph: Any, settings: Settings, run_marker: str
+) -> None:
+    """Deletes the files from OneDrive and restores them under this run's destination.
 
-    `--conflict rename` is the default and is passed explicitly: OneDrive restore writes back to the
-    original `parent_path` with no `Restore-` root of its own, so an unexpected collision must never
-    overwrite live data.
+    Issue #217: a restore now nests under a root instead of writing back over live content. The
+    suite passes `--destination` rather than taking the default `Restore-<timestamp>` root, because
+    that default lands at the drive root, outside the marker namespace cleanup is allowed to touch.
+    `--conflict rename` is still passed explicitly: an unexpected collision must never overwrite.
     """
     for file in (STATE["file"], STATE["large"]):
         drive.delete_item(graph, STATE["drive_id"], file.item_id)
@@ -183,22 +186,30 @@ def test_06_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Set
         STATE["snapshot"],
         "-c",
         "rename",
+        "--destination",
+        drive.restore_destination(run_marker),
         timeout=WHOLE_DRIVE_TIMEOUT,
     )
 
 
 def test_07_restored_bytes_match_the_seed(graph: Any, settings: Settings, run_marker: str) -> None:
     """Both restored files hash to their newest seeded version, read back through Graph."""
-    restored = drive.children(graph, STATE["drive_id"], drive.fixture_folder(run_marker))
-    assert restored, f"no files under /{drive.fixture_folder(run_marker)} after restore"
+    tree = drive.restored_tree(run_marker)
+    restored = drive.children(graph, STATE["drive_id"], tree.lstrip("/"))
+    assert restored, f"no files under {tree} after restore"
 
     digests = {
-        drive.file_sha256(
-            graph, STATE["drive_id"], f"/{drive.fixture_folder(run_marker)}/{item['name']}"
-        ) for item in restored
+        drive.file_sha256(graph, STATE["drive_id"], f"{tree}/{item['name']}") for item in restored
     }
     assert STATE["file"].sha256 in digests, "no restored file matches the seeded bytes"
     assert STATE["large"].sha256 in digests, "no restored file matches the 5 MB seeded bytes"
+
+    # The point of the restore root: live content is left alone. These paths were deleted in
+    # test_06 and a pre-#217 restore would have put them back, mixed in with real files.
+    for file in (STATE["file"], STATE["large"]):
+        assert (
+            drive.file_sha256(graph, STATE["drive_id"], file.path) is None
+        ), f"restore wrote back to the original path {file.path}"
 
 
 def test_08_status_reports_the_stored_snapshot(cli: Cli, settings: Settings) -> None:

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -42,14 +42,28 @@ def test_01_seed_a_file(graph: Any, settings: Settings, run_marker: str) -> None
     assert drive.file_sha256(graph, drive_id, STATE["large"].path) == STATE["large"].sha256
 
 
-def test_02_backup_writes_blobs_and_index(cli: Cli, settings: Settings, s3: Any) -> None:
+def test_02_backup_writes_blobs_and_index(
+    cli: Cli, settings: Settings, s3: Any, run_marker: str
+) -> None:
     """Backs up the owner's drive and asserts blobs, a manifest, and a version index landed.
 
-    `onedrive backup` has no folder scope -- it syncs the whole drive -- so absolute object counts
-    include whatever else the owner has, and the call needs `WHOLE_DRIVE_TIMEOUT` rather than the
-    default. Assertions here are existence-based, and the per-version assertion below is a delta.
+    Scoped to this run's fixture folder with `--folder`. Without it the backup syncs the owner's
+    entire drive, so the suite's runtime and object counts depended on whatever else that account
+    happened to hold, and a drive with many items pushed the call past its timeout. Scoping keeps
+    the assertions about the fixtures and nothing else.
+
+    The timeout stays generous anyway: Graph's driveItem delta is drive-wide, so the enumeration
+    still pages the whole drive even though only the scoped items are downloaded.
     """
-    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner, timeout=WHOLE_DRIVE_TIMEOUT)
+    cli.ok(
+        "onedrive",
+        "backup",
+        "-o",
+        settings.onedrive_owner,
+        "--folder",
+        f"/{run_marker}",
+        timeout=WHOLE_DRIVE_TIMEOUT,
+    )
 
     owner = _owner_segment(s3, settings.bucket)
     STATE["owner"] = owner
@@ -84,7 +98,17 @@ def test_03_a_new_version_is_stored_incrementally(
     before = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
 
     STATE["file"] = drive.seed_fixture_file(graph, STATE["drive_id"], run_marker)
-    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner, timeout=WHOLE_DRIVE_TIMEOUT)
+    # Same scope as the initial run: a scope change would force a re-crawl instead of
+    # resuming the delta link, and this test is specifically about the incremental path.
+    cli.ok(
+        "onedrive",
+        "backup",
+        "-o",
+        settings.onedrive_owner,
+        "--folder",
+        f"/{run_marker}",
+        timeout=WHOLE_DRIVE_TIMEOUT,
+    )
 
     after = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
     assert len(after - before) == 1, f"expected one new version blob, got {len(after - before)}"

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -61,7 +61,7 @@ def test_02_backup_writes_blobs_and_index(
         "-o",
         settings.onedrive_owner,
         "--folder",
-        f"/{run_marker}",
+        f"/{drive.fixture_folder(run_marker)}",
         timeout=WHOLE_DRIVE_TIMEOUT,
     )
 
@@ -106,7 +106,7 @@ def test_03_a_new_version_is_stored_incrementally(
         "-o",
         settings.onedrive_owner,
         "--folder",
-        f"/{run_marker}",
+        f"/{drive.fixture_folder(run_marker)}",
         timeout=WHOLE_DRIVE_TIMEOUT,
     )
 
@@ -189,11 +189,13 @@ def test_06_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Set
 
 def test_07_restored_bytes_match_the_seed(graph: Any, settings: Settings, run_marker: str) -> None:
     """Both restored files hash to their newest seeded version, read back through Graph."""
-    restored = drive.children(graph, STATE["drive_id"], run_marker)
-    assert restored, f"no files under /{run_marker} after restore"
+    restored = drive.children(graph, STATE["drive_id"], drive.fixture_folder(run_marker))
+    assert restored, f"no files under /{drive.fixture_folder(run_marker)} after restore"
 
     digests = {
-        drive.file_sha256(graph, STATE["drive_id"], f"/{run_marker}/{item['name']}") for item in restored
+        drive.file_sha256(
+            graph, STATE["drive_id"], f"/{drive.fixture_folder(run_marker)}/{item['name']}"
+        ) for item in restored
     }
     assert STATE["file"].sha256 in digests, "no restored file matches the seeded bytes"
     assert STATE["large"].sha256 in digests, "no restored file matches the 5 MB seeded bytes"

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 
 from atlas_e2e import drive, storage
-from atlas_e2e.atlas import Cli
+from atlas_e2e.atlas import Cli, WHOLE_DRIVE_TIMEOUT
 from atlas_e2e.config import Settings
 
 STATE: dict[str, Any] = {}
@@ -46,10 +46,10 @@ def test_02_backup_writes_blobs_and_index(cli: Cli, settings: Settings, s3: Any)
     """Backs up the owner's drive and asserts blobs, a manifest, and a version index landed.
 
     `onedrive backup` has no folder scope -- it syncs the whole drive -- so absolute object counts
-    include whatever else the owner has. Assertions here are existence-based, and the per-version
-    assertion below is a delta.
+    include whatever else the owner has, and the call needs `WHOLE_DRIVE_TIMEOUT` rather than the
+    default. Assertions here are existence-based, and the per-version assertion below is a delta.
     """
-    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner)
+    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner, timeout=WHOLE_DRIVE_TIMEOUT)
 
     owner = _owner_segment(s3, settings.bucket)
     STATE["owner"] = owner
@@ -59,12 +59,15 @@ def test_02_backup_writes_blobs_and_index(cli: Cli, settings: Settings, s3: Any)
     STATE["snapshot"] = snapshots[0]
 
     assert storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"), "no file blob written"
-    assert f"onedrive/index/{owner}/files/{STATE['file'].item_id}.json" in storage.list_keys(
-        s3, settings.bucket, f"onedrive/index/{owner}/files/"
-    ), "the seeded file has no version index of its own"
-    assert f"onedrive/index/{owner}/files/{STATE['large'].item_id}.json" in storage.list_keys(
-        s3, settings.bucket, f"onedrive/index/{owner}/files/"
-    ), "the 5 MB file has no version index of its own"
+
+    # One version-index object per run, not per file: issue #161 retired the
+    # `index/<owner>/files/<item_id>.json` layout because Hetzner bills a 64 KB minimum per object.
+    # Reads still merge legacy per-file objects, but a fresh bucket has none, so the run shard is the
+    # only thing that can be asserted from key names here. Per-file visibility is covered by
+    # `list-versions` in the next test, which exercises the read path.
+    assert f"onedrive/index/{owner}/runs/{STATE['snapshot']}.json" in storage.list_keys(
+        s3, settings.bucket, f"onedrive/index/{owner}/runs/"
+    ), "the run wrote no version index shard"
 
 
 def test_03_a_new_version_is_stored_incrementally(
@@ -81,7 +84,7 @@ def test_03_a_new_version_is_stored_incrementally(
     before = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
 
     STATE["file"] = drive.seed_fixture_file(graph, STATE["drive_id"], run_marker)
-    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner)
+    cli.ok("onedrive", "backup", "-o", settings.onedrive_owner, timeout=WHOLE_DRIVE_TIMEOUT)
 
     after = set(storage.list_keys(s3, settings.bucket, f"onedrive/data/{owner}/"))
     assert len(after - before) == 1, f"expected one new version blob, got {len(after - before)}"
@@ -96,7 +99,15 @@ def test_03_a_new_version_is_stored_incrementally(
 
 def test_04_verify_passes(cli: Cli, settings: Settings) -> None:
     """Deep verification of the snapshot: blobs decrypt, hash, and match the index rows."""
-    cli.ok("onedrive", "verify", "-o", settings.onedrive_owner, "-s", STATE["snapshot"])
+    cli.ok(
+        "onedrive",
+        "verify",
+        "-o",
+        settings.onedrive_owner,
+        "-s",
+        STATE["snapshot"],
+        timeout=WHOLE_DRIVE_TIMEOUT,
+    )
 
 
 def test_05_save_exports_the_file(cli: Cli, settings: Settings, exports: Path, run_marker: str) -> None:
@@ -115,6 +126,7 @@ def test_05_save_exports_the_file(cli: Cli, settings: Settings, exports: Path, r
         STATE["snapshot"],
         "-O",
         str(archive),
+        timeout=WHOLE_DRIVE_TIMEOUT,
     )
 
     assert archive.exists(), f"{archive} was not written"
@@ -147,6 +159,7 @@ def test_06_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Set
         STATE["snapshot"],
         "-c",
         "rename",
+        timeout=WHOLE_DRIVE_TIMEOUT,
     )
 
 

--- a/e2e/tests/test_30_sharepoint.py
+++ b/e2e/tests/test_30_sharepoint.py
@@ -111,8 +111,14 @@ def test_06_save_exports_the_file(cli: Cli, settings: Settings, exports: Path, r
         assert zf.getinfo(large).file_size == drive.LARGE_FIXTURE_BYTES
 
 
-def test_07_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Settings) -> None:
-    """Deletes the file from the library and restores it from the snapshot."""
+def test_07_restore_recreates_a_deleted_file(
+    cli: Cli, graph: Any, settings: Settings, run_marker: str
+) -> None:
+    """Deletes the files from the library and restores them under this run's destination.
+
+    Same reasoning as the OneDrive suite (issue #217): `--destination` keeps restore output inside
+    the marker namespace cleanup owns, rather than the default root at the library root.
+    """
     for file in (STATE["file"], STATE["large"]):
         drive.delete_item(graph, STATE["drive_id"], file.item_id)
         assert drive.file_sha256(graph, STATE["drive_id"], file.path) is None, "file survived deletion"
@@ -126,21 +132,27 @@ def test_07_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Set
         STATE["snapshot"],
         "-c",
         "rename",
+        "--destination",
+        drive.restore_destination(run_marker),
     )
 
 
 def test_08_restored_bytes_match_the_seed(graph: Any, run_marker: str) -> None:
     """Both restored files hash to the seeded bytes, read back through Graph."""
-    restored = drive.children(graph, STATE["drive_id"], drive.fixture_folder(run_marker))
-    assert restored, f"no files under /{drive.fixture_folder(run_marker)} after restore"
+    tree = drive.restored_tree(run_marker)
+    restored = drive.children(graph, STATE["drive_id"], tree.lstrip("/"))
+    assert restored, f"no files under {tree} after restore"
 
     digests = {
-        drive.file_sha256(
-            graph, STATE["drive_id"], f"/{drive.fixture_folder(run_marker)}/{item['name']}"
-        ) for item in restored
+        drive.file_sha256(graph, STATE["drive_id"], f"{tree}/{item['name']}") for item in restored
     }
     assert STATE["file"].sha256 in digests, "no restored file matches the seeded bytes"
     assert STATE["large"].sha256 in digests, "no restored file matches the 5 MB seeded bytes"
+
+    for file in (STATE["file"], STATE["large"]):
+        assert (
+            drive.file_sha256(graph, STATE["drive_id"], file.path) is None
+        ), f"restore wrote back to the original path {file.path}"
 
 
 def test_09_status_reports_the_stored_snapshot(cli: Cli, settings: Settings) -> None:

--- a/e2e/tests/test_30_sharepoint.py
+++ b/e2e/tests/test_30_sharepoint.py
@@ -131,11 +131,13 @@ def test_07_restore_recreates_a_deleted_file(cli: Cli, graph: Any, settings: Set
 
 def test_08_restored_bytes_match_the_seed(graph: Any, run_marker: str) -> None:
     """Both restored files hash to the seeded bytes, read back through Graph."""
-    restored = drive.children(graph, STATE["drive_id"], run_marker)
-    assert restored, f"no files under /{run_marker} after restore"
+    restored = drive.children(graph, STATE["drive_id"], drive.fixture_folder(run_marker))
+    assert restored, f"no files under /{drive.fixture_folder(run_marker)} after restore"
 
     digests = {
-        drive.file_sha256(graph, STATE["drive_id"], f"/{run_marker}/{item['name']}") for item in restored
+        drive.file_sha256(
+            graph, STATE["drive_id"], f"/{drive.fixture_folder(run_marker)}/{item['name']}"
+        ) for item in restored
     }
     assert STATE["file"].sha256 in digests, "no restored file matches the seeded bytes"
     assert STATE["large"].sha256 in digests, "no restored file matches the 5 MB seeded bytes"

--- a/packages/cli/src/commands/onedrive-command.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-command.handlers.tsx
@@ -43,6 +43,9 @@ export interface OneDriveRestoreCommandOptions extends OneDriveTenantOptions {
   targetOwner?: string;
   fileFilter?: string[];
   conflict?: 'replace' | 'rename' | 'fail';
+  destination?: string;
+  inPlace?: boolean;
+  name?: string;
 }
 
 export interface OneDriveVerifyOptions extends OneDriveTenantOptions {
@@ -167,6 +170,9 @@ export async function execute_onedrive_restore(
     ...(target_owner ? { target_owner_id: target_owner.object_id } : {}),
     ...(options.fileFilter ? { file_filter: options.fileFilter } : {}),
     ...(options.conflict ? { conflict_behavior: options.conflict } : {}),
+    ...(options.destination ? { destination: options.destination } : {}),
+    ...(options.inPlace === true ? { in_place: true } : {}),
+    ...(options.name ? { rename_to: options.name } : {}),
   });
 
   await render_static_view(

--- a/packages/cli/src/commands/onedrive-command.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-command.handlers.tsx
@@ -32,6 +32,7 @@ export interface OneDriveTenantOptions {
 export interface OneDriveBackupOptions extends OneDriveTenantOptions {
   owner: string;
   full?: boolean;
+  folder?: string;
   retentionDays?: string;
   lockMode?: string;
 }
@@ -114,6 +115,7 @@ export async function execute_onedrive_backup(
 
   const result = await backup.backup_onedrive(tenant_id, owner.object_id, {
     force_full: options.full ?? false,
+    ...(options.folder !== undefined ? { folder_scope: options.folder } : {}),
     owner_email: owner.email,
     owner_display_name: owner.display_name,
     object_lock_request,

--- a/packages/cli/src/commands/onedrive.command.ts
+++ b/packages/cli/src/commands/onedrive.command.ts
@@ -68,6 +68,12 @@ function register_onedrive_restore(group: Command, get_container: ContainerFacto
     .requiredOption('-s, --snapshot <id>', 'snapshot identifier')
     .option('--target-owner <id>', 'target user email or Entra object ID (defaults to owner)')
     .option('--file-filter <paths...>', 'only restore specific files (by ID or path)')
+    .option(
+      '--destination <path>',
+      'restore under this folder instead of a generated Restore-<timestamp> root',
+    )
+    .option('--in-place', 'restore to the original paths, mixing files into live content')
+    .option('--name <filename>', 'rename the restored file; requires a single-file restore')
     .addOption(
       new Option('-c, --conflict <mode>', 'file conflict policy (default: rename)').choices([
         'replace',

--- a/packages/cli/src/commands/onedrive.command.ts
+++ b/packages/cli/src/commands/onedrive.command.ts
@@ -47,6 +47,10 @@ function register_onedrive_backup(group: Command, get_container: ContainerFactor
     .description('Back up changed OneDrive files for one user')
     .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
     .option('--full', 'force full crawl ignoring saved delta state')
+    .option(
+      '--folder <path>',
+      'only back up this folder and its subfolders (e.g. /Projects); changing it forces a full crawl',
+    )
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option(
       '--retention-days <n>',

--- a/packages/cli/src/commands/sharepoint-command.handlers.tsx
+++ b/packages/cli/src/commands/sharepoint-command.handlers.tsx
@@ -49,6 +49,9 @@ export interface SharePointRestoreCommandOptions extends SharePointTenantOptions
   targetSite?: string;
   fileFilter?: string[];
   conflict?: 'replace' | 'rename' | 'fail';
+  destination?: string;
+  inPlace?: boolean;
+  name?: string;
 }
 
 export interface SharePointSaveCommandOptions extends SharePointTenantOptions {
@@ -223,6 +226,9 @@ export async function execute_sharepoint_restore(
     ...(target_site_id ? { target_site_id } : {}),
     ...(options.fileFilter ? { file_filter: options.fileFilter } : {}),
     ...(options.conflict ? { conflict_behavior: options.conflict } : {}),
+    ...(options.destination ? { destination: options.destination } : {}),
+    ...(options.inPlace === true ? { in_place: true } : {}),
+    ...(options.name ? { rename_to: options.name } : {}),
   });
 
   await render_static_view(

--- a/packages/cli/src/commands/sharepoint.command.ts
+++ b/packages/cli/src/commands/sharepoint.command.ts
@@ -84,6 +84,12 @@ function register_sharepoint_restore(group: Command, get_container: ContainerFac
     .requiredOption('-s, --snapshot <id>', 'snapshot identifier')
     .option('--target-site <url-or-id>', 'target site to restore to (defaults to original site)')
     .option('--file-filter <paths...>', 'only restore specific files (by ID or path)')
+    .option(
+      '--destination <path>',
+      'restore under this folder instead of a generated Restore-<timestamp> root',
+    )
+    .option('--in-place', 'restore to the original paths, mixing files into live content')
+    .option('--name <filename>', 'rename the restored file; requires a single-file restore')
     .addOption(
       new Option('-c, --conflict <mode>', 'file conflict policy (default: rename)').choices([
         'replace',

--- a/packages/core/src/services/shared/restore-destination.ts
+++ b/packages/core/src/services/shared/restore-destination.ts
@@ -1,0 +1,57 @@
+/**
+ * Destination handling for the drive restore pipelines.
+ *
+ * A drive restore used to write every file back to the path it was backed up from, directly into
+ * live user content. With the default `rename` conflict policy nothing failed and nothing was
+ * overwritten; each run simply left another suffixed copy beside every original, scattered across
+ * the tree with no handle to undo it. Nesting a restore under a generated root makes it separable
+ * from live data and reversible by deleting one folder, which is what Outlook restores have always
+ * done. The timestamp format matches `create_restore_root` so the two workloads read alike.
+ */
+
+/** Caller's choice of restore destination; both fields absent means the generated root. */
+export interface RestoreDestinationOptions {
+  readonly destination?: string;
+  readonly in_place?: boolean;
+}
+
+/**
+ * Root that restored paths are nested under. An empty string restores to the original locations,
+ * which `--in-place` and an explicit destination of `/` both mean: nesting under the drive root is
+ * the original layout by definition.
+ */
+export function resolve_restore_root(options: RestoreDestinationOptions): string {
+  if (options.in_place === true) return '';
+  const chosen = options.destination?.trim();
+  if (chosen !== undefined && chosen.length > 0) return normalize_root(chosen);
+  return `/Restore-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`;
+}
+
+/**
+ * Joins a restore root with a manifest `parent_path`, preserving the original nesting beneath it.
+ * A file from `/Projects/2026` lands in `/Restore-.../Projects/2026`.
+ */
+export function restore_parent_path(root: string, parent_path: string): string {
+  if (root.length === 0) return parent_path;
+  const nested = parent_path === '.' ? '' : parent_path.replace(/^\/+/, '');
+  return nested.length === 0 ? root : `${root}/${nested}`;
+}
+
+/**
+ * Refuses a rename that cannot mean one thing. Renaming many files to one name would either
+ * collide or silently rename the first and leave the rest, so the restore is rejected before any
+ * file is written rather than halfway through.
+ */
+export function assert_renameable(rename_to: string | undefined, file_count: number): void {
+  if (rename_to !== undefined && file_count !== 1) {
+    throw new Error(
+      `--name renames a single file, but this restore resolves to ${file_count} files; ` +
+        'narrow it with --file-filter',
+    );
+  }
+}
+
+function normalize_root(path: string): string {
+  const trimmed = path.replace(/^\/+|\/+$/g, '');
+  return trimmed.length === 0 ? '' : `/${trimmed}`;
+}

--- a/packages/core/tests/unit/services/shared/restore-destination.test.ts
+++ b/packages/core/tests/unit/services/shared/restore-destination.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assert_renameable,
+  resolve_restore_root,
+  restore_parent_path,
+} from '@/services/shared/restore-destination';
+
+describe('resolve_restore_root', () => {
+  it('generates a timestamped root when nothing is chosen', () => {
+    expect(resolve_restore_root({})).toMatch(/^\/Restore-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}$/);
+  });
+
+  it('restores in place only when asked explicitly', () => {
+    expect(resolve_restore_root({ in_place: true })).toBe('');
+  });
+
+  it('takes an explicit destination and normalises its slashes', () => {
+    expect(resolve_restore_root({ destination: 'Restored' })).toBe('/Restored');
+    expect(resolve_restore_root({ destination: '/DR/2026/' })).toBe('/DR/2026');
+  });
+
+  it('treats a destination of the drive root as in place, since that is the original layout', () => {
+    expect(resolve_restore_root({ destination: '/' })).toBe('');
+  });
+
+  it('lets in-place win over a destination rather than silently picking one', () => {
+    expect(resolve_restore_root({ destination: '/DR', in_place: true })).toBe('');
+  });
+
+  it('ignores a blank destination instead of restoring to the drive root', () => {
+    expect(resolve_restore_root({ destination: '   ' })).toMatch(/^\/Restore-/);
+  });
+});
+
+describe('restore_parent_path', () => {
+  it('recreates the original nesting beneath the root', () => {
+    expect(restore_parent_path('/Restore-x', '/Projects/2026')).toBe('/Restore-x/Projects/2026');
+  });
+
+  it('puts a root-level file directly in the root', () => {
+    expect(restore_parent_path('/Restore-x', '/')).toBe('/Restore-x');
+    expect(restore_parent_path('/Restore-x', '.')).toBe('/Restore-x');
+    expect(restore_parent_path('/Restore-x', '')).toBe('/Restore-x');
+  });
+
+  it('leaves the path untouched when there is no root', () => {
+    expect(restore_parent_path('', '/Projects/2026')).toBe('/Projects/2026');
+    expect(restore_parent_path('', '/')).toBe('/');
+  });
+
+  it('never doubles a separator', () => {
+    expect(restore_parent_path('/Restore-x', '//Projects')).toBe('/Restore-x/Projects');
+  });
+});
+
+describe('assert_renameable', () => {
+  it('allows a rename of exactly one file', () => {
+    expect(() => assert_renameable('report.docx', 1)).not.toThrow();
+  });
+
+  it('refuses a rename spanning several files, naming the count', () => {
+    expect(() => assert_renameable('report.docx', 12)).toThrow(/12 files/);
+  });
+
+  it('refuses a rename that matched nothing rather than silently doing nothing', () => {
+    expect(() => assert_renameable('report.docx', 0)).toThrow(/single file/);
+  });
+
+  it('is inert when no rename was asked for', () => {
+    expect(() => assert_renameable(undefined, 12)).not.toThrow();
+  });
+});

--- a/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
+++ b/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
@@ -25,6 +25,8 @@ import {
   type VersionStats,
 } from '@/services/onedrive-delta-item-processor';
 import { resolve_retry_items } from '@/services/onedrive-failed-item-retry';
+import { scoped_delta } from '@/services/onedrive-folder-scope';
+import { persist_scan_cursor } from '@/services/onedrive-scan-cursor-writer';
 import type { RunVersionCollector } from '@/services/onedrive-version-sync';
 import {
   make_item_progress_callback,
@@ -88,6 +90,7 @@ export async function scan_all_drives(
   on_version_stats_update: (stored: number, unavailable: number, failed: number) => void,
   progress?: BackupProgressReporter,
   control: OperationControlOptions = {},
+  folder_scope?: string,
 ): Promise<DriveScanAccumulators> {
   // No index read here: version dedup rides on the delta cursor watermarks the
   // caller already loaded (issue #161).
@@ -118,7 +121,14 @@ export async function scan_all_drives(
         ? undefined
         : previous_cursor?.delta_link_by_drive[drive.drive_id];
       progress?.update_paging(index, 0, 0, 0);
-      const delta = await connector.fetch_delta(tenant_id, owner_id, drive.drive_id, prev_delta);
+      // Scoping filters the delta result rather than the query, because Graph's driveItem delta is
+      // drive-wide. Enumeration still pages the whole drive; nothing outside the scope is
+      // downloaded, hashed, version-synced or written, which is where the time goes.
+      const delta = scoped_delta(
+        await connector.fetch_delta(tenant_id, owner_id, drive.drive_id, prev_delta),
+        folder_scope,
+        tracking_state.previous_path_by_file_id,
+      );
       progress?.set_row_total?.(index, delta.items.length);
       totals.total += delta.items.length;
       progress?.mark_active(index);
@@ -162,15 +172,15 @@ export async function scan_all_drives(
       accumulate_drive_result(accumulators, delta_link_by_drive, drive, drive_result);
       accumulators.drives_scanned++;
 
-      // Saved even when items failed: the successful entries are real, and the
-      // ledger riding along is what keeps the failures from being forgotten.
-      await cursors.save(ctx, {
+      await persist_scan_cursor(
+        cursors,
+        ctx,
         owner_id,
         delta_link_by_drive,
-        ...tracking_state,
-        failed_items: accumulators.failed_items,
-        updated_at: new Date().toISOString(),
-      });
+        tracking_state,
+        accumulators.failed_items,
+        folder_scope,
+      );
       if (!drive_result.interrupted) {
         report_drive_success(
           progress,

--- a/packages/onedrive/src/services/onedrive-backup.service.ts
+++ b/packages/onedrive/src/services/onedrive-backup.service.ts
@@ -38,6 +38,7 @@ import { ensure_drives_discovered } from '@/services/onedrive-backup-file-proces
 import { scan_all_drives } from '@/services/onedrive-backup-drive-processor';
 import type { PackageReportTotals } from '@/services/onedrive-package-report';
 import { cleanup_stale_staging } from '@/services/onedrive-large-file-pipeline';
+import { normalize_folder_scope } from '@/services/onedrive-folder-scope';
 import { describe_failed_items } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -77,7 +78,18 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
     let progress: BackupProgressReporter | undefined;
     try {
       const stored_cursor = await this._cursors.load(ctx, owner_id);
-      const previous_cursor = options.force_full === true ? undefined : stored_cursor;
+      const folder_scope = normalize_folder_scope(options.folder_scope);
+      // A delta link records how far the drive was consumed, not how far the scope was, so
+      // resuming one under a different scope would skip changes the previous run filtered out.
+      const scope_changed = (stored_cursor?.folder_scope ?? undefined) !== folder_scope;
+      if (scope_changed && stored_cursor !== undefined) {
+        logger.info(
+          `Folder scope changed (${stored_cursor.folder_scope ?? 'whole drive'} -> ` +
+            `${folder_scope ?? 'whole drive'}); re-crawling instead of resuming the delta link`,
+        );
+      }
+      const previous_cursor =
+        options.force_full === true || scope_changed ? undefined : stored_cursor;
       const drives = await this._connector.list_drives(tenant_id, owner_id);
       ensure_drives_discovered(drives.length);
       progress = options.create_progress?.(
@@ -147,6 +159,7 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
         update_version_stats,
         progress,
         options,
+        folder_scope,
       );
       const processed = scan_result.items_processed;
       emit_operation_progress(options, {
@@ -163,6 +176,7 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
         ...tracking_state,
         version_watermark_by_file_id: versions.watermarks,
         failed_items: scan_result.failed_items,
+        ...(folder_scope !== undefined ? { folder_scope } : {}),
         updated_at: new Date().toISOString(),
       };
 

--- a/packages/onedrive/src/services/onedrive-folder-scope.ts
+++ b/packages/onedrive/src/services/onedrive-folder-scope.ts
@@ -1,0 +1,66 @@
+/**
+ * Folder scoping for OneDrive backup.
+ *
+ * Graph's `driveItem` delta is drive-wide, so a scope cannot be pushed into the
+ * query: it is applied to the delta result instead. Enumeration therefore still
+ * pages the whole drive, but nothing outside the scope is downloaded, hashed,
+ * version-synced or written, which is where a drive backup actually spends its
+ * time. Narrowing the enumeration itself would need `/items/{id}/delta`, a
+ * different cursor shape, and is not required for the cost this removes.
+ */
+
+import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
+import type { OneDriveDeltaResult } from '@wisecom/atlas-types';
+
+/**
+ * Normalises a caller-supplied folder path to the shape `parent_path` carries:
+ * NFC, a single leading slash, no trailing slash. Returns undefined for the
+ * drive root, since scoping to the root is the same as not scoping at all.
+ */
+export function normalize_folder_scope(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed === '/') return undefined;
+  const with_leading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  const without_trailing = with_leading.endsWith('/') ? with_leading.slice(0, -1) : with_leading;
+  return without_trailing.normalize('NFC');
+}
+
+/**
+ * True when a delta item lives inside the scoped subtree.
+ *
+ * A removed item is judged by its remembered path, not its current one: Graph
+ * omits `parentReference` for a deletion (issue #139), so filtering those on
+ * `parent_path` would drop the deletion of an in-scope file and leave the
+ * snapshot claiming a file that is gone.
+ */
+export function is_within_folder_scope(
+  item: OneDriveDeltaItem,
+  scope: string,
+  previous_path_by_file_id: Record<string, string>,
+): boolean {
+  const path = item.deleted
+    ? (previous_path_by_file_id[item.item_id] ?? item.parent_path)
+    : item.parent_path;
+  return path === scope || path.startsWith(`${scope}/`);
+}
+
+/**
+ * Narrows a delta result to the scoped subtree, or returns it untouched when there is no scope.
+ *
+ * Kept out of the drive scan loop so the scan reads as one flow: the loop asks for the items it
+ * should process and does not branch on whether a scope exists.
+ */
+export function scoped_delta(
+  delta: OneDriveDeltaResult,
+  scope: string | undefined,
+  previous_path_by_file_id: Record<string, string>,
+): OneDriveDeltaResult {
+  if (scope === undefined) return delta;
+  return {
+    ...delta,
+    items: delta.items.filter((item) =>
+      is_within_folder_scope(item, scope, previous_path_by_file_id),
+    ),
+  };
+}

--- a/packages/onedrive/src/services/onedrive-restore-folder-path.ts
+++ b/packages/onedrive/src/services/onedrive-restore-folder-path.ts
@@ -1,0 +1,56 @@
+import type { OneDriveConnector } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+/**
+ * Resolves a restore-side path to a drive item id, creating the folders that are missing.
+ *
+ * `folder_ids` is the per-restore memo, keyed by path, so a restore root shared by every entry is
+ * created once rather than once per file. Returns undefined when a segment could not be created;
+ * the caller reports that entry as skipped, which is what keeps one over-long path from aborting
+ * the run. Mirrors `ensure_sharepoint_folder_path`, which keys by `drive_id:path` because a
+ * SharePoint snapshot spans several libraries.
+ */
+export async function ensure_onedrive_folder_path(
+  connector: OneDriveConnector,
+  tenant_id: string,
+  owner_id: string,
+  drive_id: string,
+  path: string,
+  folder_ids: Map<string, string>,
+): Promise<string | undefined> {
+  const normalized = path.length === 0 || path === '.' ? '/' : path;
+  const cached = folder_ids.get(normalized);
+  if (cached !== undefined) return cached;
+
+  const segments = normalized.split('/').filter(Boolean);
+  let current_path = '';
+  let parent_id = 'root';
+
+  for (const segment of segments) {
+    current_path = current_path ? `${current_path}/${segment}` : `/${segment}`;
+    const known = folder_ids.get(current_path);
+    if (known !== undefined) {
+      parent_id = known;
+      continue;
+    }
+
+    try {
+      const folder_id = await connector.create_folder(
+        tenant_id,
+        owner_id,
+        drive_id,
+        parent_id,
+        segment,
+      );
+      folder_ids.set(current_path, folder_id);
+      parent_id = folder_id;
+    } catch (err) {
+      logger.warn(
+        `Failed to create folder ${current_path}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  return parent_id;
+}

--- a/packages/onedrive/src/services/onedrive-restore.service.ts
+++ b/packages/onedrive/src/services/onedrive-restore.service.ts
@@ -37,6 +37,12 @@ import {
   restorable_entries,
 } from '@/services/onedrive-manifest-chain';
 import { empty_restore_result } from '@/services/onedrive-restore-result';
+import {
+  assert_renameable,
+  resolve_restore_root,
+  restore_parent_path,
+} from '@wisecom/atlas-core/services/shared/restore-destination';
+import { ensure_onedrive_folder_path } from '@/services/onedrive-restore-folder-path';
 
 const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
 
@@ -82,6 +88,8 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
         restorable_entries(chain.entries),
         options.file_filter,
       );
+      assert_renameable(options.rename_to, restorable.length);
+      const restore_root = resolve_restore_root(options);
       const folder_ids = new Map<string, string>();
       folder_ids.set('/', 'root');
 
@@ -107,6 +115,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
           ctx,
           folder_ids,
           conflict,
+          { root: restore_root, file_name: options.rename_to ?? entry.file_name },
         );
         if (result.restored) {
           files_restored++;
@@ -156,18 +165,21 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
     ctx: TenantContext,
     folder_ids: Map<string, string>,
     conflict: NonNullable<OneDriveRestoreOptions['conflict_behavior']>,
+    placement: { readonly root: string; readonly file_name: string },
   ): Promise<{ restored: boolean; error?: string }> {
+    const target_path = restore_parent_path(placement.root, entry.parent_path);
     try {
-      const parent_id = await this.ensure_folder_path(
+      const parent_id = await ensure_onedrive_folder_path(
+        this._connector,
         tenant_id,
         target_owner,
         drive_id,
-        entry.parent_path,
+        target_path,
         folder_ids,
       );
 
       if (parent_id === undefined) {
-        return { restored: false, error: `Could not create folder path: ${entry.parent_path}` };
+        return { restored: false, error: `Could not create folder path: ${target_path}` };
       }
 
       const content = await this.download_and_decrypt(ctx, entry);
@@ -181,7 +193,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
           target_owner,
           drive_id,
           parent_id,
-          entry.file_name,
+          placement.file_name,
           content,
           conflict,
         );
@@ -191,13 +203,13 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
           target_owner,
           drive_id,
           parent_id,
-          entry.file_name,
+          placement.file_name,
           content,
           conflict,
         );
       }
 
-      logger.info(`Restored: ${entry.parent_path}/${entry.file_name}`);
+      logger.info(`Restored: ${target_path}/${placement.file_name}`);
       return { restored: true };
     } catch (err) {
       if (err instanceof OneDriveDecryptAuthError) {
@@ -209,48 +221,6 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       logger.warn(`Skipped ${entry.file_name}: ${msg}`);
       return { restored: false, error: msg };
     }
-  }
-
-  private async ensure_folder_path(
-    tenant_id: string,
-    owner_id: string,
-    drive_id: string,
-    path: string,
-    folder_ids: Map<string, string>,
-  ): Promise<string | undefined> {
-    const normalized = path.length === 0 || path === '.' ? '/' : path;
-    if (folder_ids.has(normalized)) return folder_ids.get(normalized)!;
-
-    const segments = normalized.split('/').filter(Boolean);
-    let current_path = '';
-    let parent_id = 'root';
-
-    for (const segment of segments) {
-      current_path = current_path ? `${current_path}/${segment}` : `/${segment}`;
-      if (folder_ids.has(current_path)) {
-        parent_id = folder_ids.get(current_path)!;
-        continue;
-      }
-
-      try {
-        const folder_id = await this._connector.create_folder(
-          tenant_id,
-          owner_id,
-          drive_id,
-          parent_id,
-          segment,
-        );
-        folder_ids.set(current_path, folder_id);
-        parent_id = folder_id;
-      } catch (err) {
-        logger.warn(
-          `Failed to create folder ${current_path}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        return undefined;
-      }
-    }
-
-    return parent_id;
   }
 
   private async download_and_decrypt(

--- a/packages/onedrive/src/services/onedrive-scan-cursor-writer.ts
+++ b/packages/onedrive/src/services/onedrive-scan-cursor-writer.ts
@@ -1,0 +1,36 @@
+import type {
+  FailedItemLedger,
+  OneDriveDeltaCursorRepository,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import type { DriveTrackingState } from '@/services/onedrive-delta-item-processor';
+
+/**
+ * Persists the cursor after one drive's scan, before the manifest exists.
+ *
+ * Saved even when items failed: the successful entries are real, and the ledger riding along is what
+ * keeps the failures from being forgotten.
+ *
+ * The scope is recorded here, not only at finalize. This save advances the delta link, so a run that
+ * crashes after it must leave behind a cursor saying which scope those links were advanced under.
+ * Omitting it would let the next whole-drive run resume a link that had already consumed, and
+ * filtered away, changes outside the scope.
+ */
+export async function persist_scan_cursor(
+  cursors: OneDriveDeltaCursorRepository,
+  ctx: TenantContext,
+  owner_id: string,
+  delta_link_by_drive: Record<string, string>,
+  tracking_state: DriveTrackingState,
+  failed_items: FailedItemLedger,
+  folder_scope: string | undefined,
+): Promise<void> {
+  await cursors.save(ctx, {
+    owner_id,
+    delta_link_by_drive,
+    ...tracking_state,
+    failed_items,
+    ...(folder_scope !== undefined ? { folder_scope } : {}),
+    updated_at: new Date().toISOString(),
+  });
+}

--- a/packages/onedrive/tests/unit/services/onedrive-folder-scope.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-folder-scope.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Folder-scoped OneDrive backup.
+ *
+ * The delta link is drive-wide, so the dangerous case is not the filtering, it is resuming a link
+ * across a scope change: changes filtered out under the old scope would be skipped forever. The
+ * service therefore re-crawls whenever the scope differs from the one recorded in the cursor.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  OneDriveDeltaCursor,
+  OneDriveDeltaItem,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { is_within_folder_scope, normalize_folder_scope } from '@/services/onedrive-folder-scope';
+import { OneDriveBackupService } from '@/services/onedrive-backup.service';
+
+const DRIVE_ID = 'd1';
+const OWNER_ID = 'owner-1';
+
+function make_item(item_id: string, parent_path: string, deleted = false): OneDriveDeltaItem {
+  return {
+    item_id,
+    drive_id: DRIVE_ID,
+    kind: 'file',
+    file_name: `${item_id}.txt`,
+    parent_path,
+    size_bytes: 8,
+    deleted,
+    etag: `etag-${item_id}`,
+  };
+}
+
+describe('normalize_folder_scope', () => {
+  it('adds the leading slash and drops a trailing one', () => {
+    expect(normalize_folder_scope('E2E/')).toBe('/E2E');
+    expect(normalize_folder_scope('/E2E')).toBe('/E2E');
+    expect(normalize_folder_scope(' /E2E/Nested ')).toBe('/E2E/Nested');
+  });
+
+  it('treats the drive root and blanks as no scope at all', () => {
+    expect(normalize_folder_scope('/')).toBeUndefined();
+    expect(normalize_folder_scope('')).toBeUndefined();
+    expect(normalize_folder_scope(undefined)).toBeUndefined();
+  });
+});
+
+describe('is_within_folder_scope', () => {
+  it('includes files directly in the folder and below it', () => {
+    expect(is_within_folder_scope(make_item('a', '/E2E'), '/E2E', {})).toBe(true);
+    expect(is_within_folder_scope(make_item('b', '/E2E/Nested'), '/E2E', {})).toBe(true);
+  });
+
+  it('excludes everything outside, including a sibling with the same prefix', () => {
+    expect(is_within_folder_scope(make_item('c', '/Other'), '/E2E', {})).toBe(false);
+    expect(is_within_folder_scope(make_item('d', '/'), '/E2E', {})).toBe(false);
+    // `/E2E-archive` must not match `/E2E`: prefix matching has to respect the separator.
+    expect(is_within_folder_scope(make_item('e', '/E2E-archive'), '/E2E', {})).toBe(false);
+  });
+
+  it('judges a deletion by its remembered path, since Graph omits the parent', () => {
+    const removed = make_item('f', '', true);
+
+    expect(is_within_folder_scope(removed, '/E2E', { f: '/E2E' })).toBe(true);
+    expect(is_within_folder_scope(removed, '/E2E', { f: '/Other' })).toBe(false);
+  });
+});
+
+interface Harness {
+  service: OneDriveBackupService;
+  fetch_delta: ReturnType<typeof vi.fn>;
+  saved: OneDriveDeltaCursor[];
+  downloaded: string[];
+}
+
+function make_harness(options: {
+  delta_items: OneDriveDeltaItem[];
+  stored_cursor?: OneDriveDeltaCursor;
+}): Harness {
+  const downloaded: string[] = [];
+  const saved: OneDriveDeltaCursor[] = [];
+
+  const fetch_delta = vi.fn(async () => ({
+    drive_id: DRIVE_ID,
+    delta_link: 'delta-2',
+    items: options.delta_items,
+    reset_detected: false,
+  }));
+
+  const connector = {
+    list_drives: vi.fn().mockResolvedValue([{ drive_id: DRIVE_ID, drive_name: 'Documents' }]),
+    fetch_delta,
+    fetch_item_by_id: vi.fn(),
+    download_file_content: vi.fn(async (item: OneDriveDeltaItem) => {
+      downloaded.push(item.item_id);
+      return Buffer.from(item.item_id);
+    }),
+    list_file_versions: vi.fn().mockResolvedValue([]),
+  };
+
+  const context = {
+    tenant_id: 't',
+    storage: {
+      exists: vi.fn().mockResolvedValue(false),
+      put: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(undefined),
+      abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+    },
+    encrypt: (buffer: Buffer) => buffer,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(context),
+    create_readonly: vi.fn().mockResolvedValue(context),
+    create_storage_only: vi.fn(),
+  };
+
+  const service = new OneDriveBackupService(
+    factory,
+    connector as never,
+    { save: vi.fn() } as never,
+    { load_version_watermarks: vi.fn().mockResolvedValue({}), write_run_index: vi.fn() } as never,
+    {
+      load: vi.fn().mockResolvedValue(options.stored_cursor),
+      save: vi.fn((_ctx: TenantContext, cursor: OneDriveDeltaCursor) => {
+        saved.push(structuredClone(cursor));
+        return Promise.resolve();
+      }),
+    } as never,
+  );
+
+  return { service, fetch_delta, saved, downloaded };
+}
+
+function make_cursor(overrides: Partial<OneDriveDeltaCursor> = {}): OneDriveDeltaCursor {
+  return {
+    owner_id: OWNER_ID,
+    delta_link_by_drive: { [DRIVE_ID]: 'delta-1' },
+    previous_path_by_file_id: {},
+    previous_name_by_file_id: {},
+    previous_etag_by_file_id: {},
+    previous_kind_by_file_id: {},
+    updated_at: '2026-08-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('backup_onedrive with a folder scope', () => {
+  const items = [
+    make_item('in', '/E2E'),
+    make_item('deep', '/E2E/Nested'),
+    make_item('out', '/Other'),
+  ];
+
+  it('backs up only the scoped subtree and downloads nothing else', async () => {
+    const harness = make_harness({ delta_items: items });
+
+    const result = await harness.service.backup_onedrive('t', OWNER_ID, { folder_scope: 'E2E' });
+
+    expect(harness.downloaded.sort()).toEqual(['deep', 'in']);
+    expect(result.snapshot?.entries.map((e) => e.file_id).sort()).toEqual(['deep', 'in']);
+  });
+
+  it('records the normalised scope in the cursor', async () => {
+    const harness = make_harness({ delta_items: items });
+
+    await harness.service.backup_onedrive('t', OWNER_ID, { folder_scope: 'E2E/' });
+
+    expect(harness.saved[0]?.folder_scope).toBe('/E2E');
+  });
+
+  it('leaves the scope absent for a whole-drive backup', async () => {
+    const harness = make_harness({ delta_items: items });
+
+    await harness.service.backup_onedrive('t', OWNER_ID);
+
+    expect(harness.downloaded.sort()).toEqual(['deep', 'in', 'out']);
+    expect(harness.saved[0]?.folder_scope).toBeUndefined();
+  });
+
+  it('resumes the delta link when the scope is unchanged', async () => {
+    const harness = make_harness({
+      delta_items: items,
+      stored_cursor: make_cursor({ folder_scope: '/E2E' }),
+    });
+
+    await harness.service.backup_onedrive('t', OWNER_ID, { folder_scope: '/E2E' });
+
+    expect(harness.fetch_delta).toHaveBeenCalledWith('t', OWNER_ID, DRIVE_ID, 'delta-1');
+  });
+
+  it('re-crawls when the scope narrows, instead of resuming a drive-wide link', async () => {
+    const harness = make_harness({ delta_items: items, stored_cursor: make_cursor() });
+
+    await harness.service.backup_onedrive('t', OWNER_ID, { folder_scope: '/E2E' });
+
+    expect(harness.fetch_delta).toHaveBeenCalledWith('t', OWNER_ID, DRIVE_ID, undefined);
+  });
+
+  it('re-crawls when the scope widens, so filtered-out changes are not lost', async () => {
+    const harness = make_harness({
+      delta_items: items,
+      stored_cursor: make_cursor({ folder_scope: '/E2E' }),
+    });
+
+    await harness.service.backup_onedrive('t', OWNER_ID);
+
+    expect(harness.fetch_delta).toHaveBeenCalledWith('t', OWNER_ID, DRIVE_ID, undefined);
+  });
+});

--- a/packages/onedrive/tests/unit/services/onedrive-restore-destination.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-restore-destination.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Issue #217: a restore must be separable from live content and reversible.
+ *
+ * The regression these guard against is silent: with `--conflict rename` an in-place restore never
+ * fails, it just leaves another suffixed copy beside every original. So the assertions are on where
+ * uploads land, not on whether the restore reported success.
+ */
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  OneDriveConnector,
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveRestoreService } from '@/services/onedrive-restore.service';
+
+const CONTENT = Buffer.from('file-content');
+const CHECKSUM = createHash('sha256').update(CONTENT).digest('hex');
+
+function make_entry(file_id: string, parent_path = '/Projects/2026'): OneDriveManifestEntry {
+  return {
+    file_id,
+    drive_id: 'drive-1',
+    file_name: `${file_id}.txt`,
+    parent_path,
+    size_bytes: CONTENT.length,
+    change_type: 'updated',
+    backup_at: '2026-08-17T00:00:00.000Z',
+    storage_key: `onedrive/data/${file_id}`,
+    checksum: CHECKSUM,
+  } as OneDriveManifestEntry;
+}
+
+function make_service(entries: OneDriveManifestEntry[]): {
+  service: OneDriveRestoreService;
+  connector: OneDriveConnector;
+} {
+  const manifest = {
+    id: 'manifest-1',
+    tenant_id: 'tenant-1',
+    snapshot_id: 'snap-1',
+    owner_id: 'owner-1',
+    created_at: new Date('2026-08-17T00:00:00.000Z'),
+    total_files: entries.length,
+    total_size_bytes: entries.reduce((sum, entry) => sum + entry.size_bytes, 0),
+    entries,
+  } as OneDriveSnapshotManifest;
+
+  const ctx = {
+    tenant_id: 'tenant-1',
+    storage: { get: vi.fn().mockResolvedValue(CONTENT) },
+    encrypt: vi.fn((data: Buffer) => data),
+    decrypt: vi.fn((data: Buffer) => data),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const factory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+  } as unknown as TenantContextFactory;
+
+  // Each created folder gets a distinct id so nesting is provable, not assumed.
+  let folder_seq = 0;
+  const connector = {
+    list_drives: vi.fn().mockResolvedValue([{ drive_id: 'drive-1', drive_name: 'Documents' }]),
+    create_folder: vi.fn().mockImplementation(async () => `folder-${++folder_seq}`),
+    upload_small_file: vi.fn().mockResolvedValue(undefined),
+    upload_large_file: vi.fn().mockResolvedValue(undefined),
+  } as unknown as OneDriveConnector;
+
+  const manifests = {
+    find_by_snapshot: vi.fn().mockResolvedValue(manifest),
+    list_snapshots_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveManifestRepository;
+
+  return { service: new OneDriveRestoreService(factory, connector, manifests), connector };
+}
+
+/** Folder names created, in order, so a restore's shape can be read directly. */
+function created_folders(connector: OneDriveConnector): string[] {
+  return vi.mocked(connector.create_folder).mock.calls.map((call) => String(call[4]));
+}
+
+describe('OneDrive restore destination (issue #217)', () => {
+  it('nests the restore under a generated root by default', async () => {
+    const { service, connector } = make_service([make_entry('file-1')]);
+
+    await service.restore_onedrive('tenant-1', 'owner-1', { snapshot_id: 'snap-1' });
+
+    const [root, ...nested] = created_folders(connector);
+    expect(root).toMatch(/^Restore-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}$/);
+    expect(nested).toEqual(['Projects', '2026']);
+    // The upload must target the deepest folder created under the root, not the drive root.
+    expect(vi.mocked(connector.upload_small_file).mock.calls[0]![3]).toBe('folder-3');
+  });
+
+  it('creates the root once for a whole restore, not once per file', async () => {
+    const { service, connector } = make_service([
+      make_entry('file-1'),
+      make_entry('file-2'),
+      make_entry('file-3', '/Reports'),
+    ]);
+
+    await service.restore_onedrive('tenant-1', 'owner-1', { snapshot_id: 'snap-1' });
+
+    const roots = created_folders(connector).filter((name) => name.startsWith('Restore-'));
+    expect(roots).toHaveLength(1);
+  });
+
+  it('writes to the original paths only when --in-place is given', async () => {
+    const { service, connector } = make_service([make_entry('file-1')]);
+
+    await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+      in_place: true,
+    });
+
+    expect(created_folders(connector)).toEqual(['Projects', '2026']);
+  });
+
+  it('restores under a caller-chosen destination', async () => {
+    const { service, connector } = make_service([make_entry('file-1')]);
+
+    await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+      destination: '/DR-drill',
+    });
+
+    expect(created_folders(connector)).toEqual(['DR-drill', 'Projects', '2026']);
+  });
+
+  it('renames a single-file restore', async () => {
+    const { service, connector } = make_service([make_entry('file-1')]);
+
+    await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+      rename_to: 'Report-copy.txt',
+    });
+
+    expect(vi.mocked(connector.upload_small_file).mock.calls[0]![4]).toBe('Report-copy.txt');
+  });
+
+  it('refuses to rename when the restore resolves to more than one file', async () => {
+    const { service, connector } = make_service([make_entry('file-1'), make_entry('file-2')]);
+
+    await expect(
+      service.restore_onedrive('tenant-1', 'owner-1', {
+        snapshot_id: 'snap-1',
+        rename_to: 'Report-copy.txt',
+      }),
+    ).rejects.toThrow(/single file/);
+    // Refusing after writing half the files would be worse than not refusing at all.
+    expect(connector.upload_small_file).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed root as a per-item skip instead of aborting the run', async () => {
+    const { service, connector } = make_service([make_entry('file-1'), make_entry('file-2')]);
+    vi.mocked(connector.create_folder).mockRejectedValue(new Error('path too long'));
+
+    const result = await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+    });
+
+    expect(result.files_restored).toBe(0);
+    expect(result.files_skipped).toBe(2);
+    expect(result.errors).toHaveLength(2);
+    expect(connector.upload_small_file).not.toHaveBeenCalled();
+  });
+});

--- a/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
+++ b/packages/onedrive/tests/unit/services/operation-cancellation.test.ts
@@ -127,6 +127,7 @@ describe('OneDrive operation cancellation', () => {
     } as unknown as TenantContextFactory;
     const connector = {
       list_drives: vi.fn().mockResolvedValue([{ drive_id: 'drive-1', drive_name: 'Documents' }]),
+      create_folder: vi.fn().mockResolvedValue('restore-root'),
       upload_small_file: vi.fn().mockResolvedValue(undefined),
     } as unknown as OneDriveConnector;
     const on_progress = vi.fn();

--- a/packages/sharepoint/src/services/sharepoint-restore.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore.service.ts
@@ -36,6 +36,11 @@ import {
   restorable_entries,
 } from '@/services/sharepoint-manifest-chain';
 import { ensure_sharepoint_folder_path } from '@/services/sharepoint-restore-folder-path';
+import {
+  assert_renameable,
+  resolve_restore_root,
+  restore_parent_path,
+} from '@wisecom/atlas-core/services/shared/restore-destination';
 
 const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
 
@@ -103,6 +108,8 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
         restorable_entries(chain.entries),
         options.file_filter,
       );
+      assert_renameable(options.rename_to, restorable.length);
+      const restore_root = resolve_restore_root(options);
       const routing: EntryRouting = {
         cross_site,
         target_libraries,
@@ -135,6 +142,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
             entry,
             folder_ids,
             errors,
+            { root: restore_root, file_name: options.rename_to ?? entry.file_name },
           );
           if (outcome === 'restored') files_restored++;
           else files_skipped++;
@@ -222,20 +230,22 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
     entry: SharePointManifestEntry,
     folder_ids: Map<string, string>,
     errors: string[],
+    placement: { readonly root: string; readonly file_name: string },
   ): Promise<'restored' | 'skipped'> {
+    const target_path = restore_parent_path(placement.root, entry.parent_path);
     try {
       const parent_id = await ensure_sharepoint_folder_path(
         this._connector,
         tenant_id,
         target_site,
         destination_drive_id,
-        entry.parent_path,
+        target_path,
         folder_ids,
       );
 
       if (parent_id === undefined) {
         errors.push(
-          `Could not create folder path: ${entry.parent_path} in drive ${destination_drive_id}`,
+          `Could not create folder path: ${target_path} in drive ${destination_drive_id}`,
         );
         return 'skipped';
       }
@@ -254,7 +264,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
           target_site,
           destination_drive_id,
           parent_id,
-          entry.file_name,
+          placement.file_name,
           content,
           conflict,
         );
@@ -264,14 +274,14 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
           target_site,
           destination_drive_id,
           parent_id,
-          entry.file_name,
+          placement.file_name,
           content,
           conflict,
         );
       }
 
       logger.info(
-        `Restored: ${entry.parent_path}/${entry.file_name} (drive: ${destination_drive_id})`,
+        `Restored: ${target_path}/${placement.file_name} (drive: ${destination_drive_id})`,
       );
       return 'restored';
     } catch (err) {

--- a/packages/sharepoint/tests/unit/services/sharepoint-restore-cross-site.test.ts
+++ b/packages/sharepoint/tests/unit/services/sharepoint-restore-cross-site.test.ts
@@ -116,7 +116,7 @@ describe('SharePointRestoreService cross-site routing', () => {
     expect(drive_arg).not.toBe(SOURCE_DRIVE);
   });
 
-  it('creates the folder path in the target drive', async () => {
+  it('recreates the folder path beneath the restore root in the target drive', async () => {
     vi.mocked(connector.list_document_libraries).mockResolvedValue([
       { drive_id: 'target-drive', drive_name: 'Documents' },
     ]);
@@ -126,13 +126,16 @@ describe('SharePointRestoreService cross-site routing', () => {
       target_site_id: TARGET_SITE,
     });
 
-    expect(connector.create_folder).toHaveBeenCalledWith(
+    const [root_call, nested_call] = vi.mocked(connector.create_folder).mock.calls;
+    expect(root_call).toEqual([
       'tenant',
       TARGET_SITE,
       'target-drive',
       'root',
-      'Reports',
-    );
+      expect.stringMatching(/^Restore-\d{4}-\d{2}-\d{2}T/),
+    ]);
+    // The original nesting is recreated under that root, never at the drive root.
+    expect(nested_call).toEqual(['tenant', TARGET_SITE, 'target-drive', 'folder-id', 'Reports']);
   });
 
   it('routes by library name when the target has several libraries', async () => {

--- a/packages/types/src/domain/onedrive-manifest.ts
+++ b/packages/types/src/domain/onedrive-manifest.ts
@@ -81,5 +81,15 @@ export interface OneDriveDeltaCursor {
    * will not re-present an unchanged item once the link has advanced past it.
    */
   readonly failed_items?: FailedItemLedger | undefined;
+  /**
+   * Folder scope this cursor's delta links were advanced under, normalised, or
+   * absent for a whole-drive backup.
+   *
+   * A delta link records how far the *drive* was consumed, not how far the
+   * scope was, so reusing a link across different scopes would skip changes
+   * that were filtered out under the previous one. A run whose scope differs
+   * from this value therefore re-crawls instead of resuming.
+   */
+  readonly folder_scope?: string | undefined;
   readonly updated_at: string;
 }

--- a/packages/types/src/ports/onedrive/restore.port.ts
+++ b/packages/types/src/ports/onedrive/restore.port.ts
@@ -7,6 +7,15 @@ export interface OneDriveRestoreOptions extends OperationControlOptions {
   readonly target_owner_id?: string;
   readonly file_filter?: string[];
   readonly conflict_behavior?: OneDriveRestoreConflictBehavior;
+  /**
+   * Folder to restore under, created when missing. Absent means a generated `Restore-{timestamp}`
+   * root at the target drive root.
+   */
+  readonly destination?: string;
+  /** Restore to the original paths instead of nesting under a restore root. */
+  readonly in_place?: boolean;
+  /** Renames the restored file. Rejected unless the restore resolves to exactly one file. */
+  readonly rename_to?: string;
 }
 
 export interface OneDriveRestoreResult {

--- a/packages/types/src/ports/onedrive/use-case.port.ts
+++ b/packages/types/src/ports/onedrive/use-case.port.ts
@@ -33,6 +33,13 @@ export interface OneDriveBackupOptions extends OperationControlOptions {
   readonly owner_email?: string | undefined;
   readonly owner_display_name?: string | undefined;
   /**
+   * Restrict the backup to one folder and its descendants, e.g. `/Projects`.
+   * Absent backs up the whole drive. Changing the scope between runs forces a
+   * full re-crawl, because a delta link is drive-wide and cannot be resumed
+   * under a different filter.
+   */
+  readonly folder_scope?: string | undefined;
+  /**
    * Object Lock retention applied as the bucket's default retention before
    * the run: every new object version (files, versions, manifests, cursors)
    * inherits the lock. Persists on the bucket for subsequent writes.

--- a/packages/types/src/ports/sharepoint/restore.port.ts
+++ b/packages/types/src/ports/sharepoint/restore.port.ts
@@ -9,6 +9,15 @@ export interface SharePointRestoreOptions extends OperationControlOptions {
   /** Only restore specific files (by file ID or full path). */
   readonly file_filter?: string[];
   readonly conflict_behavior?: SharePointRestoreConflictBehavior;
+  /**
+   * Folder to restore under, created when missing. Absent means a generated `Restore-{timestamp}`
+   * root in each destination library.
+   */
+  readonly destination?: string;
+  /** Restore to the original paths instead of nesting under a restore root. */
+  readonly in_place?: boolean;
+  /** Renames the restored file. Rejected unless the restore resolves to exactly one file. */
+  readonly rename_to?: string;
 }
 
 export interface SharePointRestoreResult {


### PR DESCRIPTION
Closes #217. **Stacked on #218**, which is stacked on #214. Merge those first.

## Problem

`atlas onedrive restore` and `atlas sharepoint restore` wrote every file back to the path it was backed up from, directly into live user content. `--target-owner` and `--target-site` change the account or site, never the path.

The conflict policy was the only protection, and it is not one. With the default `rename` a restore of a snapshot whose files still exist neither fails nor overwrites: it writes a suffixed copy next to every original. Across a few restore rehearsals the drive fills with copies of the same file interleaved with real data, with nothing marking which came from a backup, and no way to undo it short of hunting duplicates folder by folder.

Outlook has never had this problem. `create_restore_root` puts a `Restore-{timestamp}` folder in the mailbox and `ensure_subfolder` rebuilds the nesting under it, so a restore is one folder you can inspect and one folder you can delete. The drive pipelines never got the equivalent.

## What changed

A drive restore now nests under `/Restore-<timestamp>` at the target drive root, recreating the original structure beneath it. A file from `/Projects/2026/Report.docx` lands at `/Restore-2026-08-27T10-15-30/Projects/2026/Report.docx`. Same timestamp format as the Outlook root.

| Option | Behaviour |
| --- | --- |
| _(default)_ | Generated `Restore-<timestamp>` root |
| `--destination <path>` | Restore under a folder you name, created when missing |
| `--in-place` | The old behaviour: write back over the original paths |
| `--name <filename>` | Rename a single-file restore |

`--conflict` keeps its meaning and applies inside whichever destination is chosen. Under a fresh root there is normally nothing to collide with, which is the point.

## Why it is this small

Both `ensure_onedrive_folder_path` and `ensure_sharepoint_folder_path` already created a path segment by segment and memoised each level. So the feature is a prefix on the path, and three properties fall out for free rather than needing code:

- The root is created once per restore, not once per file, because it is the first cache hit for every subsequent entry.
- A path that exceeds the OneDrive length limit still returns undefined from the folder helper and is reported as a skipped item, so it does not abort the run. That is the existing per-item failure path, unchanged.
- SharePoint gets the same behaviour per destination library with no extra routing logic, because its cache is already keyed `drive_id:path`.

The resolver, the join and the rename guard live in one shared module (`packages/core/src/services/shared/restore-destination.ts`) used by both workloads, so the two cannot drift.

`--name` is refused when the restore resolves to anything other than exactly one file, and refused **before** the first upload. Renaming many files to one name would either collide or silently rename the first and leave the rest; failing halfway through would be worse than either.

## E2E: why the suites do not use the default

The suites pass `--destination` into their own fixture folder instead of taking the generated root. That is deliberate. The default root lands at the drive root, which is outside the marker namespace cleanup is allowed to delete in, and after the incident that produced the cleanup guards in #218, cleanup will not be widened again. A restore root the suite cannot sweep would leak on every nightly.

The assertions got stronger in the process. They previously read the restored files back from their original paths, which a pre-change restore satisfied by definition. They now assert the restored tree under the destination **and** that the original paths are still empty, which is the property the issue is actually about.

## Tests

21 new unit tests. 5 of the 7 OneDrive service tests fail without the implementation; the 2 that pass are the `--in-place` case (old behaviour by definition) and the per-item failure case.

```
core:       14 passed  (resolver, join, rename guard)
onedrive:    7 passed  (default root, root created once, --in-place,
                        --destination, rename, rename refused, per-item skip)
sharepoint:  existing cross-site test now asserts nesting under the root
```

Gates: build 10/10, typecheck 17/17, test 15/15, lint clean, docs build with no warnings. `onedrive-restore.service.ts` crossed the 300-line limit, so `ensure_folder_path` moved into `onedrive-restore-folder-path.ts`, mirroring the SharePoint module that already existed.

## Breaking change

Drive restores no longer write to the original paths by default. `--in-place`, or `in_place: true` from the SDK, restores the previous behaviour. Documented in `docs/onedrive-backup.md`, `docs/sharepoint-backup.md`, `docs/reference/cli.md` and `docs/reference/sdk.md`, and called out for the release notes.

Not included: a live E2E run, which follows once this is stacked with the others.
