### PR TITLE
test(replicate): cover the drive replication and rehydration paths

### DIFF
--- a/packages/core/tests/unit/services/replication/drive-rehydration-runners.test.ts
+++ b/packages/core/tests/unit/services/replication/drive-rehydration-runners.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  OneDriveSnapshotManifest,
+  SharePointSnapshotManifest,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { rehydrate_od_manifests } from '@/services/replication/rehydration-od-manifests-runner';
+import { rehydrate_sp_manifests } from '@/services/replication/rehydration-sp-manifests-runner';
+import { replicate_onedrive_snapshot } from '@/services/replication/onedrive-snapshot-replicator';
+import { replicate_sharepoint_snapshot } from '@/services/replication/sharepoint-snapshot-replicator';
+
+/**
+ * Issue #191. These two runners are the same code apart from the scope field, yet the OneDrive one
+ * sat at 91% coverage and the SharePoint one at 4%, because the suite that exercises the OneDrive
+ * path mocks `rehydrate_sp_manifests` outright. Driving both through one table is the point: an
+ * asymmetry between them now fails a test.
+ */
+const OD_PREFIX = 'onedrive/manifests';
+const SP_PREFIX = 'sharepoint/manifests';
+
+function make_ctx(existing: string[]): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: { exists: async (key: string) => existing.includes(key) },
+  } as unknown as TenantContext;
+}
+
+const tally = {
+  objects_copied: 2,
+  objects_skipped: 1,
+  objects_failed: 0,
+  bytes_copied: 20,
+  errors: [] as string[],
+  source_manifest_checksum: 'a',
+  replicated_manifest_checksum: 'a',
+};
+
+vi.mock('@/services/replication/onedrive-snapshot-replicator', () => ({
+  replicate_onedrive_snapshot: vi.fn(async () => tally),
+}));
+vi.mock('@/services/replication/sharepoint-snapshot-replicator', () => ({
+  replicate_sharepoint_snapshot: vi.fn(async () => tally),
+}));
+const mocked_od = vi.mocked(replicate_onedrive_snapshot);
+const mocked_sp = vi.mocked(replicate_sharepoint_snapshot);
+
+const workloads = [
+  {
+    name: 'onedrive',
+    run: rehydrate_od_manifests,
+    replicate: mocked_od,
+    key_of: (id: string) => `${OD_PREFIX}/owner-1/${id}.json`,
+    manifest: (snapshot_id: string) =>
+      ({ snapshot_id, owner_id: 'owner-1' }) as OneDriveSnapshotManifest,
+  },
+  {
+    name: 'sharepoint',
+    run: rehydrate_sp_manifests,
+    replicate: mocked_sp,
+    key_of: (id: string) => `${SP_PREFIX}/site-1/${id}.json`,
+    manifest: (snapshot_id: string) =>
+      ({ snapshot_id, site_id: 'site-1' }) as SharePointSnapshotManifest,
+  },
+];
+
+describe.each(workloads)('rehydrate_$name_manifests', (w) => {
+  const source = { target_id: 'replica' } as never;
+  const run = w.run as (
+    source_ctx: TenantContext,
+    primary_ctx: TenantContext,
+    manifests: never[],
+    ancillary_keys: string[],
+    source: never,
+    tenant_id: string,
+    validate_dek: unknown,
+    passphrase: string,
+  ) => Promise<{ snapshot_id: string; objects_copied: number; objects_skipped: number }>;
+
+  beforeEach(() => {
+    mocked_od.mockClear();
+    mocked_sp.mockClear();
+  });
+
+  it('validates the DEK pair before reading any object', async () => {
+    const order: string[] = [];
+    const validate_dek = vi.fn(async () => {
+      order.push('validate');
+    });
+    w.replicate.mockImplementation(async () => {
+      order.push('replicate');
+      return tally as never;
+    });
+
+    await run(
+      make_ctx([]),
+      make_ctx([]),
+      [w.manifest('snap-1') as never],
+      [],
+      source,
+      'tenant-1',
+      validate_dek,
+      'passphrase',
+    );
+
+    expect(order).toEqual(['validate', 'replicate']);
+  });
+
+  it('skips a manifest already present on the primary without copying it', async () => {
+    w.replicate.mockImplementation(async () => tally as never);
+
+    const result = await run(
+      make_ctx([]),
+      make_ctx([w.key_of('snap-1')]),
+      [w.manifest('snap-1') as never],
+      [],
+      source,
+      'tenant-1',
+      vi.fn(async () => undefined),
+      'passphrase',
+    );
+
+    expect(w.replicate).not.toHaveBeenCalled();
+    expect(result.objects_skipped).toBe(1);
+    expect(result.objects_copied).toBe(0);
+  });
+
+  it('suppresses the replica marker, since recovered data is not a replica of itself', async () => {
+    w.replicate.mockImplementation(async () => tally as never);
+
+    await run(
+      make_ctx([]),
+      make_ctx([]),
+      [w.manifest('snap-1') as never],
+      ['drive/index/scope/runs/r1.json'],
+      source,
+      'tenant-1',
+      vi.fn(async () => undefined),
+      'passphrase',
+    );
+
+    const options = w.replicate.mock.calls[0]?.[4] as {
+      skip_marker?: boolean;
+      ancillary_keys?: string[];
+    };
+    expect(options.skip_marker).toBe(true);
+    expect(options.ancillary_keys).toEqual(['drive/index/scope/runs/r1.json']);
+  });
+
+  it('aggregates the tallies across several snapshots', async () => {
+    w.replicate.mockImplementation(async () => tally as never);
+
+    const result = await run(
+      make_ctx([]),
+      make_ctx([]),
+      [w.manifest('snap-1') as never, w.manifest('snap-2') as never],
+      [],
+      source,
+      'tenant-1',
+      vi.fn(async () => undefined),
+      'passphrase',
+    );
+
+    expect(result.objects_copied).toBe(4);
+    expect(result.objects_skipped).toBe(2);
+  });
+
+  it('labels a single-snapshot run with its snapshot id', async () => {
+    w.replicate.mockImplementation(async () => tally as never);
+
+    const result = await run(
+      make_ctx([]),
+      make_ctx([]),
+      [w.manifest('snap-1') as never],
+      [],
+      source,
+      'tenant-1',
+      vi.fn(async () => undefined),
+      'passphrase',
+    );
+
+    expect(result.snapshot_id).toBe('snap-1');
+  });
+
+  it('labels a multi-snapshot run with the count it actually copied', async () => {
+    w.replicate.mockImplementation(async () => tally as never);
+
+    const result = await run(
+      make_ctx([]),
+      make_ctx([w.key_of('snap-2')]),
+      [w.manifest('snap-1') as never, w.manifest('snap-2') as never],
+      [],
+      source,
+      'tenant-1',
+      vi.fn(async () => undefined),
+      'passphrase',
+    );
+
+    // snap-2 was already there, so one snapshot was copied out of two requested.
+    expect(result.snapshot_id).toBe('1-snapshots');
+  });
+
+  it('propagates a DEK mismatch instead of rehydrating under the wrong key', async () => {
+    const validate_dek = vi.fn(() => {
+      throw Object.assign(new Error('DEK mismatch'), { name: 'DekMismatchError' });
+    });
+
+    await expect(
+      run(
+        make_ctx([]),
+        make_ctx([]),
+        [w.manifest('snap-1') as never],
+        [],
+        source,
+        'tenant-1',
+        validate_dek,
+        'passphrase',
+      ),
+    ).rejects.toThrow('DEK mismatch');
+  });
+});

