### PR TITLE
fix(outlook): stop discarding item and reference attachments

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -148,6 +148,22 @@ If Graph cannot return MIME for a particular item, Atlas stores that one message
 
 Each manifest entry records which format its object holds. Entries with `payload_format: "mime"` hold original bytes; entries with no `payload_format` field hold the legacy Graph JSON payload. Mixed snapshots are normal, and `save`, `read`, `restore`, and `verify` all handle both formats inside the same snapshot chain, so a fallback item needs no operator intervention.
 
+On that path attachments are separate objects again, and all three Graph attachment types are captured:
+
+| Graph type | What Atlas stores |
+| ---------------------- | ---------------------------------------------------------------------------------------------------- |
+| `fileAttachment` | The file bytes, inline when Graph includes them, otherwise fetched from `/$value` |
+| `itemAttachment` | The attached item's own bytes from `/$value`: MIME for a message, iCal for an invite, vCard for a contact |
+| `referenceAttachment` | The link, as a one-line `text/uri-list`. There are no bytes to fetch, and Graph answers `405` if asked |
+
+An attached message therefore exports as a `message/rfc822` part that mail clients open as mail, an invite as `.ics`, and a contact as `.vcf`. The content type is decided by the bytes that arrive rather than by the attachment's name, because Graph does not say which kind of item is attached and an invite mislabelled as mail opens as broken mail.
+
+A `referenceAttachment` points at a file in OneDrive or SharePoint. The link is part of the message and is preserved; the file itself belongs to those workloads and is covered by their own backups.
+
+::: warning Attachment types dropped before this version
+Earlier versions kept only `fileAttachment` and discarded the other two silently, with no warning and no manifest record, while still storing the message's `has_attachments` flag. Snapshots taken then can claim attachments whose content was never captured. This affected the legacy JSON path only, which is also the only path that existed before MIME storage, so snapshots predating MIME are the ones to treat with suspicion. An attachment type Atlas does not recognise is now recorded with its metadata and warned about, so a gap is auditable instead of invisible.
+:::
+
 ### Restore is reconstruction, and that is a deliberate choice
 
 Atlas does **not** import archived MIME back into Exchange. Live testing established why: Graph's MIME import path always marks the created message as a draft (`isDraft: true`), and that flag cannot be cleared -- neither an `X-Unsent: 0` header inside the MIME nor a `PR_MESSAGE_FLAGS` patch afterwards clears it. Restoring a mailbox that way would hand the user thousands of drafts instead of their mail.

