### PR TITLE
fix(graph): engage the throttle fence on the first 429, not after the retry budget

### DIFF
--- a/docs/operations/graph-rate-limits.md
+++ b/docs/operations/graph-rate-limits.md
@@ -57,6 +57,29 @@ Microsoft Graph sends up to 4 individual Outlook requests from a batch at a time
 
 `429 Too Many Requests` with a `Retry-After` header specifying how many seconds to wait. Throttled requests still count toward usage limits.
 
+### How Atlas backs off
+
+A throttled response does two things. The call that received it enters exponential
+backoff, honoring `Retry-After`, for up to 12 retries. It also raises a global
+throttle fence for the length of the `Retry-After` window, and every mailbox
+operation in the process waits on that fence before issuing its next HTTP
+request.
+
+The fence engages on the first throttled response, not after a call has spent its
+retry budget, and calls already inside a retry loop check it between attempts. One
+throttled mailbox therefore pauses the whole Outlook path for the cooldown
+Microsoft asked for, instead of leaving every other mailbox to keep sending
+requests that are counted against the same limit and, being throttled, accomplish
+nothing.
+
+Retry lives in exactly one layer. The Graph SDK's own retry handler is disabled,
+so a single logical call is bounded at 13 HTTP attempts. Leaving both enabled
+multiplied the budgets and let one call reach roughly 52 attempts against the
+limits the backoff exists to respect.
+
+SharePoint and OneDrive have no equivalent fence yet. Their calls back off
+individually on the same schedule.
+
 ### Atlas operations in the Outlook pool
 
 | Operation               | Graph endpoint                                                   | Cost                     |

--- a/packages/core/src/services/shared/graph-request-context.ts
+++ b/packages/core/src/services/shared/graph-request-context.ts
@@ -12,10 +12,12 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { GraphRequestCounter } from './graph-request-counter';
+import type { ThrottleFence } from './throttle-fence';
 import type { GraphOperation, OperationCost } from '@wisecom/atlas-types';
 
 const _storage = new AsyncLocalStorage<GraphRequestCounter>();
 const _operation = new AsyncLocalStorage<GraphOperation>();
+const _fence = new AsyncLocalStorage<ThrottleFence>();
 
 /**
  * Runs `fn` inside a fresh cost-tracking context and returns both the result
@@ -104,4 +106,27 @@ export function run_with_graph_operation<T>(
 /** The operation the current async context is inside, if any. */
 export function get_active_operation(): GraphOperation | undefined {
   return _operation.getStore();
+}
+
+/**
+ * Publishes the throttle fence guarding `fn` so the retry loop deep inside it
+ * can reach the fence without every connector signature carrying it.
+ *
+ * The fence has to be consulted per HTTP attempt, not per logical call. A retry
+ * loop is the only layer that sees each attempt, and it sits several adapters
+ * below the wrapper that owns the fence, so the fence travels as ambient
+ * context for the same reason the request counter does.
+ */
+export function run_with_throttle_fence<T>(fence: ThrottleFence, fn: () => Promise<T>): Promise<T> {
+  return _fence.run(fence, fn);
+}
+
+/**
+ * The throttle fence guarding the current async context, if any.
+ *
+ * Absent for workloads that wire no fence, and for direct CLI calls. Callers
+ * treat undefined as "no global throttling in force" and proceed unchanged.
+ */
+export function get_active_fence(): ThrottleFence | undefined {
+  return _fence.getStore();
 }

--- a/packages/core/src/services/shared/throttle-fence.ts
+++ b/packages/core/src/services/shared/throttle-fence.ts
@@ -42,7 +42,11 @@ export class ThrottleFence {
       }
     }, seconds * 1000);
 
-    if (timer.unref) timer.unref();
+    // Deliberately not unref'd. This timer is the only thing that will ever
+    // release the callers parked in wait(), and an awaited promise is not a
+    // libuv handle, so an unref'd timer lets Node exit 0 with the whole
+    // workload still parked -- a truncated backup reported as a success.
+    // Bounded by Retry-After, and clear() exists for shutdown.
     this._timers.set(id, timer);
   }
 