--- a/packages/core/tests/unit/services/replication/drive-rehydration-service.test.ts
+++ b/packages/core/tests/unit/services/replication/drive-rehydration-service.test.ts
@@ -1,0 +1,307 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AtlasConfig } from '@/utils/config';
+import type {
+  OneDriveManifestRepository,
+  SharePointManifestRepository,
+  StorageTarget,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveReplicationService } from '@/services/replication/onedrive-replication.service';
+import { SharePointReplicationService } from '@/services/replication/sharepoint-replication.service';
+import { stub_storage_target } from '@wisecom/atlas-types/testing/stub-storage-target';
+
+/**
+ * Issue #191: the drive replication services sat at 25% and 50% branch coverage, and the
+ * disaster-recovery entry points were the untested part. These cover the three decisions a
+ * rehydration makes before it copies anything: is the source DEK on the primary, does the snapshot
+ * already exist here, and does the snapshot exist on the replica at all.
+ */
+vi.mock('@/services/replication/rehydration-dek-helper', () => ({
+  ensure_source_dek_on_primary: vi.fn(async () => undefined),
+  DekOverwriteRefusedError: class extends Error {},
+}));
+vi.mock('@/services/replication/onedrive-snapshot-copier', () => ({
+  copy_onedrive_snapshot_between: vi.fn(async () => ({ snapshot_id: 'snap-1', copied: true })),
+  copy_onedrive_snapshot_to_target: vi.fn(),
+  copy_onedrive_snapshot_into_context: vi.fn(),
+}));
+vi.mock('@/services/replication/sharepoint-snapshot-copier', () => ({
+  copy_sharepoint_snapshot_between: vi.fn(async () => ({ snapshot_id: 'snap-1', copied: true })),
+  copy_sharepoint_snapshot_to_target: vi.fn(),
+  copy_sharepoint_snapshot_into_context: vi.fn(),
+}));
+
+import { ensure_source_dek_on_primary } from '@/services/replication/rehydration-dek-helper';
+import { copy_onedrive_snapshot_between } from '@/services/replication/onedrive-snapshot-copier';
+import { copy_sharepoint_snapshot_between } from '@/services/replication/sharepoint-snapshot-copier';
+
+const CONFIG = { encryption_passphrase: 'p' } as unknown as AtlasConfig;
+const OD_KEY = 'onedrive/manifests/owner-1/snap-1.json';
+const SP_KEY = 'sharepoint/manifests/site-1/snap-1.json';
+
+/** Primary context whose bucket holds the given keys. */
+function make_primary(existing: string[]): { ctx: TenantContext; destroyed: () => number } {
+  let destroyed = 0;
+  const ctx = {
+    tenant_id: 't',
+    storage: { exists: async (key: string) => existing.includes(key) },
+    destroy: () => {
+      destroyed++;
+    },
+  } as unknown as TenantContext;
+  return { ctx, destroyed: () => destroyed };
+}
+
+describe('drive rehydration entry points', () => {
+  let primary: ReturnType<typeof make_primary>;
+  let tenant_factory: TenantContextFactory;
+  let target_factory: () => StorageTarget;
+
+  beforeEach(() => {
+    vi.mocked(ensure_source_dek_on_primary).mockClear();
+    vi.mocked(copy_onedrive_snapshot_between).mockClear();
+    vi.mocked(copy_sharepoint_snapshot_between).mockClear();
+    primary = make_primary([]);
+    tenant_factory = { create: vi.fn(async () => primary.ctx) } as unknown as TenantContextFactory;
+    target_factory = (() => stub_storage_target({ target_id: 'primary' }).target) as never;
+  });
+
+  function od_service(manifest: unknown): OneDriveReplicationService {
+    const repo = {
+      find_by_snapshot: vi.fn(async () => manifest),
+    } as unknown as OneDriveManifestRepository;
+    return new OneDriveReplicationService(
+      tenant_factory,
+      repo,
+      CONFIG,
+      vi.fn(async () => undefined),
+      target_factory as never,
+    );
+  }
+
+  function sp_service(manifest: unknown): SharePointReplicationService {
+    const repo = {
+      find_by_snapshot: vi.fn(async () => manifest),
+    } as unknown as SharePointManifestRepository;
+    return new SharePointReplicationService(
+      tenant_factory,
+      repo,
+      CONFIG,
+      vi.fn(async () => undefined),
+      target_factory as never,
+    );
+  }
+
+  describe('OneDrive', () => {
+    const manifest = { snapshot_id: 'snap-1', owner_id: 'owner-1', entries: [{}, {}] };
+
+    it('ensures the source DEK on the primary before reading any object', async () => {
+      const replica = stub_storage_target({ target_id: 'replica' });
+
+      await od_service(manifest).rehydrate_owner_snapshot('t', 'owner-1', 'snap-1', replica.target);
+
+      expect(ensure_source_dek_on_primary).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports a skip instead of copying when the primary already holds the snapshot', async () => {
+      primary = make_primary([OD_KEY]);
+      tenant_factory = {
+        create: vi.fn(async () => primary.ctx),
+      } as unknown as TenantContextFactory;
+      const replica = stub_storage_target({ target_id: 'replica' });
+
+      const result = await od_service(manifest).rehydrate_owner_snapshot(
+        't',
+        'owner-1',
+        'snap-1',
+        replica.target,
+      );
+
+      expect(copy_onedrive_snapshot_between).not.toHaveBeenCalled();
+      expect(result.objects_skipped).toBe(manifest.entries.length);
+    });
+
+    it('copies when the primary does not hold it yet', async () => {
+      const replica = stub_storage_target({ target_id: 'replica' });
+
+      await od_service(manifest).rehydrate_owner_snapshot('t', 'owner-1', 'snap-1', replica.target);
+
+      expect(copy_onedrive_snapshot_between).toHaveBeenCalledTimes(1);
+    });
+
+    it('raises when the replica has no such manifest, rather than reporting an empty success', async () => {
+      const replica = stub_storage_target({ target_id: 'replica' });
+
+      await expect(
+        od_service(undefined).rehydrate_owner_snapshot('t', 'owner-1', 'snap-1', replica.target),
+      ).rejects.toThrow(/No OneDrive manifest found/);
+    });
+
+    it('destroys both contexts on the success path and on the throwing one', async () => {
+      const ok_replica = stub_storage_target({ target_id: 'replica' });
+      await od_service(manifest).rehydrate_owner_snapshot(
+        't',
+        'owner-1',
+        'snap-1',
+        ok_replica.target,
+      );
+      expect(ok_replica.destroyed()).toBe(ok_replica.created());
+      expect(primary.destroyed()).toBe(1);
+
+      primary = make_primary([]);
+      tenant_factory = {
+        create: vi.fn(async () => primary.ctx),
+      } as unknown as TenantContextFactory;
+      const bad_replica = stub_storage_target({ target_id: 'replica' });
+      await expect(
+        od_service(undefined).rehydrate_owner_snapshot(
+          't',
+          'owner-1',
+          'snap-1',
+          bad_replica.target,
+        ),
+      ).rejects.toThrow();
+      expect(bad_replica.destroyed()).toBe(bad_replica.created());
+      expect(primary.destroyed()).toBe(1);
+    });
+  });
+
+  describe('SharePoint', () => {
+    const manifest = { snapshot_id: 'snap-1', site_id: 'site-1', entries: [{}, {}] };
+
+    it('ensures the source DEK on the primary before reading any object', async () => {
+      const replica = stub_storage_target({ target_id: 'replica' });
+
+      await sp_service(manifest).rehydrate_site_snapshot('t', 'site-1', 'snap-1', replica.target);
+
+      expect(ensure_source_dek_on_primary).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports a skip instead of copying when the primary already holds the snapshot', async () => {
+      primary = make_primary([SP_KEY]);
+      tenant_factory = {
+        create: vi.fn(async () => primary.ctx),
+      } as unknown as TenantContextFactory;
+      const replica = stub_storage_target({ target_id: 'replica' });
+
+      const result = await sp_service(manifest).rehydrate_site_snapshot(
+        't',
+        'site-1',
+        'snap-1',
+        replica.target,
+      );
+
+      expect(copy_sharepoint_snapshot_between).not.toHaveBeenCalled();
+      expect(result.objects_skipped).toBe(manifest.entries.length);
+    });
+
+    it('copies when the primary does not hold it yet', async () => {
+      const replica = stub_storage_target({ target_id: 'replica' });
+
+      await sp_service(manifest).rehydrate_site_snapshot('t', 'site-1', 'snap-1', replica.target);
+
+      expect(copy_sharepoint_snapshot_between).toHaveBeenCalledTimes(1);
+    });
+
+    it('raises when the replica has no such manifest', async () => {
+      const replica = stub_storage_target({ target_id: 'replica' });
+
+      await expect(
+        sp_service(undefined).rehydrate_site_snapshot('t', 'site-1', 'snap-1', replica.target),
+      ).rejects.toThrow(/manifest/i);
+    });
+
+    it('destroys both contexts on the throwing path', async () => {
+      const replica = stub_storage_target({ target_id: 'replica' });
+
+      await expect(
+        sp_service(undefined).rehydrate_site_snapshot('t', 'site-1', 'snap-1', replica.target),
+      ).rejects.toThrow();
+
+      expect(replica.destroyed()).toBe(replica.created());
+      expect(primary.destroyed()).toBe(1);
+    });
+  });
+});
+
+/**
+ * `rehydrate_owner` / `rehydrate_site` recover every snapshot for one scope, and were the last
+ * untested branch of these services. They delegate the per-manifest work to the runners, so what
+ * matters here is that the DEK is settled first and both contexts are closed either way.
+ */
+describe('whole-scope rehydration', () => {
+  let primary: ReturnType<typeof make_primary>;
+  let tenant_factory: TenantContextFactory;
+  let target_factory: () => StorageTarget;
+
+  beforeEach(() => {
+    vi.mocked(ensure_source_dek_on_primary).mockClear();
+    primary = make_primary([]);
+    tenant_factory = { create: vi.fn(async () => primary.ctx) } as unknown as TenantContextFactory;
+    target_factory = (() => stub_storage_target({ target_id: 'primary' }).target) as never;
+  });
+
+  it('rehydrate_owner settles the DEK first and closes both contexts', async () => {
+    const replica = stub_storage_target({ target_id: 'replica' });
+    const repo = {
+      list_snapshots_by_owner: vi.fn(async () => []),
+    } as unknown as OneDriveManifestRepository;
+    const service = new OneDriveReplicationService(
+      tenant_factory,
+      repo,
+      CONFIG,
+      vi.fn(async () => undefined),
+      target_factory as never,
+    );
+
+    await service.rehydrate_owner('t', 'owner-1', replica.target);
+
+    expect(ensure_source_dek_on_primary).toHaveBeenCalledTimes(1);
+    expect(replica.destroyed()).toBe(replica.created());
+    expect(primary.destroyed()).toBe(1);
+  });
+
+  it('rehydrate_site settles the DEK first and closes both contexts', async () => {
+    const replica = stub_storage_target({ target_id: 'replica' });
+    const repo = {
+      list_snapshots_by_site: vi.fn(async () => []),
+    } as unknown as SharePointManifestRepository;
+    const service = new SharePointReplicationService(
+      tenant_factory,
+      repo,
+      CONFIG,
+      vi.fn(async () => undefined),
+      target_factory as never,
+    );
+
+    await service.rehydrate_site('t', 'site-1', replica.target);
+
+    expect(ensure_source_dek_on_primary).toHaveBeenCalledTimes(1);
+    expect(replica.destroyed()).toBe(replica.created());
+    expect(primary.destroyed()).toBe(1);
+  });
+
+  it('closes both contexts when listing the replica throws', async () => {
+    const replica = stub_storage_target({ target_id: 'replica' });
+    const repo = {
+      list_snapshots_by_owner: vi.fn(() => {
+        throw new Error('replica unreachable');
+      }),
+    } as unknown as OneDriveManifestRepository;
+    const service = new OneDriveReplicationService(
+      tenant_factory,
+      repo,
+      CONFIG,
+      vi.fn(async () => undefined),
+      target_factory as never,
+    );
+
+    await expect(service.rehydrate_owner('t', 'owner-1', replica.target)).rejects.toThrow(
+      'replica unreachable',
+    );
+
+    expect(replica.destroyed()).toBe(replica.created());
+    expect(primary.destroyed()).toBe(1);
+  });
+});

