### PR TITLE
test(drive): cover the large-file pipeline and its chunk downloader

### DIFF
--- a/packages/core/tests/unit/services/shared/stream-encrypt-upload.test.ts
+++ b/packages/core/tests/unit/services/shared/stream-encrypt-upload.test.ts
@@ -20,7 +20,9 @@ interface Recorded {
  * A storage whose multipart handle keeps every uploaded part, so the assembled
  * layout can be asserted rather than inferred from call counts.
  */
-function make_ctx(options: { exists?: boolean; copy_fails?: boolean } = {}): Recorded {
+function make_ctx(
+  options: { exists?: boolean; copy_fails?: boolean; abort_fails?: boolean } = {},
+): Recorded {
   const parts = new Map<number, Buffer>();
   const ops: string[] = [];
   const completed: Array<Array<{ ETag: string; PartNumber: number }>> = [];
@@ -42,6 +44,7 @@ function make_ctx(options: { exists?: boolean; copy_fails?: boolean } = {}): Rec
           }),
           abort: vi.fn(async () => {
             ops.push('abort');
+            if (options.abort_fails === true) throw new Error('abort refused');
           }),
         };
       }),
@@ -53,7 +56,10 @@ function make_ctx(options: { exists?: boolean; copy_fails?: boolean } = {}): Rec
       delete: vi.fn(async (key: string) => {
         ops.push(`delete:${key}`);
       }),
