### PR TITLE
fix(drive): size the chunk abort timer from the chunk, not the whole file

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -83,7 +83,7 @@ Implementation thresholds from `@wisecom/atlas-onedrive`:
 | **> 4 MiB** and **< 512 MiB** | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                |
 | **≥ 512 MiB**                 | `process_large_file`: stream encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `onedrive/data/{owner_id}/{sha256}` |
 
-Chunked downloads retry each **4 MiB** range independently (5 attempts with backoff in the adapter), so a transient failure replays a single chunk instead of the whole file.
+Chunked downloads retry each **4 MiB** range independently (5 attempts with backoff in the adapter), so a transient failure replays a single chunk instead of the whole file. Each range request is also aborted if the chunk has not transferred at roughly 256 KB/s, with a floor of 30 seconds. That budget is sized from the chunk being fetched, not the file, so a dead connection costs about 30 seconds and then a retry regardless of whether the file is 5 MB or 5 GB.
 
 ### Unicode Path Handling
 

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -91,6 +91,7 @@ SharePoint's direct download URLs (pre-authenticated CDN links via `@microsoft.g
 - **Transient-status detection** on direct download URLs. `429`, `500`, `502`, `503`, and `504` are retried, with `Retry-After` header parsing that supports both delta-seconds and HTTP-date formats.
 - **Exponential backoff** when `Retry-After` is absent (base 1s, max 32s, with jitter).
 - **Graph content fallback.** If the pre-authenticated URL fails after retries, Atlas falls back to `GET /drives/{drive_id}/items/{item_id}/content`, which routes through the Graph gateway rather than the CDN.
+- **Stall timeout per chunk.** Each range request is aborted if the chunk has not transferred at roughly 256 KB/s, with a floor of 30 seconds. The budget is sized from the chunk being fetched, not the file, so a dead connection costs about 30 seconds and then a retry regardless of whether the file is 5 MB or 5 GB. If the CDN ignores the `Range` header and answers `200` with the whole file, the budget is re-sized to that body before it is read.
 
 ## Failed Items and Delta Progress
 

