### PR TITLE
fix(cli): one scope precedence for outlook list, save and restore

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -28,6 +28,18 @@ This matters beyond readability. Anything that post-processes the output, a log 
 
 Outlook mailbox backup, restore, and management commands. All mailbox operations live under this group; cross-cutting storage and replication commands remain at the root level.
 
+::: warning Scope flags: `-s` beats `-m`
+`restore`, `list` and `save` all select what to act on with `-s, --snapshot` (one snapshot) or `-m, --mailbox` (every snapshot for a mailbox). When both are passed, `-s` wins, matching `atlas replicate`. A snapshot id names exactly one thing, so it is the narrower request, and Atlas never silently widens it.
+
+`list` and `save` warn that `-m` was ignored and carry on. `restore` refuses the pair outright and exits `1`, because `-m` there used to mean "restore this snapshot into that mailbox instead", so guessing would decide which mailbox receives the mail. Use `-T, --target` for that, which works in both modes:
+
+```bash
+atlas outlook restore -s <snapshot-id> -T other@company.com
+```
+
+`-T` never selects what to restore, only where it lands.
+:::
+
 ### `atlas outlook backup`
 
 Back up one mailbox from an M365 tenant to object storage, with a per-folder progress dashboard. The `-m` flag is required. To back up multiple mailboxes, enumerate them with `atlas outlook mailboxes` and loop in your scheduler (cron, systemd timer, CI); fan-out across mailboxes is scheduling and belongs to the caller.