--- a/packages/core/tests/unit/services/replication/drive-replication-helpers.test.ts
+++ b/packages/core/tests/unit/services/replication/drive-replication-helpers.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  OneDriveSnapshotManifest,
+  SharePointSnapshotManifest,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import {
+  collect_od_ancillary_keys,
+  diff_od_manifests,
+} from '@/services/replication/onedrive-replication-helpers';
+import {
+  collect_sp_ancillary_keys,
+  diff_sp_manifests,
+} from '@/services/replication/sharepoint-replication-helpers';
+
+/**
+ * Issue #191: both drive helper files sat at 10% branch coverage, so the "cursor exists" and
+ * "target prefix is empty" branches were never taken by a test. Both are the difference between
+ * replicating a complete snapshot and replicating one that cannot be resumed.
+ */
+function make_ctx(keys: string[], existing: string[] = []): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: {
+      list: async (prefix: string) => keys.filter((k) => k.startsWith(prefix)),
+      exists: async (key: string) => existing.includes(key),
+    },
+  } as unknown as TenantContext;
+}
+
+const workloads = [
+  {
+    name: 'onedrive',
+    scope: 'owner-1',
+    index_prefix: 'onedrive/index',
+    cursor_key: 'onedrive/_meta/owner-1/delta.json',
+    manifest_prefix: 'onedrive/manifests',
+    collect: collect_od_ancillary_keys,
+    diff: diff_od_manifests as (
+      source: unknown[],
+      ctx: TenantContext,
+      scope: string,
+    ) => Promise<unknown[]>,
+    manifest: (snapshot_id: string) =>
+      ({ snapshot_id, owner_id: 'owner-1' }) as OneDriveSnapshotManifest,
+  },
+  {
+    name: 'sharepoint',
+    scope: 'site-1',
+    index_prefix: 'sharepoint/index',
+    cursor_key: 'sharepoint/_meta/site-1/delta.json',
+    manifest_prefix: 'sharepoint/manifests',
+    collect: collect_sp_ancillary_keys,
+    diff: diff_sp_manifests as (
+      source: unknown[],
+      ctx: TenantContext,
+      scope: string,
+    ) => Promise<unknown[]>,
+    manifest: (snapshot_id: string) =>
+      ({ snapshot_id, site_id: 'site-1' }) as SharePointSnapshotManifest,
+  },
+];
+
+describe.each(workloads)('$name ancillary keys', (w) => {
+  it('includes every version index object under the scope root', async () => {
+    // The prefix is the scope root, not `files/`: since #161 version rows live under `runs/`.
+    const ctx = make_ctx([
+      `${w.index_prefix}/${w.scope}/runs/r1.json`,
+      `${w.index_prefix}/${w.scope}/files/legacy.json`,
+      `${w.index_prefix}/other-scope/runs/r9.json`,
+    ]);
+
+    const keys = await w.collect(ctx, w.scope);
+
+    expect(keys).toEqual([
+      `${w.index_prefix}/${w.scope}/runs/r1.json`,
+      `${w.index_prefix}/${w.scope}/files/legacy.json`,
+    ]);
+  });
+
+  it('appends the delta cursor when it exists', async () => {
+    const ctx = make_ctx([`${w.index_prefix}/${w.scope}/runs/r1.json`], [w.cursor_key]);
+
+    const keys = await w.collect(ctx, w.scope);
+
+    expect(keys.at(-1)).toBe(w.cursor_key);
+  });
+
+  it('omits the delta cursor when it does not exist', async () => {
+    // A cursor key that is listed but absent would fail the copy and block the manifest, so the
+    // existence check is what keeps a first replication from failing.
+    const ctx = make_ctx([`${w.index_prefix}/${w.scope}/runs/r1.json`]);
+
+    const keys = await w.collect(ctx, w.scope);
+
+    expect(keys).not.toContain(w.cursor_key);
+  });
+
+  it('returns nothing when the scope has no index objects and no cursor', async () => {
+    expect(await w.collect(make_ctx([]), w.scope)).toEqual([]);
+  });
+});
+
+describe.each(workloads)('$name manifest diff', (w) => {
+  it('returns only the snapshots absent from the target', async () => {
+    const ctx = make_ctx([`${w.manifest_prefix}/${w.scope}/snap-1.json`]);
+    const source = [w.manifest('snap-1'), w.manifest('snap-2')];
+
+    const missing = await w.diff(source, ctx, w.scope);
+
+    expect(missing).toEqual([w.manifest('snap-2')]);
+  });
+
+  it('returns every snapshot when the target prefix is empty', async () => {
+    const source = [w.manifest('snap-1'), w.manifest('snap-2')];
+
+    const missing = await w.diff(source, make_ctx([]), w.scope);
+
+    expect(missing).toHaveLength(2);
+  });
+
+  it('returns nothing when the target already holds them all', async () => {
+    const ctx = make_ctx([
+      `${w.manifest_prefix}/${w.scope}/snap-1.json`,
+      `${w.manifest_prefix}/${w.scope}/snap-2.json`,
+    ]);
+
+    expect(await w.diff([w.manifest('snap-1'), w.manifest('snap-2')], ctx, w.scope)).toEqual([]);
+  });
+
+  it('ignores another scope holding the same snapshot id', async () => {
+    const ctx = make_ctx([`${w.manifest_prefix}/other-scope/snap-1.json`]);
+
+    const missing = await w.diff([w.manifest('snap-1')], ctx, w.scope);
+
+    expect(missing).toHaveLength(1);
+  });
+});

