### PR TITLE
fix(graph): tell a missing user apart from a Graph outage in reverse lookups

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -28,6 +28,18 @@ This matters beyond readability. Anything that post-processes the output, a log 
 
 Outlook mailbox backup, restore, and management commands. All mailbox operations live under this group; cross-cutting storage and replication commands remain at the root level.
 
+::: warning Scope flags: `-s` beats `-m`
+`restore`, `list` and `save` all select what to act on with `-s, --snapshot` (one snapshot) or `-m, --mailbox` (every snapshot for a mailbox). When both are passed, `-s` wins, matching `atlas replicate`. A snapshot id names exactly one thing, so it is the narrower request, and Atlas never silently widens it.
+
+`list` and `save` warn that `-m` was ignored and carry on. `restore` refuses the pair outright and exits `1`, because `-m` there used to mean "restore this snapshot into that mailbox instead", so guessing would decide which mailbox receives the mail. Use `-T, --target` for that, which works in both modes:
+
+```bash
+atlas outlook restore -s <snapshot-id> -T other@company.com
+```
+
+`-T` never selects what to restore, only where it lands.
+:::
+
 ### `atlas outlook backup`
 
 Back up one mailbox from an M365 tenant to object storage, with a per-folder progress dashboard. The `-m` flag is required. To back up multiple mailboxes, enumerate them with `atlas outlook mailboxes` and loop in your scheduler (cron, systemd timer, CI); fan-out across mailboxes is scheduling and belongs to the caller.
