### PR TITLE
fix(drive): scope a delta reset to the drive that triggered it

### DIFF
--- a/docs/operations/delta-sync.md
+++ b/docs/operations/delta-sync.md
@@ -40,6 +40,13 @@ Delta links are stored in the **encrypted manifest**, not in plaintext. They con
 
 The stale-delta safeguard exists to prevent a specific failure: an interrupted backup saving a delta link that skips all the messages it never actually stored.
 
+A full enumeration is scoped to the drive or library that triggered it. Delta
+links are per drive, so a site with several document libraries, or a user with
+more than one drive, keeps the valid links working while only the affected one
+rebaselines. Files in the rebaselining drive are recorded as `created` again,
+which is what a lost delta chain means; files elsewhere keep their history and a
+genuine edit there is still reported as `updated`.
+
 ## File version dedup (OneDrive and SharePoint)
 
 OneDrive and SharePoint backups capture more than the current copy of a file. For every file the delta stream reports as changed, Atlas also enumerates the file's **historical versions** through `GET /drives/{drive-id}/items/{item-id}/versions` and stores each one it has not captured before. The current version is skipped, because the manifest entry already covers it.

--- a/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
+++ b/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
@@ -254,11 +254,11 @@ export async function process_single_drive(
   on_item_processed?: (item: OneDriveDeltaItem) => void,
   control: OperationControlOptions = {},
 ): Promise<SingleDriveResult> {
+  const delta_item_ids = new Set(delta.items.map((item) => item.item_id));
   if (delta.reset_detected) {
-    clear_file_tracking_on_reset(state);
+    clear_file_tracking_on_reset(state, delta_item_ids);
   }
 
-  const delta_item_ids = new Set(delta.items.map((item) => item.item_id));
   const retry = await resolve_retry_items(
     connector,
     tenant_id,

--- a/packages/onedrive/src/services/onedrive-delta-item-processor.ts
+++ b/packages/onedrive/src/services/onedrive-delta-item-processor.ts
@@ -40,10 +40,27 @@ export interface DeltaItemOutcome {
   permanent?: boolean;
 }
 
-/** Clears file tracking maps when Graph signals a delta reset. */
-export function clear_file_tracking_on_reset(state: DriveTrackingState): void {
-  for (const [fid, kind] of Object.entries(state.previous_kind_by_file_id)) {
-    if (kind === 'file') {
+/**
+ * Forgets tracking for the files a reset re-enumerates, so they rebaseline as
+ * `created`.
+ *
+ * Scoped to the ids the resetting delta returned rather than the whole map. The
+ * maps are keyed by file id alone and shared by every drive an owner has, so
+ * clearing all of them let one drive's dead delta link wipe its siblings' path,
+ * name and etag records, and a genuine change elsewhere then looked like a first
+ * backup (issue #199). With `--folder` in play the delta is already scoped, so
+ * this also stops a reset from forgetting files outside the scope it never read.
+ *
+ * A reset delta is a full enumeration, so its ids are exactly the entries that
+ * need forgetting. That holds for cursors written before this fix too, which is
+ * why nothing has to be migrated.
+ */
+export function clear_file_tracking_on_reset(
+  state: DriveTrackingState,
+  reset_item_ids: Iterable<string>,
+): void {
+  for (const fid of reset_item_ids) {
+    if (state.previous_kind_by_file_id[fid] === 'file') {
       delete state.previous_path_by_file_id[fid];
       delete state.previous_name_by_file_id[fid];
       delete state.previous_etag_by_file_id[fid];

--- a/packages/onedrive/tests/unit/services/delta-reset-scope.test.ts
+++ b/packages/onedrive/tests/unit/services/delta-reset-scope.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clear_file_tracking_on_reset,
+  type DriveTrackingState,
+} from '@/services/onedrive-delta-item-processor';
+import { classify_change_type } from '@/services/onedrive-change-classifier';
+import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
+
+/**
+ * Issue #199 was filed against SharePoint, but this file had the identical
+ * defect: tracking keyed by file id alone, shared across every drive an owner
+ * has, wiped wholesale on any one drive's reset.
+ *
+ * OneDrive has a second way to hit it. With `--folder` the delta is scoped
+ * before it reaches here, so an unscoped clear also forgot files the run never
+ * looked at.
+ */
+function make_tracking(): DriveTrackingState {
+  return {
+    previous_path_by_file_id: { a1: '/Projects', b1: '/Archive' },
+    previous_name_by_file_id: { a1: 'a.docx', b1: 'b.docx' },
+    previous_etag_by_file_id: { a1: 'ea', b1: 'eb' },
+    previous_kind_by_file_id: { a1: 'file', b1: 'file' },
+  };
+}
+
+function make_item(overrides: Partial<OneDriveDeltaItem> = {}): OneDriveDeltaItem {
+  return {
+    item_id: 'b1',
+    drive_id: 'drive-b',
+    file_name: 'b.docx',
+    parent_path: '/Archive',
+    kind: 'file',
+    size_bytes: 10,
+    etag: 'eb2',
+    deleted: false,
+    ...overrides,
+  } as OneDriveDeltaItem;
+}
+
+describe('clear_file_tracking_on_reset', () => {
+  it('leaves a sibling drive untouched when another drive resets', () => {
+    const tracking = make_tracking();
+
+    clear_file_tracking_on_reset(tracking, ['a1']);
+
+    expect(tracking.previous_path_by_file_id.b1).toBe('/Archive');
+    expect(tracking.previous_etag_by_file_id.b1).toBe('eb');
+  });
+
+  it('classifies a sibling edit as updated, not created, after another reset', () => {
+    const tracking = make_tracking();
+    clear_file_tracking_on_reset(tracking, ['a1']);
+
+    const change = classify_change_type(
+      make_item({ etag: 'eb2' }),
+      tracking.previous_path_by_file_id,
+      tracking.previous_name_by_file_id,
+      tracking.previous_etag_by_file_id,
+    );
+
+    expect(change).toBe('updated');
+  });
+
+  it('rebaselines the resetting drive so its own files read created', () => {
+    const tracking = make_tracking();
+    clear_file_tracking_on_reset(tracking, ['a1']);
+
+    const change = classify_change_type(
+      make_item({
+        item_id: 'a1',
+        drive_id: 'drive-a',
+        file_name: 'a.docx',
+        parent_path: '/Projects',
+      }),
+      tracking.previous_path_by_file_id,
+      tracking.previous_name_by_file_id,
+      tracking.previous_etag_by_file_id,
+    );
+
+    expect(change).toBe('created');
+  });
+
+  it('keeps files outside a folder scope tracked through a reset', () => {
+    // The delta reaching the processor is already scoped, so an out-of-scope
+    // file is simply absent from it and must survive.
+    const tracking = make_tracking();
+
+    clear_file_tracking_on_reset(tracking, ['a1']);
+
+    expect(tracking.previous_path_by_file_id.b1).toBe('/Archive');
+  });
+});

--- a/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
@@ -34,10 +34,26 @@ export interface LibraryProcessingResult {
   package_report: PackageReport;
 }
 
-/** Clears file tracking maps when Graph signals a delta reset. */
-export function clear_file_tracking_on_reset(tracking: FileTrackingState): void {
-  for (const [fid, kind] of Object.entries(tracking.previous_kind_by_file_id)) {
-    if (kind === 'file') {
+/**
+ * Forgets tracking for the files a reset re-enumerates, so they rebaseline as
+ * `created`.
+ *
+ * Scoped to the ids the resetting delta returned rather than the whole map. The
+ * maps are keyed by file id alone and shared by every library in the site, so
+ * clearing all of them let one library's dead delta link wipe its siblings'
+ * path, name and etag records. A genuine change in a sibling on a still-valid
+ * link then looked like a first backup (issue #199).
+ *
+ * A reset delta is a full enumeration of that drive, so its ids are exactly the
+ * entries that need forgetting. That holds for cursors written before this fix
+ * too, which is why nothing has to be migrated.
+ */
+export function clear_file_tracking_on_reset(
+  tracking: FileTrackingState,
+  reset_item_ids: Iterable<string>,
+): void {
+  for (const fid of reset_item_ids) {
+    if (tracking.previous_kind_by_file_id[fid] === 'file') {
       delete tracking.previous_path_by_file_id[fid];
       delete tracking.previous_name_by_file_id[fid];
       delete tracking.previous_etag_by_file_id[fid];
@@ -81,7 +97,10 @@ export async function process_single_library(
   );
 
   if (delta.reset_detected) {
-    clear_file_tracking_on_reset(tracking);
+    clear_file_tracking_on_reset(
+      tracking,
+      delta.items.map((item) => item.item_id),
+    );
   }
 
   const library_state: LibraryProcessingState = {

--- a/packages/sharepoint/tests/unit/services/delta-reset-scope.test.ts
+++ b/packages/sharepoint/tests/unit/services/delta-reset-scope.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { clear_file_tracking_on_reset } from '@/services/sharepoint-backup-library-processor';
+import type { FileTrackingState } from '@/services/sharepoint-library-item-processor';
+import { classify_change_type } from '@/services/sharepoint-change-classifier';
+import type { SharePointDeltaItem } from '@wisecom/atlas-types';
+
+/**
+ * Issue #199: tracking maps are keyed by file id alone and shared by every
+ * library in a site scan, so clearing all of them on a reset let one library's
+ * dead delta link wipe its siblings' records. A genuine change in a sibling on a
+ * still-valid link then classified as `created`, and the manifest carried the
+ * wrong change type until that file happened to change again.
+ *
+ * The scenario mirrors the one in the issue: library L1 resets, library L2 keeps
+ * a valid link and has one genuinely edited file.
+ */
+function make_tracking(): FileTrackingState {
+  return {
+    // f1 lives in L1, f2 lives in L2. Nothing in the shape records that, which
+    // is the whole problem.
+    previous_path_by_file_id: { f1: '/L1', f2: '/L2' },
+    previous_name_by_file_id: { f1: 'f1.docx', f2: 'f2.docx' },
+    previous_etag_by_file_id: { f1: 'e1', f2: 'e2' },
+    previous_kind_by_file_id: { f1: 'file', f2: 'file' },
+  };
+}
+
+function make_item(overrides: Partial<SharePointDeltaItem> = {}): SharePointDeltaItem {
+  return {
+    item_id: 'f2',
+    drive_id: 'L2',
+    file_name: 'f2.docx',
+    parent_path: '/L2',
+    kind: 'file',
+    size_bytes: 10,
+    etag: 'e2b',
+    deleted: false,
+    ...overrides,
+  } as SharePointDeltaItem;
+}
+
+describe('clear_file_tracking_on_reset', () => {
+  it('leaves a sibling library untouched when another library resets', () => {
+    const tracking = make_tracking();
+
+    // L1's reset delta is a full enumeration of L1, so it carries f1 and not f2.
+    clear_file_tracking_on_reset(tracking, ['f1']);
+
+    expect(tracking.previous_path_by_file_id.f2).toBe('/L2');
+    expect(tracking.previous_name_by_file_id.f2).toBe('f2.docx');
+    expect(tracking.previous_etag_by_file_id.f2).toBe('e2');
+  });
+
+  it('classifies a sibling edit as updated, not created, after another reset', () => {
+    const tracking = make_tracking();
+    clear_file_tracking_on_reset(tracking, ['f1']);
+
+    const change = classify_change_type(
+      make_item({ etag: 'e2b' }),
+      tracking.previous_path_by_file_id,
+      tracking.previous_name_by_file_id,
+      tracking.previous_etag_by_file_id,
+    );
+
+    expect(change).toBe('updated');
+  });
+
+  it('rebaselines the resetting library so its own files read created', () => {
+    const tracking = make_tracking();
+    clear_file_tracking_on_reset(tracking, ['f1']);
+
+    const change = classify_change_type(
+      make_item({ item_id: 'f1', drive_id: 'L1', file_name: 'f1.docx', parent_path: '/L1' }),
+      tracking.previous_path_by_file_id,
+      tracking.previous_name_by_file_id,
+      tracking.previous_etag_by_file_id,
+    );
+
+    expect(change).toBe('created');
+  });
+
+  it('keeps the deleted-item name fallback working for a sibling library', () => {
+    // Issue #139 reads the name from tracking when Graph omits it on a tombstone.
+    const tracking = make_tracking();
+    clear_file_tracking_on_reset(tracking, ['f1']);
+
+    expect(tracking.previous_name_by_file_id.f2).toBe('f2.docx');
+  });
+
+  it('does not forget folder entries, only files', () => {
+    const tracking = make_tracking();
+    tracking.previous_kind_by_file_id.d1 = 'folder';
+    tracking.previous_path_by_file_id.d1 = '/L1/sub';
+
+    clear_file_tracking_on_reset(tracking, ['f1', 'd1']);
+
+    expect(tracking.previous_path_by_file_id.d1).toBe('/L1/sub');
+    expect(tracking.previous_path_by_file_id.f1).toBeUndefined();
+  });
+
+  it('ignores ids it has never tracked', () => {
+    const tracking = make_tracking();
+
+    expect(() => clear_file_tracking_on_reset(tracking, ['unknown'])).not.toThrow();
+    expect(tracking.previous_path_by_file_id.f1).toBe('/L1');
+    expect(tracking.previous_path_by_file_id.f2).toBe('/L2');
+  });
+});


### PR DESCRIPTION
Fixes #199. Cut from `dev`.

## Problem

`FileTrackingState` is four maps keyed by **file id alone**, built once per site and shared by every library in the scan. `clear_file_tracking_on_reset` walked the whole map:

```ts
for (const [fid, kind] of Object.entries(tracking.previous_kind_by_file_id)) {
  if (kind === 'file') {
    delete tracking.previous_path_by_file_id[fid];
    ...
```

So one library's dead delta link deleted every other library's path, name and etag records. A file that genuinely changed in a sibling library, on a link that was still perfectly valid, then had nothing to compare against and came out as `created`. The manifest carried that wrong change type until the file happened to change again, and #139's deleted-item name fallback lost its only source of names for those libraries.

## Fix

Scope the clear to the item ids the resetting delta returned.

```ts
clear_file_tracking_on_reset(tracking, delta.items.map((item) => item.item_id));
```

A reset delta is a full enumeration of that one drive, so its ids are exactly the entries that must be forgotten for the resetting library to rebaseline as `created`. Everything else keeps its history.

## Why there is no new field and no migration

The obvious fix is to attribute each tracked file to a drive: a `previous_drive_by_file_id` map on both the tracking state and the persisted cursor. I did not do that, because it forces a decision about cursors that already exist and carry no attribution, and both answers are wrong:

- Clear unattributed entries on a reset, and the bug survives for those files. Worse, it survives indefinitely, because unchanged files never appear in a delta and so never get re-attributed.
- Keep unattributed entries, and the resetting drive stops rebaselining, which breaks acceptance criterion 5's negative case.

The delta's own item list answers the question for old and new cursors identically, so there is nothing to migrate and no schema change. That is the whole reason the diff is this small.

## Fixed in OneDrive too

`onedrive-delta-item-processor.ts` had a byte-identical clear, and an owner with more than one drive hit the same defect for the same reason. The issue names SharePoint only.

OneDrive also had a second way in that SharePoint does not: with `--folder`, `scoped_delta` filters the delta **before** it reaches the processor, so an unscoped clear forgot tracking for files the run never enumerated. Scoping to the delta fixes that at the same time.

`process_single_drive` already built the id set one line below the clear for `resolve_retry_items`, so it now builds it one line above and reuses it.

## Tests

10 new tests, and I verified they fail against the pre-fix source rather than assuming:

```
sharepoint: 4 failed | 197 passed
  × leaves a sibling library untouched when another library resets
  × classifies a sibling edit as updated, not created, after another reset
  × keeps the deleted-item name fallback working for a sibling library
  × ignores ids it has never tracked

onedrive:   3 failed | 135 passed
  × leaves a sibling drive untouched when another drive resets
  × classifies a sibling edit as updated, not created, after another reset
  × keeps files outside a folder scope tracked through a reset
```

The scenario mirrors the one in the issue: L1 resets, L2 keeps a valid link and has one genuinely edited file, and the assertion is that L2's edit reads `updated`.

Tests that pass both before and after are the deliberate no-change cases: the resetting library still rebaselines to `created`, and folder entries are still left alone.

Verified by reverting the three source files with a patch file rather than `git stash`, after the stash mishap on #223.

Gates in CI's mode (`pnpm run test:coverage`): 15/15 tasks, build 10/10, typecheck 17/17, lint clean, docs build no warnings.

## Docs

`docs/operations/delta-sync.md` now states that a full enumeration is scoped to the drive or library that triggered it, that the rebaselining drive records `created` again, and that a genuine edit elsewhere is still `updated`.

## Acceptance criteria

- [x] One library's reset leaves other libraries' path/name/etag entries intact in the same scan
- [x] A genuine change in a non-resetting library on a valid link classifies as `updated`, never `created`
- [x] Deleted-item name fallback still resolves names for non-resetting libraries (#139)
- [x] The resetting library still rebaselines its own files as `created`
- [x] Stale-cursor migration and invalid-link recovery still clear the resetting drive's own entries
