### PR TITLE
feat(save): mark exported archives as internet-sourced on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,36 @@ jobs:
             packages/*/coverage/
           retention-days: 30
 
+  # The only Windows-specific code path in Atlas. Mark-of-the-Web is an NTFS
+  # alternate data stream, so no Linux runner can prove the write works and no
+  # unit test on macOS can either -- issue #220 was filed calling it unverifiable
+  # by CI. The stream write is an ordinary filesystem operation, so a Windows
+  # runner does prove that much. What it still cannot prove is the chain beyond
+  # the file: Explorer propagating the mark to extracted files, and Office
+  # opening them in Protected View. Those need a human on a desktop.
+  windows-motw:
+    name: Mark-of-the-Web (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Zone.Identifier stream is written on NTFS
+        run: pnpm --filter @wisecom/atlas-core exec vitest run tests/unit/utils/zone-identifier.test.ts
+
   release-guard:
     name: Release version guard
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,38 +64,6 @@ jobs:
             packages/*/coverage/
           retention-days: 30
 
-  # The only Windows-specific code path in Atlas. Mark-of-the-Web is an NTFS
-  # alternate data stream, so no Linux runner can prove the write works and no
-  # unit test on macOS can either -- issue #220 was filed calling it unverifiable
-  # by CI. The stream write is an ordinary filesystem operation, so a Windows
-  # runner does prove that much. What it still cannot prove is the chain beyond
-  # the file: Explorer propagating the mark to extracted files, and Office
-  # opening them in Protected View. Those need a human on a desktop.
-  windows-motw:
-    name: Mark-of-the-Web (Windows)
-    runs-on: windows-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Zone.Identifier stream is written on NTFS
-        # Verbose names the cases: the pass/skip counts alone are identical on
-        # Windows and POSIX (three each way), so the log has to say which three
-        # ran or the job proves nothing.
-        run: pnpm --filter @wisecom/atlas-core exec vitest run --reporter=verbose tests/unit/utils/zone-identifier.test.ts
 
   release-guard:
     name: Release version guard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Zone.Identifier stream is written on NTFS
-        run: pnpm --filter @wisecom/atlas-core exec vitest run tests/unit/utils/zone-identifier.test.ts
+        # Verbose names the cases: the pass/skip counts alone are identical on
+        # Windows and POSIX (three each way), so the log has to say which three
+        # ran or the job proves nothing.
+        run: pnpm --filter @wisecom/atlas-core exec vitest run --reporter=verbose tests/unit/utils/zone-identifier.test.ts
 
   release-guard:
     name: Release version guard

--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -257,6 +257,8 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 
 ### `atlas onedrive save`
 
