### PR TITLE
perf(replicate): derive the KEK once per target instead of once per snapshot

### DIFF
--- a/docs/operations/delta-sync.md
+++ b/docs/operations/delta-sync.md
@@ -40,6 +40,13 @@ Delta links are stored in the **encrypted manifest**, not in plaintext. They con
 
 The stale-delta safeguard exists to prevent a specific failure: an interrupted backup saving a delta link that skips all the messages it never actually stored.
 
+A full enumeration is scoped to the drive or library that triggered it. Delta
+links are per drive, so a site with several document libraries, or a user with
+more than one drive, keeps the valid links working while only the affected one
+rebaselines. Files in the rebaselining drive are recorded as `created` again,
+which is what a lost delta chain means; files elsewhere keep their history and a
+genuine edit there is still reported as `updated`.
+
 ## File version dedup (OneDrive and SharePoint)
 
 OneDrive and SharePoint backups capture more than the current copy of a file. For every file the delta stream reports as changed, Atlas also enumerates the file's **historical versions** through `GET /drives/{drive-id}/items/{item-id}/versions` and stores each one it has not captured before. The current version is skipped, because the manifest entry already covers it.

--- a/docs/operations/replication.md
+++ b/docs/operations/replication.md
@@ -73,7 +73,7 @@ Because the same passphrase protects all copies, compromising the passphrase com
 
 ### DEK mismatch protection
 