--- a/packages/core/tests/unit/services/replication/drive-snapshot-replicator-behaviour.test.ts
+++ b/packages/core/tests/unit/services/replication/drive-snapshot-replicator-behaviour.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  OneDriveSnapshotManifest,
+  SharePointSnapshotManifest,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { replicate_onedrive_snapshot } from '@/services/replication/onedrive-snapshot-replicator';
+import { replicate_sharepoint_snapshot } from '@/services/replication/sharepoint-snapshot-replicator';
+
+/**
+ * Issue #191: the drive replicators had almost no unit coverage while their Outlook twin was near
+ * fully covered, which is how #190 survived. These run both drive replicators through the same
+ * table, so a behaviour that holds for one and not the other fails here rather than in production.
+ */
+const DEK_KEY = '_meta/dek.enc';
+const MARKER_KEY = '_meta/replica.marker';
+const MANIFEST_KEY = 'drive/manifests/scope-1/snap-1.json';
+
+interface Recorder {
+  /** Every storage call, in order, as `verb:key`. */
+  readonly ops: string[];
+  readonly objects: Record<string, Buffer>;
+}
+
+function make_ctx(
+  recorder: Recorder,
+  side: 'source' | 'target',
+  fail_put_on?: string,
+): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: {
+      exists: async (key: string) => key in recorder.objects,
+      get: async (key: string) => {
+        const blob = recorder.objects[key];
+        if (!blob) throw new Error(`missing ${key}`);
+        return blob;
+      },
+      put: async (key: string, data: Buffer) => {
+        if (side === 'target') {
+          if (key === fail_put_on) throw new Error('AccessDenied');
+          recorder.ops.push(`put:${key}`);
+          recorder.objects[key] = data;
+        }
+      },
+      list: async () => [],
+    },
+  } as unknown as TenantContext;
+}
+
+/** Source holds the DEK, the manifest and the given data keys; target starts empty. */
+function make_pair(data_keys: string[], target_has: string[] = [], fail_put_on?: string) {
+  const source_objects: Record<string, Buffer> = {
+    [DEK_KEY]: Buffer.from('wrapped-dek'),
+    [MANIFEST_KEY]: Buffer.from('{"snapshot_id":"snap-1"}'),
+  };
+  for (const key of data_keys) source_objects[key] = Buffer.from(`body-${key}`);
+
+  const target: Recorder = { ops: [], objects: {} };
+  for (const key of target_has) target.objects[key] = Buffer.from('already-there');
+
+  return {
+    source_ctx: make_ctx({ ops: [], objects: source_objects }, 'source'),
+    target_ctx: make_ctx(target, 'target', fail_put_on),
+    target,
+  };
+}
+
+function od_manifest(storage_keys: string[]): OneDriveSnapshotManifest {
+  return {
+    snapshot_id: 'snap-1',
+    owner_id: 'scope-1',
+    entries: storage_keys.map((storage_key, i) => ({ item_id: `i${i}`, storage_key })),
+  } as unknown as OneDriveSnapshotManifest;
+}
+
+function sp_manifest(storage_keys: string[]): SharePointSnapshotManifest {
+  return {
+    snapshot_id: 'snap-1',
+    site_id: 'scope-1',
+    entries: storage_keys.map((storage_key, i) => ({ item_id: `i${i}`, storage_key })),
+  } as unknown as SharePointSnapshotManifest;
+}
+
+type Replicate = (
+  source_ctx: TenantContext,
+  target_ctx: TenantContext,
+  manifest: never,
+  manifest_key: string,
+  options?: { skip_marker?: boolean; ancillary_keys?: string[] },
+) => Promise<{
+  objects_copied: number;
+  objects_skipped: number;
+  objects_failed: number;
+  errors: string[];
+}>;
+
+const workloads: [string, Replicate, (keys: string[]) => never][] = [
+  ['onedrive', replicate_onedrive_snapshot as Replicate, od_manifest as (k: string[]) => never],
+  ['sharepoint', replicate_sharepoint_snapshot as Replicate, sp_manifest as (k: string[]) => never],
+];
+
+describe.each(workloads)('replicate_%s_snapshot', (_name, replicate, manifest_of) => {
+  it('writes the DEK, then the marker, then blobs, then ancillary keys, then the manifest', async () => {
+    const ancillary = 'drive/index/scope-1/runs/r1.json';
+    const { source_ctx, target_ctx, target } = make_pair([
+      'drive/data/a',
+      'drive/data/b',
+      ancillary,
+    ]);
+
+    await replicate(
+      source_ctx,
+      target_ctx,
+      manifest_of(['drive/data/a', 'drive/data/b']),
+      MANIFEST_KEY,
+      { ancillary_keys: [ancillary] },
+    );
+
+    expect(target.ops).toEqual([
+      `put:${DEK_KEY}`,
+      `put:${MARKER_KEY}`,
+      'put:drive/data/a',
+      'put:drive/data/b',
+      `put:${ancillary}`,
+      `put:${MANIFEST_KEY}`,
+    ]);
+  });
+
+  it('the manifest is written last, because it is what makes a snapshot reachable', async () => {
+    const { source_ctx, target_ctx, target } = make_pair(['drive/data/a']);
+
+    await replicate(source_ctx, target_ctx, manifest_of(['drive/data/a']), MANIFEST_KEY);
+
+    expect(target.ops.at(-1)).toBe(`put:${MANIFEST_KEY}`);
+  });
+
+  it('skip_marker suppresses the replica marker but still ensures the DEK', async () => {
+    const { source_ctx, target_ctx, target } = make_pair(['drive/data/a']);
+
+    await replicate(source_ctx, target_ctx, manifest_of(['drive/data/a']), MANIFEST_KEY, {
+      skip_marker: true,
+    });
+
+    expect(target.ops).toContain(`put:${DEK_KEY}`);
+    expect(target.ops).not.toContain(`put:${MARKER_KEY}`);
+  });
+
+  it('leaves an existing DEK alone rather than overwriting it', async () => {
+    const { source_ctx, target_ctx, target } = make_pair(['drive/data/a'], [DEK_KEY]);
+
+    await replicate(source_ctx, target_ctx, manifest_of(['drive/data/a']), MANIFEST_KEY);
+
+    expect(target.ops).not.toContain(`put:${DEK_KEY}`);
+  });
+
+  it('counts an object already on the target as skipped and does not re-upload it', async () => {
+    const { source_ctx, target_ctx, target } = make_pair(
+      ['drive/data/a', 'drive/data/b'],
+      ['drive/data/a'],
+    );
+
+    const result = await replicate(
+      source_ctx,
+      target_ctx,
+      manifest_of(['drive/data/a', 'drive/data/b']),
+      MANIFEST_KEY,
+    );
+
+    expect(result.objects_skipped).toBe(1);
+    expect(result.objects_copied).toBe(1);
+    expect(target.ops).not.toContain('put:drive/data/a');
+  });
+
+  it('tallies a failed copy and names the key in errors', async () => {
+    const { source_ctx, target_ctx } = make_pair(
+      ['drive/data/a', 'drive/data/b'],
+      [],
+      'drive/data/b',
+    );
+
+    const result = await replicate(
+      source_ctx,
+      target_ctx,
+      manifest_of(['drive/data/a', 'drive/data/b']),
+      MANIFEST_KEY,
+    );
+
+    expect(result.objects_failed).toBe(1);
+    expect(result.errors).toEqual(['drive/data/b: AccessDenied']);
+  });
+
+  it('writes no manifest when a copy failed, so the next run retries the snapshot', async () => {
+    const { source_ctx, target_ctx, target } = make_pair(['drive/data/a'], [], 'drive/data/a');
+
+    await replicate(source_ctx, target_ctx, manifest_of(['drive/data/a']), MANIFEST_KEY);
+
+    expect(target.ops).not.toContain(`put:${MANIFEST_KEY}`);
+  });
+
+  it('ignores manifest entries with no storage key', async () => {
+    const { source_ctx, target_ctx, target } = make_pair(['drive/data/a']);
+    const manifest = manifest_of(['drive/data/a']) as unknown as {
+      entries: { item_id: string; storage_key?: string }[];
+    };
+    manifest.entries.push({ item_id: 'tombstone' });
+
+    await replicate(source_ctx, target_ctx, manifest as never, MANIFEST_KEY);
+
+    expect(target.ops.filter((op) => op.startsWith('put:drive/data/'))).toEqual([
+      'put:drive/data/a',
+    ]);
+  });
+});