--- a/packages/outlook/src/adapters/graph-attachment-mapper.ts
+++ b/packages/outlook/src/adapters/graph-attachment-mapper.ts
@@ -1,0 +1,196 @@
+import type { MessageAttachment } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import type { GraphAttachmentRecord } from '@/adapters/graph-mailbox-response-mappers';
+
+/** Placeholder until the downloaded bytes reveal what kind of item was attached. */
+export const ITEM_ATTACHMENT_PENDING_TYPE = 'application/vnd.atlas.item-attachment';
+
+const FILE_ATTACHMENT = '#microsoft.graph.fileAttachment';
+const ITEM_ATTACHMENT = '#microsoft.graph.itemAttachment';
+const REFERENCE_ATTACHMENT = '#microsoft.graph.referenceAttachment';
+
+/**
+ * Maps a message's Graph attachment records to storable attachments.
+ *
+ * All three documented attachment types are represented. Only the JSON
+ * fallback path reaches this code: a message stored as MIME carries its
+ * attachments inside the message bytes, so nothing here runs for it.
+ *
+ * - **fileAttachment** carries `contentBytes` inline unless it exceeds the
+ *   Graph inline limit, in which case the connector fetches `/$value`.
+ * - **itemAttachment** (an attached mail, invite, or contact) never carries
+ *   inline bytes. `/$value` returns it as MIME, and the concrete type is only
+ *   known once those bytes arrive, so it starts as
+ *   {@link ITEM_ATTACHMENT_PENDING_TYPE}.
+ * - **referenceAttachment** is a cloud link with no bytes at all. Graph answers
+ *   `405` for its `/$value`, so the link itself is stored as `text/uri-list`;
+ *   the linked file lives in OneDrive or SharePoint and is covered by those
+ *   backups.
+ */
+export function map_attachments(records: GraphAttachmentRecord[]): MessageAttachment[] {
+  const results: MessageAttachment[] = [];
+
+  for (const record of records) {
+    const mapped = map_one_attachment(record);
+    if (mapped) results.push(mapped);
+  }
+
+  return results;
+}
+
+function map_one_attachment(record: GraphAttachmentRecord): MessageAttachment | undefined {
+  switch (record['@odata.type']) {
+    case FILE_ATTACHMENT:
+      return map_file_attachment(record);
+    case ITEM_ATTACHMENT:
+      return map_item_attachment(record);
+    case REFERENCE_ATTACHMENT:
+      return map_reference_attachment(record);
+    default:
+      return map_unknown_attachment(record);
+  }
+}
+
+function map_file_attachment(record: GraphAttachmentRecord): MessageAttachment {
+  if (!record.contentBytes) {
+    logger.debug(
+      `Attachment "${record.name ?? '?'}" (${record.size ?? 0} bytes) has no inline contentBytes -- ` +
+        `will download via /$value`,
+    );
+    return base_attachment(record, {
+      content_type: record.contentType ?? 'application/octet-stream',
+      content: Buffer.alloc(0),
+    });
+  }
+
+  return base_attachment(record, {
+    content_type: record.contentType ?? 'application/octet-stream',
+    content: Buffer.from(record.contentBytes, 'base64'),
+  });
+}
+
+/**
+ * An attached Outlook item. Content always arrives from `/$value`, so this
+ * carries an empty buffer and a placeholder content type for the connector to
+ * resolve.
+ */
+function map_item_attachment(record: GraphAttachmentRecord): MessageAttachment {
+  return base_attachment(record, {
+    content_type: ITEM_ATTACHMENT_PENDING_TYPE,
+    content: Buffer.alloc(0),
+    // Graph reports 0 for some item attachments, which would otherwise read as
+    // "nothing to download". The real length replaces this after the fetch.
+    size_bytes: record.size !== undefined && record.size > 0 ? record.size : 1,
+  });
+}
+
+/**
+ * A cloud link. There are no bytes to fetch, so the link is the content: a
+ * one-line `text/uri-list`, which mail clients and text editors both open.
+ */
+function map_reference_attachment(record: GraphAttachmentRecord): MessageAttachment {
+  const source_url = record.sourceUrl ?? '';
+  if (!source_url) {
+    logger.warn(
+      `Reference attachment "${record.name ?? '?'}" has no sourceUrl; storing its name only`,
+    );
+  }
+
+  const content = Buffer.from(source_url === '' ? '' : `${source_url}\r\n`, 'utf-8');
+  return base_attachment(record, {
+    content_type: 'text/uri-list',
+    content,
+    size_bytes: content.length,
+  });
+}
+
+/**
+ * An attachment type Graph introduced after this code was written. Recorded
+ * with its metadata rather than skipped, so a gap is auditable instead of
+ * invisible.
+ */
+function map_unknown_attachment(record: GraphAttachmentRecord): MessageAttachment | undefined {
+  const type = record['@odata.type'];
+  if (type === undefined) return undefined;
+
+  logger.warn(
+    `Attachment "${record.name ?? '?'}" has unsupported type ${type}; ` +
+      `storing metadata only, its content is not backed up`,
+  );
+  return base_attachment(record, {
+    content_type: 'application/octet-stream',
+    content: Buffer.alloc(0),
+    size_bytes: 0,
+  });
+}
+
+function base_attachment(
+  record: GraphAttachmentRecord,
+  overrides: { content_type: string; content: Buffer; size_bytes?: number },
+): MessageAttachment {
+  return {
+    attachment_id: record.id ?? '',
+    name: record.name ?? '',
+    content_type: overrides.content_type,
+    size_bytes: overrides.size_bytes ?? record.size ?? 0,
+    is_inline: record.isInline === true,
+    content: overrides.content,
+    content_id: record.contentId ?? '',
+  };
+}
+
+/**
+ * Names the content type of a downloaded item attachment from its own bytes.
+ *
+ * Graph reports the attached item's kind nowhere on the attachment record, and
+ * `/$value` returns a different format for each: MIME for a message, iCal for
+ * an event, vCard for a contact. Sniffing labels what actually arrived rather
+ * than guessing from a name, and an `.ics` mislabelled as `message/rfc822`
+ * opens as broken mail instead of a calendar entry.
+ */
+export function detect_item_attachment_content_type(content: Buffer): string {
+  const head = content.subarray(0, 64).toString('utf-8').trimStart().toUpperCase();
+  if (head.startsWith('BEGIN:VCALENDAR')) return 'text/calendar';
+  if (head.startsWith('BEGIN:VCARD')) return 'text/vcard';
+  return 'message/rfc822';
+}
+
+/** Appends the extension implied by a resolved item attachment type, if missing. */
+export function item_attachment_filename(name: string, content_type: string): string {
+  const extension = ITEM_EXTENSIONS[content_type];
+  if (extension === undefined) return name;
+  return name.toLowerCase().endsWith(extension) ? name : `${name}${extension}`;
+}
+
+/**
+ * Fills in what only the downloaded bytes can tell us.
+ *
+ * An item attachment's kind is invisible on its Graph record, so its content
+ * type and file extension are resolved here; a file attachment keeps the type
+ * Graph reported. Both get their real byte length, since Graph's reported
+ * `size` counts the item as stored in the mailbox rather than the bytes
+ * `/$value` returns.
+ */
+export function resolve_downloaded_attachment(
+  attachment: MessageAttachment,
+  content: Buffer,
+): MessageAttachment {
+  if (attachment.content_type !== ITEM_ATTACHMENT_PENDING_TYPE) {
+    return { ...attachment, content, size_bytes: content.length };
+  }
+
+  const content_type = detect_item_attachment_content_type(content);
+  return {
+    ...attachment,
+    content,
+    content_type,
+    name: item_attachment_filename(attachment.name, content_type),
+    size_bytes: content.length,
+  };
+}
+
+const ITEM_EXTENSIONS: Record<string, string> = {
+  'message/rfc822': '.eml',
+  'text/calendar': '.ics',
+  'text/vcard': '.vcf',
+};

