### PR TITLE
fix(perf): resolve the CLI entry from bin instead of a hardcoded cli.js

### DIFF
--- a/docs/development/performance-profiling.md
+++ b/docs/development/performance-profiling.md
@@ -18,6 +18,8 @@ pnpm run perf:restore -- -s <snapshot-id> -m target@example.com
 pnpm run perf:analyze -- .perf-output/CPU.20260506.123456.12345.0.001.cpuprofile
 ```
 
+Profiling runs the built CLI, so `pnpm run build` has to have produced `packages/cli/dist/`. The profiler resolves that entry from the CLI package's own `bin` field rather than a hardcoded filename, and stops with a message naming the missing file if the build is absent, instead of profiling a failed module load.
+
 ## How It Works
 
 The profiler uses Node.js built-in V8 CPU profiling (`--cpu-prof`) to sample the call stack at 500-microsecond intervals while Atlas runs. After the process exits, the captured `.cpuprofile` is parsed into an aggregated report.
@@ -26,7 +28,7 @@ The profiler uses Node.js built-in V8 CPU profiling (`--cpu-prof`) to sample the
 atlas CLI process
     |
     v
-node --cpu-prof --cpu-prof-dir=.perf-output packages/cli/dist/cli.js backup ...
+node --cpu-prof --cpu-prof-dir=.perf-output packages/cli/dist/cli.mjs backup ...
     |
     v
 .perf-output/CPU.*.cpuprofile   (raw V8 profile)

--- a/tools/perf/src/cli.ts
+++ b/tools/perf/src/cli.ts
@@ -26,13 +26,34 @@ program
 
     console.log('[atlas-perf] Starting profiled run...\n');
 
-    const result = await run_profiled({
-      atlas_args,
-      output_dir,
-      use_0x: opts.flamegraph,
-    });
+    let result;
+    try {
+      result = await run_profiled({
+        atlas_args,
+        output_dir,
+        use_0x: opts.flamegraph,
+      });
+    } catch (err) {
+      // Setup problems, a missing CLI build above all, are operator mistakes rather than crashes,
+      // so they get the message without a stack trace on top of it.
+      console.error(`[atlas-perf] ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+      return;
+    }
 
     console.log(`\n[atlas-perf] Process exited with code ${result.exit_code}`);