-Before every replication, Atlas validates that source and target share the same encryption key. If you purge and re-initialize a tenant on primary (generating a new DEK), Atlas refuses to replicate to a target that still holds objects encrypted with the old key:
+Before replicating to a target, Atlas validates that source and target share the same encryption key. The check runs once per target per run, before the first snapshot is copied. If you purge and re-initialize a tenant on primary (generating a new DEK), Atlas refuses to replicate to a target that still holds objects encrypted with the old key:
 
 ```
 Error: Target has a different encryption key than the source.

--- a/docs/security.md
+++ b/docs/security.md
@@ -247,6 +247,8 @@ If an attacker compromises one target's S3 credentials, they can read that targe
 
 Atlas validates encryption key consistency before every replication and rehydration. If the primary tenant was purged and re-initialized (generating a new DEK), replication to a target with the old DEK is refused with an explicit error. This prevents a scenario where objects encrypted with different keys coexist on the same target, making older objects permanently undecryptable.
 
+The check runs once per target per run, before the first snapshot is copied, rather than once per snapshot. Whether two buckets share a DEK is a property of the pair, and each check unwraps both wrapped DEKs, which is two scrypt derivations at N=65536. A target that fails the check is refused before anything is written to it.
+
 ### Replica Marker
 
 Atlas writes a marker file (`_meta/replica.marker`) on each target during first replication. If a user accidentally runs `atlas outlook backup` against a replica target, Atlas detects the marker and logs a warning. This guards against accidental violation of the primary-is-truth principle, which could lead to data inconsistency.

--- a/docs/security.md
+++ b/docs/security.md
@@ -227,6 +227,12 @@ This means:
 - **One passphrase protects all copies.** Compromising the passphrase compromises data on every target.
 - **One DEK per tenant across all targets.** The wrapped DEK (`_meta/dek.enc`) is copied to each target on first replication.
 
+### Key material lifetime
+
+Opening a storage target derives an envelope key service from the passphrase and unwraps the tenant DEK, so every target a replication run touches holds key material in memory for as long as its context is open. Atlas closes each context as soon as the copy it was opened for finishes, on the failure path as well as the success path, which zeroes the passphrase buffer instead of leaving it for garbage collection.
+
+This bounds exposure to the duration of one snapshot copy rather than the whole run. It is defence in depth rather than a boundary: a process that can read Atlas's heap while a copy is in flight can read the key anyway, and Node offers no guarantee that a buffer is not copied elsewhere before it is zeroed. What it does remove is key material sitting in a long-lived process after the work that needed it is over.
+
 ### Access Isolation
 
 While encryption keys are shared, **S3 access credentials should be separate per target**. Use independent IAM principals for each storage endpoint:

--- a/packages/core/src/services/replication/onedrive-replication.service.ts
+++ b/packages/core/src/services/replication/onedrive-replication.service.ts
@@ -29,6 +29,7 @@ import type { AtlasConfig } from '@/utils/config';
 import { ATLAS_CONFIG_TOKEN } from '@/utils/config';
 import {
   copy_onedrive_snapshot_between,
+  copy_onedrive_snapshot_into_context,
   copy_onedrive_snapshot_to_target,
 } from '@/services/replication/onedrive-snapshot-copier';
 import type { CopyDeps } from '@/services/replication/outlook-snapshot-copier';
@@ -95,15 +96,23 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
       for (const target of targets) {
         const target_ctx = await target.create_context(tenant_id);
         try {
+          // Once per target, not once per snapshot: whether the two buckets share a DEK does not
+          // change between snapshots, and each check is two scrypt unwraps (issue #206).
+          await this._validate_dek(
+            source_ctx.storage,
+            target_ctx.storage,
+            this._config.encryption_passphrase,
+            tenant_id,
+          );
           const missing = await diff_od_manifests(manifests, target_ctx, owner_id);
 
           for (const manifest of missing) {
-            const result = await copy_onedrive_snapshot_to_target(
+            const result = await copy_onedrive_snapshot_into_context(
               source_ctx,
-              target,
+              target_ctx,
               manifest,
               ancillary,
-              this.copy_deps(tenant_id),
+              target.target_id,
             );
             await save_replication_status(
               source_ctx,

--- a/packages/core/src/services/replication/onedrive-replication.service.ts
+++ b/packages/core/src/services/replication/onedrive-replication.service.ts
@@ -12,12 +12,10 @@ import {
   DEK_VALIDATION_FN_TOKEN,
   STORAGE_TARGET_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
-import { replicate_onedrive_snapshot } from '@/services/replication/onedrive-snapshot-replicator';
 import { save_replication_status } from '@/services/replication/replication-status-repository';
 import { ensure_source_dek_on_primary } from '@/services/replication/rehydration-dek-helper';
 import { rehydrate_od_manifests } from '@/services/replication/rehydration-od-manifests-runner';
 import {
-  build_replication_result,
   build_skip_result,
   merge_replication_results,
 } from '@/services/replication/replication-result-builder';
@@ -29,6 +27,11 @@ import {
 } from '@/services/replication/onedrive-replication-helpers';
 import type { AtlasConfig } from '@/utils/config';
 import { ATLAS_CONFIG_TOKEN } from '@/utils/config';
+import {
+  copy_onedrive_snapshot_between,
+  copy_onedrive_snapshot_to_target,
+} from '@/services/replication/onedrive-snapshot-copier';
+import type { CopyDeps } from '@/services/replication/outlook-snapshot-copier';
 
 @injectable()
 export class OneDriveReplicationService implements OneDriveReplicationUseCase {
@@ -56,12 +59,12 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
       const results: ReplicationResult[] = [];
 
       for (const target of targets) {
-        const result = await this.copy_to_target(
+        const result = await copy_onedrive_snapshot_to_target(
           source_ctx,
           target,
           manifest,
           ancillary,
-          tenant_id,
+          this.copy_deps(tenant_id),
         );
         await save_replication_status(
           source_ctx,
@@ -95,12 +98,12 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
           const missing = await diff_od_manifests(manifests, target_ctx, owner_id);
 
           for (const manifest of missing) {
-            const result = await this.copy_to_target(
+            const result = await copy_onedrive_snapshot_to_target(
               source_ctx,
               target,
               manifest,
               ancillary,
-              tenant_id,
+              this.copy_deps(tenant_id),
             );
             await save_replication_status(
               source_ctx,
@@ -139,13 +142,13 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
       }
 
       const ancillary = await collect_od_ancillary_keys(source_ctx, owner_id);
-      return this.copy_between(
+      return copy_onedrive_snapshot_between(
         source_ctx,
         primary_ctx,
         manifest,
         ancillary,
         source.target_id,
-        tenant_id,
+        this.copy_deps(tenant_id),
         true,
       );
     } finally {
@@ -218,55 +221,13 @@ export class OneDriveReplicationService implements OneDriveReplicationUseCase {
     }
   }
 
-  private async copy_to_target(
-    source_ctx: TenantContext,
-    target: StorageTarget,
-    manifest: OneDriveSnapshotManifest,
-    ancillary_keys: string[],
-    tenant_id: string,
-  ): Promise<ReplicationResult> {
-    const start = Date.now();
-    const target_ctx = await target.create_context(tenant_id);
-    await this._validate_dek(
-      source_ctx.storage,
-      target_ctx.storage,
-      this._config.encryption_passphrase,
+  /** Deps every copy needs: this service's DEK validator, passphrase and tenant. */
+  private copy_deps(tenant_id: string): CopyDeps {
+    return {
+      validate_dek: this._validate_dek,
+      passphrase: this._config.encryption_passphrase,
       tenant_id,
-    );
-    const manifest_key = `${OD_MANIFEST_PREFIX}/${manifest.owner_id}/${manifest.snapshot_id}.json`;
-    const rep = await replicate_onedrive_snapshot(source_ctx, target_ctx, manifest, manifest_key, {
-      ancillary_keys,
-    });
-    return build_replication_result(
-      rep,
-      manifest.snapshot_id,
-      target.target_id,
-      Date.now() - start,
-    );
-  }
-
-  private async copy_between(
-    source_ctx: TenantContext,
-    target_ctx: TenantContext,
-    manifest: OneDriveSnapshotManifest,
-    ancillary_keys: string[],
-    target_id: string,
-    tenant_id: string,
-    is_rehydration = false,
-  ): Promise<ReplicationResult> {
-    const start = Date.now();
-    await this._validate_dek(
-      source_ctx.storage,
-      target_ctx.storage,
-      this._config.encryption_passphrase,
-      tenant_id,
-    );
-    const manifest_key = `${OD_MANIFEST_PREFIX}/${manifest.owner_id}/${manifest.snapshot_id}.json`;
-    const rep = await replicate_onedrive_snapshot(source_ctx, target_ctx, manifest, manifest_key, {
-      skip_marker: is_rehydration,
-      ancillary_keys,
-    });
-    return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
+    };
   }
 
   /** Rehydrates one owner's manifests, supplying this service's DEK validator and passphrase. */

--- a/packages/core/src/services/replication/onedrive-snapshot-copier.ts
+++ b/packages/core/src/services/replication/onedrive-snapshot-copier.ts
@@ -14,6 +14,33 @@ function manifest_key_for(manifest: OneDriveSnapshotManifest): string {
 }
 
 /**
+ * Copies a OneDrive snapshot into a context the caller has already opened and DEK-validated.
+ *
+ * Validation is deliberately not repeated here. Whether two buckets share a DEK is a property of
+ * the pair, not of the snapshot, and `validate_dek_match` unwraps both wrapped DEKs, which is two
+ * scrypt derivations at N=65536. Doing that per snapshot cost more than the copy on small
+ * snapshots (issue #206), so the replication loop validates once per target and calls this.
+ */
+export async function copy_onedrive_snapshot_into_context(
+  source_ctx: TenantContext,
+  target_ctx: TenantContext,
+  manifest: OneDriveSnapshotManifest,
+  ancillary_keys: string[],
+  target_id: string,
+  is_rehydration = false,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  const rep = await replicate_onedrive_snapshot(
+    source_ctx,
+    target_ctx,
+    manifest,
+    manifest_key_for(manifest),
+    { skip_marker: is_rehydration, ancillary_keys },
+  );
+  return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
+}
+
+/**
  * Copies a OneDrive snapshot to a target it opens itself, destroying the target context even
  * when the copy throws.
  *
@@ -21,6 +48,9 @@ function manifest_key_for(manifest: OneDriveSnapshotManifest): string {
  * what zeroes that buffer, so without the `finally` the material was left for garbage collection
  * once per copied snapshot, on the success path as well as every failure (issue #200). Mirrors
  * `copy_outlook_snapshot_to_target`, which has always closed its target.
+ *
+ * For more than one snapshot against the same target, open one context and use
+ * `copy_onedrive_snapshot_into_context` instead: this opens and validates per call.
  */
 export async function copy_onedrive_snapshot_to_target(
   source_ctx: TenantContext,
@@ -29,7 +59,6 @@ export async function copy_onedrive_snapshot_to_target(
   ancillary_keys: string[],
   deps: CopyDeps,
 ): Promise<ReplicationResult> {
-  const start = Date.now();
   const target_ctx = await target.create_context(deps.tenant_id);
   try {
     await deps.validate_dek(
@@ -38,18 +67,12 @@ export async function copy_onedrive_snapshot_to_target(
       deps.passphrase,
       deps.tenant_id,
     );
-    const rep = await replicate_onedrive_snapshot(
+    return await copy_onedrive_snapshot_into_context(
       source_ctx,
       target_ctx,
       manifest,
-      manifest_key_for(manifest),
-      { ancillary_keys },
-    );
-    return build_replication_result(
-      rep,
-      manifest.snapshot_id,
+      ancillary_keys,
       target.target_id,
-      Date.now() - start,
     );
   } finally {
     target_ctx.destroy();
@@ -57,7 +80,8 @@ export async function copy_onedrive_snapshot_to_target(
 }
 
 /**
- * Copies a OneDrive snapshot between two contexts the caller owns and closes.
+ * Copies a OneDrive snapshot between two contexts the caller owns and closes, validating the DEK
+ * pair first.
  *
  * `is_rehydration` suppresses the replica marker, so recovered data on primary is not labelled
  * as a replica of itself.
@@ -71,14 +95,13 @@ export async function copy_onedrive_snapshot_between(
   deps: CopyDeps,
   is_rehydration = false,
 ): Promise<ReplicationResult> {
-  const start = Date.now();
   await deps.validate_dek(source_ctx.storage, target_ctx.storage, deps.passphrase, deps.tenant_id);
-  const rep = await replicate_onedrive_snapshot(
+  return copy_onedrive_snapshot_into_context(
     source_ctx,
     target_ctx,
     manifest,
-    manifest_key_for(manifest),
-    { skip_marker: is_rehydration, ancillary_keys },
+    ancillary_keys,
+    target_id,
+    is_rehydration,
   );
-  return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
 }

--- a/packages/core/src/services/replication/onedrive-snapshot-copier.ts
+++ b/packages/core/src/services/replication/onedrive-snapshot-copier.ts
@@ -1,0 +1,84 @@
+import type {
+  OneDriveSnapshotManifest,
+  ReplicationResult,
+  StorageTarget,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { replicate_onedrive_snapshot } from '@/services/replication/onedrive-snapshot-replicator';
+import { build_replication_result } from '@/services/replication/replication-result-builder';
+import { OD_MANIFEST_PREFIX } from '@/services/replication/onedrive-replication-helpers';
+import type { CopyDeps } from '@/services/replication/outlook-snapshot-copier';
+
+function manifest_key_for(manifest: OneDriveSnapshotManifest): string {
+  return `${OD_MANIFEST_PREFIX}/${manifest.owner_id}/${manifest.snapshot_id}.json`;
+}
+
+/**
+ * Copies a OneDrive snapshot to a target it opens itself, destroying the target context even
+ * when the copy throws.
+ *
+ * `create_context` derives an EnvelopeKeyService from the target passphrase and `destroy()` is
+ * what zeroes that buffer, so without the `finally` the material was left for garbage collection
+ * once per copied snapshot, on the success path as well as every failure (issue #200). Mirrors
+ * `copy_outlook_snapshot_to_target`, which has always closed its target.
+ */
+export async function copy_onedrive_snapshot_to_target(
+  source_ctx: TenantContext,
+  target: StorageTarget,
+  manifest: OneDriveSnapshotManifest,
+  ancillary_keys: string[],
+  deps: CopyDeps,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  const target_ctx = await target.create_context(deps.tenant_id);
+  try {
+    await deps.validate_dek(
+      source_ctx.storage,
+      target_ctx.storage,
+      deps.passphrase,
+      deps.tenant_id,
+    );
+    const rep = await replicate_onedrive_snapshot(
+      source_ctx,
+      target_ctx,
+      manifest,
+      manifest_key_for(manifest),
+      { ancillary_keys },
+    );
+    return build_replication_result(
+      rep,
+      manifest.snapshot_id,
+      target.target_id,
+      Date.now() - start,
+    );
+  } finally {
+    target_ctx.destroy();
+  }
+}
+
+/**
+ * Copies a OneDrive snapshot between two contexts the caller owns and closes.
+ *
+ * `is_rehydration` suppresses the replica marker, so recovered data on primary is not labelled
+ * as a replica of itself.
+ */
+export async function copy_onedrive_snapshot_between(
+  source_ctx: TenantContext,
+  target_ctx: TenantContext,
+  manifest: OneDriveSnapshotManifest,
+  ancillary_keys: string[],
+  target_id: string,
+  deps: CopyDeps,
+  is_rehydration = false,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  await deps.validate_dek(source_ctx.storage, target_ctx.storage, deps.passphrase, deps.tenant_id);
+  const rep = await replicate_onedrive_snapshot(
+    source_ctx,
+    target_ctx,
+    manifest,
+    manifest_key_for(manifest),
+    { skip_marker: is_rehydration, ancillary_keys },
+  );
+  return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
+}

--- a/packages/core/src/services/replication/rehydration-dek-helper.ts
+++ b/packages/core/src/services/replication/rehydration-dek-helper.ts
@@ -35,28 +35,50 @@ export async function ensure_source_dek_on_primary(
   source: StorageTarget,
   tenant_id: string,
 ): Promise<void> {
-  const source_ctx = await source.create_context(tenant_id);
-  const source_has_dek = await source_ctx.storage.exists(DEK_META_KEY);
-  if (!source_has_dek) return;
+  const source_dek_blob = await read_source_dek(source, tenant_id);
+  if (source_dek_blob === undefined) return;
 
-  const source_dek_blob = await source_ctx.storage.get(DEK_META_KEY);
   const primary_ctx = await primary.create_context(tenant_id);
-  const primary_has_dek = await primary_ctx.storage.exists(DEK_META_KEY);
+  try {
+    const primary_has_dek = await primary_ctx.storage.exists(DEK_META_KEY);
 
-  if (!primary_has_dek) {
+    if (!primary_has_dek) {
+      await primary_ctx.storage.put(DEK_META_KEY, source_dek_blob);
+      return;
+    }
+
+    const primary_dek_blob = await primary_ctx.storage.get(DEK_META_KEY);
+    if (primary_dek_blob.equals(source_dek_blob)) return;
+
+    const keys = await primary_ctx.storage.list('', 2);
+    const only_the_dek = keys.length === 1 && keys[0] === DEK_META_KEY;
+    if (!only_the_dek) throw new DekOverwriteRefusedError(tenant_id);
+
+    logger.info(
+      `Tenant ${tenant_id}: replacing the auto-generated key on the empty primary with the source key`,
+    );
     await primary_ctx.storage.put(DEK_META_KEY, source_dek_blob);
-    return;
+  } finally {
+    primary_ctx.destroy();
   }
+}
 
-  const primary_dek_blob = await primary_ctx.storage.get(DEK_META_KEY);
-  if (primary_dek_blob.equals(source_dek_blob)) return;
-
-  const keys = await primary_ctx.storage.list('', 2);
-  const only_the_dek = keys.length === 1 && keys[0] === DEK_META_KEY;
-  if (!only_the_dek) throw new DekOverwriteRefusedError(tenant_id);
-
-  logger.info(
-    `Tenant ${tenant_id}: replacing the auto-generated key on the empty primary with the source key`,
-  );
-  await primary_ctx.storage.put(DEK_META_KEY, source_dek_blob);
+/**
+ * Reads the source DEK blob, or undefined when the source holds no key.
+ *
+ * Split out so the context lives exactly as long as the read. Both contexts used
+ * to be created inline with no `try`, and this function has five exits, so the
+ * passphrase buffers behind them were never zeroed on any of them (issue #200).
+ */
+async function read_source_dek(
+  source: StorageTarget,
+  tenant_id: string,
+): Promise<Buffer | undefined> {
+  const source_ctx = await source.create_context(tenant_id);
+  try {
+    if (!(await source_ctx.storage.exists(DEK_META_KEY))) return undefined;
+    return await source_ctx.storage.get(DEK_META_KEY);
+  } finally {
+    source_ctx.destroy();
+  }
 }

--- a/packages/core/src/services/replication/sharepoint-replication.service.ts
+++ b/packages/core/src/services/replication/sharepoint-replication.service.ts
@@ -1,6 +1,11 @@
 import { normalize_owner_id } from '@/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type { TenantContextFactory, TenantContext } from '@wisecom/atlas-types';
+import {
+  copy_sharepoint_snapshot_between,
+  copy_sharepoint_snapshot_to_target,
+} from '@/services/replication/sharepoint-snapshot-copier';
+import type { CopyDeps } from '@/services/replication/outlook-snapshot-copier';
 import type {
   SharePointManifestRepository,
   SharePointSnapshotManifest,
@@ -15,12 +20,10 @@ import {
   DEK_VALIDATION_FN_TOKEN,
   STORAGE_TARGET_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
-import { replicate_sharepoint_snapshot } from '@/services/replication/sharepoint-snapshot-replicator';
 import { save_replication_status } from '@/services/replication/replication-status-repository';
 import { ensure_source_dek_on_primary } from '@/services/replication/rehydration-dek-helper';
 import { rehydrate_sp_manifests } from '@/services/replication/rehydration-sp-manifests-runner';
 import {
-  build_replication_result,
   build_skip_result,
   merge_replication_results,
 } from '@/services/replication/replication-result-builder';
@@ -60,12 +63,12 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
       const results: ReplicationResult[] = [];
 
       for (const target of targets) {
-        const result = await this.copy_sp_to_target(
+        const result = await copy_sharepoint_snapshot_to_target(
           source_ctx,
           target,
           manifest,
           ancillary,
-          tenant_id,
+          this.copy_deps(tenant_id),
         );
         await save_replication_status(
           source_ctx,
@@ -99,12 +102,12 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
           const missing = await diff_sp_manifests(manifests, target_ctx, site_id);
 
           for (const manifest of missing) {
-            const result = await this.copy_sp_to_target(
+            const result = await copy_sharepoint_snapshot_to_target(
               source_ctx,
               target,
               manifest,
               ancillary,
-              tenant_id,
+              this.copy_deps(tenant_id),
             );
             await save_replication_status(
               source_ctx,
@@ -143,13 +146,13 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
       }
 
       const ancillary = await collect_sp_ancillary_keys(source_ctx, site_id);
-      return this.copy_sp_between(
+      return copy_sharepoint_snapshot_between(
         source_ctx,
         primary_ctx,
         manifest,
         ancillary,
         source.target_id,
-        tenant_id,
+        this.copy_deps(tenant_id),
         true,
       );
     } finally {
@@ -226,67 +229,13 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
     }
   }
 
-  private async copy_sp_to_target(
-    source_ctx: TenantContext,
-    target: StorageTarget,
-    manifest: SharePointSnapshotManifest,
-    ancillary_keys: string[],
-    tenant_id: string,
-  ): Promise<ReplicationResult> {
-    const start = Date.now();
-    const target_ctx = await target.create_context(tenant_id);
-    await this._validate_dek(
-      source_ctx.storage,
-      target_ctx.storage,
-      this._config.encryption_passphrase,
+  /** Deps every copy needs: this service's DEK validator, passphrase and tenant. */
+  private copy_deps(tenant_id: string): CopyDeps {
+    return {
+      validate_dek: this._validate_dek,
+      passphrase: this._config.encryption_passphrase,
       tenant_id,
-    );
-    const manifest_key = `${SP_MANIFEST_PREFIX}/${manifest.site_id}/${manifest.snapshot_id}.json`;
-    const rep = await replicate_sharepoint_snapshot(
-      source_ctx,
-      target_ctx,
-      manifest,
-      manifest_key,
-      {
-        ancillary_keys,
-      },
-    );
-    return build_replication_result(
-      rep,
-      manifest.snapshot_id,
-      target.target_id,
-      Date.now() - start,
-    );
-  }
-
-  private async copy_sp_between(
-    source_ctx: TenantContext,
-    target_ctx: TenantContext,
-    manifest: SharePointSnapshotManifest,
-    ancillary_keys: string[],
-    target_id: string,
-    tenant_id: string,
-    is_rehydration = false,
-  ): Promise<ReplicationResult> {
-    const start = Date.now();
-    await this._validate_dek(
-      source_ctx.storage,
-      target_ctx.storage,
-      this._config.encryption_passphrase,
-      tenant_id,
-    );
-    const manifest_key = `${SP_MANIFEST_PREFIX}/${manifest.site_id}/${manifest.snapshot_id}.json`;
-    const rep = await replicate_sharepoint_snapshot(
-      source_ctx,
-      target_ctx,
-      manifest,
-      manifest_key,
-      {
-        skip_marker: is_rehydration,
-        ancillary_keys,
-      },
-    );
-    return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
+    };
   }
 
   private async require_sp_manifest(

--- a/packages/core/src/services/replication/sharepoint-replication.service.ts
+++ b/packages/core/src/services/replication/sharepoint-replication.service.ts
@@ -3,6 +3,7 @@ import { inject, injectable } from 'inversify';
 import type { TenantContextFactory, TenantContext } from '@wisecom/atlas-types';
 import {
   copy_sharepoint_snapshot_between,
+  copy_sharepoint_snapshot_into_context,
   copy_sharepoint_snapshot_to_target,
 } from '@/services/replication/sharepoint-snapshot-copier';
 import type { CopyDeps } from '@/services/replication/outlook-snapshot-copier';
@@ -99,15 +100,23 @@ export class SharePointReplicationService implements SharePointReplicationUseCas
       for (const target of targets) {
         const target_ctx = await target.create_context(tenant_id);
         try {
+          // Once per target, not once per snapshot: whether the two buckets share a DEK does not
+          // change between snapshots, and each check is two scrypt unwraps (issue #206).
+          await this._validate_dek(
+            source_ctx.storage,
+            target_ctx.storage,
+            this._config.encryption_passphrase,
+            tenant_id,
+          );
           const missing = await diff_sp_manifests(manifests, target_ctx, site_id);
 
           for (const manifest of missing) {
-            const result = await copy_sharepoint_snapshot_to_target(
+            const result = await copy_sharepoint_snapshot_into_context(
               source_ctx,
-              target,
+              target_ctx,
               manifest,
               ancillary,
-              this.copy_deps(tenant_id),
+              target.target_id,
             );
             await save_replication_status(
               source_ctx,

--- a/packages/core/src/services/replication/sharepoint-snapshot-copier.ts
+++ b/packages/core/src/services/replication/sharepoint-snapshot-copier.ts
@@ -1,0 +1,83 @@
+import type {
+  ReplicationResult,
+  SharePointSnapshotManifest,
+  StorageTarget,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { replicate_sharepoint_snapshot } from '@/services/replication/sharepoint-snapshot-replicator';
+import { build_replication_result } from '@/services/replication/replication-result-builder';
+import { SP_MANIFEST_PREFIX } from '@/services/replication/sharepoint-replication-helpers';
+import type { CopyDeps } from '@/services/replication/outlook-snapshot-copier';
+
+function manifest_key_for(manifest: SharePointSnapshotManifest): string {
+  return `${SP_MANIFEST_PREFIX}/${manifest.site_id}/${manifest.snapshot_id}.json`;
+}
+
+/**
+ * Copies a SharePoint snapshot to a target it opens itself, destroying the target context even
+ * when the copy throws.
+ *
+ * `create_context` derives an EnvelopeKeyService from the target passphrase and `destroy()` is
+ * what zeroes that buffer, so without the `finally` the material was left for garbage collection
+ * once per copied snapshot, on the success path as well as every failure (issue #200).
+ */
+export async function copy_sharepoint_snapshot_to_target(
+  source_ctx: TenantContext,
+  target: StorageTarget,
+  manifest: SharePointSnapshotManifest,
+  ancillary_keys: string[],
+  deps: CopyDeps,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  const target_ctx = await target.create_context(deps.tenant_id);
+  try {
+    await deps.validate_dek(
+      source_ctx.storage,
+      target_ctx.storage,
+      deps.passphrase,
+      deps.tenant_id,
+    );
+    const rep = await replicate_sharepoint_snapshot(
+      source_ctx,
+      target_ctx,
+      manifest,
+      manifest_key_for(manifest),
+      { ancillary_keys },
+    );
+    return build_replication_result(
+      rep,
+      manifest.snapshot_id,
+      target.target_id,
+      Date.now() - start,
+    );
+  } finally {
+    target_ctx.destroy();
+  }
+}
+
+/**
+ * Copies a SharePoint snapshot between two contexts the caller owns and closes.
+ *
+ * `is_rehydration` suppresses the replica marker, so recovered data on primary is not labelled
+ * as a replica of itself.
+ */
+export async function copy_sharepoint_snapshot_between(
+  source_ctx: TenantContext,
+  target_ctx: TenantContext,
+  manifest: SharePointSnapshotManifest,
+  ancillary_keys: string[],
+  target_id: string,
+  deps: CopyDeps,
+  is_rehydration = false,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  await deps.validate_dek(source_ctx.storage, target_ctx.storage, deps.passphrase, deps.tenant_id);
+  const rep = await replicate_sharepoint_snapshot(
+    source_ctx,
+    target_ctx,
+    manifest,
+    manifest_key_for(manifest),
+    { skip_marker: is_rehydration, ancillary_keys },
+  );
+  return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
+}

--- a/packages/core/src/services/replication/sharepoint-snapshot-copier.ts
+++ b/packages/core/src/services/replication/sharepoint-snapshot-copier.ts
@@ -14,12 +14,42 @@ function manifest_key_for(manifest: SharePointSnapshotManifest): string {
 }
 
 /**
+ * Copies a SharePoint snapshot into a context the caller has already opened and DEK-validated.
+ *
+ * Validation is deliberately not repeated here. Whether two buckets share a DEK is a property of
+ * the pair, not of the snapshot, and `validate_dek_match` unwraps both wrapped DEKs, which is two
+ * scrypt derivations at N=65536. Doing that per snapshot cost more than the copy on small
+ * snapshots (issue #206), so the replication loop validates once per target and calls this.
+ */
+export async function copy_sharepoint_snapshot_into_context(
+  source_ctx: TenantContext,
+  target_ctx: TenantContext,
+  manifest: SharePointSnapshotManifest,
+  ancillary_keys: string[],
+  target_id: string,
+  is_rehydration = false,
+): Promise<ReplicationResult> {
+  const start = Date.now();
+  const rep = await replicate_sharepoint_snapshot(
+    source_ctx,
+    target_ctx,
+    manifest,
+    manifest_key_for(manifest),
+    { skip_marker: is_rehydration, ancillary_keys },
+  );
+  return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
+}
+
+/**
  * Copies a SharePoint snapshot to a target it opens itself, destroying the target context even
  * when the copy throws.
  *
  * `create_context` derives an EnvelopeKeyService from the target passphrase and `destroy()` is
  * what zeroes that buffer, so without the `finally` the material was left for garbage collection
  * once per copied snapshot, on the success path as well as every failure (issue #200).
+ *
+ * For more than one snapshot against the same target, open one context and use
+ * `copy_sharepoint_snapshot_into_context` instead: this opens and validates per call.
  */
 export async function copy_sharepoint_snapshot_to_target(
   source_ctx: TenantContext,
@@ -28,7 +58,6 @@ export async function copy_sharepoint_snapshot_to_target(
   ancillary_keys: string[],
   deps: CopyDeps,
 ): Promise<ReplicationResult> {
-  const start = Date.now();
   const target_ctx = await target.create_context(deps.tenant_id);
   try {
     await deps.validate_dek(
@@ -37,18 +66,12 @@ export async function copy_sharepoint_snapshot_to_target(
       deps.passphrase,
       deps.tenant_id,
     );
-    const rep = await replicate_sharepoint_snapshot(
+    return await copy_sharepoint_snapshot_into_context(
       source_ctx,
       target_ctx,
       manifest,
-      manifest_key_for(manifest),
-      { ancillary_keys },
-    );
-    return build_replication_result(
-      rep,
-      manifest.snapshot_id,
+      ancillary_keys,
       target.target_id,
-      Date.now() - start,
     );
   } finally {
     target_ctx.destroy();
@@ -56,7 +79,8 @@ export async function copy_sharepoint_snapshot_to_target(
 }
 
 /**
- * Copies a SharePoint snapshot between two contexts the caller owns and closes.
+ * Copies a SharePoint snapshot between two contexts the caller owns and closes, validating the DEK
+ * pair first.
  *
  * `is_rehydration` suppresses the replica marker, so recovered data on primary is not labelled
  * as a replica of itself.
@@ -70,14 +94,13 @@ export async function copy_sharepoint_snapshot_between(
   deps: CopyDeps,
   is_rehydration = false,
 ): Promise<ReplicationResult> {
-  const start = Date.now();
   await deps.validate_dek(source_ctx.storage, target_ctx.storage, deps.passphrase, deps.tenant_id);
-  const rep = await replicate_sharepoint_snapshot(
+  return copy_sharepoint_snapshot_into_context(
     source_ctx,
     target_ctx,
     manifest,
-    manifest_key_for(manifest),
-    { skip_marker: is_rehydration, ancillary_keys },
+    ancillary_keys,
+    target_id,
+    is_rehydration,
   );
-  return build_replication_result(rep, manifest.snapshot_id, target_id, Date.now() - start);
 }

--- a/packages/core/tests/unit/services/replication/rehydration-dek-helper.test.ts
+++ b/packages/core/tests/unit/services/replication/rehydration-dek-helper.test.ts
@@ -3,7 +3,11 @@ import {
   ensure_source_dek_on_primary,
   DekOverwriteRefusedError,
 } from '@/services/replication/rehydration-dek-helper';
-import type { ObjectStorage, StorageTarget, TenantContext } from '@wisecom/atlas-types';
+import type { ObjectStorage, StorageTarget } from '@wisecom/atlas-types';
+import {
+  stub_storage_target,
+  type StubStorageTarget,
+} from '@wisecom/atlas-types/testing/stub-storage-target';
 
 // Regression tests for issue #26: a primary holding only OneDrive/SharePoint
 // backups must never be misclassified as empty and have its DEK overwritten.
@@ -15,12 +19,13 @@ const PRIMARY_DEK = Buffer.from('wrapped-primary-dek');
 interface FakeBucket {
   storage: ObjectStorage;
   target: StorageTarget;
+  stub: StubStorageTarget;
 }
 
-/** Storage target stub whose bucket holds the given key->blob map. */
-function make_target(objects: Record<string, Buffer>): FakeBucket {
-  const keys = () => Object.keys(objects).sort();
-  const storage = {
+/** Spy-backed storage, so assertions can check which calls the helper made. */
+function make_spy_storage(objects: Record<string, Buffer>): ObjectStorage {
+  const keys = (): string[] => Object.keys(objects).sort();
+  return {
     exists: vi.fn(async (key: string) => key in objects),
     get: vi.fn(async (key: string) => {
       const blob = objects[key];
@@ -35,15 +40,12 @@ function make_target(objects: Record<string, Buffer>): FakeBucket {
       return limit === undefined ? matched : matched.slice(0, limit);
     }),
   } as unknown as ObjectStorage;
+}
 
-  const context = { tenant_id: 't', storage } as unknown as TenantContext;
-  const target = {
-    target_id: 'target',
-    endpoint: 'http://s3.local',
-    create_context: vi.fn(async () => context),
-  } as unknown as StorageTarget;
-
-  return { storage, target };
+/** Storage target stub whose bucket holds the given key->blob map. */
+function make_target(objects: Record<string, Buffer>): FakeBucket {
+  const stub = stub_storage_target({ objects, storage: make_spy_storage(objects) });
+  return { storage: stub.storage, target: stub.target, stub };
 }
 
 describe('ensure_source_dek_on_primary (issue #26)', () => {
@@ -111,5 +113,57 @@ describe('ensure_source_dek_on_primary (issue #26)', () => {
     ).rejects.toBeInstanceOf(DekOverwriteRefusedError);
 
     expect(primary.storage.put).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Issue #200: both contexts were created inline with no `try`, and this
+   * function has five exits, so the passphrase buffer behind each
+   * EnvelopeKeyService was never zeroed on any of them.
+   */
+  describe('context lifecycle', () => {
+    it('destroys the source context on the early return, when there is no DEK', async () => {
+      const empty_source = make_target({});
+      const primary = make_target({ [DEK_KEY]: PRIMARY_DEK });
+
+      await ensure_source_dek_on_primary(primary.target, empty_source.target, 't');
+
+      expect(empty_source.stub.destroyed()).toBe(empty_source.stub.created());
+      // The primary is never opened on this path, so there is nothing to leak.
+      expect(primary.stub.created()).toBe(0);
+    });
+
+    it('destroys both contexts when the DEK is copied', async () => {
+      const primary = make_target({});
+
+      await ensure_source_dek_on_primary(primary.target, source.target, 't');
+
+      expect(source.stub.destroyed()).toBe(source.stub.created());
+      expect(primary.stub.destroyed()).toBe(primary.stub.created());
+      expect(primary.stub.created()).toBeGreaterThan(0);
+    });
+
+    it('destroys both contexts when an identical DEK short-circuits', async () => {
+      const primary = make_target({ [DEK_KEY]: SOURCE_DEK });
+
+      await ensure_source_dek_on_primary(primary.target, source.target, 't');
+
+      expect(source.stub.destroyed()).toBe(source.stub.created());
+      expect(primary.stub.destroyed()).toBe(primary.stub.created());
+    });
+
+    it('destroys both contexts when the overwrite is refused', async () => {
+      const primary = make_target({
+        [DEK_KEY]: PRIMARY_DEK,
+        'onedrive/manifests/o1.json': Buffer.from('m'),
+      });
+
+      await expect(
+        ensure_source_dek_on_primary(primary.target, source.target, 't'),
+      ).rejects.toBeInstanceOf(DekOverwriteRefusedError);
+
+      expect(source.stub.destroyed()).toBe(source.stub.created());
+      expect(primary.stub.destroyed()).toBe(primary.stub.created());
+      expect(primary.stub.created()).toBeGreaterThan(0);
+    });
   });
 });

--- a/packages/core/tests/unit/services/replication/target-context-lifecycle.test.ts
+++ b/packages/core/tests/unit/services/replication/target-context-lifecycle.test.ts
@@ -212,3 +212,131 @@ describe('drive replication target context lifecycle', () => {
     });
   });
 });
+
+/**
+ * Issue #206: the per-target loop already opened a context for the manifest diff, then every
+ * snapshot copy opened another one. Each open unwraps the tenant DEK, and each DEK validation
+ * unwraps two, so a run paid three scrypt derivations per snapshot at N=65536 instead of one per
+ * target.
+ */
+describe('drive replication context reuse', () => {
+  let source: ReturnType<typeof make_source_context>;
+  let tenant_factory: TenantContextFactory;
+  let target_factory: StorageTargetFactory;
+
+  beforeEach(() => {
+    source = make_source_context();
+    tenant_factory = { create: vi.fn(async () => source.ctx) } as unknown as TenantContextFactory;
+    target_factory = {} as unknown as StorageTargetFactory;
+  });
+
+  it('opens one OneDrive target context per target, not per snapshot', async () => {
+    const stub = stub_storage_target();
+    const manifests = [od_manifest('od-1'), od_manifest('od-2'), od_manifest('od-3')];
+    const repo = {
+      list_snapshots_by_owner: vi.fn(async () => manifests),
+    } as unknown as OneDriveManifestRepository;
+    const validate_dek = vi.fn(async () => undefined);
+    const service = new OneDriveReplicationService(
+      tenant_factory,
+      repo,
+      CONFIG,
+      validate_dek,
+      target_factory,
+    );
+
+    await service.replicate_all_owner_snapshots('t', 'owner-1', [stub.target]);
+
+    expect(stub.created()).toBe(1);
+    expect(stub.destroyed()).toBe(1);
+    expect(validate_dek).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens one SharePoint target context per target, not per snapshot', async () => {
+    const stub = stub_storage_target();
+    const manifests = [sp_manifest('sp-1'), sp_manifest('sp-2'), sp_manifest('sp-3')];
+    const repo = {
+      list_snapshots_by_site: vi.fn(async () => manifests),
+    } as unknown as SharePointManifestRepository;
+    const validate_dek = vi.fn(async () => undefined);
+    const service = new SharePointReplicationService(
+      tenant_factory,
+      repo,
+      CONFIG,
+      validate_dek,
+      target_factory,
+    );
+
+    await service.replicate_all_site_snapshots('t', 'site-1', [stub.target]);
+
+    expect(stub.created()).toBe(1);
+    expect(stub.destroyed()).toBe(1);
+    expect(validate_dek).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens one context per target when there are several targets', async () => {
+    const a = stub_storage_target({ target_id: 'a' });
+    const b = stub_storage_target({ target_id: 'b' });
+    const repo = {
+      list_snapshots_by_owner: vi.fn(async () => [od_manifest('od-1'), od_manifest('od-2')]),
+    } as unknown as OneDriveManifestRepository;
+    const validate_dek = vi.fn(async () => undefined);
+    const service = new OneDriveReplicationService(
+      tenant_factory,
+      repo,
+      CONFIG,
+      validate_dek,
+      target_factory,
+    );
+
+    await service.replicate_all_owner_snapshots('t', 'owner-1', [a.target, b.target]);
+
+    expect(a.created()).toBe(1);
+    expect(b.created()).toBe(1);
+    expect(validate_dek).toHaveBeenCalledTimes(2);
+  });
+
+  it('still opens one context for the diff when nothing is missing', async () => {
+    // The negative case: no snapshots to copy must not mean no context, since the diff needs one,
+    // and must not mean one per manifest either.
+    const stub = stub_storage_target();
+    const repo = {
+      list_snapshots_by_owner: vi.fn(async () => []),
+    } as unknown as OneDriveManifestRepository;
+    const service = new OneDriveReplicationService(
+      tenant_factory,
+      repo,
+      CONFIG,
+      vi.fn(async () => undefined),
+      target_factory,
+    );
+
+    await service.replicate_all_owner_snapshots('t', 'owner-1', [stub.target]);
+
+    expect(stub.created()).toBe(1);
+    expect(stub.destroyed()).toBe(1);
+  });
+
+  it('destroys the reused context exactly once when a copy fails mid-loop', async () => {
+    const stub = stub_storage_target();
+    const repo = {
+      list_snapshots_by_owner: vi.fn(async () => [od_manifest('od-1'), od_manifest('od-2')]),
+    } as unknown as OneDriveManifestRepository;
+    const service = new OneDriveReplicationService(
+      tenant_factory,
+      repo,
+      CONFIG,
+      vi.fn(() => {
+        throw new Error('validation blew up');
+      }),
+      target_factory,
+    );
+
+    await expect(
+      service.replicate_all_owner_snapshots('t', 'owner-1', [stub.target]),
+    ).rejects.toThrow('validation blew up');
+
+    expect(stub.created()).toBe(1);
+    expect(stub.destroyed()).toBe(1);
+  });
+});

--- a/packages/core/tests/unit/services/replication/target-context-lifecycle.test.ts
+++ b/packages/core/tests/unit/services/replication/target-context-lifecycle.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OneDriveReplicationService } from '@/services/replication/onedrive-replication.service';
+import { SharePointReplicationService } from '@/services/replication/sharepoint-replication.service';
+import { stub_storage_target } from '@wisecom/atlas-types/testing/stub-storage-target';
+import type { AtlasConfig } from '@/utils/config';
+import type {
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  SharePointManifestRepository,
+  SharePointSnapshotManifest,
+  StorageTargetFactory,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+
+/**
+ * Issue #200: every drive snapshot copy built a target TenantContext and never
+ * destroyed it, on the success path and on every throw path alike. The context
+ * owns an EnvelopeKeyService derived from the target passphrase and `destroy()`
+ * is what zeroes it, so the material was left for garbage collection instead of
+ * the explicit cleanup the port promises.
+ *
+ * Counting creates against destroys is the only way to see this from the
+ * outside, since a leaked context changes no output.
+ */
+vi.mock('@/services/replication/onedrive-snapshot-replicator', () => ({
+  replicate_onedrive_snapshot: vi.fn(async () => ({
+    objects_copied: 1,
+    bytes_copied: 10,
+    objects_skipped: 0,
+    objects_failed: 0,
+    manifests_copied: 1,
+    errors: [],
+  })),
+}));
+
+vi.mock('@/services/replication/sharepoint-snapshot-replicator', () => ({
+  replicate_sharepoint_snapshot: vi.fn(async () => ({
+    objects_copied: 1,
+    bytes_copied: 10,
+    objects_skipped: 0,
+    objects_failed: 0,
+    manifests_copied: 1,
+    errors: [],
+  })),
+}));
+
+vi.mock('@/services/replication/replication-status-repository', () => ({
+  save_replication_status: vi.fn(async () => undefined),
+  load_replicated_snapshot_ids: vi.fn(async () => new Set<string>()),
+}));
+
+const CONFIG = { encryption_passphrase: 'p' } as unknown as AtlasConfig;
+
+function make_source_context(): { ctx: TenantContext; destroyed: () => number } {
+  let destroyed = 0;
+  const ctx = {
+    tenant_id: 't',
+    storage: {
+      exists: async () => false,
+      get: async () => Buffer.alloc(0),
+      put: async () => undefined,
+      list: async () => [],
+    },
+    destroy: () => {
+      destroyed++;
+    },
+  } as unknown as TenantContext;
+  return { ctx, destroyed: () => destroyed };
+}
+
+function od_manifest(snapshot_id: string): OneDriveSnapshotManifest {
+  return { snapshot_id, owner_id: 'owner-1', sealed: true } as unknown as OneDriveSnapshotManifest;
+}
+
+function sp_manifest(snapshot_id: string): SharePointSnapshotManifest {
+  return { snapshot_id, site_id: 'site-1', sealed: true } as unknown as SharePointSnapshotManifest;
+}
+
+describe('drive replication target context lifecycle', () => {
+  let source: ReturnType<typeof make_source_context>;
+  let tenant_factory: TenantContextFactory;
+  let target_factory: StorageTargetFactory;
+
+  beforeEach(() => {
+    source = make_source_context();
+    tenant_factory = { create: vi.fn(async () => source.ctx) } as unknown as TenantContextFactory;
+    target_factory = {} as unknown as StorageTargetFactory;
+  });
+
+  describe('OneDrive', () => {
+    function make_service(manifests: OneDriveSnapshotManifest[]): OneDriveReplicationService {
+      const repo = {
+        list_snapshots_by_owner: vi.fn(async () => manifests),
+        list_all_manifests: vi.fn(async () => manifests),
+        find_by_snapshot: vi.fn(async () => manifests[0]),
+      } as unknown as OneDriveManifestRepository;
+      return new OneDriveReplicationService(
+        tenant_factory,
+        repo,
+        CONFIG,
+        vi.fn(async () => undefined),
+        target_factory,
+      );
+    }
+
+    it('destroys the target context after a successful copy', async () => {
+      const stub = stub_storage_target();
+      const service = make_service([od_manifest('od-1')]);
+
+      await service.replicate_owner('t', 'owner-1', 'od-1', [stub.target]);
+
+      expect(stub.created()).toBe(1);
+      expect(stub.destroyed()).toBe(1);
+    });
+
+    it('destroys the target context when DEK validation throws', async () => {
+      const stub = stub_storage_target();
+      const repo = {
+        find_by_snapshot: vi.fn(async () => od_manifest('od-1')),
+      } as unknown as OneDriveManifestRepository;
+      const service = new OneDriveReplicationService(
+        tenant_factory,
+        repo,
+        CONFIG,
+        vi.fn(() => {
+          throw Object.assign(new Error('DEK mismatch'), { name: 'DekMismatchError' });
+        }),
+        target_factory,
+      );
+
+      await expect(service.replicate_owner('t', 'owner-1', 'od-1', [stub.target])).rejects.toThrow(
+        'DEK mismatch',
+      );
+
+      expect(stub.created()).toBe(1);
+      expect(stub.destroyed()).toBe(1);
+    });
+
+    it('balances creates and destroys across several snapshots and targets', async () => {
+      const a = stub_storage_target({ target_id: 'a' });
+      const b = stub_storage_target({ target_id: 'b' });
+      const service = make_service([od_manifest('od-1'), od_manifest('od-2')]);
+
+      await service.replicate_all_owner_snapshots('t', 'owner-1', [a.target, b.target]);
+
+      expect(a.created()).toBeGreaterThan(0);
+      expect(a.destroyed()).toBe(a.created());
+      expect(b.destroyed()).toBe(b.created());
+    });
+  });
+
+  describe('SharePoint', () => {
+    function make_service(manifests: SharePointSnapshotManifest[]): SharePointReplicationService {
+      const repo = {
+        list_snapshots_by_site: vi.fn(async () => manifests),
+        list_all_manifests: vi.fn(async () => manifests),
+        find_by_snapshot: vi.fn(async () => manifests[0]),
+      } as unknown as SharePointManifestRepository;
+      return new SharePointReplicationService(
+        tenant_factory,
+        repo,
+        CONFIG,
+        vi.fn(async () => undefined),
+        target_factory,
+      );
+    }
+
+    it('destroys the target context after a successful copy', async () => {
+      const stub = stub_storage_target();
+      const service = make_service([sp_manifest('sp-1')]);
+
+      await service.replicate_site('t', 'site-1', 'sp-1', [stub.target]);
+
+      expect(stub.created()).toBe(1);
+      expect(stub.destroyed()).toBe(1);
+    });
+
+    it('destroys the target context when DEK validation throws', async () => {
+      const stub = stub_storage_target();
+      const repo = {
+        find_by_snapshot: vi.fn(async () => sp_manifest('sp-1')),
+      } as unknown as SharePointManifestRepository;
+      const service = new SharePointReplicationService(
+        tenant_factory,
+        repo,
+        CONFIG,
+        vi.fn(() => {
+          throw Object.assign(new Error('DEK mismatch'), { name: 'DekMismatchError' });
+        }),
+        target_factory,
+      );
+
+      await expect(service.replicate_site('t', 'site-1', 'sp-1', [stub.target])).rejects.toThrow(
+        'DEK mismatch',
+      );
+
+      expect(stub.created()).toBe(1);
+      expect(stub.destroyed()).toBe(1);
+    });
+
+    it('balances creates and destroys across several snapshots and targets', async () => {
+      const a = stub_storage_target({ target_id: 'a' });
+      const b = stub_storage_target({ target_id: 'b' });
+      const service = make_service([sp_manifest('sp-1'), sp_manifest('sp-2')]);
+
+      await service.replicate_all_site_snapshots('t', 'site-1', [a.target, b.target]);
+
+      expect(a.created()).toBeGreaterThan(0);
+      expect(a.destroyed()).toBe(a.created());
+      expect(b.destroyed()).toBe(b.created());
+    });
+  });
+});

--- a/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
+++ b/packages/onedrive/src/services/onedrive-backup-drive-processor.ts
@@ -254,11 +254,11 @@ export async function process_single_drive(
   on_item_processed?: (item: OneDriveDeltaItem) => void,
   control: OperationControlOptions = {},
 ): Promise<SingleDriveResult> {
+  const delta_item_ids = new Set(delta.items.map((item) => item.item_id));
   if (delta.reset_detected) {
-    clear_file_tracking_on_reset(state);
+    clear_file_tracking_on_reset(state, delta_item_ids);
   }
 
-  const delta_item_ids = new Set(delta.items.map((item) => item.item_id));
   const retry = await resolve_retry_items(
     connector,
     tenant_id,

--- a/packages/onedrive/src/services/onedrive-delta-item-processor.ts
+++ b/packages/onedrive/src/services/onedrive-delta-item-processor.ts
@@ -40,10 +40,27 @@ export interface DeltaItemOutcome {
   permanent?: boolean;
 }
 
-/** Clears file tracking maps when Graph signals a delta reset. */
-export function clear_file_tracking_on_reset(state: DriveTrackingState): void {
-  for (const [fid, kind] of Object.entries(state.previous_kind_by_file_id)) {
-    if (kind === 'file') {
+/**
+ * Forgets tracking for the files a reset re-enumerates, so they rebaseline as
+ * `created`.
+ *
+ * Scoped to the ids the resetting delta returned rather than the whole map. The
+ * maps are keyed by file id alone and shared by every drive an owner has, so
+ * clearing all of them let one drive's dead delta link wipe its siblings' path,
+ * name and etag records, and a genuine change elsewhere then looked like a first
+ * backup (issue #199). With `--folder` in play the delta is already scoped, so
+ * this also stops a reset from forgetting files outside the scope it never read.
+ *
+ * A reset delta is a full enumeration, so its ids are exactly the entries that
+ * need forgetting. That holds for cursors written before this fix too, which is
+ * why nothing has to be migrated.
+ */
+export function clear_file_tracking_on_reset(
+  state: DriveTrackingState,
+  reset_item_ids: Iterable<string>,
+): void {
+  for (const fid of reset_item_ids) {
+    if (state.previous_kind_by_file_id[fid] === 'file') {
       delete state.previous_path_by_file_id[fid];
       delete state.previous_name_by_file_id[fid];
       delete state.previous_etag_by_file_id[fid];

--- a/packages/onedrive/tests/unit/services/delta-reset-scope.test.ts
+++ b/packages/onedrive/tests/unit/services/delta-reset-scope.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clear_file_tracking_on_reset,
+  type DriveTrackingState,
+} from '@/services/onedrive-delta-item-processor';
+import { classify_change_type } from '@/services/onedrive-change-classifier';
+import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
+
+/**
+ * Issue #199 was filed against SharePoint, but this file had the identical
+ * defect: tracking keyed by file id alone, shared across every drive an owner
+ * has, wiped wholesale on any one drive's reset.
+ *
+ * OneDrive has a second way to hit it. With `--folder` the delta is scoped
+ * before it reaches here, so an unscoped clear also forgot files the run never
+ * looked at.
+ */
+function make_tracking(): DriveTrackingState {
+  return {
+    previous_path_by_file_id: { a1: '/Projects', b1: '/Archive' },
+    previous_name_by_file_id: { a1: 'a.docx', b1: 'b.docx' },
+    previous_etag_by_file_id: { a1: 'ea', b1: 'eb' },
+    previous_kind_by_file_id: { a1: 'file', b1: 'file' },
+  };
+}
+
+function make_item(overrides: Partial<OneDriveDeltaItem> = {}): OneDriveDeltaItem {
+  return {
+    item_id: 'b1',
+    drive_id: 'drive-b',
+    file_name: 'b.docx',
+    parent_path: '/Archive',
+    kind: 'file',
+    size_bytes: 10,
+    etag: 'eb2',
+    deleted: false,
+    ...overrides,
+  } as OneDriveDeltaItem;
+}
+
+describe('clear_file_tracking_on_reset', () => {
+  it('leaves a sibling drive untouched when another drive resets', () => {
+    const tracking = make_tracking();
+
+    clear_file_tracking_on_reset(tracking, ['a1']);
+
+    expect(tracking.previous_path_by_file_id.b1).toBe('/Archive');
+    expect(tracking.previous_etag_by_file_id.b1).toBe('eb');
+  });
+
+  it('classifies a sibling edit as updated, not created, after another reset', () => {
+    const tracking = make_tracking();
+    clear_file_tracking_on_reset(tracking, ['a1']);
+
+    const change = classify_change_type(
+      make_item({ etag: 'eb2' }),
+      tracking.previous_path_by_file_id,
+      tracking.previous_name_by_file_id,
+      tracking.previous_etag_by_file_id,
+    );
+
+    expect(change).toBe('updated');
+  });
+
+  it('rebaselines the resetting drive so its own files read created', () => {
+    const tracking = make_tracking();
+    clear_file_tracking_on_reset(tracking, ['a1']);
+
+    const change = classify_change_type(
+      make_item({
+        item_id: 'a1',
+        drive_id: 'drive-a',
+        file_name: 'a.docx',
+        parent_path: '/Projects',
+      }),
+      tracking.previous_path_by_file_id,
+      tracking.previous_name_by_file_id,
+      tracking.previous_etag_by_file_id,
+    );
+
+    expect(change).toBe('created');
+  });
+
+  it('keeps files outside a folder scope tracked through a reset', () => {
+    // The delta reaching the processor is already scoped, so an out-of-scope
+    // file is simply absent from it and must survive.
+    const tracking = make_tracking();
+
+    clear_file_tracking_on_reset(tracking, ['a1']);
+
+    expect(tracking.previous_path_by_file_id.b1).toBe('/Archive');
+  });
+});

--- a/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-library-processor.ts
@@ -34,10 +34,26 @@ export interface LibraryProcessingResult {
   package_report: PackageReport;
 }
 
-/** Clears file tracking maps when Graph signals a delta reset. */
-export function clear_file_tracking_on_reset(tracking: FileTrackingState): void {
-  for (const [fid, kind] of Object.entries(tracking.previous_kind_by_file_id)) {
-    if (kind === 'file') {
+/**
+ * Forgets tracking for the files a reset re-enumerates, so they rebaseline as
+ * `created`.
+ *
+ * Scoped to the ids the resetting delta returned rather than the whole map. The
+ * maps are keyed by file id alone and shared by every library in the site, so
+ * clearing all of them let one library's dead delta link wipe its siblings'
+ * path, name and etag records. A genuine change in a sibling on a still-valid
+ * link then looked like a first backup (issue #199).
+ *
+ * A reset delta is a full enumeration of that drive, so its ids are exactly the
+ * entries that need forgetting. That holds for cursors written before this fix
+ * too, which is why nothing has to be migrated.
+ */
+export function clear_file_tracking_on_reset(
+  tracking: FileTrackingState,
+  reset_item_ids: Iterable<string>,
+): void {
+  for (const fid of reset_item_ids) {
+    if (tracking.previous_kind_by_file_id[fid] === 'file') {
       delete tracking.previous_path_by_file_id[fid];
       delete tracking.previous_name_by_file_id[fid];
       delete tracking.previous_etag_by_file_id[fid];
@@ -81,7 +97,10 @@ export async function process_single_library(
   );
 
   if (delta.reset_detected) {
-    clear_file_tracking_on_reset(tracking);
+    clear_file_tracking_on_reset(
+      tracking,
+      delta.items.map((item) => item.item_id),
+    );
   }
 
   const library_state: LibraryProcessingState = {

--- a/packages/sharepoint/tests/unit/services/delta-reset-scope.test.ts
+++ b/packages/sharepoint/tests/unit/services/delta-reset-scope.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { clear_file_tracking_on_reset } from '@/services/sharepoint-backup-library-processor';
+import type { FileTrackingState } from '@/services/sharepoint-library-item-processor';
+import { classify_change_type } from '@/services/sharepoint-change-classifier';
+import type { SharePointDeltaItem } from '@wisecom/atlas-types';
+
+/**
+ * Issue #199: tracking maps are keyed by file id alone and shared by every
+ * library in a site scan, so clearing all of them on a reset let one library's
+ * dead delta link wipe its siblings' records. A genuine change in a sibling on a
+ * still-valid link then classified as `created`, and the manifest carried the
+ * wrong change type until that file happened to change again.
+ *
+ * The scenario mirrors the one in the issue: library L1 resets, library L2 keeps
+ * a valid link and has one genuinely edited file.
+ */
+function make_tracking(): FileTrackingState {
+  return {
+    // f1 lives in L1, f2 lives in L2. Nothing in the shape records that, which
+    // is the whole problem.
+    previous_path_by_file_id: { f1: '/L1', f2: '/L2' },
+    previous_name_by_file_id: { f1: 'f1.docx', f2: 'f2.docx' },
+    previous_etag_by_file_id: { f1: 'e1', f2: 'e2' },
+    previous_kind_by_file_id: { f1: 'file', f2: 'file' },
+  };
+}
+
+function make_item(overrides: Partial<SharePointDeltaItem> = {}): SharePointDeltaItem {
+  return {
+    item_id: 'f2',
+    drive_id: 'L2',
+    file_name: 'f2.docx',
+    parent_path: '/L2',
+    kind: 'file',
+    size_bytes: 10,
+    etag: 'e2b',
+    deleted: false,
+    ...overrides,
+  } as SharePointDeltaItem;
+}
+
+describe('clear_file_tracking_on_reset', () => {
+  it('leaves a sibling library untouched when another library resets', () => {
+    const tracking = make_tracking();
+
+    // L1's reset delta is a full enumeration of L1, so it carries f1 and not f2.
+    clear_file_tracking_on_reset(tracking, ['f1']);
+
+    expect(tracking.previous_path_by_file_id.f2).toBe('/L2');
+    expect(tracking.previous_name_by_file_id.f2).toBe('f2.docx');
+    expect(tracking.previous_etag_by_file_id.f2).toBe('e2');
+  });
+
+  it('classifies a sibling edit as updated, not created, after another reset', () => {
+    const tracking = make_tracking();
+    clear_file_tracking_on_reset(tracking, ['f1']);
+
+    const change = classify_change_type(
+      make_item({ etag: 'e2b' }),
+      tracking.previous_path_by_file_id,
+      tracking.previous_name_by_file_id,
+      tracking.previous_etag_by_file_id,
+    );
+
+    expect(change).toBe('updated');
+  });
+
+  it('rebaselines the resetting library so its own files read created', () => {
+    const tracking = make_tracking();
+    clear_file_tracking_on_reset(tracking, ['f1']);
+
+    const change = classify_change_type(
+      make_item({ item_id: 'f1', drive_id: 'L1', file_name: 'f1.docx', parent_path: '/L1' }),
+      tracking.previous_path_by_file_id,
+      tracking.previous_name_by_file_id,
+      tracking.previous_etag_by_file_id,
+    );
+
+    expect(change).toBe('created');
+  });
+
+  it('keeps the deleted-item name fallback working for a sibling library', () => {
+    // Issue #139 reads the name from tracking when Graph omits it on a tombstone.
+    const tracking = make_tracking();
+    clear_file_tracking_on_reset(tracking, ['f1']);
+
+    expect(tracking.previous_name_by_file_id.f2).toBe('f2.docx');
+  });
+
+  it('does not forget folder entries, only files', () => {
+    const tracking = make_tracking();
+    tracking.previous_kind_by_file_id.d1 = 'folder';
+    tracking.previous_path_by_file_id.d1 = '/L1/sub';
+
+    clear_file_tracking_on_reset(tracking, ['f1', 'd1']);
+
+    expect(tracking.previous_path_by_file_id.d1).toBe('/L1/sub');
+    expect(tracking.previous_path_by_file_id.f1).toBeUndefined();
+  });
+
+  it('ignores ids it has never tracked', () => {
+    const tracking = make_tracking();
+
+    expect(() => clear_file_tracking_on_reset(tracking, ['unknown'])).not.toThrow();
+    expect(tracking.previous_path_by_file_id.f1).toBe('/L1');
+    expect(tracking.previous_path_by_file_id.f2).toBe('/L2');
+  });
+});

--- a/packages/types/src/testing/stub-storage-target.ts
+++ b/packages/types/src/testing/stub-storage-target.ts
@@ -1,0 +1,83 @@
+import type { ObjectStorage, StorageTarget, TenantContext } from '@/index';
+
+/**
+ * A StorageTarget stub that counts context lifecycle calls.
+ *
+ * `create_context` derives an EnvelopeKeyService from the target passphrase and
+ * `destroy` is what zeroes that buffer, so a replication path that creates a
+ * context without destroying it leaves key material in the heap until GC
+ * happens to collect it (issue #200). Counting both sides is the only way to
+ * assert the balance, and a stub that simply omitted `destroy` was how the
+ * omission stayed invisible.
+ */
+export interface StubStorageTarget {
+  readonly target: StorageTarget;
+  readonly storage: ObjectStorage;
+  /** Contexts handed out by `create_context`. */
+  readonly created: () => number;
+  /** Contexts whose `destroy` was called. */
+  readonly destroyed: () => number;
+}
+
+export interface StubStorageTargetOptions {
+  readonly target_id?: string;
+  /** Bucket contents, keyed by object key. Mutated by `put`. Ignored when `storage` is given. */
+  readonly objects?: Record<string, Buffer>;
+  /**
+   * Storage to hand to every context. Supply one when the test needs to assert
+   * on storage calls, since this package cannot depend on a test framework and
+   * so cannot hand out spies of its own.
+   */
+  readonly storage?: ObjectStorage;
+  /** Thrown by `create_context` for failure-path tests. */
+  readonly create_error?: Error;
+}
+
+/** Builds a counting StorageTarget stub over an in-memory bucket. */
+export function stub_storage_target(options: StubStorageTargetOptions = {}): StubStorageTarget {
+  const objects = options.objects ?? {};
+  let created = 0;
+  let destroyed = 0;
+
+  const in_memory: ObjectStorage = {
+    exists: async (key: string) => key in objects,
+    get: async (key: string) => {
+      const blob = objects[key];
+      if (!blob) throw new Error(`missing ${key}`);
+      return blob;
+    },
+    put: async (key: string, data: Buffer) => {
+      objects[key] = data;
+    },
+    list: async (prefix: string, limit?: number) => {
+      const matched = Object.keys(objects)
+        .sort()
+        .filter((k) => k.startsWith(prefix));
+      return limit === undefined ? matched : matched.slice(0, limit);
+    },
+  } as unknown as ObjectStorage;
+  const storage = options.storage ?? in_memory;
+
+  const target: StorageTarget = {
+    target_id: options.target_id ?? 'target',
+    endpoint: 'http://s3.local',
+    create_context: async (tenant_id: string): Promise<TenantContext> => {
+      if (options.create_error) throw options.create_error;
+      created++;
+      return {
+        tenant_id,
+        storage,
+        destroy: () => {
+          destroyed++;
+        },
+      } as unknown as TenantContext;
+    },
+  } as unknown as StorageTarget;
+
+  return {
+    target,
+    storage,
+    created: () => created,
+    destroyed: () => destroyed,
+  };
+}


### PR DESCRIPTION
Fixes #206. **Stacked on #225** (issue #200), which the issue itself asks for: both change the same lines. Merge #225 first.

## What it actually cost

The issue estimates ~145 ms per snapshot from context creation. I measured it, and it is worse, because context creation is only one of three derivations per copy:

```
scrypt derivations per validate_dek_match call: 2
scrypt derivations per context DEK unwrap    : 1
scryptSync N=65536 median on this machine     : 128 ms
```

The per-target loop already opened a context to diff manifests against, then handed every snapshot to a copier that opened a **second** one, and each copy also ran a full DEK validation that unwraps both the source and target wrapped DEK.

| | derivations | `_meta/dek.enc` reads |
| --- | --- | --- |
| Before, 10 snapshots to 1 target | 30 (~3.8 s) | 30 |
| After, 10 snapshots to 1 target | 3 (~0.38 s) | 3 |
| After, 100 snapshots to 1 target | 3 | 3 |

Flat in snapshot count instead of linear. Against a *fresh* target the validation short-circuits on `exists()`, so the old cost there was 1 derivation per snapshot rather than 3; the win is on established targets, which is every run after the first.

Also worth correcting: the issue says N=16384. That is `SCRYPT_N_MIN`, the floor. The configured value is `SCRYPT_N = 65536`, which is why the per-derivation cost is 128 ms rather than 32 ms.

## Fix

Two things move out of the per-snapshot path and into the per-target loop:

- The context. The loop already had one open for the diff, and it is already destroyed in a `finally`.
- The DEK validation. Whether two buckets share a key is a property of the pair, not of the snapshot, so checking it per snapshot re-answered the same question N times. It still runs before the first byte is copied to that target, so a mismatched target is still refused before anything is written.

## Why a third function instead of a flag

The copiers now expose three entry points, and the only difference between them is who owns the context and who validated:

| Function | Opens context | Validates DEK | Used by |
| --- | --- | --- | --- |
| `copy_*_snapshot_into_context` | no | no | the per-target loop, after one validation |
| `copy_*_snapshot_to_target` | yes, destroys it | yes | single-snapshot `replicate_owner` / `replicate_site` |
| `copy_*_snapshot_between` | no | yes | rehydration, caller owns both contexts |

The latter two delegate to the first, so one place decides what a copy is. A `skip_validation` boolean would have been fewer lines and a worse API: the caller could pass it by accident and silently skip a safety check, whereas a function named `into_context` cannot be called without already having the context that implies the validation.

## Tests

5 new tests. 4 fail against the pre-fix source:

```
× opens one OneDrive target context per target, not per snapshot
× opens one SharePoint target context per target, not per snapshot
× opens one context per target when there are several targets
× destroys the reused context exactly once when a copy fails mid-loop
```

They assert on the instrumented stub's `created()` count and on `validate_dek` call count, which is the acceptance criterion's "observable as a single TenantContext construction in an instrumented factory" rather than a timing assertion that would be flaky in CI.

The fifth, "still opens one context for the diff when nothing is missing", passes both before and after by design. It is the negative case: zero missing snapshots must still open exactly one context for the diff, not zero and not one per manifest.

The mid-loop failure test covers the interaction with #225: the reused context must be destroyed exactly once when a copy throws partway through.

Gates in CI's mode (`pnpm run test:coverage`): 15/15 tasks, build 10/10, typecheck 17/17, lint 0 errors, docs build no warnings. Both services are 284 lines and both copiers ~107, all under the 300 limit.

## Docs

The validation frequency changed, which is security-relevant, so both places that describe it are updated rather than just the perf story:

- `docs/security.md` DEK Mismatch Protection: the check runs once per target per run, before the first snapshot is copied, and a failing target is refused before anything is written to it.
- `docs/operations/replication.md`: same correction, since it said "before every replication".

## Acceptance criteria

- [x] N snapshots to one target performs one KEK derivation set and one `_meta/dek.enc` read per target per run, observable in an instrumented stub
- [x] A 10-snapshot run drops from ~3.8 s of derivation to ~0.38 s (measured per-derivation cost, counts asserted in tests)
- [x] `replicate_owner` and `replicate_site` still work standalone; they keep `copy_*_snapshot_to_target`, which opens its own context
- [x] Zero missing snapshots still opens one context per target for the diff, not one per manifest
- [x] A failure partway through the inner loop destroys the target context exactly once