--- a/packages/core/tests/unit/services/shared/throttle-fence.test.ts
+++ b/packages/core/tests/unit/services/shared/throttle-fence.test.ts
@@ -76,4 +76,36 @@ describe('ThrottleFence', () => {
     const spread = Math.max(...results) - Math.min(...results);
     expect(spread).toBeLessThan(50);
   });
+
+  /**
+   * Issue #196. An awaited promise is not a libuv handle, so if the only thing
+   * keeping the loop alive is this timer and it is unref'd, Node exits 0 with
+   * every caller still parked in wait(): a truncated backup that reports
+   * success. Verified out of band, before the fix, with a script that raised a
+   * fence, awaited wait() and exited at 0ms without ever resolving.
+   */
+  it('keeps the event loop alive while callers are parked', async () => {
+    const real_set_timeout = globalThis.setTimeout;
+    const unref_calls: number[] = [];
+
+    globalThis.setTimeout = ((fn: () => void, ms?: number) => {
+      const timer = real_set_timeout(fn, ms);
+      const real_unref = timer.unref.bind(timer);
+      timer.unref = () => {
+        unref_calls.push(ms ?? 0);
+        return real_unref();
+      };
+      return timer;
+    }) as typeof globalThis.setTimeout;
+
+    try {
+      fence = new ThrottleFence();
+      fence.raise(0.05);
+      await fence.wait();
+    } finally {
+      globalThis.setTimeout = real_set_timeout;
+    }
+
+    expect(unref_calls).toEqual([]);
+  });
 });