+
+    if (result.exit_code !== 0) {
+      // A profile of a failed run measures the failure. Reporting on it looked like a successful
+      // analysis and exited 0, which is how a broken CLI path went unnoticed (issue #207).
+      console.error(
+        '[atlas-perf] The profiled command failed, so there is nothing worth analysing. ' +
+          'Fix the command first, then re-run.',
+      );
+      process.exitCode = result.exit_code;
+      return;
+    }
+
     console.log(`[atlas-perf] CPU profile: ${result.cpuprofile_path}`);
     if (result.flamegraph_path) {
       console.log(`[atlas-perf] Flamegraph: ${result.flamegraph_path}`);

--- a/tools/perf/src/profiler.ts
+++ b/tools/perf/src/profiler.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
-import { readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 export interface ProfileOptions {
@@ -21,13 +22,44 @@ export interface ProfileResult {
 export async function run_profiled(options: ProfileOptions): Promise<ProfileResult> {
   const { atlas_args, output_dir, use_0x } = options;
 
-  const cli_entry = resolve(process.cwd(), 'packages/cli/dist/cli.js');
+  const cli_entry = await resolve_cli_entry();
 
   if (use_0x) {
     return run_with_0x(cli_entry, atlas_args, output_dir);
   }
 
   return run_with_cpu_prof(cli_entry, atlas_args, output_dir);
+}
+
+/**
+ * Resolves the built CLI entry from the CLI package's own `bin` field.
+ *
+ * A hardcoded filename drifted once already: this looked for `dist/cli.js` while tsdown emits
+ * `dist/cli.mjs`, so every profiled run died in MODULE_NOT_FOUND and the tool then analysed the
+ * profile of that failed boot (issue #207). `bin` is what npm resolves when someone runs `atlas`,
+ * so following it cannot drift from the real entry again.
+ */
+async function resolve_cli_entry(): Promise<string> {
+  const manifest_path = resolve(process.cwd(), 'packages/cli/package.json');
+  // Repo-owned manifest rather than external input: its shape is whatever this repo commits.
+  const manifest = JSON.parse(await readFile(manifest_path, 'utf-8')) as {
+    bin?: Record<string, string>;
+  };
+
+  const relative_entry = manifest.bin?.['atlas'];
+  if (relative_entry === undefined) {
+    throw new Error(`No "bin.atlas" field in ${manifest_path}, so the CLI entry cannot be found.`);
+  }
+
+  const cli_entry = resolve(process.cwd(), 'packages/cli', relative_entry);
+  if (!existsSync(cli_entry)) {
+    throw new Error(
+      `CLI entry not found: ${cli_entry}. Run "pnpm run build" before profiling; ` +
+        'profiling a missing entry only measures the failed module load.',
+    );
+  }
+
+  return cli_entry;
 }
 
 async function run_with_cpu_prof(


### PR DESCRIPTION
Fixes #207. Cut from `dev`, nothing else open.

## Problem

```ts
const cli_entry = resolve(process.cwd(), 'packages/cli/dist/cli.js');
```

tsdown emits `cli.mjs`. Every profiled run died in MODULE_NOT_FOUND, `--cpu-prof` wrote a profile of that failed boot anyway, and the tool then analysed it and exited 0. So `perf:backup` and `perf:restore` looked like they worked while producing nothing.

## Fix

The entry comes from the CLI package's own `bin` field:

```json
{ "atlas": "dist/cli.mjs" }
```

That is what npm resolves when someone runs `atlas`, so the profiler cannot drift from the real filename again. Probing a list of candidate names would also have worked, but it would need updating the next time the build output changes; `bin` is already the single source of truth.

Two related changes, both aimed at the same thing:

- **A missing build stops the run.** With a clear message naming the file, rather than profiling a module load failure.
- **A non-zero exit from the profiled command stops the analysis.** Reporting on a profile of a failed run reads as a successful analysis, and that is precisely how this bug stayed invisible. It now exits with the child's code.

Setup failures print their message without a stack. They are operator mistakes, mostly a missing build, and an unhandled rejection trace on top buries the one line worth reading.

## Verification

The happy path, end to end:

```
$ node tools/perf/dist/cli.js profile -- --version
[atlas-perf] Profiling: node --cpu-prof ... /packages/cli/dist/cli.mjs --version
[atlas-perf] Process exited with code 0
[atlas-perf] CPU profile: .perf-output/CPU.20260828.110850.62398.0.001.cpuprofile
exit: 0                        # all four report sections present
```

I profiled `--version` rather than a real backup, because a real `atlas backup` needs a live tenant. That still exercises the whole path this issue is about: resolve the entry, spawn it, capture a profile of an actual CLI process, parse it, report, exit 0. The part I cannot verify here is that a backup's samples look like a backup, which needs credentials.

`perf:backup` and `perf:restore` both now reference `cli.mjs` and produce no MODULE_NOT_FOUND. Both exit 1 against no tenant, which is the CLI's own usage failure, and the analysis is correctly skipped.

The negative case, with `cli.mjs` temporarily moved aside:

```
[atlas-perf] Starting profiled run...
[atlas-perf] CLI entry not found: /Users/.../packages/cli/dist/cli.mjs. Run "pnpm run build"
             before profiling; profiling a missing entry only measures the failed module load.
exit: 1
```

`analyze` is untouched: run against a captured profile it still exits 0 with all four sections.

Gates: build 10/10, typecheck 17/17, test 15/15, lint 0 errors, docs build no warnings. `pnpm run perf:build` compiles clean.

## Docs

`docs/development/performance-profiling.md` carried the same stale `cli.js` in its pipeline diagram. Corrected, and the Quick Start now states that profiling needs `pnpm run build` first and that a missing build stops with a named file.

## Acceptance criteria

- [x] With only `cli.mjs` present, `perf:build && perf:backup` reaches the real CLI; happy path proven with a command that can succeed without a tenant
- [x] Same for `perf:restore`
- [x] `atlas-perf analyze` behaves exactly as before
- [x] The `Profiling: node ...` line references the file that exists; no MODULE_NOT_FOUND in a healthy run
- [x] With no CLI entry present, `profile` fails fast naming the missing file instead of analysing a crashed boot and exiting 0
