### PR TITLE
fix(release): let a dispatch tag the release when the push event never fired

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -144,6 +144,7 @@ correct it with `npm dist-tag add`, never by republishing.
 | `release-guard` fails on branch name   | Branch version disagrees with `packages/sdk/package.json` | `pnpm run release:version <branch version>`        |
 | `release-guard` fails on existing tag  | Version already released                                  | Pick a higher version                              |
 | Tag exists, `publish.yml` never ran    | Tag pushed by hand with `GITHUB_TOKEN`                    | `gh workflow run publish.yml -f version=<version>` |
+| No `publish.yml` run at all             | GitHub created no run for the push (issue #212)           | `gh workflow run publish.yml -f version=<version> --ref main`; it tags the ref when the tag is missing |
 | Publish failed on build, lint, or test | Broken release commit                                     | Delete the tag, fix via a PR into `dev`, cut again |
 | SDK published, CLI failed              | Partial publish; npm is immutable                         | Hotfix forward at the next patch version           |
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,40 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          if [ "$GITHUB_REF_TYPE" = tag ] || [ -n "$INPUT_VERSION" ]; then
+          # A tag ref is already the thing to publish.
+          if [ "$GITHUB_REF_TYPE" = tag ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Manual dispatch. This is the repair path for the case where GitHub
+          # created no run for the push to main, so nothing tagged the release
+          # (issue #212). It used to assume the tag existed and hand `publish` a
+          # ref that did not, which failed inside actions/checkout with a bare
+          # git exit code and no mention of the tag.
+          if [ -n "$INPUT_VERSION" ]; then
+            if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+              echo "v$VERSION is already tagged; publishing that tag."
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            # Tag the dispatched ref, but only when its packages really say this
+            # version. A tag that disagrees with the packages is what hard rule 5
+            # forbids, and the automated path must not do what an operator is told
+            # not to do by hand.
+            PACKAGE_VERSION=$(node -p "require('./packages/sdk/package.json').version")
+            if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+              echo "::error::Cannot tag v$VERSION: $GITHUB_REF_NAME has packages at $PACKAGE_VERSION." \
+                "Dispatch against a ref whose packages match the requested version."
+              exit 1
+            fi
+
+            git config user.name 'github-actions[bot]'
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git tag -a "v$VERSION" -m "Release v$VERSION"
+            git push origin "v$VERSION"
+            echo "Tagged v$VERSION on $GITHUB_REF_NAME."
             echo "publish=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -239,3 +239,40 @@ npm versions are immutable, so recovery is always forward, never a re-publish:
    lockstep, so a partial publish must be resolved by moving both forward.
 3. **Wrong dist-tag:** correct it with `npm dist-tag add` rather than
    republishing.
+
+## If no workflow run appears at all
+
+Distinct from a publish that ran and failed. Here GitHub created no run for the
+push, so nothing tagged anything and there is no failure to read. It happened on
+the v3.0.0 merge: `publish.yml` declares `on: push: branches: [main]`, the merge
+landed, and no run existed. Pushing the tag by hand produced no run either, even
+though the same file declares `on: push: tags: ['v*']`. `pull_request` and
+`workflow_dispatch` events fired normally throughout, which is what made the
+release recoverable.
+
+Recovery, in this order:
+
+```bash
+gh run list --workflow publish.yml --limit 3        # confirm no run exists for the merge
+gh workflow run publish.yml -f version=<version> --ref main
+gh run watch
+```
+
+The dispatch creates the tag when it is missing, provided the dispatched ref's
+packages already say that version. If they disagree it stops and says so, rather
+than tagging a commit the version guard would reject. There is no need to push a
+tag by hand for this case any more.
+
+Confirm all four artefacts afterwards, since a dispatch that tags and publishes
+still leaves `sync-dev` to run:
+
+```bash
+git ls-remote --tags origin | grep "v<version>"
+npm view @wisecom/atlas-sdk@<version> version
+gh release view "v<version>"
+git log --oneline -1 origin/dev                     # should be at or ahead of main
+```
+
+If `sync-dev` was skipped or failed, fast-forward `dev` onto `main` by hand. A
+`dev` that lacks the release commit means the next release branch is cut without
+it.

--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -315,7 +315,7 @@ A restore creates `/Restore-<timestamp>` at the target drive root and recreates 
 
 This exists because the conflict policy is not a safety net. With the default `rename`, restoring a snapshot whose files still exist neither fails nor overwrites; it writes a suffixed copy next to every original. Repeated across a few DR rehearsals that leaves copies of the same file interleaved with real data, with nothing marking which is which. A restore root makes the result reviewable before it matters and reversible afterwards: delete the folder and the restore is undone.
 
-`--destination` replaces the generated root with one you name, created if missing. `--in-place` restores to the original paths, which was the behaviour before 3.1.0 and is now opt-in. `--conflict` keeps its meaning and applies inside whichever destination is chosen; under a fresh root there is normally nothing to collide with.
+`--destination` replaces the generated root with one you name, created if missing. `--in-place` restores to the original paths, which was the behaviour before 4.0.0 and is now opt-in. `--conflict` keeps its meaning and applies inside whichever destination is chosen; under a fresh root there is normally nothing to collide with.
 
 `--name` renames a single restored file and is rejected when the restore resolves to more than one file, since renaming many files to one name would either collide or silently rename only the first. Pair it with `--file-filter`.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -447,7 +447,7 @@ A snapshot taken with `--folder` contains only that folder's files. Restoring it
 | `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`)          |
 | `-t, --tenant <id>`        | Override tenant ID from config                                                     |
 
-A drive restore nests under `/Restore-<timestamp>` at the target drive root and recreates the original folder structure beneath it, matching how Outlook restores have always worked. `--in-place` reproduces the pre-3.1.0 behaviour of writing back over the original paths; it is never the default, because `--conflict rename` turns a repeated in-place restore into suffixed duplicates scattered through live content rather than a failure. See [Where restored files land](/onedrive-backup#where-restored-files-land).
+A drive restore nests under `/Restore-<timestamp>` at the target drive root and recreates the original folder structure beneath it, matching how Outlook restores have always worked. `--in-place` reproduces the pre-4.0.0 behaviour of writing back over the original paths; it is never the default, because `--conflict rename` turns a repeated in-place restore into suffixed duplicates scattered through live content rather than a failure. See [Where restored files land](/onedrive-backup#where-restored-files-land).
 
 Identifiers are matched case-insensitively: `--owner`, `--site`, and `--file-filter` all accept whatever case a listing or portal shows. Owner and site IDs are lowercased before they become storage keys, so one identifier always addresses one tree. Earlier releases wrote a second tree for a second spelling and deleted from whichever one they were handed.
 
@@ -614,7 +614,7 @@ Graph returns only the subsites the application can read. A subsite that cannot 
 
 Restored files nest under `Restore-<timestamp>` in each destination library, with the original
 structure recreated beneath it. `--in-place` restores over the original paths, which was the
-behaviour before 3.1.0. See
+behaviour before 4.0.0. See
 [Where restored files land](../sharepoint-backup.md#where-restored-files-land).
 
 With `--target-site`, each file goes to the target library whose name matches the

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -180,13 +180,13 @@ The callback is optional and runs inline with the operation. Keep it fast; move 
 
 OneDrive and SharePoint expose parallel methods on `atlas.onedrive` and `atlas.sharepoint` (including workload-specific replication). See [OneDrive Backup](/onedrive-backup) and [SharePoint Backup](/sharepoint-backup) for full SDK examples per workload.
 
-The drive restore methods take `destination`, `in_place` and `rename_to` alongside `conflict_behavior`. As of 3.1.0 they default to a generated `Restore-<timestamp>` root rather than writing back over the original paths, so an embedder that relied on the old behaviour has to pass `in_place: true`:
+The drive restore methods take `destination`, `in_place` and `rename_to` alongside `conflict_behavior`. As of 4.0.0 they default to a generated `Restore-<timestamp>` root rather than writing back over the original paths, so an embedder that relied on the old behaviour has to pass `in_place: true`:
 
 ```typescript
 const snapshot_id = 'od-snap-123';
 await atlas.onedrive.restore('owner-id', { snapshot_id }); // /Restore-2026-08-27T10-15-30/...
 await atlas.onedrive.restore('owner-id', { snapshot_id, destination: '/DR-drill' });
-await atlas.onedrive.restore('owner-id', { snapshot_id, in_place: true }); // pre-3.1.0 behaviour
+await atlas.onedrive.restore('owner-id', { snapshot_id, in_place: true }); // pre-4.0.0 behaviour
 ```
 
 `restore` and `save` on both drive workloads require an options object containing `snapshot_id`. TypeScript enforces that at compile time; a JavaScript caller that omits it now gets a `TypeError` naming the method, for example `onedrive.restore() requires an options object with a snapshot_id`, instead of a crash from inside the service about an internal property. `verify` continues to accept options optionally.

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -288,7 +288,7 @@ atlas sharepoint restore --site https://contoso.sharepoint.com/sites/Engineering
 
 A restore creates `Restore-<timestamp>` in each destination library and recreates the original folder structure beneath it, so a file backed up from `/Reports/2026` returns to `/Restore-2026-08-27T10-15-30/Reports/2026`. Deleting that one folder undoes the whole restore.
 
-Before 3.1.0 a restore wrote every file back over its original path. With the default `rename` conflict policy that neither failed nor overwrote; it left a suffixed copy beside each original, scattered through live library content with nothing marking which copy came from a backup. `--in-place` still does exactly that, but it now has to be asked for.
+Before 4.0.0 a restore wrote every file back over its original path. With the default `rename` conflict policy that neither failed nor overwrote; it left a suffixed copy beside each original, scattered through live library content with nothing marking which copy came from a backup. `--in-place` still does exactly that, but it now has to be asked for.
 
 `--destination` names the folder instead of generating one, and is created when missing. `--name` renames a single restored file and is rejected when more than one file matches, so pair it with `--file-filter`. Path length limits apply to the deeper nesting: a file that exceeds one is reported as a skipped item and does not abort the run.
 


### PR DESCRIPTION
Refs #212. Preflight for the v4.0.0 release.

## The fixable half of #212

Most of #212 is an upstream event-delivery problem I cannot fix here. One part is ours, and it is criterion 4:

```yaml
if [ "$GITHUB_REF_TYPE" = tag ] || [ -n "$INPUT_VERSION" ]; then
  echo "publish=true" >> "$GITHUB_OUTPUT"
  exit 0            # never checks whether the tag exists
fi
```

A dispatch declared itself publishable, then `publish` checked out `ref: v<version>` and a missing tag surfaced as a bare git exit code inside `actions/checkout`. So the documented repair path could not create the tag it needed, which is why v3.0.0 needed a hand-pushed tag.

The dispatch path now tags the dispatched ref when the tag is missing, guarded on the ref's packages already carrying that version:

```
$ GITHUB_REF_NAME=main INPUT_VERSION=9.9.9 ./decide
::error::Cannot tag v9.9.9: main has packages at 3.0.0. Dispatch against a ref
whose packages match the requested version.
```

Hard rule 5 forbids an operator pushing a tag that disagrees with the packages, so the automated path refuses it too rather than tagging something the version guard would reject.

## Version references move to 4.0.0

Two commits in this release declare `BREAKING CHANGE`:

- `feat(drive): restore under a Restore-<timestamp> root instead of over live files`
- `fix(cli): one scope precedence for outlook list, save and restore`

So the release is a major. Six doc notes written as "as of 3.1.0" / "pre-3.1.0" against the old milestone name are now 4.0.0.

## Docs

`docs/development/releases.md` had a row for *a tag exists but no run*, which is a different situation from *no run exists at all*. The new section covers the second, in order: confirm no run, dispatch with `--ref main`, then verify all four artefacts including that `sync-dev` actually reached `dev`. The release skill's recovery table carries the same row.

Gates: build 10/10, test 15/15, lint 0 errors, docs build no warnings. The `plan` script was extracted and run directly to check both the shell syntax and the mismatch guard.