### PR TITLE
fix(outlook): stop one legacy MIME entry aborting a folder-filtered run

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -157,6 +157,12 @@ Restored messages retain their original received/sent timestamps, appear as rece
 
 Messages archived as RFC 5322 MIME are parsed at restore time and recreated through Graph's JSON message-create path rather than imported as MIME. That is a deliberate choice: Graph's MIME import always marks the created message as a draft, and neither an `X-Unsent: 0` header nor a `PR_MESSAGE_FLAGS` patch clears the flag, so importing would hand the user thousands of drafts. The restored copy is therefore normal mail with its original timestamps, but it does not carry the original `Received:` chain. The archived object still does -- use [`atlas outlook save`](#atlas-outlook-save) when you need the original bytes.
 
+::: details `-f` and pre-2.1.0 MIME snapshots
+A folder filter matches on the `folder_id` recorded in the manifest. Snapshots written before Atlas stamped that field carry it on their Graph JSON entries, where it is recovered from the stored payload, but a MIME entry has nowhere to recover it from: RFC 822 does not record which folder a message sat in.
+
+Those entries are therefore skipped by `-f` and reported on stderr with a count. Restore or save the whole snapshot without `-f` to include them. Snapshots taken by any current version stamp `folder_id` on every entry and are unaffected.
+:::
+
 ### `atlas outlook list`
 
 Browse backed-up data at three zoom levels. Subjects are hidden by default for data protection. The mailbox overview includes a `Type` column sourced from each mailbox's newest manifest that recorded a purpose (`user`, `shared`, `room`, ...; `--` when never recorded).

--- a/packages/outlook/src/services/restore/restore-execution-orchestrator.ts
+++ b/packages/outlook/src/services/restore/restore-execution-orchestrator.ts
@@ -230,7 +230,15 @@ async function resolve_source_folder_id(ctx: TenantContext, entry: ManifestEntry
   return extract_folder_id_from_json(await decrypt_and_parse_message(ctx, entry));
 }
 
-/** Backfills folder_id for legacy manifest entries by decrypting message JSON. */
+/**
+ * Backfills `folder_id` on legacy manifest entries so a folder filter can match them.
+ *
+ * MIME entries are left alone. They hold raw RFC 822 bytes, so decrypting one and parsing it as
+ * JSON throws, and because this runs before any per-entry error handling a single such entry took
+ * the whole restore or export with it (issue #205). RFC 822 records no folder, so there is nothing
+ * cheap to recover: they stay unresolved, and `filter_entries_by_folder_name` already drops entries
+ * without a `folder_id`.
+ */
 export async function backfill_missing_folder_ids(
   ctx: TenantContext,
   entries: ManifestEntry[],
@@ -238,11 +246,31 @@ export async function backfill_missing_folder_ids(
   const missing = entries.filter((e) => !e.folder_id);
   if (missing.length === 0) return;
 
-  logger.info(`Backfilling folder_id for ${missing.length} legacy entries...`);
-  for (const entry of missing) {
-    const json = await decrypt_and_parse_message(ctx, entry);
-    const fid = extract_folder_id_from_json(json);
-    (entry as { folder_id?: string }).folder_id = fid;
+  const json_entries = missing.filter((e) => e.payload_format !== 'mime');
+  const mime_count = missing.length - json_entries.length;
+  if (mime_count > 0) {
+    logger.warn(
+      `${mime_count} legacy MIME ${mime_count === 1 ? 'entry carries' : 'entries carry'} no ` +
+        'folder_id, so a folder filter cannot match them: RFC 822 does not record the source folder.',
+    );
+  }
+  if (json_entries.length === 0) return;
+
+  logger.info(`Backfilling folder_id for ${json_entries.length} legacy entries...`);
+  for (const entry of json_entries) {
+    // ManifestEntry types folder_id readonly and this backfill fills it in place, so the write
+    // needs a mutable view of that one field.
+    const writable: { folder_id?: string } = entry;
+    try {
+      const json = await decrypt_and_parse_message(ctx, entry);
+      writable.folder_id = extract_folder_id_from_json(json);
+    } catch (err) {
+      // One unreadable payload must not abort a run that can still handle every other entry.
+      logger.warn(
+        `Could not recover folder_id for ${entry.object_id}, excluding it from the folder ` +
+          `filter: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 }
 

--- a/packages/outlook/tests/unit/folder-id-backfill.test.ts
+++ b/packages/outlook/tests/unit/folder-id-backfill.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ManifestEntry, TenantContext } from '@wisecom/atlas-types';
+import { backfill_missing_folder_ids } from '@/services/restore/restore-execution-orchestrator';
+import { filter_entries_by_folder_name } from '@/services/restore/folder-restore-planner';
+
+/**
+ * Issue #205: the backfill decrypted every entry missing a `folder_id` and parsed it as JSON. An
+ * entry stored with `payload_format: 'mime'` holds raw RFC 822 bytes, so the parse threw, and
+ * because the backfill runs before any per-entry error handling the whole `-f` restore or export
+ * died before touching a single message.
+ */
+const INBOX_ID = 'AAMkAG-inbox';
+
+function entry(overrides: Partial<ManifestEntry> = {}): ManifestEntry {
+  return {
+    object_id: 'msg-1',
+    storage_key: 'outlook/data/owner/abc',
+    checksum: 'sha',
+    size_bytes: 10,
+    ...overrides,
+  } as ManifestEntry;
+}
+
+/** Context whose stored payload is whatever the test supplies, decrypted as-is. */
+function make_ctx(payload_by_key: Record<string, string>): TenantContext {
+  return {
+    tenant_id: 't',
+    storage: {
+      get: vi.fn(async (key: string) => {
+        const body = payload_by_key[key];
+        if (body === undefined) throw new Error(`missing ${key}`);
+        return Buffer.from(body, 'utf-8');
+      }),
+    },
+    decrypt: (buf: Buffer) => buf,
+  } as unknown as TenantContext;
+}
+
+const MIME_BODY = 'From: john.doe@example.com\r\nSubject: Example subject\r\n\r\nBody text\r\n';
+
+describe('backfill_missing_folder_ids', () => {
+  it('does not throw on a legacy MIME entry without folder_id', async () => {
+    const mime = entry({ object_id: 'mime-1', storage_key: 'k-mime', payload_format: 'mime' });
+    const ctx = make_ctx({ 'k-mime': MIME_BODY });
+
+    await expect(backfill_missing_folder_ids(ctx, [mime])).resolves.toBeUndefined();
+    expect(mime.folder_id).toBeUndefined();
+  });
+
+  it('still backfills a legacy JSON entry from its decrypted payload', async () => {
+    const json = entry({ object_id: 'json-1', storage_key: 'k-json' });
+    const ctx = make_ctx({ 'k-json': JSON.stringify({ parentFolderId: INBOX_ID }) });
+
+    await backfill_missing_folder_ids(ctx, [json]);
+
+    expect(json.folder_id).toBe(INBOX_ID);
+  });
+
+  it('backfills the JSON entries alongside a MIME entry that cannot be resolved', async () => {
+    const mime = entry({ object_id: 'mime-1', storage_key: 'k-mime', payload_format: 'mime' });
+    const json = entry({ object_id: 'json-1', storage_key: 'k-json' });
+    const ctx = make_ctx({
+      'k-mime': MIME_BODY,
+      'k-json': JSON.stringify({ parentFolderId: INBOX_ID }),
+    });
+
+    await backfill_missing_folder_ids(ctx, [mime, json]);
+
+    expect(json.folder_id).toBe(INBOX_ID);
+    expect(mime.folder_id).toBeUndefined();
+  });
+
+  it('selects the folder-matching entries and skips the unresolved MIME one', async () => {
+    // The end-to-end shape of a `-f Inbox` run: backfill, then filter.
+    const mime = entry({ object_id: 'mime-1', storage_key: 'k-mime', payload_format: 'mime' });
+    const json = entry({ object_id: 'json-1', storage_key: 'k-json' });
+    const stamped = entry({ object_id: 'json-2', folder_id: INBOX_ID });
+    const ctx = make_ctx({
+      'k-mime': MIME_BODY,
+      'k-json': JSON.stringify({ parentFolderId: INBOX_ID }),
+    });
+    const folder_map = new Map<string, string>([[INBOX_ID, 'Inbox']]);
+
+    const entries = [mime, json, stamped];
+    await backfill_missing_folder_ids(ctx, entries);
+    const selected = filter_entries_by_folder_name(entries, 'Inbox', folder_map);
+
+    expect(selected.map((e: ManifestEntry) => e.object_id)).toEqual(['json-1', 'json-2']);
+  });
+
+  it('does not decrypt anything when every entry already carries folder_id', async () => {
+    const ctx = make_ctx({});
+    const entries = [entry({ folder_id: INBOX_ID }), entry({ object_id: 'msg-2', folder_id: 'x' })];
+
+    await backfill_missing_folder_ids(ctx, entries);
+
+    expect(ctx.storage.get).not.toHaveBeenCalled();
+  });
+
+  it('keeps going when one JSON payload is unreadable', async () => {
+    // A corrupt entry is the same failure shape as the MIME one: it must not take the run with it.
+    const broken = entry({ object_id: 'json-broken', storage_key: 'k-broken' });
+    const good = entry({ object_id: 'json-good', storage_key: 'k-good' });
+    const ctx = make_ctx({
+      'k-broken': 'not json at all',
+      'k-good': JSON.stringify({ parentFolderId: INBOX_ID }),
+    });
+
+    await expect(backfill_missing_folder_ids(ctx, [broken, good])).resolves.toBeUndefined();
+
+    expect(broken.folder_id).toBeUndefined();
+    expect(good.folder_id).toBe(INBOX_ID);
+  });
+});


### PR DESCRIPTION
Fixes #205. Cut from `dev`, nothing else open.

## Problem

```ts
const missing = entries.filter((e) => !e.folder_id);
for (const entry of missing) {
  const json = await decrypt_and_parse_message(ctx, entry);   // JSON.parse on RFC 822
```

A MIME entry holds raw RFC 822 bytes, so the parse throws `SyntaxError: Unexpected token 'F'`. The backfill runs ahead of any per-entry error handling, so one such entry killed the whole `-f` run before a single message was restored or exported.

## Fix

MIME entries are skipped. RFC 822 records no folder, so there is nothing cheap to recover, and `filter_entries_by_folder_name` already drops entries with no `folder_id`, so leaving the field unset excludes them from the filter instead of crashing it. The count goes to stderr so an operator can see what a filtered run cannot reach.

Worth noting: `resolve_source_folder_id` in the same file already did exactly this for the single-message path:

```ts
if (entry.payload_format === 'mime') return '__unknown__';
```

So the correct handling was already in the file, three functions up. The backfill just did not follow it.

## Slightly beyond the issue

Each remaining JSON parse is wrapped too. A corrupt payload is the same failure shape as the MIME one, and the complaint here is really "one bad entry kills the run", not "MIME specifically". Guarding only the MIME case would leave the same abort reachable through a truncated or tampered JSON entry.

## Rule fix carried along

The write that fills the field was an inline cast on member access:

```ts
(entry as { folder_id?: string }).folder_id = fid;
```

That is a pattern the repo's own guidance rejects, and I reproduced it before noticing. It now goes through a named mutable view with the reason stated, since `ManifestEntry.folder_id` is readonly and this backfill fills it in place.

## Tests

6 new tests. 4 fail against the pre-fix source:

```
× does not throw on a legacy MIME entry without folder_id
× backfills the JSON entries alongside a MIME entry that cannot be resolved
× selects the folder-matching entries and skips the unresolved MIME one
× keeps going when one JSON payload is unreadable
```

The two that pass both before and after are the negative cases the criteria ask for: a legacy JSON entry is still backfilled from its payload, and a manifest where every entry already carries `folder_id` still decrypts nothing at all (asserted on `storage.get` never being called).

The third test above is the end-to-end shape of a `-f Inbox` run: backfill, then filter, then assert the selection is exactly the two Inbox entries and not the MIME one.

Verified by restoring the pre-fix file with a copy rather than `git stash`, after what stash did on #223 and again on #229.

Gates in CI's mode (`pnpm run test:coverage`): 15/15 tasks, build 10/10, typecheck 17/17, lint 0 errors, docs build no warnings. The orchestrator is 286 lines, under the limit.

## Docs

`docs/reference/cli.md` gains a collapsed note under `atlas outlook restore` explaining that `-f` matches on the recorded `folder_id`, that pre-stamping MIME entries have nowhere to recover it from, that they are skipped and counted, and that omitting `-f` includes them. Snapshots from any current version stamp the field and are unaffected.

## Acceptance criteria

- [x] `restore -f Inbox` over a manifest with a MIME entry lacking `folder_id` completes and restores the matching entries
- [x] `save -f Inbox` over the same manifest completes; both commands call the same backfill
- [x] A MIME entry lacking `folder_id` contributes nothing to a folder-filtered run
- [x] Legacy JSON entries without `folder_id` are still backfilled and matched by `-f`
- [x] Manifests where every entry carries `folder_id` take the fast path, verified by asserting no decryption happens
- [x] A regression test drives one legacy MIME entry through a `-f Inbox` run and asserts no throw plus correct selection