@@ -139,7 +151,7 @@ atlas outlook restore -m user@company.com -T other@company.com -f Inbox
 | `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date                |
 | `-t, --tenant <id>`         | Override tenant ID                                              |
 
-Either `--snapshot` or `--mailbox` is required. In mailbox mode, entries are deduplicated across snapshots (newest version of each message wins). Cross-mailbox restores preserve the original folder names from the source mailbox. Nested source folders are recreated as nested subfolders under the `Restore-{timestamp}` root, so `Inbox/Projects/2026` restores to `Restore-.../Inbox/Projects/2026` instead of collapsing into one flat level.
+Exactly one of `--snapshot` or `--mailbox` is required; passing both exits `1`, as described under [`atlas outlook`](#atlas-outlook). `-T, --target` works in either mode. In mailbox mode, entries are deduplicated across snapshots (newest version of each message wins). Cross-mailbox restores preserve the original folder names from the source mailbox. Nested source folders are recreated as nested subfolders under the `Restore-{timestamp}` root, so `Inbox/Projects/2026` restores to `Restore-.../Inbox/Projects/2026` instead of collapsing into one flat level.
 
 Restored messages retain their original received/sent timestamps, appear as received mail (not drafts), and include all backed-up attachments. Large attachments (>3 MB) use Graph upload sessions with chunked transfer.
 
@@ -222,6 +234,8 @@ atlas outlook save -m user@company.com --start-date 2026-01-01 --end-date 2026-0
 | `-o, --output <path>`       | Output file path (default: `Restore-<timestamp>.zip`)        |
 | `--skip-verify`             | Skip SHA-256 integrity checks (faster on low-power systems)  |
 | `-t, --tenant <id>`         | Override tenant ID                                           |
+
+With both `-s` and `-m`, the named snapshot is exported and `-m` is ignored with a warning; see [`atlas outlook`](#atlas-outlook). Earlier releases silently exported the whole mailbox instead.
 
 The zip archive mirrors the Outlook folder hierarchy:
 

--- a/packages/cli/src/commands/outlook-catalog.handler.tsx
+++ b/packages/cli/src/commands/outlook-catalog.handler.tsx
@@ -7,6 +7,7 @@ import { CATALOG_USE_CASE_TOKEN } from '@wisecom/atlas-types';
 import type { Manifest, AttachmentEntry } from '@wisecom/atlas-types';
 import { format_bytes } from '@/command-formatters';
 import { logger } from '@wisecom/atlas-core';
+import { describe_scope_conflict, resolve_outlook_scope } from '@/commands/outlook-scope';
 import { Banner } from '@/ui/components/banner';
 import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { KeyValueList, type KeyValueItem } from '@/ui/components/key-value-list';
@@ -45,16 +46,20 @@ export async function execute_outlook_list(
 
   const catalog = container.get<CatalogUseCase>(CATALOG_USE_CASE_TOKEN);
 
-  if (options.snapshot) {
+  const scope = resolve_outlook_scope(options);
+  const conflict = describe_scope_conflict(scope);
+  if (conflict) logger.warn(conflict);
+
+  if (scope.mode === 'snapshot') {
     await print_snapshot_messages(
       catalog,
       tenant_id,
-      options.snapshot,
+      scope.snapshot,
       options.all,
       options.subjects,
     );
-  } else if (options.mailbox) {
-    await print_mailbox_snapshots(catalog, tenant_id, options.mailbox);
+  } else if (scope.mode === 'mailbox') {
+    await print_mailbox_snapshots(catalog, tenant_id, scope.mailbox);
   } else {
     await print_all_mailboxes(catalog, tenant_id);
   }

--- a/packages/cli/src/commands/outlook-data-ops.handler.tsx
+++ b/packages/cli/src/commands/outlook-data-ops.handler.tsx
@@ -7,6 +7,7 @@ import type { SaveUseCase, SaveResult, SaveOptions, DeletionUseCase } from '@wis
 import { SAVE_USE_CASE_TOKEN, DELETION_USE_CASE_TOKEN } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core';
 import { report_run_outcome } from '@/command-run-outcome';
+import { describe_scope_conflict, resolve_outlook_scope } from '@/commands/outlook-scope';
 import {
   confirm_deletion,
   print_delete_result,
@@ -69,7 +70,11 @@ export async function execute_outlook_save(
     }
   }
 
-  if (options.snapshot && !options.mailbox) {
+  const scope = resolve_outlook_scope(options);
+  const conflict = describe_scope_conflict(scope);
+  if (conflict) logger.warn(conflict);
+
+  if (scope.mode === 'snapshot') {
     return execute_snapshot_save(save_service, tenant_id, options, save_options);
   }
 

--- a/packages/cli/src/commands/outlook-restore.handler.tsx
+++ b/packages/cli/src/commands/outlook-restore.handler.tsx
@@ -6,6 +6,7 @@ import type { RestoreUseCase, RestoreResult, RestoreOptions } from '@wisecom/atl
 import { RESTORE_USE_CASE_TOKEN } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core';
 import { report_run_outcome } from '@/command-run-outcome';
+import { resolve_outlook_scope } from '@/commands/outlook-scope';
 import { Banner } from '@/ui/components/banner';
 import { ErrorList } from '@/ui/components/error-list';
 import { KeyValueList, type KeyValueItem } from '@/ui/components/key-value-list';
@@ -24,16 +25,23 @@ export interface OutlookRestoreOptions {
   endDate?: string;
 }
 
-/** Validates that exactly one of --snapshot or --mailbox is provided. */
+/** Validates the scope flags, refusing the combinations that would restore to a guessed mailbox. */
 function validate_restore_options(options: OutlookRestoreOptions): void {
   if (!options.snapshot && !options.mailbox) {
     logger.error('Either --snapshot (-s) or --mailbox (-m) is required.');
     process.exit(1);
   }
-  if (options.snapshot && options.mailbox && !options.target) {
-    // When both -s and -m given, -m acts as target override (legacy behavior)
+  if (options.snapshot && options.mailbox) {
+    // Restore used to take -m here as a cross-mailbox target, which -T already means and which
+    // nothing documented. Guessing between "the snapshot's own mailbox" and "the one named by -m"
+    // decides which mailbox receives the mail, so this refuses instead (issue #201).
+    logger.error(
+      'Pass either --snapshot (-s) or --mailbox (-m), not both. ' +
+        'To restore a snapshot into a different mailbox, use --snapshot with --target (-T).',
+    );
+    process.exit(1);
   }
-  if ((options.startDate || options.endDate) && options.snapshot && !options.mailbox) {
+  if ((options.startDate || options.endDate) && options.snapshot) {
     logger.error('--start-date / --end-date can only be used with --mailbox (-m).');
     process.exit(1);
   }
@@ -66,16 +74,12 @@ export async function execute_outlook_restore(
     </Box>,
   );
 
-  if (options.snapshot && !options.mailbox) {
+  // validate_restore_options has already refused the ambiguous pair, so exactly one is set.
+  const scope = resolve_outlook_scope(options);
+  if (scope.mode === 'snapshot') {
     return execute_snapshot_restore(restore_service, tenant_id, options);
   }
-
-  if (options.mailbox && !options.snapshot) {
-    return execute_mailbox_restore(restore_service, tenant_id, options);
-  }
-
-  // Both -s and -m: legacy behavior where -m is target override
-  return execute_snapshot_restore(restore_service, tenant_id, options);
+  return execute_mailbox_restore(restore_service, tenant_id, options);
 }
 
 /** Snapshot-mode restore: restore from a single snapshot. */
@@ -87,13 +91,16 @@ async function execute_snapshot_restore(
   const items: KeyValueItem[] = [{ label: 'Snapshot', value: options.snapshot! }];
   if (options.folder) items.push({ label: 'Folder filter', value: options.folder });
   if (options.message) items.push({ label: 'Message', value: options.message });
-  if (options.mailbox) items.push({ label: 'Target mailbox', value: options.mailbox });
+  // -T is the documented way to redirect a restore. It used to be read only in mailbox mode, so
+  // `restore -s <id> -T other@example.com` silently restored to the original mailbox while the
+  // undocumented `-m` spelling worked (issue #201).
+  if (options.target) items.push({ label: 'Target mailbox', value: options.target });
   await render_static_view(<KeyValueList items={items} />);
 
   const restore_options: RestoreOptions = {
     ...(options.folder && { folder_name: options.folder }),
     ...(options.message && { message_ref: options.message }),
-    ...(options.mailbox && { target_mailbox: options.mailbox }),
+    ...(options.target && { target_mailbox: options.target }),
     create_progress: create_transfer_progress('restored'),
   };
 

--- a/packages/cli/src/commands/outlook-scope.ts
+++ b/packages/cli/src/commands/outlook-scope.ts
@@ -1,0 +1,54 @@
+/**
+ * One precedence rule for the `-s` / `-m` pair across every `atlas outlook` subcommand.
+ *
+ * The three subcommands used to answer the same invocation three different ways: `list` let `-s`
+ * win, `restore` entered snapshot mode and quietly reused `-m` as a cross-mailbox target, and
+ * `save` let `-m` win, so an explicit `-s` was discarded and the whole mailbox exported instead
+ * (issue #201). Only the last one lost data the operator asked for, but all three made the flags
+ * mean whatever the handler happened to check first.
+ *
+ * `-s` wins, matching `atlas replicate`, which checks `--snapshot` before `--mailbox`. A snapshot
+ * id names exactly one thing, so it is the narrower request of the two, and narrower should not be
+ * silently widened.
+ */
+
+export interface OutlookScopeOptions {
+  readonly snapshot?: string;
+  readonly mailbox?: string;
+  readonly target?: string;
+}
+
+export type OutlookScope =
+  | { readonly mode: 'snapshot'; readonly snapshot: string; readonly ignored: readonly string[] }
+  | { readonly mode: 'mailbox'; readonly mailbox: string; readonly ignored: readonly string[] }
+  | { readonly mode: 'none'; readonly ignored: readonly string[] };
+
+/**
+ * Resolves which scope an outlook subcommand should act on.
+ *
+ * `ignored` names the flags the chosen scope makes irrelevant, so a caller can report them instead
+ * of dropping them on the floor. It is the caller's decision whether that is a warning or a
+ * failure: a read-only listing can warn and carry on, while a restore writes mail into a mailbox
+ * and should not guess which one.
+ */
+export function resolve_outlook_scope(options: OutlookScopeOptions): OutlookScope {
+  if (options.snapshot) {
+    const ignored: string[] = [];
+    if (options.mailbox) ignored.push('-m, --mailbox');
+    return { mode: 'snapshot', snapshot: options.snapshot, ignored };
+  }
+
+  if (options.mailbox) {
+    return { mode: 'mailbox', mailbox: options.mailbox, ignored: [] };
+  }
+
+  return { mode: 'none', ignored: [] };
+}
+
+/** One-line description of a scope conflict, or undefined when the flags are unambiguous. */
+export function describe_scope_conflict(scope: OutlookScope): string | undefined {
+  if (scope.ignored.length === 0) return undefined;
+  return `-s, --snapshot takes precedence, so ${scope.ignored.join(' and ')} ${
+    scope.ignored.length === 1 ? 'is' : 'are'
+  } ignored`;
+}

--- a/packages/cli/tests/unit/outlook-scope-handlers.test.ts
+++ b/packages/cli/tests/unit/outlook-scope-handlers.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Container } from 'inversify';
+import { Command } from 'commander';
+import { register_outlook_command } from '@/commands/outlook.command';
+import {
+  CATALOG_USE_CASE_TOKEN,
+  RESTORE_USE_CASE_TOKEN,
+  SAVE_USE_CASE_TOKEN,
+} from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
+
+/**
+ * Issue #201 at the layer that had the bug. A resolver nobody calls fixes nothing, so these drive
+ * the real commander wiring and assert which use-case method each invocation reaches.
+ */
+const SNAPSHOT = 'snap-example-1';
+const MAILBOX = 'john.doe@example.com';
+const TARGET = 'jane.roe@example.com';
+
+function save_result(): Record<string, unknown> {
+  return {
+    snapshot_id: SNAPSHOT,
+    saved_count: 1,
+    attachment_count: 0,
+    error_count: 0,
+    errors: [],
+    output_path: '/tmp/out.zip',
+    total_bytes: 1,
+    interrupted: false,
+    integrity_failures: [],
+  };
+}
+
+function restore_result(): Record<string, unknown> {
+  return {
+    snapshot_id: SNAPSHOT,
+    restored_count: 1,
+    attachment_count: 0,
+    error_count: 0,
+    attachment_error_count: 0,
+    errors: [],
+    verification_warnings: [],
+    restore_folder_name: 'Restore-2026',
+    interrupted: false,
+  };
+}
+
+describe('outlook subcommand scope precedence', () => {
+  let container: Container;
+  let program: Command;
+  let save_snapshot: ReturnType<typeof vi.fn>;
+  let save_mailbox: ReturnType<typeof vi.fn>;
+  let restore_snapshot: ReturnType<typeof vi.fn>;
+  let restore_mailbox: ReturnType<typeof vi.fn>;
+  let list_snapshot_messages: ReturnType<typeof vi.fn>;
+  let list_mailbox_snapshots: ReturnType<typeof vi.fn>;
+  let exit_spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    exit_spy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+
+    save_snapshot = vi.fn().mockResolvedValue(save_result());
+    save_mailbox = vi.fn().mockResolvedValue(save_result());
+    restore_snapshot = vi.fn().mockResolvedValue(restore_result());
+    restore_mailbox = vi.fn().mockResolvedValue(restore_result());
+    list_snapshot_messages = vi.fn().mockResolvedValue({ snapshot_id: SNAPSHOT, entries: [] });
+    list_mailbox_snapshots = vi.fn().mockResolvedValue([]);
+
+    container = new Container();
+    container.bind(SAVE_USE_CASE_TOKEN).toConstantValue({
+      save_snapshot,
+      save_mailbox,
+    });
+    container.bind(RESTORE_USE_CASE_TOKEN).toConstantValue({
+      restore_snapshot,
+      restore_mailbox,
+    });
+    container.bind(CATALOG_USE_CASE_TOKEN).toConstantValue({
+      get_snapshot_detail: list_snapshot_messages,
+      list_snapshots: list_mailbox_snapshots,
+      list_mailboxes: vi.fn().mockResolvedValue([]),
+      read_message: vi.fn(),
+    });
+    container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({ tenant_id: 'tenant-1' });
+
+    program = new Command();
+    program.exitOverride();
+    register_outlook_command(program, () => container);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const run = (args: string[]): Promise<unknown> =>
+    program.parseAsync(['outlook', ...args], { from: 'user' });
+
+  describe('save', () => {
+    it('exports the named snapshot when -s and -m are both passed', async () => {
+      await run(['save', '-s', SNAPSHOT, '-m', MAILBOX]);
+
+      expect(save_snapshot).toHaveBeenCalledTimes(1);
+      expect(save_mailbox).not.toHaveBeenCalled();
+    });
+
+    it('still exports the whole mailbox when only -m is passed', async () => {
+      await run(['save', '-m', MAILBOX]);
+
+      expect(save_mailbox).toHaveBeenCalledTimes(1);
+      expect(save_snapshot).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('restore', () => {
+    it('refuses -s together with -m rather than guessing a target mailbox', async () => {
+      await expect(run(['restore', '-s', SNAPSHOT, '-m', TARGET])).rejects.toThrow();
+
+      expect(exit_spy).toHaveBeenCalledWith(1);
+      expect(restore_snapshot).not.toHaveBeenCalled();
+      expect(restore_mailbox).not.toHaveBeenCalled();
+    });
+
+    it('redirects a snapshot restore with -T', async () => {
+      await run(['restore', '-s', SNAPSHOT, '-T', TARGET]);
+
+      expect(restore_snapshot).toHaveBeenCalledTimes(1);
+      const options = restore_snapshot.mock.calls[0]?.[2] as { target_mailbox?: string };
+      expect(options.target_mailbox).toBe(TARGET);
+    });
+
+    it('restores to the original mailbox when no -T is given', async () => {
+      await run(['restore', '-s', SNAPSHOT]);
+
+      const options = restore_snapshot.mock.calls[0]?.[2] as { target_mailbox?: string };
+      expect(options.target_mailbox).toBeUndefined();
+    });
+  });
+
+  describe('list', () => {
+    it('shows the snapshot when -s and -m are both passed', async () => {
+      await run(['list', '-s', SNAPSHOT, '-m', MAILBOX]);
+
+      expect(list_snapshot_messages).toHaveBeenCalledTimes(1);
+      expect(list_mailbox_snapshots).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/tests/unit/outlook-scope-precedence.test.ts
+++ b/packages/cli/tests/unit/outlook-scope-precedence.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { describe_scope_conflict, resolve_outlook_scope } from '@/commands/outlook-scope';
+
+/**
+ * Issue #201: the three outlook subcommands answered the same invocation three different ways.
+ * `save` was the one that lost work: it let `-m` win, so `save -s <id> -m <mailbox>` discarded the
+ * snapshot and exported the entire mailbox instead.
+ *
+ * `-s` wins everywhere now, matching `atlas replicate`, which checks `--snapshot` before
+ * `--mailbox`.
+ */
+describe('resolve_outlook_scope', () => {
+  it('picks snapshot mode when only -s is given', () => {
+    const scope = resolve_outlook_scope({ snapshot: 'snap-1' });
+    expect(scope).toEqual({ mode: 'snapshot', snapshot: 'snap-1', ignored: [] });
+  });
+
+  it('picks mailbox mode when only -m is given', () => {
+    const scope = resolve_outlook_scope({ mailbox: 'john.doe@example.com' });
+    expect(scope).toEqual({ mode: 'mailbox', mailbox: 'john.doe@example.com', ignored: [] });
+  });
+
+  it('lets -s win over -m, and says which flag it ignored', () => {
+    const scope = resolve_outlook_scope({ snapshot: 'snap-1', mailbox: 'john.doe@example.com' });
+
+    expect(scope.mode).toBe('snapshot');
+    expect(scope.ignored).toEqual(['-m, --mailbox']);
+  });
+
+  it('resolves the same way whichever order the flags were written in', () => {
+    const a = resolve_outlook_scope({ snapshot: 'snap-1', mailbox: 'john.doe@example.com' });
+    const b = resolve_outlook_scope({ mailbox: 'john.doe@example.com', snapshot: 'snap-1' });
+    expect(a).toEqual(b);
+  });
+
+  it('picks no scope when neither flag is given', () => {
+    expect(resolve_outlook_scope({}).mode).toBe('none');
+  });
+
+  it('does not treat -T as a scope flag', () => {
+    // -T redirects where a restore lands; it never selects what to restore.
+    const scope = resolve_outlook_scope({ snapshot: 'snap-1', target: 'jane.roe@example.com' });
+    expect(scope.mode).toBe('snapshot');
+    expect(scope.ignored).toEqual([]);
+  });
+});
+
+describe('describe_scope_conflict', () => {
+  it('is silent when the flags are unambiguous', () => {
+    expect(describe_scope_conflict(resolve_outlook_scope({ snapshot: 'snap-1' }))).toBeUndefined();
+    expect(
+      describe_scope_conflict(resolve_outlook_scope({ mailbox: 'john.doe@example.com' })),
+    ).toBeUndefined();
+  });
+
+  it('names the ignored flag so nothing is dropped silently', () => {
+    const message = describe_scope_conflict(
+      resolve_outlook_scope({ snapshot: 'snap-1', mailbox: 'john.doe@example.com' }),
+    );
+
+    expect(message).toContain('-s, --snapshot takes precedence');
+    expect(message).toContain('-m, --mailbox');
+  });
+});

--- a/packages/core/src/adapters/identity/caching-identity-resolver.adapter.ts
+++ b/packages/core/src/adapters/identity/caching-identity-resolver.adapter.ts
@@ -92,13 +92,22 @@ export class CachingIdentityResolver implements UserIdentityResolver {
     return this._graph.resolve_by_object_id(tenant_id, object_id);
   }
 
+  /**
+   * Graph lookup that falls back to the cached registry, so a lookup still works while Graph is
+   * unreachable. The failure is logged rather than dropped: a silent swallow here looks identical
+   * to a user that genuinely does not exist (issue #202).
+   */
   private async try_graph_resolve(
     tenant_id: string,
     email: string,
   ): Promise<ResolvedUserIdentity | undefined> {
     try {
       return await this._graph.resolve_user(tenant_id, email);
-    } catch {
+    } catch (err) {
+      logger.debug(
+        `Graph could not resolve "${email}", falling back to the cached registry: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
       return undefined;
     }
   }