--- a/packages/core/tests/unit/services/replication/snapshot-copiers.test.ts
+++ b/packages/core/tests/unit/services/replication/snapshot-copiers.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CopyDeps } from '@/services/replication/outlook-snapshot-copier';
+import type { TenantContext } from '@wisecom/atlas-types';
+import {
+  copy_outlook_snapshot_between,
+  copy_outlook_snapshot_to_target,
+} from '@/services/replication/outlook-snapshot-copier';
+import {
+  copy_onedrive_snapshot_between,
+  copy_onedrive_snapshot_into_context,
+  copy_onedrive_snapshot_to_target,
+} from '@/services/replication/onedrive-snapshot-copier';
+import {
+  copy_sharepoint_snapshot_between,
+  copy_sharepoint_snapshot_into_context,
+  copy_sharepoint_snapshot_to_target,
+} from '@/services/replication/sharepoint-snapshot-copier';
+import { stub_storage_target } from '@wisecom/atlas-types/testing/stub-storage-target';
+
+/**
+ * Issue #191. These are the three entry points a replication or rehydration copy goes through, and
+ * they differ only in who owns the context and who validated the DEK. That is exactly the kind of
+ * near-duplicate trio where one drifting from the others goes unnoticed, so all three are asserted
+ * on the same three properties.
+ */
+const tally = {
+  objects_copied: 1,
+  objects_skipped: 0,
+  objects_failed: 0,
+  bytes_copied: 10,
+  errors: [] as string[],
+  source_manifest_checksum: 'a',
+  replicated_manifest_checksum: 'a',
+};
+
+vi.mock('@/services/replication/snapshot-replicator', () => ({
+  replicate_snapshot_to_target: vi.fn(async () => tally),
+}));
+vi.mock('@/services/replication/onedrive-snapshot-replicator', () => ({
+  replicate_onedrive_snapshot: vi.fn(async () => tally),
+}));
+vi.mock('@/services/replication/sharepoint-snapshot-replicator', () => ({
+  replicate_sharepoint_snapshot: vi.fn(async () => tally),
+}));
+
+import { replicate_snapshot_to_target } from '@/services/replication/snapshot-replicator';
+import { replicate_onedrive_snapshot } from '@/services/replication/onedrive-snapshot-replicator';
+import { replicate_sharepoint_snapshot } from '@/services/replication/sharepoint-snapshot-replicator';
+
+const source_ctx = { tenant_id: 't', storage: {} } as unknown as TenantContext;
+
+function open_ctx(): { ctx: TenantContext; destroyed: () => number } {
+  let destroyed = 0;
+  const ctx = {
+    tenant_id: 't',
+    storage: {},
+    destroy: () => {
+      destroyed++;
+    },
+  } as unknown as TenantContext;
+  return { ctx, destroyed: () => destroyed };
+}
+
+const od_manifest = { snapshot_id: 'snap-1', owner_id: 'owner-1' } as never;
+const sp_manifest = { snapshot_id: 'snap-1', site_id: 'site-1' } as never;
+const outlook_manifest = { snapshot_id: 'snap-1', mailbox_id: 'mbx-1' } as never;
+
+function make_deps(validate_dek = vi.fn(async () => undefined)): CopyDeps & {
+  validate_dek: ReturnType<typeof vi.fn>;
+} {
+  return { validate_dek, passphrase: 'p', tenant_id: 't' } as never;
+}
+
+const workloads = [
+  {
+    name: 'outlook',
+    manifest: outlook_manifest,
+    replicate: vi.mocked(replicate_snapshot_to_target),
+    to_target: (target: never, deps: CopyDeps) =>
+      copy_outlook_snapshot_to_target(source_ctx, target, outlook_manifest, deps),
+    between: (target_ctx: TenantContext, deps: CopyDeps, is_rehydration?: boolean) =>
+      copy_outlook_snapshot_between(
+        source_ctx,
+        target_ctx,
+        outlook_manifest,
+        'replica',
+        deps,
+        is_rehydration,
+      ),
+  },
+  {
+    name: 'onedrive',
+    manifest: od_manifest,
+    replicate: vi.mocked(replicate_onedrive_snapshot),
+    to_target: (target: never, deps: CopyDeps) =>
+      copy_onedrive_snapshot_to_target(source_ctx, target, od_manifest, [], deps),
+    between: (target_ctx: TenantContext, deps: CopyDeps, is_rehydration?: boolean) =>
+      copy_onedrive_snapshot_between(
+        source_ctx,
+        target_ctx,
+        od_manifest,
+        [],
+        'replica',
+        deps,
+        is_rehydration,
+      ),
+  },
+  {
+    name: 'sharepoint',
+    manifest: sp_manifest,
+    replicate: vi.mocked(replicate_sharepoint_snapshot),
+    to_target: (target: never, deps: CopyDeps) =>
+      copy_sharepoint_snapshot_to_target(source_ctx, target, sp_manifest, [], deps),
+    between: (target_ctx: TenantContext, deps: CopyDeps, is_rehydration?: boolean) =>
+      copy_sharepoint_snapshot_between(
+        source_ctx,
+        target_ctx,
+        sp_manifest,
+        [],
+        'replica',
+        deps,
+        is_rehydration,
+      ),
+  },
+];
+
+describe.each(workloads)('$name snapshot copier', (w) => {
+  beforeEach(() => {
+    w.replicate.mockClear();
+  });
+
+  describe('to_target', () => {
+    it('opens a context, validates the DEK, copies, and destroys the context', async () => {
+      const stub = stub_storage_target({ target_id: 'replica' });
+      const deps = make_deps();
+
+      const result = await w.to_target(stub.target as never, deps);
+
+      expect(deps.validate_dek).toHaveBeenCalledTimes(1);
+      expect(w.replicate).toHaveBeenCalledTimes(1);
+      expect(stub.destroyed()).toBe(1);
+      expect(result.snapshot_id).toBe('snap-1');
+    });
+
+    it('destroys the context when validation throws', async () => {
+      const stub = stub_storage_target({ target_id: 'replica' });
+      const deps = make_deps(
+        vi.fn(() => {
+          throw new Error('DEK mismatch');
+        }) as never,
+      );
+
+      await expect(w.to_target(stub.target as never, deps)).rejects.toThrow('DEK mismatch');
+
+      expect(stub.destroyed()).toBe(1);
+      expect(w.replicate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('between', () => {
+    it('validates the DEK and copies without touching the caller-owned context', async () => {
+      const target = open_ctx();
+      const deps = make_deps();
+
+      await w.between(target.ctx, deps);
+
+      expect(deps.validate_dek).toHaveBeenCalledTimes(1);
+      expect(w.replicate).toHaveBeenCalledTimes(1);
+      // The caller opened it, so the caller closes it.
+      expect(target.destroyed()).toBe(0);
+    });
+
+    it('suppresses the replica marker when rehydrating', async () => {
+      const target = open_ctx();
+
+      await w.between(target.ctx, make_deps(), true);
+
+      const options = w.replicate.mock.calls[0]?.at(-1) as { skip_marker?: boolean };
+      expect(options.skip_marker).toBe(true);
+    });
+
+    it('writes the replica marker when replicating', async () => {
+      const target = open_ctx();
+
+      await w.between(target.ctx, make_deps(), false);
+
+      const options = w.replicate.mock.calls[0]?.at(-1) as { skip_marker?: boolean };
+      expect(options.skip_marker).toBe(false);
+    });
+  });
+});
+
+describe('drive into_context', () => {
+  beforeEach(() => {
+    vi.mocked(replicate_onedrive_snapshot).mockClear();
+    vi.mocked(replicate_sharepoint_snapshot).mockClear();
+  });
+
+  it('copies without validating, because the loop validated once per target', async () => {
+    const target = open_ctx();
+
+    await copy_onedrive_snapshot_into_context(source_ctx, target.ctx, od_manifest, [], 'replica');
+    await copy_sharepoint_snapshot_into_context(source_ctx, target.ctx, sp_manifest, [], 'replica');
+
+    expect(replicate_onedrive_snapshot).toHaveBeenCalledTimes(1);
+    expect(replicate_sharepoint_snapshot).toHaveBeenCalledTimes(1);
+    expect(target.destroyed()).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #191. Cut from `dev`, nothing else open. **No source changes**, 75 tests across five files.

## The issue's baseline is stale

It measured `dev` at `fe49b3b`, before #224, #225 and #226 landed. Those had already taken the two snapshot replicators from 0% to 92% as a side effect of their own tests. So I re-measured before writing anything rather than working from the issue's table.

| File | Issue (fe49b3b) | Before this PR | After |
| --- | --- | --- | --- |
| `onedrive-snapshot-replicator.ts` | 0.0 / 0.0 | 92.45 / 65.21 | **98.11 / 86.95** |
| `sharepoint-snapshot-replicator.ts` | 3.9 / 0.0 | 92.45 / 65.21 | **98.11 / 86.95** |
| `rehydration-sp-manifests-runner.ts` | 0.0 / 0.0 | 4.34 / 0 | **100 / 100** |
| `rehydration-od-manifests-runner.ts` | not listed | 91.3 / 75 | **100 / 100** |
| `onedrive-replication.service.ts` | 29.5 / 28.6 | 72.09 / 50 | **100 / 100** |
| `sharepoint-replication.service.ts` | 26.5 / 11.1 | 67.41 / 25 | **97.75 / 75** |
| `onedrive-replication-helpers.ts` | 52.9 / 10.0 | 94.11 / 70 | **100 / 80** |
| `sharepoint-replication-helpers.ts` | 52.9 / 10.0 | 94.11 / 70 | **100 / 80** |
| `onedrive-snapshot-copier.ts` | did not exist | 81.81 / 50 | **100 / 100** |
| `sharepoint-snapshot-copier.ts` | did not exist | 81.81 / 50 | **100 / 100** |
| `outlook-snapshot-copier.ts` | did not exist | 63.63 / 0 | **100 / 100** |

Statements / branches. Every drive replication file is now at or above 90 / 70.

The three copiers did not exist when the issue was filed; #225 created two of them and they arrived at 81.81 / 50, so they were part of the same gap by the time I got here.

## Shape of the tests

Each file drives **both** drive workloads through one table. The gap this closes is not "these lines are untested", it is "these two files are the same code and only one of them is tested", which is how #190 survived. A table makes an asymmetry fail a test rather than pass unnoticed.

The SharePoint rehydration runner is the clearest case. It is byte-identical to the OneDrive one apart from the scope field:

```
$ diff <(sed 's/sharepoint/DRIVE/g; s/site_id/SCOPE/g' rehydration-sp-manifests-runner.ts) \
       <(sed 's/onedrive/DRIVE/g; s/owner_id/SCOPE/g' rehydration-od-manifests-runner.ts)
# differs only in how a doc comment wraps
```

It sat at 4% against the OneDrive twin's 91%, because `workload-tenant-rehydration.test.ts` mocks `rehydrate_sp_manifests` outright while exercising the OneDrive path for real.

## Behaviours, not line counts

Every acceptance criterion, asserted per workload:

- Copy ordering: DEK, replica marker, data blobs, ancillary keys, manifest **last**, asserted as an exact op sequence.
- `skip_marker` suppresses the marker while still ensuring the DEK; an existing DEK is not overwritten.
- An object already on the target is skipped, not re-uploaded.
- A failed copy is tallied with its key in `errors`, and no manifest is written, so the next run retries.
- Manifest entries with no storage key are ignored.
- Ancillary keys take the scope root, so per-run version objects from #161 are included; the delta cursor is appended only when it exists.
- Manifest diffing returns only what is absent, handles an empty target prefix, and is not fooled by another scope holding the same snapshot id.
- Rehydration validates the DEK pair before reading anything (asserted by call ordering), skips a snapshot the primary already holds, aggregates tallies, and propagates a DEK mismatch rather than recovering under the wrong key.
- A missing manifest on the replica raises rather than reporting an empty success.
- Source and target contexts are destroyed on success and on throw, for single-snapshot and whole-scope rehydration.

## Two things worth knowing

**The asymmetry is now inverted.** Four files in that directory remain below 90 / 70, and all four are Outlook or shared, not drive:

```
replication-integrity-verifier.ts   84.61 / 70
replication-status-repository.ts    85.71 / 75
replication.service.ts  (Outlook)   86.81 / 66.66
rehydration-manifests-runner.ts     90.90 / 50
```

The drive files now beat their Outlook twins on both metrics, which satisfies the criterion but recreates the same class of divergence in the other direction. I did not expand into them: the issue scopes to drive replication, and `rehydrate_manifests` has a different signature (no `ancillary_keys`), so it does not slot into the table I built. Worth its own issue if you want the directory uniform.

**Reused the shared stub.** `stub_storage_target` from `packages/types/src/testing/`, added in #225, rather than hand-rolling context fakes, per the repo testing rules. Contexts that need call-order recording are local to their file, since a recording storage is not reusable across these three shapes.

Gates in CI's mode (`pnpm run test:coverage`): 15/15 tasks, build 10/10, typecheck 17/17, lint 0 errors, docs build no warnings. Largest new file is 241 effective lines, inside the 300 limit.

## Acceptance criteria

- [x] Copy ordering: DEK, marker, blobs, ancillary, manifest last
- [x] `skip_marker` suppresses the marker, DEK still ensured
- [x] An object already present is skipped, not copied or re-uploaded
- [x] A failing copy is tallied in `objects_failed` with the key in `errors`
- [x] `collect_*_storage_keys` skips entries without a storage key
- [x] `collect_*_ancillary_keys` includes version indexes, cursor only when it exists
- [x] `diff_*_manifests` returns only absent snapshots, including an empty target prefix
- [x] `rehydrate_*_snapshot` reports a skip rather than copying when the manifest exists
- [x] Rehydration ensures the source DEK on the primary before any object is read
- [x] A missing manifest on the source raises rather than producing an empty result
- [x] Source and target contexts destroyed on both success and throw
- [x] Every drive replication file at >=90% statements and >=70% branches