+On Windows the archive is stamped with Mark-of-the-Web (`Zone.Identifier`, `ZoneId=3`), so files extracted from it open in Protected View and their macros are blocked. Explorer propagates the mark to every extracted file; clear it with `Get-ChildItem -Recurse <dir> | Unblock-File` once you trust the content. Nothing is written on macOS or Linux, and an export to a filesystem without alternate data streams still succeeds with a warning. See [Exported archives and Mark-of-the-Web](./reference/cli.md#atlas-outlook-save).
+
 | Flag                       | Description                              | Default        |
 | -------------------------- | ---------------------------------------- | -------------- |
 | `-o, --owner <id>`         | User email or Entra object ID            | Required       |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -235,6 +235,18 @@ The formatted view is identical for both formats -- subject, from, to, cc, date,
 
 Export backed-up emails as standard `.eml` files (RFC 5322) in a compressed zip archive. Messages archived as MIME are written **byte-for-byte** from the stored object -- no re-encoding, so the exported file is the message Exchange received. Legacy entries stored as Graph JSON are reconstructed into `.eml` at export time, as they always were. Attachments are embedded as MIME parts in both cases. Every message and attachment is SHA-256 verified after decryption by default.
 
+::: warning Exported archives are marked as internet-sourced on Windows
+On Windows, Atlas stamps the archive with Mark-of-the-Web: a `Zone.Identifier` alternate data stream carrying `ZoneId=3` (Internet). The content came from a Microsoft 365 tenant over the network, and Atlas does not vet it, so an export must not be the step that strips a protection the same file would have had if it arrived by browser or mail attachment. Without the mark, Office opens recovered documents with macros enabled; with it, they open in [Protected View](https://learn.microsoft.com/en-us/microsoft-365-apps/security/internet-macros-blocked) and macros are blocked.
+
+**This propagates.** Windows Explorer and WinRAR copy the mark onto every extracted file (7-Zip only since 22.0, and not by default), so a 10,000-file recovery yields 10,000 files in Protected View and no macro-bearing workbook that runs. That is intended, and it is the behaviour operators notice first. When you have decided the content is trustworthy, clear it with PowerShell:
+
+```powershell
+Get-ChildItem -Recurse .\Restore-2026-03-10 | Unblock-File
+```
+
+Nothing is written on macOS or Linux, which have no equivalent. If the target filesystem cannot hold an alternate data stream (FAT32 or exFAT removable media, SMB to a non-NTFS server) the export still succeeds and logs a warning: a recovered archive is worth more than its mark.
+:::
+
 **Snapshot mode:**
 
 ```bash

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -229,6 +229,8 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 
 ### `atlas sharepoint save`
 
+On Windows the archive is stamped with Mark-of-the-Web (`Zone.Identifier`, `ZoneId=3`), so files extracted from it open in Protected View and their macros are blocked. Explorer propagates the mark to every extracted file; clear it with `Get-ChildItem -Recurse <dir> | Unblock-File` once you trust the content. Nothing is written on macOS or Linux, and an export to a filesystem without alternate data streams still succeeds with a warning. See [Exported archives and Mark-of-the-Web](./reference/cli.md#atlas-outlook-save).
+
 | Flag                       | Description                                  | Default        |
 | -------------------------- | -------------------------------------------- | -------------- |
 | `--site <url-or-id>`       | SharePoint site URL or Graph site ID         | Required       |

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -17,3 +17,4 @@ export { CONFIG_KEYS, find_config_key, mask_secret } from './config-keys';
 export type { ConfigKeySpec } from './config-keys';
 export { html_to_text } from './html-to-text';
 export { is_gcm_auth_failure } from './gcm-auth';
+export { mark_downloaded_from_internet } from './zone-identifier';

--- a/packages/core/src/utils/zone-identifier.ts
+++ b/packages/core/src/utils/zone-identifier.ts
@@ -1,0 +1,51 @@
+import { writeFile } from 'node:fs/promises';
+import { platform } from 'node:os';
+import { logger } from '@/utils/logger';
+
+/**
+ * Windows zone for content that came over the network from outside the
+ * organisation. Exported mail and drive files came from a Microsoft 365
+ * tenant, not from this machine and not from an intranet share.
+ */
+const ZONE_ID_INTERNET = 3;
+
+const ZONE_TRANSFER_CONTENT = `[ZoneTransfer]\r\nZoneId=${ZONE_ID_INTERNET}\r\n`;
+
+/**
+ * Stamps Mark-of-the-Web on a file Atlas just wrote, on Windows only.
+ *
+ * An archive written by a local process carries no `Zone.Identifier` stream,
+ * so everything extracted from it is unmarked too. The same content arriving
+ * through a browser or a mail attachment would open in Protected View, and
+ * since Office 2203 its macros would be blocked outright. Atlas does not vet
+ * backed-up content and should not have to, so an export must not be the path
+ * that launders that mark away.
+ *
+ * NTFS exposes alternate data streams as `path:stream`, which is the form
+ * `CreateFileW` accepts, so this needs no dependency. It is gated on Windows
+ * because elsewhere a `:` in the path is an ordinary character and would
+ * create a junk file instead of a stream.
+ *
+ * Never throws. A filesystem without ADS support (FAT32 or exFAT removable
+ * media, SMB to a non-NTFS server) rejects the write, and a recovered archive
+ * is worth more than its mark.
+ *
+ * @param file_path Path to the archive that was just flushed and closed.
+ * @returns Whether the mark was written.
+ * @see https://learn.microsoft.com/en-us/microsoft-365-apps/security/internet-macros-blocked
+ */
+export async function mark_downloaded_from_internet(file_path: string): Promise<boolean> {
+  if (platform() !== 'win32') return false;
+
+  try {
+    await writeFile(`${file_path}:Zone.Identifier`, ZONE_TRANSFER_CONTENT, 'utf-8');
+    return true;
+  } catch (err) {
+    logger.warn(
+      `Could not mark ${file_path} as downloaded from the internet ` +
+        `(${err instanceof Error ? err.message : String(err)}). ` +
+        `Files extracted from it will not open in Protected View.`,
+    );
+    return false;
+  }
+}

--- a/packages/core/tests/unit/utils/zone-identifier.test.ts
+++ b/packages/core/tests/unit/utils/zone-identifier.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp, readdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir, platform } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mark_downloaded_from_internet } from '@/utils/zone-identifier';
+
+const is_windows = platform() === 'win32';
+
+let dir: string;
+let archive: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'atlas-motw-'));
+  archive = join(dir, 'export.zip');
+  await writeFile(archive, 'PK\u0003\u0004 pretend archive');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('mark_downloaded_from_internet', () => {
+  it.runIf(is_windows)('writes an Internet-zone Zone.Identifier stream', async () => {
+    const marked = await mark_downloaded_from_internet(archive);
+
+    expect(marked).toBe(true);
+    const stream = await readFile(`${archive}:Zone.Identifier`, 'utf-8');
+    expect(stream).toContain('[ZoneTransfer]');
+    expect(stream).toContain('ZoneId=3');
+  });
+
+  it.runIf(is_windows)('leaves the archive bytes untouched', async () => {
+    const before = await readFile(archive);
+
+    await mark_downloaded_from_internet(archive);
+
+    expect(await readFile(archive)).toEqual(before);
+  });
+
+  it.runIf(is_windows)(
+    'reports failure rather than throwing when the stream is refused',
+    async () => {
+      // A directory that no longer exists stands in for a filesystem with no ADS
+      // support: the write is rejected, and the save must survive it.
+      await expect(mark_downloaded_from_internet(join(dir, 'gone', 'missing.zip'))).resolves.toBe(
+        false,
+      );
+    },
+  );
+
+  it.skipIf(is_windows)('does nothing on platforms with no Mark-of-the-Web', async () => {
+    const marked = await mark_downloaded_from_internet(archive);
+
+    expect(marked).toBe(false);
+  });
+
+  it.skipIf(is_windows)(
+    'creates no junk file, since a colon is an ordinary character here',
+    async () => {
+      // Without the platform gate this is what happens on macOS and Linux: a file
+      // literally named "export.zip:Zone.Identifier" next to the archive.
+      await mark_downloaded_from_internet(archive);
+
+      expect(await readdir(dir)).toEqual(['export.zip']);
+    },
+  );
+
+  it.skipIf(is_windows)('never throws for a path that cannot exist', async () => {
+    await expect(mark_downloaded_from_internet(join(dir, 'gone', 'missing.zip'))).resolves.toBe(
+      false,
+    );
+  });
+});

--- a/packages/core/tests/unit/utils/zone-identifier.test.ts
+++ b/packages/core/tests/unit/utils/zone-identifier.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, readdir, writeFile } from 'node:fs/promises';
 import { tmpdir, platform } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -20,34 +20,6 @@ afterEach(() => {
 });
 
 describe('mark_downloaded_from_internet', () => {
-  it.runIf(is_windows)('writes an Internet-zone Zone.Identifier stream', async () => {
-    const marked = await mark_downloaded_from_internet(archive);
-
-    expect(marked).toBe(true);
-    const stream = await readFile(`${archive}:Zone.Identifier`, 'utf-8');
-    expect(stream).toContain('[ZoneTransfer]');
-    expect(stream).toContain('ZoneId=3');
-  });
-
-  it.runIf(is_windows)('leaves the archive bytes untouched', async () => {
-    const before = await readFile(archive);
-
-    await mark_downloaded_from_internet(archive);
-
-    expect(await readFile(archive)).toEqual(before);
-  });
-
-  it.runIf(is_windows)(
-    'reports failure rather than throwing when the stream is refused',
-    async () => {
-      // A directory that no longer exists stands in for a filesystem with no ADS
-      // support: the write is rejected, and the save must survive it.
-      await expect(mark_downloaded_from_internet(join(dir, 'gone', 'missing.zip'))).resolves.toBe(
-        false,
-      );
-    },
-  );
-
   it.skipIf(is_windows)('does nothing on platforms with no Mark-of-the-Web', async () => {
     const marked = await mark_downloaded_from_internet(archive);
 

--- a/packages/onedrive/src/services/onedrive-save.service.ts
+++ b/packages/onedrive/src/services/onedrive-save.service.ts
@@ -1,3 +1,4 @@
+import { mark_downloaded_from_internet } from '@wisecom/atlas-core/utils/zone-identifier';
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import {
   begin_operation_progress,
@@ -97,6 +98,7 @@ export class OneDriveSaveService implements OneDriveSaveUseCase {
       });
       await finalize_file_archive(archive);
       const total_bytes = await promise;
+      await mark_downloaded_from_internet(output_path);
       const interrupted =
         files_saved + files_skipped < restorable.length || options.should_interrupt?.() === true;
       emit_operation_progress(options, {

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -1,3 +1,4 @@
+import { mark_downloaded_from_internet } from '@wisecom/atlas-core/utils/zone-identifier';
 import type { TenantContext } from '@wisecom/atlas-types';
 import type { ManifestEntry } from '@wisecom/atlas-types';
 import type { SaveResult } from '@wisecom/atlas-types';
@@ -91,6 +92,7 @@ export async function save_entries_to_archive(
   });
   await finalize_archive(archive);
   const total_bytes = await promise;
+  await mark_downloaded_from_internet(output_path);
 
   log_save_summary(global_saved, global_att, global_errors, total_bytes, start);
 

--- a/packages/sharepoint/src/services/sharepoint-save.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-save.service.ts
@@ -1,3 +1,4 @@
+import { mark_downloaded_from_internet } from '@wisecom/atlas-core/utils/zone-identifier';
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import {
   begin_operation_progress,
@@ -97,6 +98,7 @@ export class SharePointSaveService implements SharePointSaveUseCase {
       });
       await finalize_file_archive(archive);
       const total_bytes = await promise;
+      await mark_downloaded_from_internet(output_path);
       const interrupted =
         files_saved + files_skipped < restorable.length || options.should_interrupt?.() === true;
       emit_operation_progress(options, {


### PR DESCRIPTION
Fixes #220. Cut from `dev`. #241 and #242 are also open and touch Outlook folders and drive metadata; this touches the local export path only.

## Fix

One helper in `packages/core`, gated on `platform() === 'win32'`, called after the archive bytes are flushed in all three save paths. NTFS exposes alternate data streams as `path:stream`, which is what `CreateFileW` accepts, so no dependency and no native module.

```
export.zip:Zone.Identifier  ->  [ZoneTransfer]
                                ZoneId=3
```

`ZoneId=3` because the content came from a Microsoft 365 tenant over the network. Atlas does not vet it, and #53 already accepts that backed-up content can be hostile, so an export must not be the step that strips a protection the same file would have had arriving by browser or attachment.

## Never fails the save

A filesystem without ADS support (FAT32 or exFAT removable media, SMB to a non-NTFS server) rejects the write. The helper warns and returns false; the archive, the byte count, and the exit code are untouched.

## Windows verification: done once, not carried

The issue flagged this as unverified:

> **Unverified:** that Node writes an ADS through this path on a real Windows host. It follows from the Win32 API but has not been run.

It has now been run, on `windows-latest` against real NTFS, in [run 33259074482](https://github.com/wisecom-oy/atlas/actions/runs/33259074482):

```
✓ writes an Internet-zone Zone.Identifier stream          7ms
✓ leaves the archive bytes untouched                      4ms
✓ reports failure rather than throwing when refused       4ms
```

That was the one-time check the acceptance criteria asked for, so the temporary job and its Windows-only cases have been removed rather than kept on every PR. The evidence stays in that run and in the comment below it.

Getting that evidence took two attempts worth noting: the first green run reported `3 passed | 3 skipped`, which is the identical count on Windows and POSIX (three `runIf(win32)` against three `skipIf(win32)`), so a passing job said nothing about which three ran. `--reporter=verbose` was what turned a green tick into an actual record.

**Still manual, and unclaimed:** extracting an archive with Explorer and confirming Office opens the files in Protected View. CI can write the stream; it cannot drive Explorer or Office.

## What is tested on every PR

The platform gate, which is the part that can regress silently on the machines Atlas is actually developed on:

- The helper is a no-op off Windows.
- **No junk file appears beside the archive.** Without the gate, macOS and Linux would create a real file literally named `export.zip:Zone.Identifier`, since a colon is an ordinary character there.
- A path that cannot exist returns false rather than throwing.

## Docs lead with the failure operators hit first

Not "we added a security mark", but: **Explorer propagates it to every extracted file**, so a 10,000-file recovery lands entirely in Protected View with no macro-bearing workbook running. That is intended, and it is what generates the support ticket. So the docs say it plainly and give the remedy:

```powershell
Get-ChildItem -Recurse .\Restore-2026-03-10 | Unblock-File
```

Covered in `docs/reference/cli.md` under `atlas outlook save`, with shorter pointers from the OneDrive and SharePoint save sections.

## Local evidence on darwin

```
platform      : darwin
marked        : false
dir contents  : ["export.zip"]
refused path  : false
```

Gates: build 10/10, typecheck 17/17, test 15/15, lint 0 errors, format clean, docs build no warnings.

## Left alone deliberately

The issue's "out of scope" note about unsanitized zip entry names on the drive save path is untouched. It is unreachable today (Graph rejects the Windows-illegal characters and `root:` is stripped before storage), and mixing a path-traversal hardening into a Mark-of-the-Web change would make both harder to review. It deserves its own issue.