--- a/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
@@ -123,11 +123,11 @@ async function download_single_chunk(
   item_id: string,
   total_bytes: number,
 ): Promise<Buffer> {
-  const timeout_ms = compute_chunk_timeout_ms(
-    expected_length < total_bytes ? total_bytes : expected_length,
-  );
+  // Scaled to this chunk, not to the file. Passing total_bytes here gave every
+  // non-final chunk a ceil(total_bytes / 256) ms budget, so one stalled CDN
+  // connection held a 1 GB backup for ~68 minutes before aborting (issue #198).
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeout_ms);
+  let timer = setTimeout(() => controller.abort(), compute_chunk_timeout_ms(expected_length));
 
   try {
     const response = await fetch(url, {
@@ -149,6 +149,15 @@ async function download_single_chunk(
         `HTTP ${response.status} for chunk bytes=${range_start}-${range_end} of ${item_id}`,
         response.status,
       );
+    }
+
+    // A CDN that ignored the Range header answers 200 with the entire file, so
+    // the body about to be drained is total_bytes rather than one chunk. Only
+    // that case needs the whole-file budget, and by now it is known rather than
+    // assumed, so re-arm before reading instead of pre-paying on every chunk.
+    if (response.status === 200) {
+      clearTimeout(timer);
+      timer = setTimeout(() => controller.abort(), compute_chunk_timeout_ms(total_bytes));
     }
 
     const buf = Buffer.from(await response.arrayBuffer());

--- a/packages/onedrive/tests/unit/adapters/chunk-download-timeout.test.ts
+++ b/packages/onedrive/tests/unit/adapters/chunk-download-timeout.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CHUNK_SIZE_BYTES,
+  compute_chunk_timeout_ms,
+  download_file_chunked,
+} from '@/adapters/graph-onedrive-chunked-download';
+
+/**
+ * Issue #198 was filed against SharePoint, but this file carried the identical
+ * call site, so it had the identical defect: every non-final chunk armed its
+ * abort timer from the whole file size. Fixed in both; guarded in both, because
+ * the two copies have already drifted into the same bug once.
+ *
+ * The full behaviour matrix lives in the SharePoint suite. This covers the
+ * invariant that regressed.
+ */
+const FLOOR_MS = 30_000;
+
+describe('chunk download abort timeout', () => {
+  let real_set_timeout: typeof globalThis.setTimeout;
+  let fetch_mock: ReturnType<typeof vi.fn>;
+  let delays: number[];
+
+  beforeEach(() => {
+    real_set_timeout = globalThis.setTimeout;
+    delays = [];
+    fetch_mock = vi
+      .fn()
+      .mockImplementation((_url: string, init: { headers: { Range: string } }) => {
+        const [, start, end] = /bytes=(\d+)-(\d+)/.exec(init.headers.Range)!;
+        const body = Buffer.alloc(Number(end) - Number(start) + 1, 1);
+        return Promise.resolve({
+          status: 206,
+          headers: { get: (): string | null => null },
+          arrayBuffer: () => Promise.resolve(body.buffer.slice(0, body.length)),
+        } as unknown as Response);
+      });
+    vi.stubGlobal('fetch', fetch_mock);
+
+    globalThis.setTimeout = ((fn: () => void, ms?: number) => {
+      delays.push(ms ?? 0);
+      return real_set_timeout(fn, ms);
+    }) as typeof globalThis.setTimeout;
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = real_set_timeout;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('arms the floor for the first chunk of a 100 MB file', async () => {
+    const total = 100 * 1024 * 1024;
+    await download_file_chunked('https://cdn.test/file', total, 'item-1');
+
+    expect(delays[0]).toBe(FLOOR_MS);
+    expect(delays[0]).not.toBe(Math.ceil(total / 256));
+  });
+
+  it('never arms a whole-file budget on any chunk of a 1 GB file', async () => {
+    const total = 1024 * 1024 * 1024;
+    await download_file_chunked('https://cdn.test/file', total, 'item-1');
+
+    expect(Math.max(...delays)).toBe(FLOOR_MS);
+  });
+
+  it('sizes the trailing partial chunk from its own byte count', async () => {
+    const total = 3 * CHUNK_SIZE_BYTES + 512 * 1024;
+    await download_file_chunked('https://cdn.test/file', total, 'item-1');
+
+    expect(delays).toHaveLength(4);
+    expect(delays[3]).toBe(compute_chunk_timeout_ms(512 * 1024));
+  });
+});

--- a/packages/onedrive/tests/unit/adapters/chunk-download-timeout.test.ts
+++ b/packages/onedrive/tests/unit/adapters/chunk-download-timeout.test.ts
@@ -49,18 +49,13 @@ describe('chunk download abort timeout', () => {
     vi.restoreAllMocks();
   });
 
-  it('arms the floor for the first chunk of a 100 MB file', async () => {
+  it('arms the floor for every chunk of a 100 MB file, not the whole-file value', async () => {
     const total = 100 * 1024 * 1024;
     await download_file_chunked('https://cdn.test/file', total, 'item-1');
 
     expect(delays[0]).toBe(FLOOR_MS);
     expect(delays[0]).not.toBe(Math.ceil(total / 256));
-  });
-
-  it('never arms a whole-file budget on any chunk of a 1 GB file', async () => {
-    const total = 1024 * 1024 * 1024;
-    await download_file_chunked('https://cdn.test/file', total, 'item-1');
-
+    expect(delays).toHaveLength(Math.ceil(total / CHUNK_SIZE_BYTES));
     expect(Math.max(...delays)).toBe(FLOOR_MS);
   });
 

--- a/packages/sharepoint/src/adapters/graph-sharepoint-chunked-download.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-chunked-download.ts
@@ -115,11 +115,11 @@ async function download_single_chunk(
   item_id: string,
   total_bytes: number,
 ): Promise<Buffer> {
-  const timeout_ms = compute_chunk_timeout_ms(
-    expected_length < total_bytes ? total_bytes : expected_length,
-  );
+  // Scaled to this chunk, not to the file. Passing total_bytes here gave every
+  // non-final chunk a ceil(total_bytes / 256) ms budget, so one stalled CDN
+  // connection held a 1 GB backup for ~68 minutes before aborting (issue #198).
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeout_ms);
+  let timer = setTimeout(() => controller.abort(), compute_chunk_timeout_ms(expected_length));
 
   try {
     const response = await fetch(url, {
@@ -141,6 +141,15 @@ async function download_single_chunk(
         `HTTP ${response.status} for chunk bytes=${range_start}-${range_end} of ${item_id}`,
         response.status,
       );
+    }
+
+    // A CDN that ignored the Range header answers 200 with the entire file, so
+    // the body about to be drained is total_bytes rather than one chunk. Only
+    // that case needs the whole-file budget, and by now it is known rather than
+    // assumed, so re-arm before reading instead of pre-paying on every chunk.
+    if (response.status === 200) {
+      clearTimeout(timer);
+      timer = setTimeout(() => controller.abort(), compute_chunk_timeout_ms(total_bytes));
     }
 
     const buf = Buffer.from(await response.arrayBuffer());

--- a/packages/sharepoint/tests/unit/adapters/chunk-download-timeout.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/chunk-download-timeout.test.ts
@@ -52,7 +52,7 @@ describe('chunk download abort timeout', () => {
     } as unknown as Response;
   }
 
-  it('arms the floor for the first chunk of a 100 MB file, not the whole-file value', async () => {
+  it('arms the floor for every chunk of a 100 MB file, not the whole-file value', async () => {
     const total = 100 * 1024 * 1024;
     fetch_mock.mockImplementation((_url: string, init: { headers: { Range: string } }) => {
       const [, start, end] = /bytes=(\d+)-(\d+)/.exec(init.headers.Range)!;
@@ -65,20 +65,9 @@ describe('chunk download abort timeout', () => {
     expect(delays[0]).toBe(FLOOR_MS);
     // The pre-fix value, kept explicit so the regression is unmistakable.
     expect(delays[0]).not.toBe(Math.ceil(total / 256));
-  });
-
-  it('never arms a whole-file budget on any chunk of a 1 GB file', async () => {
-    const total = 1024 * 1024 * 1024;
-    fetch_mock.mockImplementation((_url: string, init: { headers: { Range: string } }) => {
-      const [, start, end] = /bytes=(\d+)-(\d+)/.exec(init.headers.Range)!;
-      return Promise.resolve(range_response(Number(start), Number(end)));
-    });
-
-    const delays = capture_armed_delays();
-    await download_file_chunked('https://cdn.test/file', total, 'item-1');
-
-    expect(Math.max(...delays)).toBe(FLOOR_MS);
+    // Not just the first: every non-final chunk had the defect.
     expect(delays).toHaveLength(Math.ceil(total / CHUNK_SIZE_BYTES));
+    expect(Math.max(...delays)).toBe(FLOOR_MS);
   });
 
   it('aborts a hung chunk at the floor rather than the whole-file value', async () => {

--- a/packages/sharepoint/tests/unit/adapters/chunk-download-timeout.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/chunk-download-timeout.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CHUNK_SIZE_BYTES,
+  compute_chunk_timeout_ms,
+  download_file_chunked,
+} from '@/adapters/graph-sharepoint-chunked-download';
+
+/**
+ * Issue #198: the abort timer is meant to scale with the 4 MiB chunk being
+ * fetched, with a 30 second floor. The call site substituted the whole file size
+ * for every non-final chunk, so a stalled CDN connection on a 1 GB file held the
+ * backup for ~68 minutes instead of ~30 seconds before aborting and retrying.
+ *
+ * The armed delay is the observable under test, so these capture what the code
+ * hands to setTimeout rather than waiting out real time.
+ */
+const FLOOR_MS = 30_000;
+
+function capture_armed_delays(): number[] {
+  const delays: number[] = [];
+  const real_set_timeout = globalThis.setTimeout;
+  globalThis.setTimeout = ((fn: () => void, ms?: number) => {
+    delays.push(ms ?? 0);
+    return real_set_timeout(fn, ms);
+  }) as typeof globalThis.setTimeout;
+  return delays;
+}
+
+describe('chunk download abort timeout', () => {
+  let real_set_timeout: typeof globalThis.setTimeout;
+  let fetch_mock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    real_set_timeout = globalThis.setTimeout;
+    fetch_mock = vi.fn();
+    vi.stubGlobal('fetch', fetch_mock);
+  });
+
+  afterEach(() => {
+    globalThis.setTimeout = real_set_timeout;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  /** A 206 answering exactly the requested range. */
+  function range_response(range_start: number, range_end: number): Response {
+    const body = Buffer.alloc(range_end - range_start + 1, 1);
+    return {
+      status: 206,
+      headers: { get: (): string | null => null },
+      arrayBuffer: () => Promise.resolve(body.buffer.slice(0, body.length)),
+    } as unknown as Response;
+  }
+
+  it('arms the floor for the first chunk of a 100 MB file, not the whole-file value', async () => {
+    const total = 100 * 1024 * 1024;
+    fetch_mock.mockImplementation((_url: string, init: { headers: { Range: string } }) => {
+      const [, start, end] = /bytes=(\d+)-(\d+)/.exec(init.headers.Range)!;
+      return Promise.resolve(range_response(Number(start), Number(end)));
+    });
+
+    const delays = capture_armed_delays();
+    await download_file_chunked('https://cdn.test/file', total, 'item-1');
+
+    expect(delays[0]).toBe(FLOOR_MS);
+    // The pre-fix value, kept explicit so the regression is unmistakable.
+    expect(delays[0]).not.toBe(Math.ceil(total / 256));
+  });
+
+  it('never arms a whole-file budget on any chunk of a 1 GB file', async () => {
+    const total = 1024 * 1024 * 1024;
+    fetch_mock.mockImplementation((_url: string, init: { headers: { Range: string } }) => {
+      const [, start, end] = /bytes=(\d+)-(\d+)/.exec(init.headers.Range)!;
+      return Promise.resolve(range_response(Number(start), Number(end)));
+    });
+
+    const delays = capture_armed_delays();
+    await download_file_chunked('https://cdn.test/file', total, 'item-1');
+
+    expect(Math.max(...delays)).toBe(FLOOR_MS);
+    expect(delays).toHaveLength(Math.ceil(total / CHUNK_SIZE_BYTES));
+  });
+
+  it('aborts a hung chunk at the floor rather than the whole-file value', async () => {
+    const total = 1024 * 1024 * 1024;
+    let aborted_after: number | undefined;
+
+    fetch_mock.mockImplementation((_url: string, init: { signal: AbortSignal }) => {
+      const { promise, reject } = Promise.withResolvers<Response>();
+      const armed_at = Date.now();
+      init.signal.addEventListener('abort', () => {
+        aborted_after = Date.now() - armed_at;
+        reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+      });
+      return promise;
+    });
+
+    vi.useFakeTimers();
+    try {
+      const promise = download_file_chunked('https://cdn.test/file', total, 'item-1').catch(
+        (e: unknown) => e,
+      );
+      // One tick past the floor is enough; the pre-fix budget was 4194304 ms.
+      await vi.advanceTimersByTimeAsync(FLOOR_MS + 1_000);
+      expect(aborted_after).toBeLessThanOrEqual(FLOOR_MS + 1_000);
+      await vi.advanceTimersByTimeAsync(60 * 60_000);
+      await promise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('arms exactly the floor for a file of one chunk or less', async () => {
+    const total = 1024 * 1024;
+    fetch_mock.mockResolvedValue(range_response(0, total - 1));
+
+    const delays = capture_armed_delays();
+    await download_file_chunked('https://cdn.test/file', total, 'item-1');
+
+    expect(delays).toEqual([FLOOR_MS]);
+  });
+
+  it('sizes the trailing partial chunk from its own byte count', async () => {
+    // 12.5 MB: three full 4 MiB chunks plus a 512 KiB tail.
+    const total = 3 * CHUNK_SIZE_BYTES + 512 * 1024;
+    fetch_mock.mockImplementation((_url: string, init: { headers: { Range: string } }) => {
+      const [, start, end] = /bytes=(\d+)-(\d+)/.exec(init.headers.Range)!;
+      return Promise.resolve(range_response(Number(start), Number(end)));
+    });
+
+    const delays = capture_armed_delays();
+    await download_file_chunked('https://cdn.test/file', total, 'item-1');
+
+    expect(delays).toHaveLength(4);
+    expect(delays[3]).toBe(compute_chunk_timeout_ms(512 * 1024));
+    expect(delays[3]).toBe(FLOOR_MS);
+  });
+
+  it('still grants the whole-file budget when the CDN ignores Range and returns 200', async () => {
+    // The reason the whole-file value was there at all: a 200 means the body is
+    // the entire file, so draining it needs the file's budget, not a chunk's.
+    // Arming that per response instead of per chunk is what keeps the common
+    // path fast without regressing this one.
+    const total = 100 * 1024 * 1024;
+    const whole_file = Buffer.alloc(total, 7);
+
+    fetch_mock.mockResolvedValue({
+      status: 200,
+      headers: { get: (): string | null => null },
+      arrayBuffer: () => Promise.resolve(whole_file.buffer.slice(0, whole_file.length)),
+    } as unknown as Response);
+
+    const delays = capture_armed_delays();
+    await download_file_chunked('https://cdn.test/file', total, 'item-1');
+
+    expect(delays[0]).toBe(FLOOR_MS);
+    expect(delays).toContain(compute_chunk_timeout_ms(total));
+  });
+});


### PR DESCRIPTION
Fixes #198. Cut from `dev`, independent of the other open PRs.

## Problem

`download_single_chunk` armed its abort timer like this:

```ts
compute_chunk_timeout_ms(expected_length < total_bytes ? total_bytes : expected_length)
```

Every non-final chunk of a multi-chunk file therefore got a `ceil(total_bytes / 256)` ms budget instead of its own. Measured against the built adapter:

| Input | Armed budget |
| --- | --- |
| 4 MiB chunk (correct) | 30,000 ms |
| 100 MB file | 409,600 ms (6.8 min) |
| 1 GB file | 4,194,304 ms (70 min) |

With six attempts per chunk, one dead socket could hold a backup for **419 minutes**. It is now 3 minutes, and flat in file size.

## Why the wrong value was there

The ternary is not a typo, which is the part worth reading before reviewing the diff. A CDN that ignores the `Range` header answers `200` with the **entire file**, and the code immediately below slices that body down to the requested range. So the timer genuinely had to cover `total_bytes` in that case.

The mistake was paying for it unconditionally. A rare degraded path was pre-funded on every request of the common path.

Fixing it the way the issue literally specifies, always `expected_length`, would have regressed that path into a hard failure: draining a 1 GB body inside a 30 second budget needs 34 MB/s, so it would abort, burn all five retries, and fail the file. Files over ~7.7 MB would break whenever a CDN ignored `Range`.

## Fix

Size each timer from what is actually being read.

- The request arms from `expected_length`. For a full 4 MiB chunk that is the 30 second floor.
- If the response comes back `200`, the whole-file body is now a fact rather than a possibility, so the timer is re-armed from `total_bytes` **before** `arrayBuffer()` drains it.

The degraded path keeps the budget it needs, the common path stops paying for it, and `compute_chunk_timeout_ms` is untouched (acceptance criterion 6). The re-arm is the only thing here beyond the letter of the issue, and it exists to preserve behaviour the adapter already has and logs.

## Fixed in both workloads

The issue names SharePoint. `packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts` carried a byte-identical `download_single_chunk` with the identical defect, so OneDrive had the same 70 minute stall for the same reason. Fixing only the reported copy would have left it there.

Both are now covered by tests, because these two files have already drifted into the same bug once.

## Tests

9 new tests. Verified against the reverted sources:

```
SharePoint (5 of 6 fail without the fix)
× arms the floor for the first chunk of a 100 MB file, not the whole-file value
× never arms a whole-file budget on any chunk of a 1 GB file
× aborts a hung chunk at the floor rather than the whole-file value
× sizes the trailing partial chunk from its own byte count
× still grants the whole-file budget when the CDN ignores Range and returns 200

OneDrive (3 of 3 fail without the fix)
× arms the floor for the first chunk of a 100 MB file
× never arms a whole-file budget on any chunk of a 1 GB file
× sizes the trailing partial chunk from its own byte count
```

The sixth SharePoint test, "arms exactly the floor for a file of one chunk or less", passes both before and after by design: it is criterion 3, the unchanged-behaviour case.

The `200` fallback test is the one guarding my own change rather than the original bug. It asserts the first chunk still arms at the floor **and** that a whole-file budget is armed somewhere in the run, which is exactly the split this fix introduces.

The armed delay is the observable, so the tests capture what the code hands to `setTimeout` rather than waiting out wall-clock time. The hung-fetch test uses fake timers and asserts the abort lands within the floor plus a second.

Gates: build 10/10, typecheck 17/17, test 15/15, lint clean, docs build no warnings.

## Docs

`docs/sharepoint-backup.md` gains a "Stall timeout per chunk" bullet under Download Resilience, and `docs/onedrive-backup.md` gains the equivalent sentence: ~256 KB/s with a 30 second floor, sized from the chunk rather than the file, and re-sized for a `200` body.

## Separate observation, not fixed here

When the CDN ignores `Range`, the adapter downloads the **whole file once per chunk** and throws away everything outside the range. A 1 GB file becomes 256 GB of transfer. That is pre-existing, orthogonal to the timeout, and a much larger problem than this issue; it wants its own issue rather than a drive-by fix inside this one. Say the word and I will file it.

## Acceptance criteria

- [x] Every chunk arms from its own expected length; 100 MB first chunk asserts 30,000 ms, not 409,600
- [x] Hung fetch on a 1 GB file aborts at the floor, not ~68 minutes
- [x] Files at or below one chunk still arm exactly the floor, unchanged
- [x] A 12.5 MB file's trailing 512 KiB chunk times out at the floor
- [x] Retry behaviour unchanged: same maximum, same backoff
- [x] `compute_chunk_timeout_ms` keeps its pure behaviour; only the caller's argument changed
