### PR TITLE
test(cli): guard that atlas config never prints a secret

### DIFF
--- a/packages/cli/tests/unit/config-command.test.ts
+++ b/packages/cli/tests/unit/config-command.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { register_config_command } from '@/commands/config.command';
+
+vi.mock('dotenv', () => ({ config: vi.fn() }));
+
+const fs_mocks = vi.hoisted(() => ({ readFileSync: vi.fn() }));
+vi.mock('node:fs', () => fs_mocks);
+
+const azure_mocks = vi.hoisted(() => ({ get_token: vi.fn() }));
+// A `function`, not `vi.fn(() => ...)`: the credential is constructed with
+// `new`, and an arrow mock fails with "is not a constructor", which surfaces as
+// a failed Graph probe rather than as a broken test.
+vi.mock('@azure/identity', () => ({
+  ClientSecretCredential: function () {
+    return { getToken: azure_mocks.get_token };
+  },
+}));
+
+const s3_mocks = vi.hoisted(() => ({ send: vi.fn(), destroy: vi.fn() }));
+vi.mock('@wisecom/atlas-s3', () => ({
+  create_s3_client: vi.fn(() => ({ send: s3_mocks.send, destroy: s3_mocks.destroy })),
+}));
+vi.mock('@aws-sdk/client-s3', () => ({ ListBucketsCommand: vi.fn() }));
+
+const mocks = vi.hoisted(() => ({
+  read_secure_config: vi.fn(),
+  write_secure_config: vi.fn(),
+  read_env_overrides: vi.fn(),
+  try_load_config_file: vi.fn(),
+  secure_config_dir: vi.fn(() => '/tmp/fake-atlas'),
+}));
+vi.mock('@wisecom/atlas-core', async (import_original) => {
+  const actual = await import_original<Record<string, unknown>>();
+  return { ...actual, ...mocks };
+});
+
+const COMPLETE_GRAPH = {
+  tenant_id: '00000000-0000-0000-0000-000000000001',
+  client_id: '00000000-0000-0000-0000-000000000002',
+  client_secret: 'FAKE-client-secret',
+};
+const COMPLETE_S3 = {
+  s3_endpoint: 'https://s3.example.invalid',
+  s3_access_key: 'FAKEACCESSKEYID12345',
+  s3_secret_key: 'FAKE-s3-secret-key',
+};
+
+let output: string[];
+
+function run(args: string[]): Promise<unknown> {
+  const program = new Command();
+  program.exitOverride();
+  register_config_command(program);
+  return program.parseAsync(['config', ...args], { from: 'user' });
+}
+
+beforeEach(() => {
+  // restoreAllMocks only restores spies; the hoisted module mocks keep their
+  // call history between tests without this.
+  vi.clearAllMocks();
+  output = [];
+  const capture = (...parts: unknown[]): void => {
+    output.push(parts.map(String).join(' '));
+  };
+  vi.spyOn(console, 'log').mockImplementation(capture);
+  vi.spyOn(console, 'warn').mockImplementation(capture);
+  vi.spyOn(console, 'error').mockImplementation(capture);
+
+  mocks.try_load_config_file.mockReturnValue({});
+  mocks.read_env_overrides.mockReturnValue({});
+  mocks.read_secure_config.mockReturnValue({});
+  azure_mocks.get_token.mockResolvedValue({ token: 'fake' });
+  s3_mocks.send.mockResolvedValue({ Buckets: [] });
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = undefined;
+});
+
+describe('atlas config set', () => {
+  it('reads the value from stdin when given "-", keeping it out of shell history', async () => {
+    fs_mocks.readFileSync.mockReturnValue('  FAKE-secret-from-stdin  \n');
+
+    await run(['client.secret', '-']);
+
+    // Read from fd 0, not from the argument vector.
+    expect(fs_mocks.readFileSync).toHaveBeenCalledWith(0, 'utf-8');
+    expect(mocks.write_secure_config).toHaveBeenCalledWith({
+      client_secret: 'FAKE-secret-from-stdin',
+    });
+  });
+
+  it('rejects an invalid value and writes nothing', async () => {
+    await expect(run(['tenant.id', 'not-a-guid'])).rejects.toThrow(/Invalid value for tenant.id/);
+
+    expect(mocks.write_secure_config).not.toHaveBeenCalled();
+  });
+
+  it('rejects a passphrase below the minimum length', async () => {
+    await expect(run(['encryption.passphrase', 'short'])).rejects.toThrow(/at least 12/);
+
+    expect(mocks.write_secure_config).not.toHaveBeenCalled();
+  });
+
+  it('keeps existing keys when storing a new one', async () => {
+    mocks.read_secure_config.mockReturnValue({ tenant_id: 'existing-tenant' });
+
+    await run(['s3.region', 'eu-north-1']);
+
+    expect(mocks.write_secure_config).toHaveBeenCalledWith({
+      tenant_id: 'existing-tenant',
+      s3_region: 'eu-north-1',
+    });
+  });
+
+  it('warns that an ATLAS_* variable overrides the value just stored', async () => {
+    mocks.read_env_overrides.mockReturnValue({ s3_region: 'us-west-2' });
+
+    await run(['s3.region', 'eu-north-1']);
+
+    expect(output.join('\n')).toMatch(/environment variable currently overrides s3\.region/);
+  });
+
+  it('does not warn when the environment agrees with the stored value', async () => {
+    mocks.read_env_overrides.mockReturnValue({ s3_region: 'eu-north-1' });
+
+    await run(['s3.region', 'eu-north-1']);
+
+    expect(output.join('\n')).not.toMatch(/environment variable currently overrides/);
+  });
+
+  it('skips the live probe while the credential group is incomplete', async () => {
+    await run(['client.id', '00000000-0000-0000-0000-000000000002']);
+
+    expect(output.join('\n')).toMatch(/Graph credentials incomplete/);
+    expect(azure_mocks.get_token).not.toHaveBeenCalled();
+  });
+
+  it('probes Graph once the last credential in the group is stored', async () => {
+    mocks.read_secure_config.mockReturnValue(COMPLETE_GRAPH);
+
+    await run(['client.secret', 'FAKE-client-secret']);
+
+    expect(azure_mocks.get_token).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an unknown key', async () => {
+    await expect(run(['nope.key', 'value'])).rejects.toThrow(/Unknown config key "nope.key"/);
+
+    expect(mocks.write_secure_config).not.toHaveBeenCalled();
+  });
+});
+
+describe('atlas config get', () => {
+  it('warns and prints nothing when the key is unset', async () => {
+    await run(['tenant.id']);
+
+    expect(output.join('\n')).toMatch(/tenant\.id is not set/);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+});
+
+describe('atlas config list', () => {
+  it('marks unset keys rather than omitting them', async () => {
+    await run(['list']);
+
+    expect(output.join('\n')).toContain('<unset>');
+  });
+
+  it('names the source a value resolves from, environment winning', async () => {
+    mocks.try_load_config_file.mockReturnValue({ s3_region: 'from-file' });
+    mocks.read_secure_config.mockReturnValue({ s3_region: 'from-store' });
+    mocks.read_env_overrides.mockReturnValue({ s3_region: 'from-env' });
+
+    await run(['list']);
+
+    const line = output.find((l) => l.includes('s3.region'));
+    expect(line).toContain('from-env');
+    expect(line).toContain('(env)');
+  });
+
+  it('reports the secure store as the source when no variable overrides it', async () => {
+    mocks.read_secure_config.mockReturnValue({ s3_region: 'from-store' });
+
+    await run(['list']);
+
+    expect(output.find((l) => l.includes('s3.region'))).toContain('(secure store)');
+  });
+});
+
+describe('atlas config unset', () => {
+  it('errors with usage when no key is given', async () => {
+    await expect(run(['unset'])).rejects.toThrow(/Usage: atlas config unset/);
+
+    expect(mocks.write_secure_config).not.toHaveBeenCalled();
+  });
+
+  it('errors on an unknown key without mutating the store', async () => {
+    await expect(run(['unset', 'nope.key'])).rejects.toThrow(/Unknown config key/);
+
+    expect(mocks.write_secure_config).not.toHaveBeenCalled();
+  });
+
+  it('warns and writes nothing when the key is not in the store', async () => {
+    await run(['unset', 'tenant.id']);
+
+    expect(output.join('\n')).toMatch(/not set in the secure store/);
+    expect(mocks.write_secure_config).not.toHaveBeenCalled();
+  });
+
+  it('removes only the named key', async () => {
+    mocks.read_secure_config.mockReturnValue({
+      tenant_id: 'keep-me',
+      client_secret: 'FAKE-remove-me',
+    });
+
+    await run(['unset', 'client.secret']);
+
+    expect(mocks.write_secure_config).toHaveBeenCalledWith({ tenant_id: 'keep-me' });
+  });
+});
+
+describe('atlas config validate', () => {
+  it('leaves the exit code clean when both probes pass', async () => {
+    mocks.read_secure_config.mockReturnValue({ ...COMPLETE_GRAPH, ...COMPLETE_S3 });
+
+    await run(['validate']);
+
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('exits non-zero when the Graph probe fails', async () => {
+    mocks.read_secure_config.mockReturnValue({ ...COMPLETE_GRAPH, ...COMPLETE_S3 });
+    azure_mocks.get_token.mockRejectedValue(new Error('AADSTS7000215'));
+
+    await run(['validate']);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.join('\n')).toMatch(/Graph validation failed/);
+  });
+
+  it('exits non-zero when the S3 probe fails, and still releases the client', async () => {
+    mocks.read_secure_config.mockReturnValue({ ...COMPLETE_GRAPH, ...COMPLETE_S3 });
+    s3_mocks.send.mockRejectedValue(new Error('InvalidAccessKeyId'));
+
+    await run(['validate']);
+
+    expect(process.exitCode).toBe(1);
+    expect(s3_mocks.destroy).toHaveBeenCalled();
+  });
+
+  it('exits non-zero when credentials are missing entirely', async () => {
+    await run(['validate']);
+
+    expect(process.exitCode).toBe(1);
+    expect(output.join('\n')).toMatch(/Graph credentials incomplete/);
+    expect(output.join('\n')).toMatch(/S3 settings incomplete/);
+  });
+});

--- a/packages/cli/tests/unit/config-secret-masking.test.ts
+++ b/packages/cli/tests/unit/config-secret-masking.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { CONFIG_KEYS } from '@wisecom/atlas-core';
+import type { AtlasConfig } from '@wisecom/atlas-core';
+import { register_config_command } from '@/commands/config.command';
+
+vi.mock('dotenv', () => ({ config: vi.fn() }));
+vi.mock('@azure/identity', () => ({
+  ClientSecretCredential: function () {
+    return { getToken: vi.fn().mockResolvedValue({ token: 'fake' }) };
+  },
+}));
+vi.mock('@wisecom/atlas-s3', () => ({ create_s3_client: vi.fn() }));
+
+const mocks = vi.hoisted(() => ({
+  read_secure_config: vi.fn(),
+  write_secure_config: vi.fn(),
+  read_env_overrides: vi.fn(),
+  try_load_config_file: vi.fn(),
+  secure_config_dir: vi.fn(() => '/tmp/fake-atlas'),
+}));
+
+// Real CONFIG_KEYS, find_config_key and mask_secret: the point is to drive the
+// assertions from the shipped key table, not from a copy of it. Only the store
+// and environment readers are replaced, so no test touches ~/.atlas/config.enc.
+vi.mock('@wisecom/atlas-core', async (import_original) => {
+  const actual = await import_original<Record<string, unknown>>();
+  return { ...actual, ...mocks };
+});
+
+/** Obviously fake, and long enough that masking cannot be mistaken for truncation. */
+const FAKE_VALUES: Record<string, string> = {
+  'tenant.id': '00000000-0000-0000-0000-000000000001',
+  'client.id': '00000000-0000-0000-0000-000000000002',
+  'client.secret': 'FAKE-client-secret-do-not-use-9Q7xVt',
+  's3.endpoint': 'https://s3.example.invalid',
+  's3.access-key': 'FAKEACCESSKEYID12345',
+  's3.secret-key': 'FAKE-s3-secret-access-key-do-not-use-8Zk2',
+  's3.region': 'us-east-1',
+  'encryption.passphrase': 'FAKE-passphrase-do-not-use-4Wm9',
+};
+
+function full_config(): Partial<AtlasConfig> {
+  const config: Record<string, string> = {};
+  for (const spec of CONFIG_KEYS) {
+    config[spec.field] = FAKE_VALUES[spec.key]!;
+  }
+  return config as Partial<AtlasConfig>;
+}
+
+let output: string[];
+
+function run(args: string[]): Promise<unknown> {
+  const program = new Command();
+  program.exitOverride();
+  register_config_command(program);
+  return program.parseAsync(['config', ...args], { from: 'user' });
+}
+
+beforeEach(() => {
+  output = [];
+  const capture = (...parts: unknown[]): void => {
+    output.push(parts.map(String).join(' '));
+  };
+  vi.spyOn(console, 'log').mockImplementation(capture);
+  vi.spyOn(console, 'warn').mockImplementation(capture);
+  vi.spyOn(console, 'error').mockImplementation(capture);
+
+  mocks.try_load_config_file.mockReturnValue({});
+  mocks.read_env_overrides.mockReturnValue({});
+  mocks.read_secure_config.mockReturnValue(full_config());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const secret_keys = CONFIG_KEYS.filter((spec) => spec.secret);
+const plain_keys = CONFIG_KEYS.filter((spec) => !spec.secret);
+
+describe('atlas config never prints a secret in full', () => {
+  it.each(secret_keys.map((spec) => spec.key))('config list masks %s', async (key) => {
+    await run(['list']);
+
+    const full_value = FAKE_VALUES[key]!;
+    expect(output.join('\n')).not.toContain(full_value);
+  });
+
+  it.each(secret_keys.map((spec) => spec.key))('config get masks %s', async (key) => {
+    await run([key]);
+
+    const full_value = FAKE_VALUES[key]!;
+    expect(output.join('\n')).not.toContain(full_value);
+    // Something was printed: an empty output would pass the check above while
+    // telling the operator nothing.
+    expect(output.join('').length).toBeGreaterThan(0);
+  });
+
+  it.each(plain_keys.map((spec) => spec.key))('config get prints %s in full', async (key) => {
+    await run([key]);
+
+    // Distinguishes masking from blanket redaction: a non-secret must survive.
+    expect(output.join('\n')).toContain(FAKE_VALUES[key]!);
+  });
+
+  it('lists every key, so a masked value is still reported as set', async () => {
+    await run(['list']);
+
+    const listed = output.join('\n');
+    for (const spec of CONFIG_KEYS) {
+      expect(listed).toContain(spec.key);
+    }
+    expect(listed).not.toContain('<unset>');
+  });
+});
+
+describe('credential-shaped keys carry the secret flag', () => {
+  // The guarantee "secrets are never printed" holds only while every credential
+  // entry in CONFIG_KEYS is flagged. A key added later without it prints a
+  // client secret to stdout and into CI logs, which is what #174 and #175 were.
+  const CREDENTIAL_PATTERN = /secret|passphrase|password|credential|token/i;
+
+  it.each(CONFIG_KEYS.map((spec) => [spec.key, spec.field, spec.secret] as const))(
+    '%s is flagged correctly for its name',
+    (key, field, secret) => {
+      const looks_like_credential =
+        CREDENTIAL_PATTERN.test(key) || CREDENTIAL_PATTERN.test(String(field));
+      if (looks_like_credential) {
+        expect(secret, `${key} looks like a credential and must set secret: true`).toBe(true);
+      }
+    },
+  );
+
+  it('flags the three credential fields Atlas holds', () => {
+    // Named explicitly as well as by pattern: a rename that dodges the regex
+    // still has to fail something.
+    const flagged = CONFIG_KEYS.filter((spec) => spec.secret).map((spec) => spec.field);
+
+    expect(flagged).toContain('client_secret');
+    expect(flagged).toContain('s3_secret_key');
+    expect(flagged).toContain('encryption_passphrase');
+  });
+
+  it('does not flag an S3 access key ID, which is an identifier', () => {
+    // Blanket flagging would pass every masking test above while making the
+    // output useless, so the negative case is worth pinning.
+    const access_key = CONFIG_KEYS.find((spec) => spec.field === 's3_access_key');
+
+    expect(access_key?.secret).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #195. Cut from `dev`. Touches only new CLI test files, so it overlaps none of #241, #242 or #243.

## Coverage was the symptom; the flag is the actual guarantee

`config.command.ts` was at 0.0% over 102 statements, in the one command that reads the encrypted credential store and prints values to a terminal. Masking is per-key:

```ts
console.log(spec.secret ? mask_secret(value) : value);
```

So "secrets are never printed" holds exactly as long as every credential entry in `CONFIG_KEYS` carries `secret: true`. A key added later without it prints a client secret to stdout and into CI logs, and nothing fails.

Tests are table-driven over the shipped `CONFIG_KEYS`, as the issue asked, so a key added later is covered without a new case: every secret key must be absent in full from `config list` and `config get`, and every non-secret key must be present in full, which separates masking from blanket redaction.

## The table alone is not enough, and I checked

I flipped `client.secret` to `secret: false` to confirm the tests bite. The masking cases **did not fail**. They disappeared:

```
Tests  2 failed | 19 passed (21)     <- 22 before
× client.secret is flagged correctly for its name
× flags the three credential fields Atlas holds
```

A key with `secret: false` drops out of the filtered table, so the count slid 22 to 21 and the two cases that would have caught the leak simply stopped existing. Table-driven tests over a filtered list cannot detect a key leaving the filter.

That is why there is a separate invariant, and why it is the part that matters:

- **By name pattern:** any key or field matching `/secret|passphrase|password|credential|token/i` must set `secret: true`. That failure names the key and the reason.
- **By explicit list:** `client_secret`, `s3_secret_key` and `encryption_passphrase` are asserted flagged, so a rename that dodges the regex still fails something.
- **Negatively:** `s3_access_key` must stay unflagged. Blanket flagging would satisfy every masking assertion above while making the command useless, so the negative case is pinned too.

## Also covered

`set <key> -` reads from fd 0 (asserted as `readFileSync(0, 'utf-8')`) so secrets stay out of shell history and out of the argument vector; invalid values rejected with nothing written to the store; existing keys preserved on write; the `ATLAS_*` override warning, including that it stays quiet when the environment agrees; probe skipped while a credential group is incomplete and fired when the last field lands; source precedence in `list` (env over store over file); `get` on an unset key warning with nothing on stdout; `unset` with no key and with an unknown key, neither mutating the store; and `validate`'s exit code on all four probe outcomes.

## One mock bug worth naming

`vi.mock('@azure/identity', () => ({ ClientSecretCredential: vi.fn(() => ({ getToken })) }))` looks right and is not: the credential is constructed with `new`, and an arrow mock throws *"is not a constructor"*. That surfaced as a **failed Graph probe**, not as a broken test, so `validate` looked like it was exercising the failure path when it was really failing to build a mock. Vitest warns about it in stderr, which is where I found it. It is now a `function` mock, with a comment, because the next person will reach for `vi.fn` too.

## Result

| | Before | After |
| --- | --- | --- |
| Statements | 0.0% | **98.03%** |
| Branches | 0.0% | 94.82% |
| Functions | 0.0% | 100% |

43 tests across two files, split to stay inside the 300-line rule: the masking and flag invariant in one, command behaviour in the other. No production code changed, so no docs: nothing user-visible moved.

Gates: build 10/10, typecheck 17/17, test 15/15, lint 0 errors, format clean.