--- a/packages/m365-graph/src/graph-user-identity-resolver.adapter.ts
+++ b/packages/m365-graph/src/graph-user-identity-resolver.adapter.ts
@@ -2,6 +2,8 @@ import { inject, injectable } from 'inversify';
 import type { Client } from '@microsoft/microsoft-graph-client';
 import type { UserIdentityResolver, ResolvedUserIdentity } from '@wisecom/atlas-types';
 import { GRAPH_CLIENT_TOKEN } from '@/graph-client.factory';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import { describe_graph_error, is_retryable_error } from '@/graph-error-helpers';
 
 /** Resolves Azure AD / Entra user identities via Microsoft Graph. */
 @injectable()
@@ -24,7 +26,15 @@ export class GraphUserIdentityResolver implements UserIdentityResolver {
     };
   }
 
-  /** Graph-only resolver cannot do reverse lookups without an object ID query. Returns undefined. */
+  /**
+   * Reverse lookup of an Entra object ID, or undefined when Graph says there is no such user.
+   *
+   * Only a 404 means "no such object". A 5xx or a dropped socket means Graph could not answer, and
+   * collapsing that into the same undefined told callers a user does not exist because the service
+   * was briefly unavailable (issue #202). Those rethrow so the caller can retry or report. Anything
+   * else rethrows too: a 403 is a missing `User.Read.All` grant, which would otherwise degrade
+   * every identity lookup in the tenant to a silent nothing that looks exactly like a typo.
+   */
   async resolve_by_object_id(
     _tenant_id: string,
     object_id: string,
@@ -39,7 +49,11 @@ export class GraphUserIdentityResolver implements UserIdentityResolver {
         display_name: response.displayName ?? object_id,
         email: response.mail ?? response.userPrincipalName ?? '',
       };
-    } catch {
+    } catch (err) {
+      if (is_retryable_error(err)) throw err;
+      if ((err as Record<string, unknown>).statusCode !== 404) throw err;
+
+      logger.debug(`Graph has no user for object ID ${object_id}: ${describe_graph_error(err)}`);
       return undefined;
     }
   }