@@ -139,7 +151,7 @@ atlas outlook restore -m user@company.com -T other@company.com -f Inbox
 | `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date                |
 | `-t, --tenant <id>`         | Override tenant ID                                              |
 
-Either `--snapshot` or `--mailbox` is required. In mailbox mode, entries are deduplicated across snapshots (newest version of each message wins). Cross-mailbox restores preserve the original folder names from the source mailbox. Nested source folders are recreated as nested subfolders under the `Restore-{timestamp}` root, so `Inbox/Projects/2026` restores to `Restore-.../Inbox/Projects/2026` instead of collapsing into one flat level.
+Exactly one of `--snapshot` or `--mailbox` is required; passing both exits `1`, as described under [`atlas outlook`](#atlas-outlook). `-T, --target` works in either mode. In mailbox mode, entries are deduplicated across snapshots (newest version of each message wins). Cross-mailbox restores preserve the original folder names from the source mailbox. Nested source folders are recreated as nested subfolders under the `Restore-{timestamp}` root, so `Inbox/Projects/2026` restores to `Restore-.../Inbox/Projects/2026` instead of collapsing into one flat level.
 
 Restored messages retain their original received/sent timestamps, appear as received mail (not drafts), and include all backed-up attachments. Large attachments (>3 MB) use Graph upload sessions with chunked transfer.
 
@@ -222,6 +234,8 @@ atlas outlook save -m user@company.com --start-date 2026-01-01 --end-date 2026-0
 | `-o, --output <path>`       | Output file path (default: `Restore-<timestamp>.zip`)        |
 | `--skip-verify`             | Skip SHA-256 integrity checks (faster on low-power systems)  |
 | `-t, --tenant <id>`         | Override tenant ID                                           |
+
+With both `-s` and `-m`, the named snapshot is exported and `-m` is ignored with a warning; see [`atlas outlook`](#atlas-outlook). Earlier releases silently exported the whole mailbox instead.
 
 The zip archive mirrors the Outlook folder hierarchy:
 

--- a/packages/cli/src/commands/outlook-catalog.handler.tsx
+++ b/packages/cli/src/commands/outlook-catalog.handler.tsx
@@ -7,6 +7,7 @@ import { CATALOG_USE_CASE_TOKEN } from '@wisecom/atlas-types';
 import type { Manifest, AttachmentEntry } from '@wisecom/atlas-types';
 import { format_bytes } from '@/command-formatters';
 import { logger } from '@wisecom/atlas-core';
+import { describe_scope_conflict, resolve_outlook_scope } from '@/commands/outlook-scope';
 import { Banner } from '@/ui/components/banner';
 import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { KeyValueList, type KeyValueItem } from '@/ui/components/key-value-list';
@@ -45,16 +46,20 @@ export async function execute_outlook_list(
 
   const catalog = container.get<CatalogUseCase>(CATALOG_USE_CASE_TOKEN);
 
-  if (options.snapshot) {
+  const scope = resolve_outlook_scope(options);
+  const conflict = describe_scope_conflict(scope);
+  if (conflict) logger.warn(conflict);
+
+  if (scope.mode === 'snapshot') {
     await print_snapshot_messages(
       catalog,
       tenant_id,
-      options.snapshot,
+      scope.snapshot,
       options.all,
       options.subjects,
     );
-  } else if (options.mailbox) {
-    await print_mailbox_snapshots(catalog, tenant_id, options.mailbox);
+  } else if (scope.mode === 'mailbox') {
+    await print_mailbox_snapshots(catalog, tenant_id, scope.mailbox);
   } else {
     await print_all_mailboxes(catalog, tenant_id);
   }

--- a/packages/cli/src/commands/outlook-data-ops.handler.tsx
+++ b/packages/cli/src/commands/outlook-data-ops.handler.tsx
@@ -7,6 +7,7 @@ import type { SaveUseCase, SaveResult, SaveOptions, DeletionUseCase } from '@wis
 import { SAVE_USE_CASE_TOKEN, DELETION_USE_CASE_TOKEN } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core';
 import { report_run_outcome } from '@/command-run-outcome';
+import { describe_scope_conflict, resolve_outlook_scope } from '@/commands/outlook-scope';
 import {
   confirm_deletion,
   print_delete_result,
@@ -69,7 +70,11 @@ export async function execute_outlook_save(
     }
   }
 
-  if (options.snapshot && !options.mailbox) {
+  const scope = resolve_outlook_scope(options);
+  const conflict = describe_scope_conflict(scope);
+  if (conflict) logger.warn(conflict);
+
+  if (scope.mode === 'snapshot') {
     return execute_snapshot_save(save_service, tenant_id, options, save_options);
   }
 

--- a/packages/cli/src/commands/outlook-restore.handler.tsx
+++ b/packages/cli/src/commands/outlook-restore.handler.tsx
@@ -6,6 +6,7 @@ import type { RestoreUseCase, RestoreResult, RestoreOptions } from '@wisecom/atl
 import { RESTORE_USE_CASE_TOKEN } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core';
 import { report_run_outcome } from '@/command-run-outcome';
+import { resolve_outlook_scope } from '@/commands/outlook-scope';
 import { Banner } from '@/ui/components/banner';
 import { ErrorList } from '@/ui/components/error-list';
 import { KeyValueList, type KeyValueItem } from '@/ui/components/key-value-list';
@@ -24,16 +25,23 @@ export interface OutlookRestoreOptions {
   endDate?: string;
 }
 
-/** Validates that exactly one of --snapshot or --mailbox is provided. */
+/** Validates the scope flags, refusing the combinations that would restore to a guessed mailbox. */
 function validate_restore_options(options: OutlookRestoreOptions): void {
   if (!options.snapshot && !options.mailbox) {
     logger.error('Either --snapshot (-s) or --mailbox (-m) is required.');
     process.exit(1);
   }
-  if (options.snapshot && options.mailbox && !options.target) {
-    // When both -s and -m given, -m acts as target override (legacy behavior)
+  if (options.snapshot && options.mailbox) {
+    // Restore used to take -m here as a cross-mailbox target, which -T already means and which
+    // nothing documented. Guessing between "the snapshot's own mailbox" and "the one named by -m"
+    // decides which mailbox receives the mail, so this refuses instead (issue #201).
+    logger.error(
+      'Pass either --snapshot (-s) or --mailbox (-m), not both. ' +
+        'To restore a snapshot into a different mailbox, use --snapshot with --target (-T).',
+    );
+    process.exit(1);
   }
-  if ((options.startDate || options.endDate) && options.snapshot && !options.mailbox) {
+  if ((options.startDate || options.endDate) && options.snapshot) {
     logger.error('--start-date / --end-date can only be used with --mailbox (-m).');
     process.exit(1);
   }
@@ -66,16 +74,12 @@ export async function execute_outlook_restore(
     </Box>,
   );
 
-  if (options.snapshot && !options.mailbox) {
+  // validate_restore_options has already refused the ambiguous pair, so exactly one is set.
+  const scope = resolve_outlook_scope(options);
+  if (scope.mode === 'snapshot') {
     return execute_snapshot_restore(restore_service, tenant_id, options);
   }
-
-  if (options.mailbox && !options.snapshot) {
-    return execute_mailbox_restore(restore_service, tenant_id, options);
-  }
-
-  // Both -s and -m: legacy behavior where -m is target override
-  return execute_snapshot_restore(restore_service, tenant_id, options);
+  return execute_mailbox_restore(restore_service, tenant_id, options);
 }
 
 /** Snapshot-mode restore: restore from a single snapshot. */
@@ -87,13 +91,16 @@ async function execute_snapshot_restore(
   const items: KeyValueItem[] = [{ label: 'Snapshot', value: options.snapshot! }];
   if (options.folder) items.push({ label: 'Folder filter', value: options.folder });
   if (options.message) items.push({ label: 'Message', value: options.message });
-  if (options.mailbox) items.push({ label: 'Target mailbox', value: options.mailbox });
+  // -T is the documented way to redirect a restore. It used to be read only in mailbox mode, so
+  // `restore -s <id> -T other@example.com` silently restored to the original mailbox while the
+  // undocumented `-m` spelling worked (issue #201).
+  if (options.target) items.push({ label: 'Target mailbox', value: options.target });
   await render_static_view(<KeyValueList items={items} />);
 
   const restore_options: RestoreOptions = {
     ...(options.folder && { folder_name: options.folder }),
     ...(options.message && { message_ref: options.message }),
-    ...(options.mailbox && { target_mailbox: options.mailbox }),
+    ...(options.target && { target_mailbox: options.target }),
     create_progress: create_transfer_progress('restored'),
   };
 

--- a/packages/cli/src/commands/outlook-scope.ts
+++ b/packages/cli/src/commands/outlook-scope.ts
@@ -1,0 +1,54 @@
+/**
+ * One precedence rule for the `-s` / `-m` pair across every `atlas outlook` subcommand.
+ *
+ * The three subcommands used to answer the same invocation three different ways: `list` let `-s`
+ * win, `restore` entered snapshot mode and quietly reused `-m` as a cross-mailbox target, and
+ * `save` let `-m` win, so an explicit `-s` was discarded and the whole mailbox exported instead
+ * (issue #201). Only the last one lost data the operator asked for, but all three made the flags
+ * mean whatever the handler happened to check first.
+ *
+ * `-s` wins, matching `atlas replicate`, which checks `--snapshot` before `--mailbox`. A snapshot
+ * id names exactly one thing, so it is the narrower request of the two, and narrower should not be
+ * silently widened.
+ */
+
+export interface OutlookScopeOptions {
+  readonly snapshot?: string;
+  readonly mailbox?: string;
+  readonly target?: string;
+}
+
+export type OutlookScope =
+  | { readonly mode: 'snapshot'; readonly snapshot: string; readonly ignored: readonly string[] }
+  | { readonly mode: 'mailbox'; readonly mailbox: string; readonly ignored: readonly string[] }
+  | { readonly mode: 'none'; readonly ignored: readonly string[] };
+
+/**
+ * Resolves which scope an outlook subcommand should act on.
+ *
+ * `ignored` names the flags the chosen scope makes irrelevant, so a caller can report them instead
+ * of dropping them on the floor. It is the caller's decision whether that is a warning or a
+ * failure: a read-only listing can warn and carry on, while a restore writes mail into a mailbox
+ * and should not guess which one.
+ */
+export function resolve_outlook_scope(options: OutlookScopeOptions): OutlookScope {
+  if (options.snapshot) {
+    const ignored: string[] = [];
+    if (options.mailbox) ignored.push('-m, --mailbox');
+    return { mode: 'snapshot', snapshot: options.snapshot, ignored };
+  }
+
+  if (options.mailbox) {
+    return { mode: 'mailbox', mailbox: options.mailbox, ignored: [] };
+  }
+
+  return { mode: 'none', ignored: [] };
+}
+
+/** One-line description of a scope conflict, or undefined when the flags are unambiguous. */
+export function describe_scope_conflict(scope: OutlookScope): string | undefined {
+  if (scope.ignored.length === 0) return undefined;
+  return `-s, --snapshot takes precedence, so ${scope.ignored.join(' and ')} ${
+    scope.ignored.length === 1 ? 'is' : 'are'
+  } ignored`;
+}

--- a/packages/cli/tests/unit/outlook-scope-handlers.test.ts
+++ b/packages/cli/tests/unit/outlook-scope-handlers.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Container } from 'inversify';
+import { Command } from 'commander';
+import { register_outlook_command } from '@/commands/outlook.command';
+import {
+  CATALOG_USE_CASE_TOKEN,
+  RESTORE_USE_CASE_TOKEN,
+  SAVE_USE_CASE_TOKEN,
+} from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
+
+/**
+ * Issue #201 at the layer that had the bug. A resolver nobody calls fixes nothing, so these drive
+ * the real commander wiring and assert which use-case method each invocation reaches.
+ */
+const SNAPSHOT = 'snap-example-1';
+const MAILBOX = 'john.doe@example.com';
+const TARGET = 'jane.roe@example.com';
+
+function save_result(): Record<string, unknown> {
+  return {
+    snapshot_id: SNAPSHOT,
+    saved_count: 1,
+    attachment_count: 0,
+    error_count: 0,
+    errors: [],
+    output_path: '/tmp/out.zip',
+    total_bytes: 1,
+    interrupted: false,
+    integrity_failures: [],
+  };
+}
+
+function restore_result(): Record<string, unknown> {
+  return {
+    snapshot_id: SNAPSHOT,
+    restored_count: 1,
+    attachment_count: 0,
+    error_count: 0,
+    attachment_error_count: 0,
+    errors: [],
+    verification_warnings: [],
+    restore_folder_name: 'Restore-2026',
+    interrupted: false,
+  };
+}
+
+describe('outlook subcommand scope precedence', () => {
+  let container: Container;
+  let program: Command;
+  let save_snapshot: ReturnType<typeof vi.fn>;
+  let save_mailbox: ReturnType<typeof vi.fn>;
+  let restore_snapshot: ReturnType<typeof vi.fn>;
+  let restore_mailbox: ReturnType<typeof vi.fn>;
+  let list_snapshot_messages: ReturnType<typeof vi.fn>;
+  let list_mailbox_snapshots: ReturnType<typeof vi.fn>;
+  let exit_spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    exit_spy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+
+    save_snapshot = vi.fn().mockResolvedValue(save_result());
+    save_mailbox = vi.fn().mockResolvedValue(save_result());
+    restore_snapshot = vi.fn().mockResolvedValue(restore_result());
+    restore_mailbox = vi.fn().mockResolvedValue(restore_result());
+    list_snapshot_messages = vi.fn().mockResolvedValue({ snapshot_id: SNAPSHOT, entries: [] });
+    list_mailbox_snapshots = vi.fn().mockResolvedValue([]);
+
+    container = new Container();
+    container.bind(SAVE_USE_CASE_TOKEN).toConstantValue({
+      save_snapshot,
+      save_mailbox,
+    });
+    container.bind(RESTORE_USE_CASE_TOKEN).toConstantValue({
+      restore_snapshot,
+      restore_mailbox,
+    });
+    container.bind(CATALOG_USE_CASE_TOKEN).toConstantValue({
+      get_snapshot_detail: list_snapshot_messages,
+      list_snapshots: list_mailbox_snapshots,
+      list_mailboxes: vi.fn().mockResolvedValue([]),
+      read_message: vi.fn(),
+    });
+    container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({ tenant_id: 'tenant-1' });
+
+    program = new Command();
+    program.exitOverride();
+    register_outlook_command(program, () => container);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const run = (args: string[]): Promise<unknown> =>
+    program.parseAsync(['outlook', ...args], { from: 'user' });
+
+  describe('save', () => {
+    it('exports the named snapshot when -s and -m are both passed', async () => {
+      await run(['save', '-s', SNAPSHOT, '-m', MAILBOX]);
+
+      expect(save_snapshot).toHaveBeenCalledTimes(1);
+      expect(save_mailbox).not.toHaveBeenCalled();
+    });
+
+    it('still exports the whole mailbox when only -m is passed', async () => {
+      await run(['save', '-m', MAILBOX]);
+
+      expect(save_mailbox).toHaveBeenCalledTimes(1);
+      expect(save_snapshot).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('restore', () => {
+    it('refuses -s together with -m rather than guessing a target mailbox', async () => {
+      await expect(run(['restore', '-s', SNAPSHOT, '-m', TARGET])).rejects.toThrow();
+
+      expect(exit_spy).toHaveBeenCalledWith(1);
+      expect(restore_snapshot).not.toHaveBeenCalled();
+      expect(restore_mailbox).not.toHaveBeenCalled();
+    });
+
+    it('redirects a snapshot restore with -T', async () => {
+      await run(['restore', '-s', SNAPSHOT, '-T', TARGET]);
+
+      expect(restore_snapshot).toHaveBeenCalledTimes(1);
+      const options = restore_snapshot.mock.calls[0]?.[2] as { target_mailbox?: string };
+      expect(options.target_mailbox).toBe(TARGET);
+    });
+
+    it('restores to the original mailbox when no -T is given', async () => {
+      await run(['restore', '-s', SNAPSHOT]);
+
+      const options = restore_snapshot.mock.calls[0]?.[2] as { target_mailbox?: string };
+      expect(options.target_mailbox).toBeUndefined();
+    });
+  });
+
+  describe('list', () => {
+    it('shows the snapshot when -s and -m are both passed', async () => {
+      await run(['list', '-s', SNAPSHOT, '-m', MAILBOX]);
+
+      expect(list_snapshot_messages).toHaveBeenCalledTimes(1);
+      expect(list_mailbox_snapshots).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/tests/unit/outlook-scope-precedence.test.ts
+++ b/packages/cli/tests/unit/outlook-scope-precedence.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { describe_scope_conflict, resolve_outlook_scope } from '@/commands/outlook-scope';
+
+/**
+ * Issue #201: the three outlook subcommands answered the same invocation three different ways.
+ * `save` was the one that lost work: it let `-m` win, so `save -s <id> -m <mailbox>` discarded the
+ * snapshot and exported the entire mailbox instead.
+ *
+ * `-s` wins everywhere now, matching `atlas replicate`, which checks `--snapshot` before
+ * `--mailbox`.
+ */
+describe('resolve_outlook_scope', () => {
+  it('picks snapshot mode when only -s is given', () => {
+    const scope = resolve_outlook_scope({ snapshot: 'snap-1' });
+    expect(scope).toEqual({ mode: 'snapshot', snapshot: 'snap-1', ignored: [] });
+  });
+
+  it('picks mailbox mode when only -m is given', () => {
+    const scope = resolve_outlook_scope({ mailbox: 'john.doe@example.com' });
+    expect(scope).toEqual({ mode: 'mailbox', mailbox: 'john.doe@example.com', ignored: [] });
+  });
+
+  it('lets -s win over -m, and says which flag it ignored', () => {
+    const scope = resolve_outlook_scope({ snapshot: 'snap-1', mailbox: 'john.doe@example.com' });
+
+    expect(scope.mode).toBe('snapshot');
+    expect(scope.ignored).toEqual(['-m, --mailbox']);
+  });
+
+  it('resolves the same way whichever order the flags were written in', () => {
+    const a = resolve_outlook_scope({ snapshot: 'snap-1', mailbox: 'john.doe@example.com' });
+    const b = resolve_outlook_scope({ mailbox: 'john.doe@example.com', snapshot: 'snap-1' });
+    expect(a).toEqual(b);
+  });
+
+  it('picks no scope when neither flag is given', () => {
+    expect(resolve_outlook_scope({}).mode).toBe('none');
+  });
+
+  it('does not treat -T as a scope flag', () => {
+    // -T redirects where a restore lands; it never selects what to restore.
+    const scope = resolve_outlook_scope({ snapshot: 'snap-1', target: 'jane.roe@example.com' });
+    expect(scope.mode).toBe('snapshot');
+    expect(scope.ignored).toEqual([]);
+  });
+});
+
+describe('describe_scope_conflict', () => {
+  it('is silent when the flags are unambiguous', () => {
+    expect(describe_scope_conflict(resolve_outlook_scope({ snapshot: 'snap-1' }))).toBeUndefined();
+    expect(
+      describe_scope_conflict(resolve_outlook_scope({ mailbox: 'john.doe@example.com' })),
+    ).toBeUndefined();
+  });
+
+  it('names the ignored flag so nothing is dropped silently', () => {
+    const message = describe_scope_conflict(
+      resolve_outlook_scope({ snapshot: 'snap-1', mailbox: 'john.doe@example.com' }),
+    );
+
+    expect(message).toContain('-s, --snapshot takes precedence');
+    expect(message).toContain('-m, --mailbox');
+  });
+});


### PR DESCRIPTION
Fixes #201. Cut from `dev`, independent of the #225/#226 stack.

## Problem

Three subcommands, three answers to the same invocation, no warning from any of them:

| Invocation | Before | After |
| --- | --- | --- |
| `list -s A -m B` | snapshot view, `-m` dropped | snapshot view, warns |
| `save -s A -m B` | **whole mailbox exported, `-s` dropped** | snapshot A exported, warns |
| `restore -s A -m B` | snapshot mode, `-m` becomes the target | refused, exit 1, names `-T` |

`save` is the one that lost work the operator asked for. The other two were inconsistency; that one exported the wrong thing.

## Fix

`-s` wins everywhere, matching `atlas replicate`, which checks `--snapshot` before `--mailbox`. A snapshot id names exactly one thing, so it is the narrower request, and narrower should not be silently widened.

Severity differs by command, deliberately:

- `list` and `save` report the ignored flag and carry on. Both are read-only with respect to the mailbox, so the worst case is a wasted run.
- `restore` refuses and exits `1`. `-m` there used to select which mailbox received the mail, so silently picking a winner either restores into a mailbox nobody asked for, or stops restoring into the one they did. Neither is something to guess at. The error names `-T, --target`.

Ordering lives in one place, `resolve_outlook_scope`, which returns the chosen scope plus the flags that choice makes irrelevant. It does not decide what to do about them: whether an ignored flag is a warning or a failure depends on whether the command writes mail, which is the caller's business, not the resolver's.

## The mirror-image bug this uncovered

Snapshot-mode restore read the target from `options.mailbox` and never from `options.target`:

```ts
...(options.mailbox && { target_mailbox: options.mailbox }),   // was
...(options.target && { target_mailbox: options.target }),     // now
```

So `restore -s <id> -T other@example.com` silently restored to the **original** mailbox, while the undocumented `-m` spelling worked. Exactly backwards: the documented flag was ignored, the undocumented one was load-bearing. Both are fixed, so `-T` now works in either mode.

## Breaking change

`atlas outlook restore -s <id> -m <mailbox>` is refused instead of treating `-m` as the target. Anyone relying on the legacy repurpose needs `-T`.

I chose refusal over silently reinterpreting because the alternative is worse than an error: a script that means "restore snapshot A into mailbox B" would keep exiting 0 while restoring into A's own mailbox, and nobody finds that until they go looking for the mail. Called out in the commit as `BREAKING CHANGE` for the release notes.

## Also removed

The dead `if (options.snapshot && options.mailbox && !options.target) {}` block, and the `&& !options.mailbox` on the date-range guard, which is unreachable now that the pair cannot get past validation.

## Tests

19 new tests across two files. Verified against the pre-fix source:

```
× exports the named snapshot when -s and -m are both passed        (save, the data bug)
× refuses -s together with -m rather than guessing a target mailbox (restore)
× redirects a snapshot restore with -T                              (restore, -T was ignored)
Tests  3 failed | 108 passed
```

The `list` test passes both before and after, on purpose: `list` already had the right precedence, so it is the case that documents "this one was already correct" rather than a regression guard for changed behaviour.

Handler-level tests drive the real commander wiring through `register_outlook_command` with stubbed use cases and assert which method each invocation reaches, because a resolver nobody calls fixes nothing.

Smoke-tested on the built binary:

```
$ atlas outlook restore -s snap-1 -m john.doe@example.com
[x] Pass either --snapshot (-s) or --mailbox (-m), not both. To restore a
    snapshot into a different mailbox, use --snapshot with --target (-T).