-      abort_incomplete_uploads: vi.fn(async () => 0),
+      abort_incomplete_uploads: vi.fn(async (prefix: string) => {
+        ops.push(`abort_incomplete:${prefix}`);
+        return 0;
+      }),
     },
     create_cipher: () => {
       const iv = randomBytes(12);
@@ -131,6 +137,90 @@ describe('stream_encrypt_to_multipart', () => {
       expect(recorded.parts.get(part.PartNumber)!.length).toBeGreaterThanOrEqual(5 * 1024 * 1024);
     }
     expect(ordered.map((p) => p.PartNumber)).toEqual([1, 2, 3]);
+  });
+
+  it('produces no zero-length trailing part when the stream is an exact multiple', async () => {
+    // AES-GCM is a stream cipher, so ciphertext length equals plaintext length:
+    // an exact multiple of the part size leaves nothing pending at the end, and
+    // a zero-length part would be rejected by S3.
+    const recorded = make_ctx();
+
+    const result = await stream_encrypt_to_multipart(
+      recorded.ctx,
+      'staging/a',
+      chunks_of(PART_SIZE * 2, 1024 * 64),
+    );
+
+    expect(result.completed_parts.map((p) => p.PartNumber)).toEqual([1, 2]);
+    for (const [, data] of recorded.parts) {
+      expect(data.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('emits a short final part when the stream is one byte over a boundary', async () => {
+    const recorded = make_ctx();
+
+    const result = await stream_encrypt_to_multipart(
+      recorded.ctx,
+      'staging/a',
+      chunks_of(PART_SIZE * 2 + 1, 1024 * 64),
+    );
+
+    const ordered = [...result.completed_parts].sort((a, b) => a.PartNumber - b.PartNumber);
+    expect(ordered.map((p) => p.PartNumber)).toEqual([1, 2, 3]);
+    // Only the highest-numbered part may fall under the part size.
+    expect(recorded.parts.get(2)!.length).toBe(PART_SIZE);
+    expect(recorded.parts.get(3)!.length).toBe(1);
+  });
+
+  it('splits one oversized chunk into whole parts instead of a growing buffer', async () => {
+    // A single 3-part chunk must drain through the flush loop. If it flushed
+    // once per chunk the remainder would sit in memory, which is the failure
+    // the bounded pipeline exists to avoid.
+    const recorded = make_ctx();
+
+    async function* one_big_chunk(): AsyncGenerator<Buffer> {
+      yield Buffer.alloc(PART_SIZE * 3, 0xcd);
+    }
+
+    const result = await stream_encrypt_to_multipart(recorded.ctx, 'staging/a', one_big_chunk());
+
+    expect(result.completed_parts.map((p) => p.PartNumber).sort((a, b) => a - b)).toEqual([
+      1, 2, 3,
+    ]);
+    expect(recorded.parts.get(2)!.length).toBe(PART_SIZE);
+    expect(recorded.parts.get(3)!.length).toBe(PART_SIZE);
+  });
+
+  it('hands the completed parts to complete in ascending order', async () => {
+    const recorded = make_ctx();
+
+    const result = await stream_encrypt_to_multipart(
+      recorded.ctx,
+      'staging/a',
+      chunks_of(PART_SIZE * 2 + 1024, 1024 * 64),
+    );
+    await recorded.ctx.storage.begin_multipart_upload('x');
+    const handle = await recorded.ctx.storage.begin_multipart_upload('y');
+    await handle.complete(result.completed_parts);
+
+    const assembled = recorded.completed.at(-1)!;
+    const numbers = assembled.map((p) => p.PartNumber);
+    expect(numbers).toEqual([...numbers].sort((a, b) => a - b));
+  });
+
+  it('sweeps orphaned parts by prefix when the abort itself fails', async () => {
+    const recorded = make_ctx({ abort_fails: true });
+    async function* failing(): AsyncGenerator<Buffer> {
+      yield Buffer.alloc(1024, 1);
+      throw new Error('source died');
+    }
+
+    await expect(stream_encrypt_to_multipart(recorded.ctx, 'staging/a', failing())).rejects.toThrow(
+      'source died',
+    );
+    // Otherwise the tenant pays storage for parts nothing will ever complete.
+    expect(recorded.ops).toContain('abort_incomplete:staging/');
   });
 
   it('aborts the upload when the source fails mid-stream', async () => {

--- a/packages/onedrive/tests/unit/services/large-file-pipeline.test.ts
+++ b/packages/onedrive/tests/unit/services/large-file-pipeline.test.ts
@@ -1,0 +1,243 @@
+import { createCipheriv, randomBytes } from 'node:crypto';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  OneDriveConnector,
+  OneDriveDeltaItem,
+  StorageObjectLockPolicy,
+  TenantContext,
+} from '@wisecom/atlas-types';
+
+const chunk_mocks = vi.hoisted(() => ({ fetch_file_chunks: vi.fn() }));
+vi.mock('@/adapters/graph-onedrive-chunked-download', () => chunk_mocks);
+
+const { cleanup_stale_staging, process_large_file } =
+  await import('@/services/onedrive-large-file-pipeline');
+
+const KEY = randomBytes(32);
+const OWNER = 'owner-1';
+
+interface Recorded {
+  readonly ctx: TenantContext;
+  readonly ops: string[];
+  readonly copy_args: Array<{ from: string; to: string; policy: unknown }>;
+}
+
+function make_ctx(options: { exists?: boolean; list?: string[] } = {}): Recorded {
+  const ops: string[] = [];
+  const copy_args: Array<{ from: string; to: string; policy: unknown }> = [];
+
+  const ctx = {
+    tenant_id: 'tenant-1',
+    storage: {
+      begin_multipart_upload: vi.fn(async (key: string) => {
+        ops.push(`begin:${key}`);
+        return {
+          upload_part: vi.fn(async () => 'etag'),
+          complete: vi.fn(async () => {
+            ops.push('complete');
+          }),
+          abort: vi.fn(async () => {
+            ops.push('abort');
+          }),
+        };
+      }),
+      exists: vi.fn(async () => options.exists === true),
+      copy: vi.fn(async (from: string, to: string, _meta: unknown, policy: unknown) => {
+        ops.push('copy');
+        copy_args.push({ from, to, policy });
+      }),
+      delete: vi.fn(async (key: string) => {
+        ops.push(`delete:${key}`);
+      }),
+      list: vi.fn(async () => options.list ?? []),
+      abort_incomplete_uploads: vi.fn(async () => 0),
+    },
+    create_cipher: () => {
+      const iv = randomBytes(12);
+      return { cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }), iv };
+    },
+  } as unknown as TenantContext;
+
+  return { ctx, ops, copy_args };
+}
+
+function make_item(overrides: Partial<OneDriveDeltaItem> = {}): OneDriveDeltaItem {
+  return {
+    item_id: 'item-1',
+    drive_id: 'drive-1',
+    kind: 'file',
+    file_name: 'movie.mp4',
+    parent_path: '/Videos',
+    size_bytes: 400 * 1024 * 1024,
+    deleted: false,
+    ...overrides,
+  } as OneDriveDeltaItem;
+}
+
+function make_connector(url?: string): OneDriveConnector {
+  return {
+    resolve_download_url: vi.fn().mockResolvedValue(url),
+  } as unknown as OneDriveConnector;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  chunk_mocks.fetch_file_chunks.mockImplementation(async function* () {
+    yield Buffer.alloc(1024, 7);
+  });
+});
+
+describe('process_large_file', () => {
+  it('uses the download URL the delta item already carries', async () => {
+    const recorded = make_ctx();
+    const connector = make_connector();
+
+    await process_large_file(
+      connector,
+      make_item({ download_url: 'https://cdn.example/abc' }),
+      OWNER,
+      recorded.ctx,
+    );
+
+    // Resolving again would spend a Graph request per large file for nothing.
+    expect(connector.resolve_download_url).not.toHaveBeenCalled();
+    expect(chunk_mocks.fetch_file_chunks).toHaveBeenCalledWith(
+      'https://cdn.example/abc',
+      400 * 1024 * 1024,
+      'item-1',
+    );
+  });
+
+  it('resolves the download URL when the delta item has none', async () => {
+    const recorded = make_ctx();
+    const connector = make_connector('https://cdn.example/resolved');
+
+    await process_large_file(connector, make_item(), OWNER, recorded.ctx);
+
+    expect(connector.resolve_download_url).toHaveBeenCalledTimes(1);
+    expect(chunk_mocks.fetch_file_chunks.mock.calls[0]?.[0]).toBe('https://cdn.example/resolved');
+  });
+
+  it('throws before starting an upload when the URL cannot be resolved', async () => {
+    const recorded = make_ctx();
+
+    await expect(
+      process_large_file(make_connector(undefined), make_item(), OWNER, recorded.ctx),
+    ).rejects.toThrow(/Could not resolve download URL for large file item-1/);
+
+    // A begun multipart upload with no bytes is an orphan that accrues cost.
+    expect(recorded.ops).toEqual([]);
+  });
+
+  it('stores under a content-addressed key derived from the plaintext hash', async () => {
+    const recorded = make_ctx();
+
+    const result = await process_large_file(
+      make_connector('https://cdn.example/abc'),
+      make_item(),
+      OWNER,
+      recorded.ctx,
+    );
+
+    expect(result.stored).toBe(true);
+    expect(result.deduplicated).toBe(false);
+    expect(result.storage_key).toContain(result.checksum);
+    expect(recorded.copy_args[0]?.to).toBe(result.storage_key);
+  });
+
+  it('aborts instead of completing when the content is already stored', async () => {
+    const recorded = make_ctx({ exists: true });
+
+    const result = await process_large_file(
+      make_connector('https://cdn.example/abc'),
+      make_item(),
+      OWNER,
+      recorded.ctx,
+    );
+
+    expect(result).toMatchObject({ stored: false, deduplicated: true });
+    expect(recorded.ops).toContain('abort');
+    expect(recorded.ops).not.toContain('complete');
+    expect(recorded.ops).not.toContain('copy');
+  });
+
+  it('passes the Object Lock policy through to the canonical copy', async () => {
+    const recorded = make_ctx();
+    const policy: StorageObjectLockPolicy = {
+      mode: 'COMPLIANCE',
+      retain_until: '2030-01-01T00:00:00.000Z',
+    };
+
+    await process_large_file(
+      make_connector('https://cdn.example/abc'),
+      make_item(),
+      OWNER,
+      recorded.ctx,
+      policy,
+    );
+
+    // A retained object that is copied without its policy is unprotected data
+    // reported as protected.
+    expect(recorded.copy_args[0]?.policy).toBe(policy);
+  });
+
+  it('stages under the owner prefix, keeping the canonical key out of the way', async () => {
+    const recorded = make_ctx();
+
+    await process_large_file(
+      make_connector('https://cdn.example/abc'),
+      make_item(),
+      OWNER,
+      recorded.ctx,
+    );
+
+    const begin = recorded.ops.find((op) => op.startsWith('begin:'))!;
+    expect(begin).toContain('staging');
+    expect(begin).toContain('item-1');
+    expect(recorded.copy_args[0]?.from).toBe(begin.slice('begin:'.length));
+  });
+});
+
+describe('cleanup_stale_staging', () => {
+  it('deletes every leftover staging object', async () => {
+    const recorded = make_ctx({ list: ['staging/o/a-1', 'staging/o/b-2'] });
+
+    await cleanup_stale_staging(recorded.ctx, OWNER);
+
+    expect(recorded.ops).toContain('delete:staging/o/a-1');
+    expect(recorded.ops).toContain('delete:staging/o/b-2');
+  });
+
+  it('keeps going when one delete fails', async () => {
+    const recorded = make_ctx({ list: ['staging/o/a-1', 'staging/o/b-2'] });
+    vi.mocked(recorded.ctx.storage.delete as ReturnType<typeof vi.fn>).mockImplementation(
+      async (key: string) => {
+        if (key.endsWith('a-1')) throw new Error('locked');
+      },
+    );
+
+    await expect(cleanup_stale_staging(recorded.ctx, OWNER)).resolves.toBeUndefined();
+    expect(recorded.ctx.storage.delete).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts incomplete uploads under the staging prefix', async () => {
+    const recorded = make_ctx();
+    vi.mocked(
+      recorded.ctx.storage.abort_incomplete_uploads as ReturnType<typeof vi.fn>,
+    ).mockResolvedValue(3);
+
+    await cleanup_stale_staging(recorded.ctx, OWNER);
+
+    const prefix = vi.mocked(recorded.ctx.storage.abort_incomplete_uploads).mock.calls[0]?.[0];
+    expect(prefix).toContain('staging');
+    expect(prefix).toContain(OWNER);
+  });
+
+  it('does nothing to delete when no staging objects are left', async () => {
+    const recorded = make_ctx({ list: [] });
+
+    await cleanup_stale_staging(recorded.ctx, OWNER);
+
+    expect(recorded.ctx.storage.delete).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sharepoint/tests/unit/services/large-file-chunk-download.test.ts
+++ b/packages/sharepoint/tests/unit/services/large-file-chunk-download.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetch_file_chunks } from '@/services/sharepoint-large-file-chunk-download';
+
+// The OneDrive twin of this file has had tests since issue #36; this one had
+// none. Divergent coverage between the two drive pipelines is what let the
+// replication gate divergence through (#190), so it gets the same suite.
+
+const CHUNK_SIZE = 4 * 1024 * 1024;
+
+function to_array_buffer(body: Buffer): ArrayBuffer {
+  const copy = new ArrayBuffer(body.byteLength);
+  new Uint8Array(copy).set(body);
+  return copy;
+}
+
+function range_response(status: number, body = Buffer.alloc(0)): Response {
+  return {
+    status,
+    headers: { get: (): string | null => null },
+    arrayBuffer: (): Promise<ArrayBuffer> => Promise.resolve(to_array_buffer(body)),
+    text: (): Promise<string> => Promise.resolve(''),
+  } as unknown as Response;
+}
+
+async function collect(url: string, total: number, item = 'item-1'): Promise<Buffer> {
+  const parts: Buffer[] = [];
+  for await (const chunk of fetch_file_chunks(url, total, item)) parts.push(chunk);
+  return Buffer.concat(parts);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('fetch_file_chunks', () => {
+  it('requests one Range per chunk and yields them in order', async () => {
+    const first = Buffer.alloc(CHUNK_SIZE, 1);
+    const second = Buffer.alloc(1024, 2);
+    const fetch_mock = vi
+      .fn()
+      .mockResolvedValueOnce(range_response(206, first))
+      .mockResolvedValueOnce(range_response(206, second));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    const body = await collect('https://cdn.test/file', CHUNK_SIZE + 1024);
+
+    expect(body.length).toBe(CHUNK_SIZE + 1024);
+    expect(fetch_mock).toHaveBeenCalledTimes(2);
+    const ranges = fetch_mock.mock.calls.map(
+      (call) => (call[1] as { headers: Record<string, string> }).headers['Range'],
+    );
+    expect(ranges).toEqual([
+      `bytes=0-${CHUNK_SIZE - 1}`,
+      `bytes=${CHUNK_SIZE}-${CHUNK_SIZE + 1023}`,
+    ]);
+  });
+
+  it.each([429, 503, 504])('retries a chunk the CDN refused with HTTP %i', async (status) => {
+    const payload = Buffer.from('chunk-payload');
+    const fetch_mock = vi
+      .fn()
+      .mockResolvedValueOnce(range_response(status))
+      .mockResolvedValueOnce(range_response(206, payload));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    const promise = collect('https://cdn.test/file', payload.length);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(await promise).toEqual(payload);
+    expect(fetch_mock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails a chunk that returned HTTP 404 without retrying', async () => {
+    const fetch_mock = vi.fn().mockResolvedValue(range_response(404));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    // A missing object is not a transient CDN fault, and retrying it spends the
+    // budget that a genuinely transient chunk needs.
+    await expect(collect('https://cdn.test/file', 10)).rejects.toThrow(/HTTP 404/);
+    expect(fetch_mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after the retry budget is spent', async () => {
+    const fetch_mock = vi.fn().mockResolvedValue(range_response(503));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    const promise = collect('https://cdn.test/file', 10);
+    const settled = expect(promise).rejects.toThrow(/HTTP 503/);
+    await vi.advanceTimersByTimeAsync(300_000);
+    await settled;
+
+    // Six attempts: the first plus MAX_CHUNK_RETRIES.
+    expect(fetch_mock).toHaveBeenCalledTimes(6);
+  });
+
+  it('slices the whole body when the CDN ignores the Range header', async () => {
+    // A 200 means the server sent everything; taking it as the chunk would
+    // duplicate the head of the file into every later chunk.
+    const whole = Buffer.concat([Buffer.alloc(CHUNK_SIZE, 1), Buffer.alloc(1024, 2)]);
+    const fetch_mock = vi.fn().mockResolvedValue(range_response(200, whole));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    const parts: Buffer[] = [];
+    for await (const chunk of fetch_file_chunks(
+      'https://cdn.test/file',
+      CHUNK_SIZE + 1024,
+      'item-1',
+    )) {
+      parts.push(chunk);
+    }
+
+    expect(parts[0]?.length).toBe(CHUNK_SIZE);
+    expect(parts[1]?.length).toBe(1024);
+    expect(parts[1]?.[0]).toBe(2);
+  });
+
+  it('rejects a 200 body too short to satisfy the requested range', async () => {
+    const fetch_mock = vi.fn().mockResolvedValue(range_response(200, Buffer.alloc(10, 1)));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    await expect(collect('https://cdn.test/file', CHUNK_SIZE + 1024)).rejects.toThrow(
+      /returned 200 with 10 bytes/,
+    );
+  });
+
+  it('yields nothing for a zero-byte file', async () => {
+    const fetch_mock = vi.fn();
+    vi.stubGlobal('fetch', fetch_mock);
+
+    expect((await collect('https://cdn.test/file', 0)).length).toBe(0);
+    expect(fetch_mock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sharepoint/tests/unit/services/large-file-pipeline.test.ts
+++ b/packages/sharepoint/tests/unit/services/large-file-pipeline.test.ts
@@ -1,0 +1,243 @@
+import { createCipheriv, randomBytes } from 'node:crypto';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  SharePointSiteConnector,
+  SharePointDeltaItem,
+  StorageObjectLockPolicy,
+  TenantContext,
+} from '@wisecom/atlas-types';
+
+const chunk_mocks = vi.hoisted(() => ({ fetch_file_chunks: vi.fn() }));
+vi.mock('@/services/sharepoint-large-file-chunk-download', () => chunk_mocks);
+
+const { cleanup_stale_staging, process_large_file } =
+  await import('@/services/sharepoint-large-file-pipeline');
+
+const KEY = randomBytes(32);
+const SITE = 'site-1';
+
+interface Recorded {
+  readonly ctx: TenantContext;
+  readonly ops: string[];
+  readonly copy_args: Array<{ from: string; to: string; policy: unknown }>;
+}
+
+function make_ctx(options: { exists?: boolean; list?: string[] } = {}): Recorded {
+  const ops: string[] = [];
+  const copy_args: Array<{ from: string; to: string; policy: unknown }> = [];
+
+  const ctx = {
+    tenant_id: 'tenant-1',
+    storage: {
+      begin_multipart_upload: vi.fn(async (key: string) => {
+        ops.push(`begin:${key}`);
+        return {
+          upload_part: vi.fn(async () => 'etag'),
+          complete: vi.fn(async () => {
+            ops.push('complete');
+          }),
+          abort: vi.fn(async () => {
+            ops.push('abort');
+          }),
+        };
+      }),
+      exists: vi.fn(async () => options.exists === true),
+      copy: vi.fn(async (from: string, to: string, _meta: unknown, policy: unknown) => {
+        ops.push('copy');
+        copy_args.push({ from, to, policy });
+      }),
+      delete: vi.fn(async (key: string) => {
+        ops.push(`delete:${key}`);
+      }),
+      list: vi.fn(async () => options.list ?? []),
+      abort_incomplete_uploads: vi.fn(async () => 0),
+    },
+    create_cipher: () => {
+      const iv = randomBytes(12);
+      return { cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }), iv };
+    },
+  } as unknown as TenantContext;
+
+  return { ctx, ops, copy_args };
+}
+
+function make_item(overrides: Partial<SharePointDeltaItem> = {}): SharePointDeltaItem {
+  return {
+    item_id: 'item-1',
+    drive_id: 'drive-1',
+    kind: 'file',
+    file_name: 'movie.mp4',
+    parent_path: '/Videos',
+    size_bytes: 400 * 1024 * 1024,
+    deleted: false,
+    ...overrides,
+  } as SharePointDeltaItem;
+}
+
+function make_connector(url?: string): SharePointSiteConnector {
+  return {
+    resolve_download_url: vi.fn().mockResolvedValue(url),
+  } as unknown as SharePointSiteConnector;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  chunk_mocks.fetch_file_chunks.mockImplementation(async function* () {
+    yield Buffer.alloc(1024, 7);
+  });
+});
+
+describe('process_large_file', () => {
+  it('uses the download URL the delta item already carries', async () => {
+    const recorded = make_ctx();
+    const connector = make_connector();
+
+    await process_large_file(
+      connector,
+      make_item({ download_url: 'https://cdn.example/abc' }),
+      SITE,
+      recorded.ctx,
+    );
+
+    // Resolving again would spend a Graph request per large file for nothing.
+    expect(connector.resolve_download_url).not.toHaveBeenCalled();
+    expect(chunk_mocks.fetch_file_chunks).toHaveBeenCalledWith(
+      'https://cdn.example/abc',
+      400 * 1024 * 1024,
+      'item-1',
+    );
+  });
+
+  it('resolves the download URL when the delta item has none', async () => {
+    const recorded = make_ctx();
+    const connector = make_connector('https://cdn.example/resolved');
+
+    await process_large_file(connector, make_item(), SITE, recorded.ctx);
+
+    expect(connector.resolve_download_url).toHaveBeenCalledTimes(1);
+    expect(chunk_mocks.fetch_file_chunks.mock.calls[0]?.[0]).toBe('https://cdn.example/resolved');
+  });
+
+  it('throws before starting an upload when the URL cannot be resolved', async () => {
+    const recorded = make_ctx();
+
+    await expect(
+      process_large_file(make_connector(undefined), make_item(), SITE, recorded.ctx),
+    ).rejects.toThrow(/Could not resolve download URL for large file item-1/);
+
+    // A begun multipart upload with no bytes is an orphan that accrues cost.
+    expect(recorded.ops).toEqual([]);
+  });
+
+  it('stores under a content-addressed key derived from the plaintext hash', async () => {
+    const recorded = make_ctx();
+
+    const result = await process_large_file(
+      make_connector('https://cdn.example/abc'),
+      make_item(),
+      SITE,
+      recorded.ctx,
+    );
+
+    expect(result.stored).toBe(true);
+    expect(result.deduplicated).toBe(false);
+    expect(result.storage_key).toContain(result.checksum);
+    expect(recorded.copy_args[0]?.to).toBe(result.storage_key);
+  });
+
+  it('aborts instead of completing when the content is already stored', async () => {
+    const recorded = make_ctx({ exists: true });
+
+    const result = await process_large_file(
+      make_connector('https://cdn.example/abc'),
+      make_item(),
+      SITE,
+      recorded.ctx,
+    );
+
+    expect(result).toMatchObject({ stored: false, deduplicated: true });
+    expect(recorded.ops).toContain('abort');
+    expect(recorded.ops).not.toContain('complete');
+    expect(recorded.ops).not.toContain('copy');
+  });
+
+  it('passes the Object Lock policy through to the canonical copy', async () => {
+    const recorded = make_ctx();
+    const policy: StorageObjectLockPolicy = {
+      mode: 'COMPLIANCE',
+      retain_until: '2030-01-01T00:00:00.000Z',
+    };
+
+    await process_large_file(
+      make_connector('https://cdn.example/abc'),
+      make_item(),
+      SITE,
+      recorded.ctx,
+      policy,
+    );
+
+    // A retained object that is copied without its policy is unprotected data
+    // reported as protected.
+    expect(recorded.copy_args[0]?.policy).toBe(policy);
+  });
+
+  it('stages under the owner prefix, keeping the canonical key out of the way', async () => {
+    const recorded = make_ctx();
+
+    await process_large_file(
+      make_connector('https://cdn.example/abc'),
+      make_item(),
+      SITE,
+      recorded.ctx,
+    );
+
+    const begin = recorded.ops.find((op) => op.startsWith('begin:'))!;
+    expect(begin).toContain('staging');
+    expect(begin).toContain('item-1');
+    expect(recorded.copy_args[0]?.from).toBe(begin.slice('begin:'.length));
+  });
+});
+
+describe('cleanup_stale_staging', () => {
+  it('deletes every leftover staging object', async () => {
+    const recorded = make_ctx({ list: ['staging/o/a-1', 'staging/o/b-2'] });
+
+    await cleanup_stale_staging(recorded.ctx, SITE);
+
+    expect(recorded.ops).toContain('delete:staging/o/a-1');
+    expect(recorded.ops).toContain('delete:staging/o/b-2');
+  });
+
+  it('keeps going when one delete fails', async () => {
+    const recorded = make_ctx({ list: ['staging/o/a-1', 'staging/o/b-2'] });
+    vi.mocked(recorded.ctx.storage.delete as ReturnType<typeof vi.fn>).mockImplementation(
+      async (key: string) => {
+        if (key.endsWith('a-1')) throw new Error('locked');
+      },
+    );
+
+    await expect(cleanup_stale_staging(recorded.ctx, SITE)).resolves.toBeUndefined();
+    expect(recorded.ctx.storage.delete).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts incomplete uploads under the staging prefix', async () => {
+    const recorded = make_ctx();
+    vi.mocked(
+      recorded.ctx.storage.abort_incomplete_uploads as ReturnType<typeof vi.fn>,
+    ).mockResolvedValue(3);
+
+    await cleanup_stale_staging(recorded.ctx, SITE);
+
+    const prefix = vi.mocked(recorded.ctx.storage.abort_incomplete_uploads).mock.calls[0]?.[0];
+    expect(prefix).toContain('staging');
+    expect(prefix).toContain(SITE);
+  });
+
+  it('does nothing to delete when no staging objects are left', async () => {
+    const recorded = make_ctx({ list: [] });
+
+    await cleanup_stale_staging(recorded.ctx, SITE);
+
+    expect(recorded.ctx.storage.delete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #192. Cut from `dev`. Only new test files plus additions to one existing test file, so it overlaps nothing open.

## I re-measured before writing, and it changed the work

The issue's table predates #37, which moved the part arithmetic into a shared core module and tested it there. Coverage on `dev` before this branch:

| File | Issue | On `dev` today |
| --- | --- | --- |
| `onedrive-large-file-pipeline.ts` | 7.8% | 22.2% |
| `sharepoint-large-file-pipeline.ts` | 7.4% | 22.2% |
| `graph-sharepoint-chunked-download.ts` | 8.9% | **81.8%** |
| `sharepoint-large-file-chunk-download.ts` | 10.6% | 10.6% |
| `core/stream-encrypt-upload.ts` | n/a | 87.9% |

So several acceptance criteria were already met, just not where the issue expected them: part-1 ordering, the IV and auth tag layout, dedup aborting the upload, and the copy-failure cleanup are all covered in core. Writing them again in the drive packages would have been duplicate coverage of code that no longer lives there.

What was genuinely bare was orchestration and cleanup, including `cleanup_stale_staging` at 0% — the code that stops a tenant paying storage for multipart uploads nothing will ever complete.

## What this adds

**Part arithmetic** (core, beside the existing cases), the criteria not yet covered:

- An exact multiple of the part size produces **no zero-length trailing part**. AES-GCM is a stream cipher, so ciphertext length equals plaintext length and nothing is left pending; a zero-length part would be rejected by S3.
- One byte over a boundary produces a short final part, with every earlier part exactly the part size.
- A single chunk three parts wide drains through the flush loop into three parts. If it flushed once per chunk the remainder would sit in memory, which is the failure the bounded pipeline exists to prevent.
- Completed parts reach `complete` in ascending order.
- When `handle.abort()` itself throws, the staging prefix is swept via `abort_incomplete_uploads`.

**Pipeline orchestration** (both drives, identical suites):

- An item's own `download_url` is reused rather than re-resolved, which would spend a Graph request per large file for nothing.
- A URL that cannot be resolved throws **before any multipart upload is begun**, asserted as no storage operations at all. A begun upload with no bytes is an orphan that accrues cost.
- The canonical key derives from the plaintext hash, and the copy targets it.
- Dedup aborts without completing and without copying.
- The Object Lock policy reaches the `copy` call. A retained object copied without its policy is unprotected data reported as protected.
- `cleanup_stale_staging` deletes every listed object, keeps going when one delete fails, and aborts incomplete uploads under the right prefix.

**`sharepoint-large-file-chunk-download.ts`**, which had no tests while its OneDrive twin has had them since #36. The issue names this as a constraint, and #190 was the divergence that constraint exists to prevent. Same suite: one Range header per chunk with exact byte boundaries, retry on 429/503/504, no retry on 404, the exhausted budget at six attempts, and the CDN-ignores-Range path where a `200` must be sliced to the requested range rather than stored as every chunk.

## Result

| File | Before | After |
| --- | --- | --- |
| `onedrive-large-file-pipeline.ts` | 7.8% (22.2% on dev) | **88.88%** |
| `sharepoint-large-file-pipeline.ts` | 7.4% (22.2% on dev) | **88.88%** |
| `sharepoint-large-file-chunk-download.ts` | 10.6% | **95.74%** |
| `core/stream-encrypt-upload.ts` | 87.9% | **95.45%** |

Criterion was ≥85% on both pipelines.

**No 512 MB allocation**, per the constraint: the largest buffer in any test is three part sizes (24 MB), and the pipeline tests mock the chunk source entirely, so the multipart arithmetic is exercised at small sizes through the seam rather than by moving real bytes.

## One type error worth naming

My Object Lock fixture used `retain_until: new Date(...)`, and the field is a `string`. Vitest passed; `tsc` caught it. That is the drift `pnpm run typecheck` exists for, and it would have made the assertion pass against a shape production never produces.

## Not done, and deliberately

`graph-onedrive-download-helpers.ts` (0.0%) and `graph-sharepoint-download-helpers.ts` (1.2%) are still bare. They appear in the issue's table but not in its acceptance criteria, and they are the per-item download path rather than the large-file pipeline: `resolve_download_url`, `download_with_fallback`, expired-URL detection. Worth their own issue rather than being folded in here, where they would double the diff for code the stated criteria do not name. Say the word and I will take them next.

Gates: build 10/10, typecheck 17/17, test 15/15, lint 0 errors, format clean.
