### PR TITLE
docs(release): the v3.0.0 push events were late, not dropped

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -144,7 +144,7 @@ correct it with `npm dist-tag add`, never by republishing.
 | `release-guard` fails on branch name   | Branch version disagrees with `packages/sdk/package.json` | `pnpm run release:version <branch version>`        |
 | `release-guard` fails on existing tag  | Version already released                                  | Pick a higher version                              |
 | Tag exists, `publish.yml` never ran    | Tag pushed by hand with `GITHUB_TOKEN`                    | `gh workflow run publish.yml -f version=<version>` |
-| No `publish.yml` run at all             | GitHub created no run for the push (issue #212)           | `gh workflow run publish.yml -f version=<version> --ref main`; it tags the ref when the tag is missing |
+| No `publish.yml` run after the merge    | Event delivery is late, not dropped (issue #212)          | Wait a few minutes and re-check; only then `gh workflow run publish.yml -f version=<version> --ref main`, which tags the ref when the tag is missing |
 | Publish failed on build, lint, or test | Broken release commit                                     | Delete the tag, fix via a PR into `dev`, cut again |
 | SDK published, CLI failed              | Partial publish; npm is immutable                         | Hotfix forward at the next patch version           |
 

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -240,20 +240,37 @@ npm versions are immutable, so recovery is always forward, never a re-publish:
 3. **Wrong dist-tag:** correct it with `npm dist-tag add` rather than
    republishing.
 
-## If no workflow run appears at all
+## If no workflow run appears after the merge
 
-Distinct from a publish that ran and failed. Here GitHub created no run for the
-push, so nothing tagged anything and there is no failure to read. It happened on
-the v3.0.0 merge: `publish.yml` declares `on: push: branches: [main]`, the merge
-landed, and no run existed. Pushing the tag by hand produced no run either, even
-though the same file declares `on: push: tags: ['v*']`. `pull_request` and
-`workflow_dispatch` events fired normally throughout, which is what made the
-release recoverable.
+Distinct from a publish that ran and failed. Here there is no run to read, so
+there is nothing to diagnose yet.
 
-Recovery, in this order:
+**Wait and re-check before doing anything.** The v3.0.0 release looked like
+dropped events and was actually late ones. Push runs for that merge commit do
+exist, timestamped five and eight minutes after the merge, which is after the
+manual repair had already published. That is what produced the duplicate
+publish attempt:
+
+```
+16:51 workflow_dispatch  failure   <- repair attempt, no tag existed yet
+16:56 workflow_dispatch  success   <- repair after pushing the tag by hand
+16:59 push               failure   <- the merge event, arriving late: version already published
+17:02 push               success   <- the tag event, also late
+```
+
+For comparison, the v4.0.0 merge created its run seven seconds after the merge
+with byte-identical workflow config. Repository configuration was never the
+problem; event delivery was slow during a GitHub incident window.
+
+So give it several minutes and look again:
 
 ```bash
-gh run list --workflow publish.yml --limit 3        # confirm no run exists for the merge
+gh run list --workflow publish.yml --limit 5   # check twice, a few minutes apart
+```
+
+Only when a run genuinely never arrives, dispatch it:
+
+```bash
 gh workflow run publish.yml -f version=<version> --ref main
 gh run watch
 ```


### PR DESCRIPTION
Refs #212, follow-up to #234.

Recovering the run history after v4.0.0 shipped contradicts what #212 assumed, and what I wrote in #234.

The push runs for the v3.0.0 merge commit **do exist**:

```
16:51 workflow_dispatch  failure   <- repair attempt, no tag existed yet
16:56 workflow_dispatch  success   <- repair after pushing the tag by hand
16:59 push               failure   <- the merge event, arriving late: 3.0.0 already on npm
17:02 push               success   <- the tag event, also late
```

So events were delivered five and eight minutes late, not dropped. I checked too early, concluded nothing was coming, and repaired by hand. The 16:59 failure is my repair racing the delayed delivery, not an independent fault.

For comparison, the v4.0.0 merge created its run **seven seconds** after merging with byte-identical workflow config. Repository configuration was never involved.

## Why this needs a docs change

The section I added in #234 told an operator to confirm no run exists and then dispatch. Followed during a delivery lag, that is precisely what produced the duplicate publish. It now says to wait several minutes and re-check first, and to dispatch only when a run genuinely never arrives. The release skill's recovery row says the same.

The `publish.yml` change from #234 stands: when a run really is absent, the dispatch has to be able to create the tag, and it now can.