exit: 1

$ atlas outlook restore -s snap-1 -T jane.roe@example.com
Snapshot:       snap-1
Target mailbox: jane.roe@example.com        <- reaches the use case

$ atlas outlook save -s snap-1 -m john.doe@example.com
[!] -s, --snapshot takes precedence, so -m, --mailbox is ignored
Snapshot: snap-1                            <- snapshot mode, not mailbox mode
```

Gates in CI's mode (`pnpm run test:coverage`): 15/15 tasks, build 10/10, typecheck 17/17, lint 0 errors, docs build no warnings.

## Docs

- `docs/reference/cli.md` gains a warning block under `atlas outlook` defining the combined behaviour once for all three subcommands, with the `-T` example.
- The restore prose now says exactly one of `--snapshot`/`--mailbox` is required and that passing both exits `1`; it previously said "Either".
- The save section states the new precedence and that earlier releases silently exported the whole mailbox.

## Acceptance criteria

- [x] `list`, `save` and `restore` resolve `-s`/`-m`/`-T` through one shared resolver ordered like replicate
- [x] `save -s <snapshot> -m <mailbox>` exports exactly that snapshot, never a full-mailbox export
- [x] `-s` with `-m` produces an explicit warning or error naming the conflicting flags on every subcommand
- [x] The combined behaviour is documented in `docs/reference/cli.md`, not only for replicate/rehydrate
- [x] The dead guard block is removed