--- a/packages/m365-graph/src/graph-client.factory.ts
+++ b/packages/m365-graph/src/graph-client.factory.ts
@@ -4,8 +4,6 @@ import {
   Client,
   HTTPMessageHandler,
   RedirectHandler,
-  RetryHandler,
-  RetryHandlerOptions,
   RedirectHandlerOptions,
   TelemetryHandler,
   type Middleware,
@@ -25,10 +23,10 @@ const GRAPH_BASE_URL = 'https://graph.microsoft.com';
  *
  * The middleware chain is spelled out rather than derived from `authProvider`
  * so a cost middleware can sit immediately before the HTTP handler, where it
- * observes every request actually sent -- including each retry the RetryHandler
- * makes and each redirect the RedirectHandler follows, since both re-execute
- * the chain below them. It is otherwise the SDK's own default chain, in the
- * SDK's own order.
+ * observes every request actually sent, including each redirect the
+ * RedirectHandler follows, since it re-executes the chain below it. It is
+ * otherwise the SDK's default chain in the SDK's order, minus its RetryHandler:
+ * `with_graph_retry` owns retry policy for every call.
  *
  * Hardcodes the base URL to https://graph.microsoft.com to prevent
  * any downstream override to a non-TLS endpoint. Refuses to start
@@ -45,18 +43,26 @@ export function create_graph_client(config: GraphConfig): Client {
 }
 
 /**
- * The SDK's default handlers with cost accounting spliced in.
+ * The SDK's default handlers with cost accounting spliced in, and the SDK's own
+ * retry disabled.
  *
- * Position matters twice over. The cost middleware sits below RetryHandler and
- * RedirectHandler, both of which re-execute everything beneath them, so it sees
- * each attempt and each followed redirect rather than one logical call. It sits
- * above TelemetryHandler because the SDK requires telemetry to be the handler
- * immediately before the transport, so its usage flags cover the real request.
+ * `with_graph_retry` wraps every Graph call this client serves and is strictly
+ * more capable: it honours Retry-After, adds jitter, retries network faults the
+ * SDK handler ignores, and raises the global throttle fence. Leaving the SDK
+ * handler retrying as well multiplied the two budgets, so one logical call could
+ * reach ~52 HTTP attempts, every one of them counted against the throttling
+ * limits the backoff exists to respect. Retry lives in exactly one layer now,
+ * bounding a call at MAX_RETRIES + 1 attempts.
+ *
+ * Position still matters. The cost middleware sits below RedirectHandler, which
+ * re-executes everything beneath it, so it sees each followed redirect rather
+ * than one logical call. It sits above TelemetryHandler because the SDK requires
+ * telemetry to be the handler immediately before the transport, so its usage
+ * flags cover the real request.
  */
 function build_middleware_chain(auth_provider: TokenCredentialAuthenticationProvider): Middleware {
   const chain: Middleware[] = [
     new AuthenticationHandler(auth_provider),
-    new RetryHandler(new RetryHandlerOptions()),
     new RedirectHandler(new RedirectHandlerOptions()),
     new GraphCostMiddleware(),
     new TelemetryHandler(),

--- a/packages/m365-graph/src/graph-cost-middleware.ts
+++ b/packages/m365-graph/src/graph-cost-middleware.ts
@@ -4,14 +4,15 @@
  * Recording at the connector-method boundary counted one request per method,
  * but a method routinely issues many: a delta sync follows `@odata.nextLink`
  * until the collection is exhausted, and a throttled call is retried by
- * `with_graph_retry` (up to 12 attempts) and again by the SDK's own
- * RetryHandler, which this layer is the only place able to see. Reported cost
- * was therefore a floor, and consumers computing a throttling cooldown from it
- * got a number that was always too small -- the unsafe direction.
+ * `with_graph_retry` (up to 12 attempts), which this layer is the only place
+ * able to see. Reported cost was therefore a floor, and consumers computing a
+ * throttling cooldown from it got a number that was always too small, the
+ * unsafe direction.
  *
  * Placed immediately before HTTPMessageHandler, this middleware is invoked once
  * per outgoing HTTP request, including every retry and every followed redirect,
- * because both of those handlers re-execute the chain downstream of themselves.
+ * because RedirectHandler re-executes the chain downstream of itself and the
+ * retry wrapper re-enters the client entirely.
  *
  * @see https://learn.microsoft.com/en-us/graph/throttling-limits
  */

--- a/packages/m365-graph/src/graph-error-helpers.ts
+++ b/packages/m365-graph/src/graph-error-helpers.ts
@@ -1,4 +1,5 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { get_active_fence } from '@wisecom/atlas-core/services/shared/graph-request-context';
 
 /**
  * Statuses Graph recovers from on its own, per Microsoft's throttling and
@@ -28,6 +29,8 @@ const MAX_RETRIES = 12;
 const BASE_DELAY_MS = 1_000;
 const MAX_DELAY_MS = 300_000;
 const REQUEST_TIMEOUT_MS = 60_000;
+/** Cooldown applied to a 429 that arrives without a usable Retry-After. */
+const DEFAULT_THROTTLE_SECONDS = 30;
 
 export interface GraphRetryOptions {
   /**
@@ -159,12 +162,18 @@ export async function with_graph_retry<T>(
 ): Promise<T> {
   const timeout_ms = options.timeout_ms ?? REQUEST_TIMEOUT_MS;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    // Per attempt, not per call. A retry loop that started before the fence
+    // went up would otherwise keep firing into Graph for the whole cooldown.
+    await get_active_fence()?.wait();
     try {
       return await race_timeout(fn(), timeout_ms);
     } catch (err) {
       if (!is_retryable_error(err) || attempt === MAX_RETRIES) throw err;
 
       const retry_after = extract_retry_after(err);
+      // Raise on the response that carried the 429, not after the budget is
+      // spent, so every other owner backs off during this cooldown too.
+      raise_fence_on_throttle(err, retry_after);
       const base = retry_after ?? BASE_DELAY_MS * 2 ** attempt;
       const jitter = Math.random() * BASE_DELAY_MS;
       const delay = Math.min(base + jitter, MAX_DELAY_MS);
@@ -177,8 +186,26 @@ export async function with_graph_retry<T>(
       await sleep(delay);
     }
   }
-
   throw new Error('with_graph_retry: unreachable');
+}
+
+/**
+ * Raises the ambient throttle fence when `err` is a 429, so the cooldown starts
+ * on the first throttled response rather than after a retry budget is spent.
+ *
+ * Only 429 raises the fence. A 500 or a socket reset is one unlucky request and
+ * is the retry loop's business alone; a 429 is Graph asking the whole client to
+ * slow down. `raise` is non-additive, so concurrent owners hitting the same
+ * cooldown extend it rather than stacking it.
+ */
+function raise_fence_on_throttle(err: unknown, retry_after_ms: number | undefined): void {
+  if ((err as Record<string, unknown>).statusCode !== 429) return;
+
+  const fence = get_active_fence();
+  if (!fence) return;
+
+  const seconds = retry_after_ms !== undefined ? retry_after_ms / 1000 : DEFAULT_THROTTLE_SECONDS;
+  fence.raise(seconds);
 }
 
 /** Extracts the Retry-After header value (in ms) from a Graph error, if present. */

--- a/packages/m365-graph/src/rate-limited-graph-connector.adapter.ts
+++ b/packages/m365-graph/src/rate-limited-graph-connector.adapter.ts
@@ -24,7 +24,10 @@ import type {
   MailboxRateLimiterFactory,
 } from '@wisecom/atlas-core/services/shared/mailbox-rate-limiter';
 import type { ThrottleFence } from '@wisecom/atlas-core/services/shared/throttle-fence';
-import { run_with_graph_operation } from '@wisecom/atlas-core/services/shared/graph-request-context';
+import {
+  run_with_graph_operation,
+  run_with_throttle_fence,
+} from '@wisecom/atlas-core/services/shared/graph-request-context';
 import { GRAPH_SERVICE_LIMITS } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -179,7 +182,9 @@ export class RateLimitedGraphConnector implements MailboxConnector {
     const limiter = this.getLimiter(owner_id);
     await limiter.acquire(cost);
     try {
-      return await fn();
+      // Published so the retry loop inside `fn` parks on the fence between its
+      // own attempts. acquire() above only covers the first one.
+      return await run_with_throttle_fence(this._fence, fn);
     } catch (err) {
       this.handleThrottle(err);
       throw err;

--- a/packages/m365-graph/tests/unit/graph-retry-throttle-fence.test.ts
+++ b/packages/m365-graph/tests/unit/graph-retry-throttle-fence.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Issue #196: the throttle fence has to engage on the response that carried the
+ * 429 and has to gate every subsequent HTTP attempt, including attempts made by
+ * retry loops that were already running when the fence went up.
+ *
+ * The regression these guard against is invisible from the outside: a call still
+ * fails with 429 either way, it just spends the whole cooldown hammering Graph
+ * with the requests the cooldown exists to prevent.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ThrottleFence } from '@wisecom/atlas-core/services/shared/throttle-fence';
+import { run_with_throttle_fence } from '@wisecom/atlas-core/services/shared/graph-request-context';
+import { with_graph_retry } from '@/graph-error-helpers';
+
+/** Retry budget in `with_graph_retry`: 12 retries after the first attempt. */
+const MAX_ATTEMPTS = 13;
+
+function throttled(retry_after_seconds: string): Record<string, unknown> {
+  return {
+    statusCode: 429,
+    message: 'Too Many Requests',
+    headers: { 'retry-after': retry_after_seconds },
+  };
+}
+
+describe('with_graph_retry and the throttle fence', () => {
+  let fence: ThrottleFence;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fence = new ThrottleFence();
+  });
+
+  afterEach(() => {
+    fence.clear();
+    vi.useRealTimers();
+  });
+
+  it('raises the fence on the first 429, not after the retry budget', async () => {
+    let attempts = 0;
+    const fn = (): Promise<never> => {
+      attempts++;
+      return Promise.reject(throttled('5'));
+    };
+
+    const promise = run_with_throttle_fence(fence, () => with_graph_retry(fn)).catch(
+      (e: unknown) => e,
+    );
+
+    // Let the first attempt run and reject, without advancing into the backoff.
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(attempts).toBe(1);
+    expect(fence.is_raised).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+    await promise;
+  });
+
+  it('parks a retry loop that started before the fence went up', async () => {
+    // The fence is raised by a third party mid-loop, so this asserts the per
+    // attempt wait() on its own rather than the raise path. A loop failing on
+    // 500s backs off ~1-2s, so without that wait its next attempt lands well
+    // inside the cooldown.
+    const fired_while_raised: number[] = [];
+    let attempts = 0;
+    const fn = (): Promise<string> => {
+      attempts++;
+      if (fence.is_raised) fired_while_raised.push(attempts);
+      if (attempts < 3) return Promise.reject({ statusCode: 500, message: 'Server error' });
+      return Promise.resolve('ok');
+    };
+
+    const promise = run_with_throttle_fence(fence, () => with_graph_retry(fn));
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(attempts).toBe(1);
+
+    // Another owner hits a 429 and the cooldown starts while this loop is between
+    // attempts.
+    fence.raise(60);
+    await vi.advanceTimersByTimeAsync(59_000);
+    expect(attempts).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+
+    await expect(promise).resolves.toBe('ok');
+    expect(fired_while_raised).toEqual([]);
+  });
+
+  it('leaves the fence lowered and retries untouched when no 429 arrives', async () => {
+    let attempts = 0;
+    const fn = (): Promise<string> => {
+      attempts++;
+      if (attempts === 1) return Promise.reject({ statusCode: 503, message: 'Unavailable' });
+      return Promise.resolve('recovered');
+    };
+
+    const promise = run_with_throttle_fence(fence, () => with_graph_retry(fn));
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await expect(promise).resolves.toBe('recovered');
+    expect(attempts).toBe(2);
+    expect(fence.is_raised).toBe(false);
+  });
+
+  it('bounds a logical call at the retry budget, with no second retry layer under it', async () => {
+    let attempts = 0;
+    const fn = (): Promise<never> => {
+      attempts++;
+      return Promise.reject(throttled('1'));
+    };
+
+    const promise = run_with_throttle_fence(fence, () => with_graph_retry(fn)).catch(
+      (e: unknown) => e,
+    );
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    await promise;
+
+    expect(attempts).toBe(MAX_ATTEMPTS);
+  });
+
+  it('is inert with no fence in context, so unfenced workloads are unchanged', async () => {
+    let attempts = 0;
+    const fn = (): Promise<never> => {
+      attempts++;
+      return Promise.reject(throttled('1'));
+    };
+
+    const promise = with_graph_retry(fn).catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+
+    expect(await promise).toMatchObject({ statusCode: 429 });
+    expect(attempts).toBe(MAX_ATTEMPTS);
+  });
+
+  it('applies a default cooldown when a 429 carries no usable Retry-After', async () => {
+    const fn = (): Promise<never> => Promise.reject({ statusCode: 429, message: 'Throttled' });
+
+    const promise = run_with_throttle_fence(fence, () => with_graph_retry(fn)).catch(
+      (e: unknown) => e,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fence.is_raised).toBe(true);
+
+    // 30s default: still raised just before, lowered just after.
+    await vi.advanceTimersByTimeAsync(29_000);
+    expect(fence.is_raised).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    await promise;
+  });
+});


### PR DESCRIPTION
Fixes #196. Cut from `dev`, independent of the five PRs already open.

## Root cause

The fence was in the wrong layer, on both sides.

```
rateLimited()
  ├─ acquire() → fence.wait()          ← consulted ONCE, before the loop
  ├─ fn() → inner connector → with_graph_retry: 13 attempts / ~12s
  │                            ↑ never looks at the fence again
  └─ catch → handleThrottle → raise()  ← only after the budget is spent
```

`with_graph_retry` is the only layer that sees an individual 429, and it did nothing global with one. So the fence rose ~12 seconds into pure backoff, and for that whole window there was no global protection at all. Worse, a call already inside a retry loop never re-entered rate limiting, so it kept firing into Graph while the fence was raised: requests sent during a cooldown the client itself had asked for.

## The fix

Both fence interactions move into the retry loop, because that is the only place an attempt exists:

- `await get_active_fence()?.wait()` before **every** attempt, not once per logical call.
- `raise()` on the response that carried the 429, not after the budget is gone.

The fence reaches that loop as ambient context (`run_with_throttle_fence` / `get_active_fence`), following the `AsyncLocalStorage` pattern the request counter and the graph operation already use. The retry loop sits several adapters below the wrapper that owns the fence, and threading a fence through every connector signature would be a much larger diff for a worse result.

`handleThrottle` stays as the backstop for any path that does not retry. Only 429 raises the fence: a 500 or a socket reset is one unlucky request and is the retry loop's business, while a 429 is Graph asking the whole client to slow down.

Workloads that wire no fence read `undefined` and behave exactly as before. Today that is OneDrive and SharePoint, which is why the acceptance criteria talk about the Outlook path.

## Two defects found on the way

**The fence timer was `unref`'d, so parked work could be abandoned.** An awaited promise is not a libuv handle. With nothing else holding the loop open, Node exits 0 while every caller sits in `wait()`, which is a truncated backup reported as a success. Proven before the fix:

```
$ node -e "f.raise(2); f.wait().then(() => console.log('RESOLVED'))"
PROCESS EXIT code 0 at 0 ms          ← never resolved

# after
RESOLVED after 1002 ms
exit at 1006 ms
```

This was rare only because the fence almost never rose. Making the fence work correctly would have made parking the normal path during any throttling, converting a latent bug into a common one, so it is fixed here rather than deferred.

**Retry was stacked twice.** `with_graph_retry` (13 attempts) ran on top of the SDK `RetryHandler` (4), so one logical call could reach ~52 HTTP attempts, every one counted against the limits the backoff exists to respect. I audited every `_client.api(` call in the repo: all are wrapped by `with_graph_retry` except the usage report in `graph-mailbox-discovery.adapter.ts:144`, which is best-effort and swallows its own failures. `with_graph_retry` is strictly more capable than the SDK handler (Retry-After, jitter, network faults, and now the fence), so the SDK handler is removed and retry lives in exactly one layer, bounded at 13 attempts. The docs already claimed 12 retries; they are now true rather than optimistic.

## Verification

Reproduced the issue's harness against the built output. With one owner throttled on a 5s cooldown and another failing on 500s (backoff ~1-2s, far shorter than the cooldown):

```
[ 16246ms] A-alice attempt #4 (fence_raised=false)
[ 16247ms] FENCE.raise(5s)
[ 21248ms] B-bob   attempt #4 (fence_raised=false)   ← 1ms after the fence dropped
[ 27142ms] A-alice attempt #6
[ 27142ms] FENCE.raise(5s)
[ 32143ms] B-bob   attempt #5                        ← again, right on the boundary
ATTEMPTS FIRED WHILE FENCE RAISED: 0
```

B's attempts snap to fence-drop boundaries instead of its own backoff schedule, and the raise lands on the attempt that got the 429. Before the fix the raise did not happen until attempt 13.

7 new unit tests, and I checked they actually fail without the implementation:

```
× raises the fence on the first 429, not after the retry budget
× parks a retry loop that started before the fence went up
× applies a default cooldown when a 429 carries no usable Retry-After
Tests  3 failed | 85 passed
```

The parking test was worthless in its first form: it passed without the fix, because nothing in that unit path raised the fence, so the assertion was vacuously true. It now raises the fence from outside the code under test and asserts the loop is still on attempt 1 after 59 seconds of a 60 second cooldown, which is decisive for the `wait()` per attempt.

`throttle-fence.test.ts` gains a test asserting the timer is never `unref`'d, which fails on the pre-fix file.

Gates: build 10/10, typecheck 17/17, test 15/15, lint clean, docs build no warnings. CLI smoke-tested and the Graph client still constructs with the shortened middleware chain.

## Docs

`docs/operations/graph-rate-limits.md` gains a "How Atlas backs off" section under the Outlook pool: the fence engages on the first throttled response, in-flight retries check it between attempts, retry is one layer bounded at 13, and SharePoint/OneDrive have no equivalent fence yet.

## Acceptance criteria

- [x] First observed 429 raises the fence on that response; never requires exhausting the budget
- [x] Zero requests leave the Outlook path while raised, including a loop that began before it went up
- [x] No 429 means the fence stays lowered and retry/backoff is unchanged
- [x] Worst-case attempts per logical call bounded and unit tested, with both retry layers accounted for
- [x] After the fence lowers, fresh requests serialize through `acquire` as before