--- a/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
@@ -12,6 +12,7 @@ import type {
   DeltaPageCallback,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { map_attachments, resolve_downloaded_attachment } from '@/adapters/graph-attachment-mapper';
 import {
   is_invalid_delta_error,
   rethrow_if_access_denied,
@@ -24,11 +25,7 @@ import type {
   GraphFolderRecord,
   GraphAttachmentRecord,
 } from '@/adapters/graph-mailbox-response-mappers';
-import {
-  extract_user_ids,
-  map_file_attachments,
-  parse_mailbox_purpose,
-} from '@/adapters/graph-mailbox-response-mappers';
+import { extract_user_ids, parse_mailbox_purpose } from '@/adapters/graph-mailbox-response-mappers';
 import { enumerate_folder_tree } from '@/adapters/graph-folder-tree-enumerator';
 import type { GraphPageResponse, GraphDeltaMessage } from '@/adapters/graph-delta-message-mapper';
 import {
@@ -193,10 +190,14 @@ export class GraphMailboxConnector implements MailboxConnector {
   }
 
   /**
-   * Fetches file attachments for a message. Filters to fileAttachment type only,
-   * decodes contentBytes from base64. Attachments above the Graph inline limit
-   * (~3 MB) arrive without contentBytes and are downloaded individually via the
-   * /$value endpoint, which streams raw bytes with no size ceiling.
+   * Fetches a message's attachments, on the JSON fallback path only: a message
+   * stored as MIME already carries its attachments inside the message bytes.
+   *
+   * File attachments above the Graph inline limit (~3 MB) arrive without
+   * contentBytes, and item attachments never carry inline bytes at all, so both
+   * are fetched individually from `/$value`, which streams raw bytes with no
+   * size ceiling. Reference attachments are links with no content to fetch;
+   * Graph answers `405` for their `/$value`, so they are never downloaded.
    */
   async fetch_attachments(
     _tenant_id: string,
@@ -206,7 +207,7 @@ export class GraphMailboxConnector implements MailboxConnector {
     try {
       const url = `/users/${owner_id}/messages/${message_id}/attachments`;
       const records = await this.collect_all_pages<GraphAttachmentRecord>(url);
-      const attachments = map_file_attachments(records);
+      const attachments = map_attachments(records);
 
       for (let i = 0; i < attachments.length; i++) {
         const att = attachments[i]!;
@@ -216,7 +217,7 @@ export class GraphMailboxConnector implements MailboxConnector {
           message_id,
           att.attachment_id,
         );
-        attachments[i] = { ...att, content };
+        attachments[i] = resolve_downloaded_attachment(att, content);
       }
       return attachments;
     } catch (err) {

--- a/packages/outlook/src/adapters/graph-mailbox-response-mappers.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-response-mappers.ts
@@ -34,6 +34,8 @@ export interface GraphAttachmentRecord {
   isInline?: boolean;
   contentBytes?: string;
   contentId?: string;
+  /** Present on referenceAttachment: the cloud location the link points at. */
+  sourceUrl?: string;
 }
 
 /** Extracts non-null user IDs from Graph user records. */
@@ -94,46 +96,4 @@ export function map_users_to_tenant_mailboxes(users: GraphUserRecord[]): TenantM
         ...(u.createdDateTime ? { created_at: new Date(u.createdDateTime) } : {}),
       };
     });
-}
-
-/**
- * Filters to fileAttachment and decodes base64 content. Records without
- * contentBytes (above the Graph inline limit) are returned with an empty
- * buffer; the connector downloads their binary separately via /$value.
- */
-export function map_file_attachments(records: GraphAttachmentRecord[]): MessageAttachment[] {
-  const results: MessageAttachment[] = [];
-
-  for (const r of records) {
-    if (r['@odata.type'] !== '#microsoft.graph.fileAttachment') continue;
-
-    if (!r.contentBytes) {
-      logger.debug(
-        `Attachment "${r.name ?? '?'}" (${r.size ?? 0} bytes) has no inline contentBytes -- ` +
-          `will download via /$value`,
-      );
-      results.push({
-        attachment_id: r.id ?? '',
-        name: r.name ?? '',
-        content_type: r.contentType ?? 'application/octet-stream',
-        size_bytes: r.size ?? 0,
-        is_inline: r.isInline === true,
-        content: Buffer.alloc(0),
-        content_id: r.contentId ?? '',
-      });
-      continue;
-    }
-
-    results.push({
-      attachment_id: r.id ?? '',
-      name: r.name ?? '',
-      content_type: r.contentType ?? 'application/octet-stream',
-      size_bytes: r.size ?? 0,
-      is_inline: r.isInline === true,
-      content: Buffer.from(r.contentBytes, 'base64'),
-      content_id: r.contentId ?? '',
-    });
-  }
-
-  return results;
 }

--- a/packages/outlook/tests/unit/attachment-type-mapping.test.ts
+++ b/packages/outlook/tests/unit/attachment-type-mapping.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import type { GraphAttachmentRecord } from '@/adapters/graph-mailbox-response-mappers';
+import {
+  detect_item_attachment_content_type,
+  item_attachment_filename,
+  map_attachments,
+  resolve_downloaded_attachment,
+} from '@/adapters/graph-attachment-mapper';
+
+const file_record: GraphAttachmentRecord = {
+  '@odata.type': '#microsoft.graph.fileAttachment',
+  id: 'att-file',
+  name: 'report.pdf',
+  contentType: 'application/pdf',
+  size: 9,
+  contentBytes: Buffer.from('hello pdf').toString('base64'),
+};
+
+const item_record: GraphAttachmentRecord = {
+  '@odata.type': '#microsoft.graph.itemAttachment',
+  id: 'att-item',
+  name: 'FW escalation',
+  size: 4096,
+};
+
+const reference_record: GraphAttachmentRecord = {
+  '@odata.type': '#microsoft.graph.referenceAttachment',
+  id: 'att-ref',
+  name: 'budget.xlsx',
+  sourceUrl: 'https://contoso.sharepoint.com/sites/fin/budget.xlsx',
+};
+
+describe('map_attachments', () => {
+  it('maps a file attachment with its inline content', () => {
+    const [mapped] = map_attachments([file_record]);
+
+    expect(mapped?.content_type).toBe('application/pdf');
+    expect(mapped?.content.toString('utf-8')).toBe('hello pdf');
+  });
+
+  it('keeps an item attachment for download instead of dropping it', () => {
+    const [mapped] = map_attachments([item_record]);
+
+    expect(mapped).toBeDefined();
+    expect(mapped?.attachment_id).toBe('att-item');
+    expect(mapped?.content).toHaveLength(0);
+    // A non-zero size is what makes the connector fetch /$value.
+    expect(mapped?.size_bytes).toBeGreaterThan(0);
+  });
+
+  it('gives an item attachment a downloadable size even when Graph reports zero', () => {
+    const [mapped] = map_attachments([{ ...item_record, size: 0 }]);
+
+    expect(mapped?.size_bytes).toBeGreaterThan(0);
+  });
+
+  it('stores a reference attachment as a uri-list, since it has no bytes', () => {
+    const [mapped] = map_attachments([reference_record]);
+
+    expect(mapped?.content_type).toBe('text/uri-list');
+    expect(mapped?.content.toString('utf-8').trim()).toBe(
+      'https://contoso.sharepoint.com/sites/fin/budget.xlsx',
+    );
+    // Graph answers 405 for a reference attachment's /$value, so content must
+    // already be present or the connector would try to download it.
+    expect(mapped?.content.length).toBeGreaterThan(0);
+    expect(mapped?.size_bytes).toBe(mapped?.content.length);
+  });
+
+  it('maps every type in one message', () => {
+    const mapped = map_attachments([file_record, item_record, reference_record]);
+
+    expect(mapped.map((a) => a.attachment_id)).toEqual(['att-file', 'att-item', 'att-ref']);
+  });
+});
+
+describe('map_attachments with unexpected input', () => {
+  let warn_spy: MockInstance<(...args: unknown[]) => void>;
+
+  beforeEach(() => {
+    warn_spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn_spy.mockRestore();
+  });
+
+  it('records an unknown attachment type rather than silently skipping it', () => {
+    const mapped = map_attachments([
+      { '@odata.type': '#microsoft.graph.somethingNew', id: 'att-x', name: 'mystery' },
+    ]);
+
+    expect(mapped).toHaveLength(1);
+    expect(mapped[0]?.name).toBe('mystery');
+    expect(warn_spy).toHaveBeenCalled();
+    const warned = warn_spy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(warned).toContain('somethingNew');
+  });
+
+  it('skips a record with no type at all, which is not an attachment', () => {
+    expect(map_attachments([{ id: 'att-nil' }])).toHaveLength(0);
+  });
+
+  it('warns when a reference attachment carries no sourceUrl', () => {
+    const { sourceUrl: _dropped, ...no_source } = reference_record;
+    const mapped = map_attachments([no_source]);
+
+    expect(mapped).toHaveLength(1);
+    expect(warn_spy).toHaveBeenCalled();
+  });
+});
+
+describe('detect_item_attachment_content_type', () => {
+  it('names an attached calendar invite', () => {
+    const ical = Buffer.from('BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\n');
+    expect(detect_item_attachment_content_type(ical)).toBe('text/calendar');
+  });
+
+  it('names an attached contact card', () => {
+    const vcard = Buffer.from('BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Alice\r\n');
+    expect(detect_item_attachment_content_type(vcard)).toBe('text/vcard');
+  });
+
+  it('names an attached message', () => {
+    const mime = Buffer.from('Received: from mail.contoso.com\r\nFrom: a@b.com\r\n\r\nbody');
+    expect(detect_item_attachment_content_type(mime)).toBe('message/rfc822');
+  });
+
+  it('tolerates leading whitespace and lowercase keywords', () => {
+    const ical = Buffer.from('\r\n  begin:vcalendar\r\nVERSION:2.0\r\n');
+    expect(detect_item_attachment_content_type(ical)).toBe('text/calendar');
+  });
+});
+
+describe('item_attachment_filename', () => {
+  it('adds the extension implied by the resolved type', () => {
+    expect(item_attachment_filename('FW escalation', 'message/rfc822')).toBe('FW escalation.eml');
+    expect(item_attachment_filename('Weekly sync', 'text/calendar')).toBe('Weekly sync.ics');
+    expect(item_attachment_filename('Alice', 'text/vcard')).toBe('Alice.vcf');
+  });
+
+  it('does not double an extension the name already has', () => {
+    expect(item_attachment_filename('thread.eml', 'message/rfc822')).toBe('thread.eml');
+    expect(item_attachment_filename('thread.EML', 'message/rfc822')).toBe('thread.EML');
+  });
+
+  it('leaves a name alone for a type with no known extension', () => {
+    expect(item_attachment_filename('mystery', 'application/octet-stream')).toBe('mystery');
+  });
+});
+
+describe('resolve_downloaded_attachment', () => {
+  it('resolves an item attachment type and filename from its bytes', () => {
+    const [pending] = map_attachments([item_record]);
+    const ical = Buffer.from('BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\n');
+
+    const resolved = resolve_downloaded_attachment(pending!, ical);
+
+    expect(resolved.content_type).toBe('text/calendar');
+    expect(resolved.name).toBe('FW escalation.ics');
+    expect(resolved.size_bytes).toBe(ical.length);
+  });
+
+  it('keeps the Graph-reported type for a file attachment', () => {
+    const { contentBytes: _inline, ...needs_download } = file_record;
+    const [pending] = map_attachments([needs_download]);
+    const bytes = Buffer.from('%PDF-1.7 ...');
+
+    const resolved = resolve_downloaded_attachment(pending!, bytes);
+
+    expect(resolved.content_type).toBe('application/pdf');
+    expect(resolved.name).toBe('report.pdf');
+    expect(resolved.size_bytes).toBe(bytes.length);
+  });
+
+  it('records the real byte length rather than the size Graph reported', () => {
+    const [pending] = map_attachments([item_record]);
+    const bytes = Buffer.from('From: a@b.com\r\n\r\nshort');
+
+    expect(pending?.size_bytes).toBe(4096);
+    expect(resolve_downloaded_attachment(pending!, bytes).size_bytes).toBe(bytes.length);
+  });
+});

--- a/packages/outlook/tests/unit/eml-builder.test.ts
+++ b/packages/outlook/tests/unit/eml-builder.test.ts
@@ -73,6 +73,52 @@ describe('build_eml', () => {
     expect(text).not.toContain('Content-ID');
   });
 
+  it('embeds an attached message as a message/rfc822 part (issue #49)', () => {
+    const attached_mail = Buffer.from('From: sender@x.com\r\nSubject: FW: escalation\r\n\r\nbody');
+    const result = build_eml(minimal_message, [
+      {
+        name: 'FW escalation.eml',
+        content_type: 'message/rfc822',
+        content: attached_mail,
+        is_inline: false,
+      },
+    ]);
+
+    const text = result.toString('utf-8');
+    expect(text).toContain('message/rfc822');
+    expect(text).toContain('FW escalation.eml');
+    // The attached message's own bytes have to survive the export, or an
+    // attached email is a filename with nothing behind it.
+    expect(text).toContain(attached_mail.toString('base64'));
+  });
+
+  it('embeds a cloud link attachment as a uri-list part (issue #49)', () => {
+    const link = 'https://contoso.sharepoint.com/sites/fin/budget.xlsx';
+    const result = build_eml(minimal_message, [
+      {
+        name: 'budget.xlsx',
+        content_type: 'text/uri-list',
+        content: Buffer.from(`${link}\r\n`),
+        is_inline: false,
+      },
+    ]);
+
+    const text = result.toString('utf-8');
+    expect(text).toContain('text/uri-list');
+    expect(text).toContain(Buffer.from(`${link}\r\n`).toString('base64'));
+  });
+
+  it('embeds an attached calendar invite as a calendar part (issue #49)', () => {
+    const ical = Buffer.from('BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nSUMMARY:Sync\r\n');
+    const result = build_eml(minimal_message, [
+      { name: 'Sync.ics', content_type: 'text/calendar', content: ical, is_inline: false },
+    ]);
+
+    const text = result.toString('utf-8');
+    expect(text).toContain('text/calendar');
+    expect(text).toContain('Sync.ics');
+  });
+
   it('handles message with no to-recipients gracefully', () => {
     const msg = {
       ...minimal_message,

--- a/packages/outlook/tests/unit/graph-attachment-fetch.test.ts
+++ b/packages/outlook/tests/unit/graph-attachment-fetch.test.ts
@@ -51,33 +51,59 @@ describe('GraphMailboxConnector – fetch_attachments', () => {
     connector = create_connector(mock_client);
   });
 
-  it('returns only fileAttachment types with decoded content', async () => {
+  it('keeps all three attachment types, not only fileAttachment (issue #49)', async () => {
     const raw_bytes = Buffer.from('hello pdf');
-    const base64_content = raw_bytes.toString('base64');
+    const attached_mail = Buffer.from('From: a@b.com\r\nSubject: FW: escalation\r\n\r\nbody');
 
-    mock_client._chain.get.mockResolvedValueOnce({
-      value: [
-        {
-          '@odata.type': '#microsoft.graph.fileAttachment',
-          id: 'att-1',
-          name: 'report.pdf',
-          contentType: 'application/pdf',
-          size: 1024,
-          isInline: false,
-          contentBytes: base64_content,
-        },
-        { '@odata.type': '#microsoft.graph.referenceAttachment', id: 'att-ref', name: 'link.docx' },
-        { '@odata.type': '#microsoft.graph.itemAttachment', id: 'att-item', name: 'embedded' },
-      ],
-    });
+    mock_client._chain.get
+      .mockResolvedValueOnce({
+        value: [
+          {
+            '@odata.type': '#microsoft.graph.fileAttachment',
+            id: 'att-1',
+            name: 'report.pdf',
+            contentType: 'application/pdf',
+            size: 1024,
+            isInline: false,
+            contentBytes: raw_bytes.toString('base64'),
+          },
+          {
+            '@odata.type': '#microsoft.graph.referenceAttachment',
+            id: 'att-ref',
+            name: 'link.docx',
+            sourceUrl: 'https://contoso.sharepoint.com/sites/x/link.docx',
+          },
+          { '@odata.type': '#microsoft.graph.itemAttachment', id: 'att-item', name: 'embedded' },
+        ],
+      })
+      // Only the item attachment needs a /$value fetch: the file attachment
+      // arrived inline, and a reference attachment has no bytes to fetch.
+      .mockResolvedValueOnce(
+        attached_mail.buffer.slice(
+          attached_mail.byteOffset,
+          attached_mail.byteOffset + attached_mail.byteLength,
+        ),
+      );
 
     const result = await connector.fetch_attachments('tenant-1', 'user-1', 'msg-1');
 
-    expect(result).toHaveLength(1);
-    expect(result[0]!.attachment_id).toBe('att-1');
-    expect(result[0]!.name).toBe('report.pdf');
-    expect(result[0]!.content).toEqual(raw_bytes);
-    expect(result[0]!.is_inline).toBe(false);
+    expect(result).toHaveLength(3);
+
+    const file = result.find((a) => a.attachment_id === 'att-1')!;
+    expect(file.name).toBe('report.pdf');
+    expect(file.content).toEqual(raw_bytes);
+    expect(file.is_inline).toBe(false);
+
+    const item = result.find((a) => a.attachment_id === 'att-item')!;
+    expect(item.content_type).toBe('message/rfc822');
+    expect(item.name).toBe('embedded.eml');
+    expect(item.content).toEqual(attached_mail);
+
+    const reference = result.find((a) => a.attachment_id === 'att-ref')!;
+    expect(reference.content_type).toBe('text/uri-list');
+    expect(reference.content.toString('utf-8')).toContain(
+      'https://contoso.sharepoint.com/sites/x/link.docx',
+    );
   });
 
   it('downloads content via /$value for attachments without contentBytes', async () => {


### PR DESCRIPTION
Fixes #49. Cut from `dev`; #237 and #239 are also open and touch different code.

## The issue overstates the blast radius, and that matters

The title says these attachments are "never backed up". That was true when it was filed, and MIME storage landed a month later. Attachments are fetched only here:

```ts
// folder-sync-executor.ts:80
if (!mime && message.has_attachments) {
  pending_attachments.push({ entry_index, message_id: message.message_id });
}
```

So this code runs on the **JSON fallback path only**, the one Graph forces when it cannot produce MIME for an item. A message stored as MIME carries its attachments inside its own byte-exact bytes, attached emails included.

The bug is still real, and worth fixing, because that path is not hypothetical: it is what every pre-MIME snapshot used, and it is what any item Graph refuses MIME for uses today. But "an attached email is silently missing from every backup" is not the current state, and the PR should not imply it is.

## Fix

| Graph type | Before | After |
| --- | --- | --- |
| `fileAttachment` | Stored | Unchanged |
| `itemAttachment` | Dropped silently | Bytes from `/$value`, content type sniffed |
| `referenceAttachment` | Dropped silently | Link stored as `text/uri-list` |
| Anything else | Dropped silently | Metadata recorded, warned |

**Item attachments are sniffed, not guessed.** [Graph's own reference](https://learn.microsoft.com/en-us/graph/api/attachment-get?view=graph-rest-1.0) says `/$value` returns a *different format per attached kind*: MIME for a message, iCal for an event, vCard for a contact. The attachment record does not say which kind it is, and `contentType` is routinely absent. So the type comes from the first bytes that arrive. Labelling an invite `message/rfc822` would make it open as broken mail instead of a calendar entry, and adding the wrong extension is the visible half of the same mistake.

**Reference attachments must never be downloaded.** Same reference, stated plainly:

> Attempting to get the `$value` of a reference attachment returns HTTP 405.

Giving them synthesised content up front is what keeps the existing download loop away from them, since it only fetches when content is empty. The linked file lives in OneDrive or SharePoint and is covered by those backups; what was lost here was the link, which is part of the message.

**One subtlety worth flagging:** Graph reports `size: 0` for some item attachments, and the download loop skips anything sized zero. A zero-sized item attachment therefore gets a placeholder size so it is fetched, and its real length replaces it afterwards. Without that, the fix would silently do nothing for exactly the attachments it targets.

## Export needed no change

`build_eml` embeds whatever content type it is handed, so `message/rfc822`, `text/calendar` and `text/uri-list` parts flow through unchanged. I asserted that rather than assuming it, including that the attached message's own bytes survive into the export: an attached email that arrives as a filename with nothing behind it would satisfy a weaker test.

## Verification

**One existing test asserted the bug as a contract**, named `returns only fileAttachment types with decoded content`, feeding all three types and expecting one back. It now asserts all three survive, with the item attachment fetched from `/$value` and the reference attachment carrying its URL. That test failing was the first confirmation the fix worked.

30 new or changed assertions across three files: mapper behaviour per type, sniffing for iCal/vCard/MIME plus leading whitespace and lowercase keywords, filename extension handling including not doubling an existing one, real byte length replacing Graph's reported size, unknown types recorded and warned, a record with no type at all skipped, and the three EML part types.

**Checked, not assumed:** metadata-only entries (empty `storage_key`) are newly reachable via unknown types, so I verified the read path. `save-entry-writer.ts:82` already guards with `if (!att.storage_key) continue;`, so export skips them without crashing.

**Typecheck caught what vitest could not.** Three errors in my own test file: an implicit `any` and two `exactOptionalPropertyTypes` violations from spreading `{ ...record, field: undefined }`. Vitest ran green while `tsc` did not, which is exactly the drift `pnpm run typecheck` exists to catch.

Gates: build 10/10, typecheck 17/17, test 15/15, lint 0 errors, docs build no warnings.

## Docs

`docs/security.md` gains the per-type table under "When Graph cannot produce MIME", where the fallback path is already described, plus a warning that snapshots taken before this version can claim attachments whose content was never captured. That is the operator-visible consequence: `has_attachments` was stored either way, so an old snapshot can look complete and not be.
