### PR TITLE
fix(outlook): report which mailboxes have an unbacked-up archive

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -326,7 +326,7 @@ Archive     never backed up        -
 
 ### `atlas outlook mailboxes`
 
-List tenant mailboxes directly from Microsoft Graph (live data, not from the backup catalog). Shows email address, display name, Exchange Online license status, account status, mailbox type, creation date, and optionally mailbox size.
+List tenant mailboxes directly from Microsoft Graph (live data, not from the backup catalog). Shows email address, display name, Exchange Online license status, account status, mailbox type, creation date, and optionally mailbox size and In-Place Archive state.
 
 ```bash
 atlas outlook mailboxes
@@ -343,6 +343,14 @@ atlas outlook mailboxes -t <tenant-id>
 Mailbox size requires the `Reports.Read.All` Graph API permission. If the permission is not granted, the Size column is omitted without error.
 
 The `Type` column shows the Graph `mailboxSettings.userPurpose` value (`user`, `shared`, `room`, `equipment`, ...). To keep discovery fast, it is only resolved for unlicensed mailboxes; `--` means the purpose was not resolved. Note that `--licensed-only` excludes shared mailboxes, which are typically unlicensed.
+:::
+
+::: warning An In-Place Archive is not backed up
+The `Archive` column comes from the same `Reports.Read.All` report and reports whether the mailbox has an **In-Place Archive** (Online Archive). Graph cannot read archive mailboxes at all, so that content is outside backup scope, and the command prints a warning naming every affected mailbox.
+
+`--` means **unknown**, not "no archive": either the permission is missing or the report omitted the column. Atlas does not report coverage it cannot confirm.
+
+This is not the `Archive` folder that Outlook's Archive button uses; that folder is in the primary mailbox and is backed up normally. See [In-Place Archive is out of scope](../security.md#in-place-archive-is-out-of-scope).
 :::
 
 ## `atlas delete`

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -208,6 +208,21 @@ const mailboxes = await atlas.outlook.listAvailableMailboxes();
 const shared = mailboxes.filter((mb) => mb.mailbox_purpose === 'shared');
 ```
 