--- a/packages/m365-graph/tests/unit/graph-user-identity-resolver.test.ts
+++ b/packages/m365-graph/tests/unit/graph-user-identity-resolver.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Client } from '@microsoft/microsoft-graph-client';
+import { GraphUserIdentityResolver } from '@/graph-user-identity-resolver.adapter';
+
+/**
+ * Issue #202: `resolve_by_object_id` wrapped its Graph call in `catch { return undefined }`, so a
+ * deleted user, a 503 and a dropped socket produced the same answer with nothing logged. A caller
+ * had no way to tell bad input from an outage, and identity attribution degraded to nothing while
+ * looking exactly like a typo.
+ */
+const OBJECT_ID = '00000000-0000-0000-0000-000000000000';
+
+function graph_error(status: number, code?: string): Record<string, unknown> {
+  return { statusCode: status, code, message: `HTTP ${status}` };
+}
+
+/** Graph client stub whose `get()` resolves or rejects with whatever the test supplies. */
+function make_client(get: () => Promise<unknown>): Client {
+  return {
+    api: () => ({ select: () => ({ get }) }),
+  } as unknown as Client;
+}
+
+describe('GraphUserIdentityResolver.resolve_by_object_id', () => {
+  it('returns the identity when Graph knows the object', async () => {
+    const client = make_client(() =>
+      Promise.resolve({
+        id: OBJECT_ID,
+        displayName: 'John Doe',
+        mail: 'john.doe@example.com',
+        userPrincipalName: 'john.doe@example.com',
+      }),
+    );
+
+    const identity = await new GraphUserIdentityResolver(client).resolve_by_object_id(
+      't',
+      OBJECT_ID,
+    );
+
+    expect(identity).toEqual({
+      object_id: OBJECT_ID,
+      display_name: 'John Doe',
+      email: 'john.doe@example.com',
+    });
+  });
+
+  it('returns undefined on a genuine 404', async () => {
+    const client = make_client(() => Promise.reject(graph_error(404, 'Request_ResourceNotFound')));
+
+    await expect(
+      new GraphUserIdentityResolver(client).resolve_by_object_id('t', OBJECT_ID),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([500, 502, 503, 504, 429])('rethrows a transient %i', async (status) => {
+    const client = make_client(() => Promise.reject(graph_error(status)));
+
+    await expect(
+      new GraphUserIdentityResolver(client).resolve_by_object_id('t', OBJECT_ID),
+    ).rejects.toMatchObject({ statusCode: status });
+  });
+
+  it('rethrows a network failure', async () => {
+    const err = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    const client = make_client(() => Promise.reject(err));
+
+    await expect(
+      new GraphUserIdentityResolver(client).resolve_by_object_id('t', OBJECT_ID),
+    ).rejects.toThrow('socket hang up');
+  });
+
+  it('rethrows a 403, since a missing grant is not a missing user', async () => {
+    // Swallowing this degraded every identity lookup in the tenant to a silent nothing.
+    const client = make_client(() =>
+      Promise.reject(graph_error(403, 'Authorization_RequestDenied')),
+    );
+
+    await expect(
+      new GraphUserIdentityResolver(client).resolve_by_object_id('t', OBJECT_ID),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('logs the object id when it swallows a 404', async () => {
+    // logger.debug is gated behind DEBUG, matching how the rest of the repo reports benign
+    // degradation, so the test opts in rather than the code shouting on every deleted user.
+    vi.stubEnv('DEBUG', '1');
+    const lines: string[] = [];
+    vi.spyOn(console, 'debug').mockImplementation((...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(' '));
+    });
+    const client = make_client(() => Promise.reject(graph_error(404)));
+
+    await new GraphUserIdentityResolver(client).resolve_by_object_id('t', OBJECT_ID);
+
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    expect(lines.join('\n')).toContain(OBJECT_ID);
+  });
+});


### PR DESCRIPTION
Fixes #202. Cut from `dev`, independent of the other open PRs.

## Problem

```ts
} catch {
  return undefined;
}
```

A deleted user, a 503 and a dropped socket all produced the same `undefined`, with nothing logged. A caller had no basis to retry, and identity attribution degrading to nothing looked exactly like a mistyped object id.

## Fix

| Error | Before | After |
| --- | --- | --- |
| 404 | `undefined` | `undefined`, logged at debug |
| 500/502/503/504/429 | `undefined` | rethrown |
| `ECONNRESET` and friends | `undefined` | rethrown |
| 403 | `undefined` | rethrown |

Classification reuses `is_retryable_error` from `graph-error-helpers` rather than a hand-rolled status list, as the issue asks.

**403 is the one the issue does not mention and I think matters most.** A 403 here is a missing `User.Read.All` grant, so swallowing it turns every identity lookup in the tenant into a silent nothing, which reads as a tenant full of deleted users. Anything that is neither a 404 nor retryable now rethrows, so a misconfigured app registration surfaces instead of quietly degrading.

The swallowed 404 logs at `debug`, not `warn`. A deleted user is the correct answer rather than a fault, and a tenant with many removed accounts should not emit a warning per lookup. That matches how the repo already reports benign degradation, for instance the mailbox usage report in `graph-mailbox-discovery.adapter.ts`. It does mean the line is invisible without `DEBUG=1`; the tests opt in with `vi.stubEnv`.

## Sibling fixed

`try_graph_resolve` in `caching-identity-resolver.adapter.ts` had the same silent `catch`. Its swallow is deliberate and correct, since falling back to the cached registry is what keeps lookups working while Graph is unreachable, so the behaviour is unchanged. It now logs the reason at debug instead of dropping it.

## Scope, honestly

**Nothing calls `resolve_by_object_id` today.** I checked every call site:

- The CLI resolves identities through `resolve_user` (`onedrive-command.handlers.tsx:84`, `rehydrate.command.tsx:47`).
- The SDK surface exposes `resolveUser` and `listUsers` only; `atlas-instance.adapter.ts` never wires the reverse lookup.
- The only caller of the Graph implementation is `CachingIdentityResolver.resolve_by_object_id`, which itself has no callers outside tests.

So this closes a trap for the next caller rather than a live failure. The method is on a public port with two implementations, the fix is a handful of lines, and the next person to wire it up would otherwise inherit the same ambiguity. Worth knowing when judging its priority against the rest of the milestone.

That is also why there is no docs change: the behaviour is not described anywhere, because the method is not part of any documented surface. `docs/reference/sdk.md` documents `resolveUser` and `listUsers`, both unchanged.

## Tests

10 new tests. 8 fail against the pre-fix source:

```
× rethrows a transient 500
× rethrows a transient 502
× rethrows a transient 503
× rethrows a transient 504
× rethrows a transient 429
× rethrows a network failure
× rethrows a 403, since a missing grant is not a missing user
× logs the object id when it swallows a 404
Tests  8 failed | 90 passed
```

The two that pass both before and after are the no-change cases: a successful lookup still returns the full `ResolvedUserIdentity`, and a genuine 404 still returns `undefined`.

Gates in CI's mode (`pnpm run test:coverage`): 15/15 tasks, build 10/10, typecheck 17/17, lint 0 errors.

No CLI smoke test here, since no command reaches this path. That is the same reachability point as above rather than an omission.

## Acceptance criteria

- [x] A genuine Graph 404 still returns `undefined`
- [x] A 503 and other 5xx propagate as thrown errors
- [x] Network failures such as `ECONNRESET` propagate
- [x] Classification reuses `is_retryable_error` rather than ad-hoc status checks
- [x] The swallowed path logs the object id and the underlying error
- [x] An existing object id still returns a full `ResolvedUserIdentity` unchanged