+### In-Place Archive coverage
+
+`TenantMailbox.has_in_place_archive` (from `listAvailableMailboxes()`) reports whether a mailbox has an In-Place Archive (Online Archive). That store is **not backed up**: Graph cannot read archive mailboxes at all, so a successful backup of such a mailbox is not a backup of all its mail. See [In-Place Archive is out of scope](/security#in-place-archive-is-out-of-scope).
+
+The field is tri-state, and the third state matters:
+
+```typescript
+const mailboxes = await atlas.outlook.listAvailableMailboxes();
+
+const uncovered = mailboxes.filter((mb) => mb.has_in_place_archive === true);
+const unknown = mailboxes.filter((mb) => mb.has_in_place_archive === undefined);
+```
+
+`undefined` means unknown, not "no archive". The signal is the `Has Archive` column of the mailbox usage report, which needs the optional `Reports.Read.All` permission, so an embedder that treats absence as "covered" will report coverage Atlas never confirmed. No per-mailbox Graph property exposes archive state on v1.0 or beta.
+
 ### Identifier case
 
 Every method taking a mailbox address, an Entra object ID, or a SharePoint site ID lowercases it before it becomes a storage key segment, so two spellings of one identifier address one tree.

--- a/docs/security.md
+++ b/docs/security.md
@@ -171,6 +171,37 @@ Two consequences worth stating plainly:
 Atlas does not currently capture Microsoft Purview sensitivity labels or IRM protection state for drive items. Labelled files whose content Graph does serve are backed up as ciphertext like any other file, but the label itself is not recorded, so a restored copy does not carry its original classification. Treat restored content as unclassified until it is relabelled. Capturing label metadata is tracked separately; it is a metered Graph surface and is deliberately out of scope for the quarantine handling described above.
 :::
 
+### In-Place Archive is out of scope
+
+Atlas backs up the **primary mailbox**. A mailbox with an **In-Place Archive** (also called Online Archive, or the archive mailbox) has a second, separate store, and none of it is backed up.
+
+This is not an implementation gap Atlas can close on the current API. Microsoft states it directly in the [Outlook mail API overview](https://learn.microsoft.com/en-us/graph/api/resources/mail-api-overview?view=graph-rest-1.0):
+
+> The API does not support accessing in-place archive mailboxes, not on Exchange Online nor on Exchange Server.
+
+Every Atlas sync path is built on that API. `GET /users/{id}/mailFolders` and the per-folder `/messages/delta` calls only ever see the primary store, and no folder ID or query parameter reaches the archive.
+
+Do not confuse this with the **`Archive` well-known folder**, the one Outlook's one-click Archive button moves mail into. That folder lives in the primary mailbox and is backed up like any other folder.
+
+::: warning Retention policies move mail out of backup scope
+This matters most where it is least visible. A Microsoft 365 retention or MRM policy that auto-moves mail to the archive after a set age silently removes that mail from backup scope, and it removes the **oldest** mail first, which is usually the most compliance-relevant. Under an aggressive policy, most of a mailbox's history can sit unprotected.
+
+Worse, when a policy moves an already backed-up message, the folder delta reports it as removed from the primary mailbox. Depending on how you prune snapshots, that message can eventually age out of your backups while the only live copy sits in an archive Atlas cannot read.
+:::
+
+**How to tell which mailboxes are affected.** `atlas outlook mailboxes` shows an `Archive` column and warns for every affected mailbox by name:
+
+```
+[!] 2 mailbox(es) have an In-Place Archive (Online Archive), which Graph cannot read
+    and Atlas does not back up:
+      alice@contoso.com
+      bob@contoso.com
+```
+
+The signal is the `Has Archive` column of the [mailbox usage report](https://learn.microsoft.com/en-us/graph/api/reportroot-getmailboxusagedetail?view=graph-rest-1.0), which needs the optional `Reports.Read.All` application permission. Without that permission the column reads `--`, meaning **unknown**, never "no archive": Atlas will not report coverage it cannot confirm. No per-mailbox Graph property exposes archive state on either v1.0 or beta, so the tenant-wide report is the only source.
+
+**If archive content must be protected**, the mail has to leave the archive before Atlas can see it: adjust the retention policy so it stays in the primary mailbox, or move the content back. The Microsoft [mailbox import and export APIs](https://learn.microsoft.com/en-us/graph/mailbox-import-export-concept-overview) do cover archive mailboxes, but on a different model (job-based FastTransfer export streams and a separate `MailboxImportExport.*` permission set) that is not a drop-in for per-folder delta sync.
+
 ## Integrity Validation
 
 Atlas validates data integrity at three independent layers. Each layer catches a different class of failure:

--- a/packages/cli/src/commands/outlook-mgmt.handler.tsx
+++ b/packages/cli/src/commands/outlook-mgmt.handler.tsx
@@ -23,6 +23,9 @@ import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { KeyValueList } from '@/ui/components/key-value-list';
 import { render_static_view } from '@/ui/render';
 
+/** Archive-enabled mailboxes named individually before the warning summarises. */
+const ARCHIVE_WARNING_LIMIT = 10;
+
 export interface OutlookVerifyOptions {
   snapshot: string;
   mailbox: string;
@@ -217,6 +220,7 @@ async function print_status_result(result: MailboxStatusResult): Promise<void> {
 
 async function print_mailbox_table(mailboxes: TenantMailbox[]): Promise<void> {
   const has_sizes = mailboxes.some((m) => m.mailbox_size_bytes !== undefined);
+  const archive_known = mailboxes.some((m) => m.has_in_place_archive !== undefined);
 
   interface MailboxRow {
     mail: string;
@@ -225,6 +229,7 @@ async function print_mailbox_table(mailboxes: TenantMailbox[]): Promise<void> {
     status: string;
     type: string;
     size: string;
+    archive: string;
     created: string;
   }
   const columns: TableColumn<MailboxRow>[] = [
@@ -234,6 +239,9 @@ async function print_mailbox_table(mailboxes: TenantMailbox[]): Promise<void> {
     { key: 'status', header: 'Status' },
     { key: 'type', header: 'Type' },
     ...(has_sizes ? [{ key: 'size', header: 'Size' } satisfies TableColumn<MailboxRow>] : []),
+    ...(archive_known
+      ? [{ key: 'archive', header: 'Archive' } satisfies TableColumn<MailboxRow>]
+      : []),
     { key: 'created', header: 'Created' },
   ];
   const rows = mailboxes.map((m) => ({
@@ -243,7 +251,42 @@ async function print_mailbox_table(mailboxes: TenantMailbox[]): Promise<void> {
     status: m.exchange_plan_status ?? '--',
     type: m.mailbox_purpose ?? '--',
     size: m.mailbox_size_bytes === undefined ? '--' : format_bytes(m.mailbox_size_bytes, 2),
+    archive: format_in_place_archive(m.has_in_place_archive),
     created: m.created_at ? m.created_at.toISOString().slice(0, 10) : '--',
   }));
   await render_static_view(<DataTable columns={columns} rows={rows} />);
+  warn_about_in_place_archives(mailboxes);
+}
+
+/**
+ * Renders the tri-state archive cell.
+ *
+ * `--` is unknown, never "no": the signal comes from an optional usage report,
+ * and claiming a mailbox has no archive when Atlas could not check is the
+ * false reassurance this column exists to remove.
+ */
+export function format_in_place_archive(has_archive: boolean | undefined): string {
+  if (has_archive === undefined) return '--';
+  return has_archive ? 'Yes' : 'No';
+}
+
+/**
+ * Names mailboxes whose In-Place Archive sits outside backup scope.
+ *
+ * Graph cannot read archive mailboxes at all, so this is the only signal an
+ * operator gets that a backup of this mailbox is not a backup of all its mail.
+ */
+function warn_about_in_place_archives(mailboxes: TenantMailbox[]): void {
+  const archived = mailboxes.filter((m) => m.has_in_place_archive === true);
+  if (archived.length === 0) return;
+
+  logger.warn(
+    `${archived.length} mailbox(es) have an In-Place Archive (Online Archive), which Graph cannot read and Atlas does not back up:`,
+  );
+  for (const m of archived.slice(0, ARCHIVE_WARNING_LIMIT)) {
+    logger.warn(`  ${m.mail}`);
+  }
+  const hidden = archived.length - ARCHIVE_WARNING_LIMIT;
+  if (hidden > 0) logger.warn(`  ...and ${hidden} more`);
+  logger.info('Coverage detail: docs/security.md, "In-Place Archive is out of scope".');
 }

--- a/packages/cli/tests/unit/mailboxes-command.test.ts
+++ b/packages/cli/tests/unit/mailboxes-command.test.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { Container } from 'inversify';
 import 'reflect-metadata';
 import { register_outlook_command } from '@/commands/outlook.command';
+import { format_in_place_archive } from '@/commands/outlook-mgmt.handler';
 import { MAILBOX_DISCOVERY_TOKEN } from '@wisecom/atlas-types';
 import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
 import type { MailboxDiscoveryService, MailboxPurpose, TenantMailbox } from '@wisecom/atlas-types';
@@ -76,5 +77,67 @@ describe('register_outlook_command mailboxes subcommand', () => {
     const logged = log_spy.mock.calls.map((c) => c.join(' ')).join('\n');
     expect(logged).toContain('2 mailbox(es) found (1 Exchange-licensed, 1 shared)');
     log_spy.mockRestore();
+  });
+
+  it('names every archive-enabled mailbox, because its archive is not backed up', async () => {
+    vi.mocked(mock_discovery.list_tenant_mailboxes).mockResolvedValue([
+      { ...make_mailbox('alice@t.com'), has_in_place_archive: true },
+      { ...make_mailbox('bob@t.com'), has_in_place_archive: false },
+      { ...make_mailbox('carol@t.com'), has_in_place_archive: true },
+    ]);
+    const warn_spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const log_spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await program.parseAsync(['outlook', 'mailboxes'], { from: 'user' });
+
+    const warned = warn_spy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(warned).toContain('2 mailbox(es) have an In-Place Archive');
+    expect(warned).toContain('alice@t.com');
+    expect(warned).toContain('carol@t.com');
+    expect(warned).not.toContain('bob@t.com');
+    warn_spy.mockRestore();
+    log_spy.mockRestore();
+  });
+
+  it('stays silent when no mailbox has an archive', async () => {
+    vi.mocked(mock_discovery.list_tenant_mailboxes).mockResolvedValue([
+      { ...make_mailbox('alice@t.com'), has_in_place_archive: false },
+    ]);
+    const warn_spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const log_spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await program.parseAsync(['outlook', 'mailboxes'], { from: 'user' });
+
+    const warned = warn_spy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(warned).not.toContain('In-Place Archive');
+    warn_spy.mockRestore();
+    log_spy.mockRestore();
+  });
+
+  it('says nothing about archives when the report never reported their state', async () => {
+    // Unknown must not render as "no archive": that is the false reassurance
+    // issue #46 is about. The default fixture carries no archive field at all.
+    const warn_spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const log_spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await program.parseAsync(['outlook', 'mailboxes'], { from: 'user' });
+
+    const warned = warn_spy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(warned).not.toContain('In-Place Archive');
+    warn_spy.mockRestore();
+    log_spy.mockRestore();
+  });
+});
+
+describe('format_in_place_archive', () => {
+  it('renders a known archive state', () => {
+    expect(format_in_place_archive(true)).toBe('Yes');
+    expect(format_in_place_archive(false)).toBe('No');
+  });
+
+  it('renders unknown as -- rather than No', () => {
+    // Reports.Read.All is optional, so "could not check" must never read as
+    // "no archive" (issue #46).
+    expect(format_in_place_archive(undefined)).toBe('--');
   });
 });

--- a/packages/outlook/src/adapters/graph-mailbox-discovery.adapter.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-discovery.adapter.ts
@@ -35,6 +35,7 @@ interface MailboxUsageRow {
   upn: string;
   storage_bytes: number;
   item_count: number;
+  has_archive?: boolean;
 }
 
 @injectable()
@@ -69,7 +70,12 @@ export class GraphMailboxDiscoveryAdapter implements MailboxDiscoveryService {
         mailboxes = mailboxes.map((m) => {
           const row = usage.get(m.mail.toLowerCase());
           if (!row) return m;
-          return { ...m, mailbox_size_bytes: row.storage_bytes, item_count: row.item_count };
+          return {
+            ...m,
+            mailbox_size_bytes: row.storage_bytes,
+            item_count: row.item_count,
+            ...(row.has_archive === undefined ? {} : { has_in_place_archive: row.has_archive }),
+          };
         });
       }
 
@@ -161,6 +167,9 @@ export function parse_usage_csv(csv: string): Map<string, MailboxUsageRow> {
   const upn_idx = cols.indexOf('User Principal Name');
   const storage_idx = cols.indexOf('Storage Used (Byte)');
   const items_idx = cols.indexOf('Item Count');
+  // Documented on getMailboxUsageDetail, but absent from the example schema in
+  // the same reference page, so it is treated as optional rather than assumed.
+  const archive_idx = cols.indexOf('Has Archive');
 
   if (upn_idx < 0 || storage_idx < 0) return map;
 
@@ -171,14 +180,29 @@ export function parse_usage_csv(csv: string): Map<string, MailboxUsageRow> {
     const upn = fields[upn_idx]?.trim().toLowerCase();
     if (!upn) continue;
 
+    const has_archive = archive_idx >= 0 ? parse_csv_boolean(fields[archive_idx]) : undefined;
+
     map.set(upn, {
       upn,
       storage_bytes: parseInt(fields[storage_idx] ?? '0', 10) || 0,
       item_count: items_idx >= 0 ? parseInt(fields[items_idx] ?? '0', 10) || 0 : 0,
+      ...(has_archive === undefined ? {} : { has_archive }),
     });
   }
 
   return map;
+}
+
+/**
+ * Reads a usage-report boolean, returning undefined for a blank or unrecognised
+ * value so a parse miss cannot be mistaken for a definite "false".
+ */
+function parse_csv_boolean(value: string | undefined): boolean | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === undefined || normalized === '') return undefined;
+  if (['true', 'yes', '1'].includes(normalized)) return true;
+  if (['false', 'no', '0'].includes(normalized)) return false;
+  return undefined;
 }
 
 function split_csv_line(line: string): string[] {

--- a/packages/outlook/tests/unit/mailbox-archive-detection.test.ts
+++ b/packages/outlook/tests/unit/mailbox-archive-detection.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Container } from 'inversify';
+import { GRAPH_CLIENT_TOKEN } from '@wisecom/atlas-m365-graph';
+import {
+  GraphMailboxDiscoveryAdapter,
+  parse_usage_csv,
+} from '@/adapters/graph-mailbox-discovery.adapter';
+
+const LICENSED_PLAN = [{ service: 'exchange', capabilityStatus: 'Enabled', servicePlanId: 'p' }];
+
+/** A Graph client whose `get` returns the queued responses in order. */
+function make_client(responses: unknown[]): { api: ReturnType<typeof vi.fn> } {
+  const get = vi.fn();
+  for (const response of responses) {
+    if (response instanceof Error) get.mockRejectedValueOnce(response);
+    else get.mockResolvedValueOnce(response);
+  }
+  get.mockRejectedValue(new Error('no further responses queued'));
+  const chain = { header: vi.fn(), get };
+  chain.header.mockReturnValue(chain);
+  return { api: vi.fn().mockReturnValue(chain) };
+}
+
+function discover(client: {
+  api: ReturnType<typeof vi.fn>;
+}): ReturnType<GraphMailboxDiscoveryAdapter['list_tenant_mailboxes']> {
+  const container = new Container();
+  container.bind(GRAPH_CLIENT_TOKEN).toConstantValue(client);
+  container.bind(GraphMailboxDiscoveryAdapter).toSelf();
+  return container
+    .get(GraphMailboxDiscoveryAdapter)
+    .list_tenant_mailboxes('t1', { licensed_only: true });
+}
+
+describe('In-Place Archive detection (issue #46)', () => {
+  it('reads the Has Archive column when the report includes it', () => {
+    const csv = [
+      'User Principal Name,Storage Used (Byte),Item Count,Has Archive',
+      'alice@contoso.com,999,10,True',
+      'bob@contoso.com,999,10,False',
+    ].join('\n');
+
+    const result = parse_usage_csv(csv);
+    expect(result.get('alice@contoso.com')?.has_archive).toBe(true);
+    expect(result.get('bob@contoso.com')?.has_archive).toBe(false);
+  });
+
+  it('leaves archive state unknown when the column is absent', () => {
+    // The column is documented on getMailboxUsageDetail but missing from the
+    // example schema on the same reference page, so absence must not read as
+    // "no archive": that false reassurance is what this issue is about.
+    const csv = [
+      'User Principal Name,Storage Used (Byte),Item Count',
+      'alice@contoso.com,999,10',
+    ].join('\n');
+
+    const row = parse_usage_csv(csv).get('alice@contoso.com');
+    expect(row).toBeDefined();
+    expect(row?.has_archive).toBeUndefined();
+  });
+
+  it('leaves archive state unknown for a blank or unrecognised value', () => {
+    const csv = [
+      'User Principal Name,Storage Used (Byte),Item Count,Has Archive',
+      'alice@contoso.com,999,10,',
+      'bob@contoso.com,999,10,Maybe',
+    ].join('\n');
+
+    const result = parse_usage_csv(csv);
+    expect(result.get('alice@contoso.com')?.has_archive).toBeUndefined();
+    expect(result.get('bob@contoso.com')?.has_archive).toBeUndefined();
+  });
+
+  it('carries archive state from the usage report onto the mailbox', async () => {
+    const client = make_client([
+      {
+        value: [
+          { id: 'u1', mail: 'a@t.com', displayName: 'A', assignedPlans: LICENSED_PLAN },
+          { id: 'u2', mail: 'b@t.com', displayName: 'B', assignedPlans: LICENSED_PLAN },
+        ],
+      },
+      [
+        'User Principal Name,Storage Used (Byte),Item Count,Has Archive',
+        'a@t.com,1024,10,True',
+        'b@t.com,2048,20,False',
+      ].join('\n'),
+    ]);
+
+    const result = await discover(client);
+
+    expect(result.find((m) => m.mail === 'a@t.com')?.has_in_place_archive).toBe(true);
+    expect(result.find((m) => m.mail === 'b@t.com')?.has_in_place_archive).toBe(false);
+  });
+
+  it('leaves archive state unset when the usage report is unavailable', async () => {
+    // Reports.Read.All is optional, and discovery already tolerates its
+    // absence. An unreadable report means unknown coverage, not clear coverage.
+    const client = make_client([
+      { value: [{ id: 'u1', mail: 'a@t.com', displayName: 'A', assignedPlans: LICENSED_PLAN }] },
+      new Error('no Reports.Read.All'),
+    ]);
+
+    const result = await discover(client);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.has_in_place_archive).toBeUndefined();
+  });
+});

--- a/packages/types/src/ports/mail/discovery.port.ts
+++ b/packages/types/src/ports/mail/discovery.port.ts
@@ -11,6 +11,16 @@ export interface TenantMailbox {
   readonly created_at?: Date;
   readonly mailbox_size_bytes?: number;
   readonly item_count?: number;
+  /**
+   * Whether the mailbox has an In-Place Archive (Online Archive) enabled, from
+   * the `Has Archive` column of the mailbox usage report.
+   *
+   * `undefined` means unknown, not absent: the report needs `Reports.Read.All`
+   * and the column is missing from some report revisions. Archive content is
+   * outside backup scope, so reporting "no archive" for a mailbox that has one
+   * is the failure worth avoiding.
+   */
+  readonly has_in_place_archive?: boolean;
 }
 
 export interface MailboxDiscoveryOptions {


### PR DESCRIPTION
Fixes #46. Files #238 as the follow-up design issue. Cut from `dev`; #237 is also open but touches drive code, no overlap.

## What this issue actually asked for

The acceptance criteria are narrow on purpose, and worth restating because the title reads like a feature request:

- [x] Docs state the In-Place Archive limitation with a Graph citation
- [x] Decision recorded on detection feasibility
- [x] Follow-up design issue filed for import/export-based coverage

Coverage is explicitly out of scope: Graph cannot read archive mailboxes at all, so no amount of Atlas code fixes it. What Atlas can fix is the silence.

## The spike, since criterion 2 asked for a decision

Detection is feasible, and cheaper than expected. The answer was in a report Atlas **already downloads and parses**.

| Candidate | Result |
| --- | --- |
| `getMailboxUsageDetail` v1.0 | **`Has Archive` is a documented column.** Already fetched by discovery for mailbox size |
| `/users` v1.0 | No archive property, as the issue said |
| `/admin/exchange/mailboxes` (beta) | Only `id` plus import/export operations. No archive property |
| `mailboxSettings.archiveFolder` | The primary mailbox's `Archive` folder, not the archive store. This is the confusion the issue warns about |
| Exchange Online PowerShell | `Get-Mailbox ArchiveStatus` works, but is not a dependency Atlas will take |

So: no beta dependency, no heuristic, no spike ticket. One column of a CSV that was already on the wire, which made implementing detection smaller than writing up why we hadn't.

## One trap worth naming

The `getMailboxUsageDetail` reference page lists `Has Archive` in its column list and then **omits it from the example schema string further down the same page**. Treating a missing column as `false` would reintroduce the exact bug this issue is about, in a subtler form: a confident "no archive" on a mailbox that has one.

So the field is tri-state, and unknown is a first-class state:

| State | Meaning |
| --- | --- |
| `Yes` | Archive exists, contents are not backed up |
| `No` | Confirmed no archive |
| `--` | Unknown: no `Reports.Read.All`, or the column was absent |

Atlas does not report coverage it could not confirm. When no mailbox has a known state the column is omitted entirely, matching how the `Size` column already behaves.

## What an operator sees

```
[!] 2 mailbox(es) have an In-Place Archive (Online Archive), which Graph cannot read
    and Atlas does not back up:
      alice@contoso.com
      carol@contoso.com
[*] Coverage detail: docs/security.md, "In-Place Archive is out of scope".
```

Naming is capped at 10 mailboxes, then `...and N more`, so a tenant with hundreds of archive-enabled mailboxes does not flood the terminal.

Placed on `atlas outlook mailboxes` deliberately: that is the command whose output operators loop over in their scheduler, so the warning lands at the moment backup scope is chosen. I did **not** add it to `atlas outlook status`, and that is a judgement call worth your review: status depends on the connector and manifests, not discovery, so warning there would mean a tenant-wide CSV fetch plus a new dependency on every status call, for a property that changes about never. It would also skew the `graph_cost` that status reports.

## Docs

`docs/security.md` gets an "In-Place Archive is out of scope" section under **Backup Fidelity**, which already carries the "what did Atlas actually store" material. It covers the Graph citation, the primary-mailbox `Archive` folder distinction, why retention policies make this worse over time, how to identify affected mailboxes, and what an operator can actually do about it.

`docs/reference/cli.md` documents the column and the `--` semantics. `docs/reference/sdk.md` documents `TenantMailbox.has_in_place_archive` with the tri-state trap spelled out for embedders, since an SDK consumer filtering `=== false` would silently exclude unknown mailboxes.

## Verification

12 new tests. Parser: reads `True`/`False`, and leaves state unknown for an absent column, a blank value, and an unrecognised value. Adapter: the flag reaches `TenantMailbox` end to end through a stubbed Graph client, and stays unset when the usage report is unavailable, since `Reports.Read.All` is optional and discovery already tolerates its absence. Command: the warning names exactly the affected mailboxes and not the unaffected one, stays silent when none have an archive, and stays silent when state is unknown.

The archive tests went into their own `mailbox-archive-detection.test.ts` rather than growing `mailbox-discovery.test.ts` past the 300-line rule.

**One verification limit, stated plainly.** I could not assert the rendered table text. Stubbing `process.stdout.write` to capture ink's output deadlocks the renderer, which is why no existing CLI test asserts table content either. I confirmed the warning path through `console.warn` on the real registered command, and pulled the tri-state cell into `format_in_place_archive` so the `--` semantics are covered by assertions rather than by inspection. The `Archive` column header itself is a conditional spread mirroring the existing `Size` column and is not directly asserted.

Gates: build 10/10, typecheck 17/17, test 15/15, lint 0 errors, docs build no warnings.
