### PR TITLE
test(drive): cover OneDriveVerificationService, including the #173 chain rules

### DIFF
--- a/packages/onedrive/tests/unit/services/onedrive-verification-chain.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-verification-chain.test.ts
@@ -1,0 +1,229 @@
+import { createHash } from 'node:crypto';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  OneDriveFileVersionIndex,
+  OneDriveFileVersionIndexRepository,
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { stub_encrypted_object_store } from '@wisecom/atlas-types/testing/stub-encrypted-object-store';
+import { OneDriveVerificationService } from '@/services/onedrive-verification.service';
+
+// Issue #173: verification walks the manifest chain, and a carried-over file
+// has its index row under the snapshot that recorded it. Both rules are
+// invisible in a single-snapshot fixture, which is how the original defect
+// reported carried-over files as checked when they were never read.
+
+const TENANT_ID = 'tenant-1';
+const OWNER_ID = '00000000-0000-0000-0000-000000000001';
+const OLDER = 'od-snap-1';
+const TARGET = 'od-snap-2';
+
+const sha256 = (data: Buffer): string => createHash('sha256').update(data).digest('hex');
+const CONTENT = Buffer.from('file-content');
+
+function make_entry(file_id: string, file_name: string): OneDriveManifestEntry {
+  return {
+    file_id,
+    drive_id: 'drive-1',
+    file_name,
+    parent_path: '/Documents',
+    size_bytes: CONTENT.length,
+    storage_key: `onedrive/data/${OWNER_ID}/${sha256(CONTENT)}`,
+    checksum: sha256(CONTENT),
+    backup_at: new Date().toISOString(),
+    change_type: 'created',
+  };
+}
+
+function make_manifest(
+  snapshot_id: string,
+  created_at: string,
+  entries: OneDriveManifestEntry[],
+): OneDriveSnapshotManifest {
+  return {
+    id: `${OWNER_ID}-${snapshot_id}`,
+    tenant_id: TENANT_ID,
+    owner_id: OWNER_ID,
+    snapshot_id,
+    created_at: new Date(created_at),
+    total_files: entries.length,
+    total_size_bytes: entries.reduce((sum, e) => sum + e.size_bytes, 0),
+    entries,
+  };
+}
+
+function make_index(file_id: string, snapshot_ids: string[]): OneDriveFileVersionIndex {
+  return {
+    file_id,
+    owner_id: OWNER_ID,
+    versions: snapshot_ids.map((snapshot_id) => ({
+      snapshot_id,
+      backup_at: new Date().toISOString(),
+      drive_id: 'drive-1',
+      file_name: 'Report.docx',
+      parent_path: '/Documents',
+      size_bytes: CONTENT.length,
+      change_type: 'created' as const,
+    })),
+  };
+}
+
+function create_mocks() {
+  const store = stub_encrypted_object_store();
+  const stored = store.encrypt(CONTENT);
+  const read_keys: string[] = [];
+
+  const ctx: TenantContext = {
+    storage: {
+      exists: vi.fn().mockResolvedValue(true),
+      get_stream: vi.fn().mockImplementation(async (key: string) => {
+        read_keys.push(key);
+        return store.stream(stored);
+      }),
+      put: vi.fn(),
+      delete: vi.fn(),
+      list: vi.fn(),
+      get_with_etag: vi.fn(),
+    },
+    encrypt: vi.fn(),
+    create_decipher: vi.fn().mockImplementation(store.create_decipher),
+    create_cipher: vi.fn(),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const tenant_factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+    create_storage_only: vi.fn().mockResolvedValue(ctx),
+  };
+
+  const manifests: OneDriveManifestRepository = {
+    save: vi.fn(),
+    find_by_snapshot: vi.fn(),
+    find_latest_by_owner: vi.fn(),
+    list_snapshots_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveManifestRepository;
+
+  const indexes: OneDriveFileVersionIndexRepository = {
+    list_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveFileVersionIndexRepository;
+
+  return { ctx, tenant_factory, manifests, indexes, read_keys };
+}
+
+describe('OneDriveVerificationService chain rules (issue #173)', () => {
+  let service: OneDriveVerificationService;
+  let mocks: ReturnType<typeof create_mocks>;
+
+  /** `carried` last changed in OLDER; `fresh` changed in TARGET. */
+  const carried = make_entry('file-carried', 'Carried.docx');
+  const fresh = make_entry('file-fresh', 'Fresh.docx');
+
+  beforeEach(() => {
+    mocks = create_mocks();
+    service = new OneDriveVerificationService(
+      mocks.tenant_factory as unknown as TenantContextFactory,
+      mocks.manifests,
+      mocks.indexes,
+    );
+
+    const older = make_manifest(OLDER, '2026-03-01T00:00:00Z', [carried]);
+    const target = make_manifest(TARGET, '2026-03-02T00:00:00Z', [fresh]);
+    vi.mocked(mocks.manifests.find_by_snapshot).mockResolvedValue(target);
+    vi.mocked(mocks.manifests.list_snapshots_by_owner).mockResolvedValue([target, older]);
+  });
+
+  const verify = (): ReturnType<OneDriveVerificationService['verify_onedrive_snapshot']> =>
+    service.verify_onedrive_snapshot(TENANT_ID, OWNER_ID, TARGET);
+
+  it('verifies a file inherited from an earlier snapshot in the chain', async () => {
+    vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue([
+      make_index('file-fresh', [TARGET]),
+      make_index('file-carried', [OLDER]),
+    ]);
+
+    const result = await verify();
+
+    // Two entries, though the target manifest lists only one: verifying the
+    // target alone would report the carried file as checked without reading it.
+    expect(result.total_checked).toBe(2);
+    expect(result.passed).toBe(2);
+    expect(mocks.read_keys).toHaveLength(2);
+  });
+
+  it('looks an index row up against the snapshot that recorded the entry', async () => {
+    vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue([
+      make_index('file-fresh', [TARGET]),
+      make_index('file-carried', [OLDER]),
+    ]);
+
+    const result = await verify();
+
+    // The carried file's row sits under OLDER. Comparing against the verified
+    // snapshot instead would flag it as a missing index version.
+    expect(result.index_issues).toHaveLength(0);
+  });
+
+  it('flags a carried entry whose index row is filed under the verified snapshot', async () => {
+    // The mirror image of the rule above, so the assertion cannot pass by
+    // accepting any snapshot id at all.
+    vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue([
+      make_index('file-fresh', [TARGET]),
+      make_index('file-carried', [TARGET]),
+    ]);
+
+    const result = await verify();
+
+    expect(result.index_issues).toHaveLength(1);
+    expect(result.index_issues[0]).toContain('file-carried');
+    expect(result.index_issues[0]).toContain(OLDER);
+  });
+
+  it('reports interrupted and reads nothing when aborted before the first entry', async () => {
+    const result = await service.verify_onedrive_snapshot(TENANT_ID, OWNER_ID, TARGET, {
+      should_interrupt: () => true,
+    });
+
+    expect(result).toMatchObject({ interrupted: true, total_checked: 0, passed: 0 });
+    expect(mocks.read_keys).toHaveLength(0);
+    // Aborted before any work: the context is never even created.
+    expect(mocks.tenant_factory.create_readonly).not.toHaveBeenCalled();
+  });
+
+  it('starts no further object read after an interrupt mid-chain', async () => {
+    vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue([
+      make_index('file-fresh', [TARGET]),
+      make_index('file-carried', [OLDER]),
+    ]);
+    let interrupted = false;
+    vi.mocked(mocks.ctx.storage.get_stream as ReturnType<typeof vi.fn>).mockImplementation(
+      async (key: string) => {
+        mocks.read_keys.push(key);
+        interrupted = true;
+        return stub_encrypted_object_store().stream(Buffer.alloc(64));
+      },
+    );
+
+    const result = await service.verify_onedrive_snapshot(TENANT_ID, OWNER_ID, TARGET, {
+      should_interrupt: () => interrupted,
+    });
+
+    expect(mocks.read_keys).toHaveLength(1);
+    expect(result.interrupted).toBe(true);
+    expect(result.total_checked).toBe(1);
+  });
+
+  it('accepts an owner id in any case, normalising before the lookup', async () => {
+    await service.verify_onedrive_snapshot(TENANT_ID, OWNER_ID.toUpperCase(), TARGET);
+
+    expect(mocks.manifests.find_by_snapshot).toHaveBeenCalledWith(
+      expect.anything(),
+      OWNER_ID,
+      TARGET,
+    );
+  });
+});

--- a/packages/onedrive/tests/unit/services/onedrive-verification.service.test.ts
+++ b/packages/onedrive/tests/unit/services/onedrive-verification.service.test.ts
@@ -1,0 +1,304 @@
+import { createHash } from 'node:crypto';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  OneDriveFileVersionIndex,
+  OneDriveFileVersionIndexRepository,
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { stub_encrypted_object_store } from '@wisecom/atlas-types/testing/stub-encrypted-object-store';
+import { OneDriveVerificationService } from '@/services/onedrive-verification.service';
+
+/** Fixture overrides may blank an optional field; an explicit `undefined` drops the key. */
+type Overrides<T> = { [K in keyof T]?: T[K] | undefined };
+
+function apply_overrides<T extends object>(base: T, overrides: Overrides<T>): T {
+  const merged: Record<string, unknown> = { ...base, ...overrides };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete merged[key];
+  }
+  return merged as T;
+}
+
+const TENANT_ID = 'tenant-1';
+const OWNER_ID = '00000000-0000-0000-0000-000000000001';
+const SNAPSHOT_ID = 'od-snap-2';
+
+const sha256 = (data: Buffer): string => createHash('sha256').update(data).digest('hex');
+const CONTENT = Buffer.from('file-content');
+
+function make_entry(overrides: Overrides<OneDriveManifestEntry> = {}): OneDriveManifestEntry {
+  return apply_overrides<OneDriveManifestEntry>(
+    {
+      file_id: 'file-1',
+      drive_id: 'drive-1',
+      file_name: 'Report.docx',
+      parent_path: '/Documents',
+      size_bytes: CONTENT.length,
+      storage_key: `onedrive/data/${OWNER_ID}/${sha256(CONTENT)}`,
+      checksum: sha256(CONTENT),
+      backup_at: new Date().toISOString(),
+      change_type: 'created',
+    },
+    overrides,
+  );
+}
+
+function make_manifest(
+  entries: OneDriveManifestEntry[],
+  snapshot_id = SNAPSHOT_ID,
+  created_at = new Date('2026-03-02T00:00:00Z'),
+): OneDriveSnapshotManifest {
+  return {
+    id: `${OWNER_ID}-${snapshot_id}`,
+    tenant_id: TENANT_ID,
+    owner_id: OWNER_ID,
+    snapshot_id,
+    created_at,
+    total_files: entries.length,
+    total_size_bytes: entries.reduce((sum, e) => sum + e.size_bytes, 0),
+    entries,
+  };
+}
+
+function make_index(file_id: string, snapshot_ids: string[]): OneDriveFileVersionIndex {
+  return {
+    file_id,
+    owner_id: OWNER_ID,
+    versions: snapshot_ids.map((snapshot_id) => ({
+      snapshot_id,
+      backup_at: new Date().toISOString(),
+      drive_id: 'drive-1',
+      file_name: 'Report.docx',
+      parent_path: '/Documents',
+      size_bytes: CONTENT.length,
+      change_type: 'created' as const,
+    })),
+  };
+}
+
+function create_mocks() {
+  const store = stub_encrypted_object_store();
+  const stored = store.encrypt(CONTENT);
+
+  const ctx: TenantContext = {
+    storage: {
+      exists: vi.fn().mockResolvedValue(true),
+      get_stream: vi.fn().mockImplementation(async () => store.stream(stored)),
+      put: vi.fn(),
+      delete: vi.fn(),
+      list: vi.fn(),
+      get_with_etag: vi.fn(),
+    },
+    encrypt: vi.fn().mockReturnValue(stored),
+    create_decipher: vi.fn().mockImplementation(store.create_decipher),
+    create_cipher: vi.fn(),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const tenant_factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+    create_storage_only: vi.fn().mockResolvedValue(ctx),
+  };
+
+  const manifests: OneDriveManifestRepository = {
+    save: vi.fn(),
+    find_by_snapshot: vi.fn(),
+    find_latest_by_owner: vi.fn(),
+    list_snapshots_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveManifestRepository;
+
+  const indexes: OneDriveFileVersionIndexRepository = {
+    list_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveFileVersionIndexRepository;
+
+  return { ctx, tenant_factory, manifests, indexes, store };
+}
+
+describe('OneDriveVerificationService', () => {
+  let service: OneDriveVerificationService;
+  let mocks: ReturnType<typeof create_mocks>;
+
+  beforeEach(() => {
+    mocks = create_mocks();
+    service = new OneDriveVerificationService(
+      mocks.tenant_factory as unknown as TenantContextFactory,
+      mocks.manifests,
+      mocks.indexes,
+    );
+  });
+
+  /** Replaces the bytes storage streams back for every object read. */
+  const serve_object = (stored: Buffer): void => {
+    vi.mocked(mocks.ctx.storage.get_stream as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => mocks.store.stream(stored),
+    );
+  };
+
+  /** Points the repository at one manifest, as its own single-snapshot chain. */
+  const given_snapshot = (entries: OneDriveManifestEntry[]): OneDriveSnapshotManifest => {
+    const manifest = make_manifest(entries);
+    vi.mocked(mocks.manifests.find_by_snapshot).mockResolvedValue(manifest);
+    vi.mocked(mocks.manifests.list_snapshots_by_owner).mockResolvedValue([manifest]);
+    return manifest;
+  };
+
+  const verify = (): ReturnType<OneDriveVerificationService['verify_onedrive_snapshot']> =>
+    service.verify_onedrive_snapshot(TENANT_ID, OWNER_ID, SNAPSHOT_ID);
+
+  it('throws when no manifest is found', async () => {
+    vi.mocked(mocks.manifests.find_by_snapshot).mockResolvedValue(undefined);
+
+    await expect(verify()).rejects.toThrow(/No OneDrive manifest found/);
+  });
+
+  it('returns all passed when blobs are intact and the index is consistent', async () => {
+    const entry = make_entry();
+    given_snapshot([entry]);
+    vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue([
+      make_index(entry.file_id, [SNAPSHOT_ID]),
+    ]);
+
+    const result = await verify();
+
+    expect(result.total_checked).toBe(1);
+    expect(result.passed).toBe(1);
+    expect(result.failed_file_ids).toHaveLength(0);
+    expect(result.index_issues).toHaveLength(0);
+  });
+
+  it('reports a mismatch when the stored content has a different checksum', async () => {
+    const entry = make_entry();
+    given_snapshot([entry]);
+    vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue([
+      make_index(entry.file_id, [SNAPSHOT_ID]),
+    ]);
+    serve_object(mocks.store.encrypt(Buffer.from('tampered-content')));
+
+    const result = await verify();
+
+    expect(result.failed_file_ids).toContain(entry.file_id);
+    expect(result.passed).toBe(0);
+    expect(result.total_checked).toBe(1);
+  });
+
+  it('reports a blob that is absent from storage', async () => {
+    const entry = make_entry();
+    given_snapshot([entry]);
+    vi.mocked(mocks.ctx.storage.exists as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    const result = await verify();
+
+    expect(result.failed_file_ids).toContain(entry.file_id);
+  });
+
+  it('reports a blob whose ciphertext fails its auth tag', async () => {
+    const entry = make_entry();
+    given_snapshot([entry]);
+    const corrupted = mocks.store.encrypt(CONTENT);
+    corrupted[corrupted.length - 1] ^= 0xff;
+    serve_object(corrupted);
+
+    const result = await verify();
+
+    expect(result.failed_file_ids).toContain(entry.file_id);
+  });
+
+  it('records an index issue when the file has no index at all', async () => {
+    const entry = make_entry();
+    given_snapshot([entry]);
+    vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue([]);
+
+    const result = await verify();
+
+    expect(result.index_issues.join(' ')).toContain(entry.file_id);
+    // A missing index row is not a corrupt blob: the content still verified.
+    expect(result.failed_file_ids).toHaveLength(0);
+  });
+
+  it('records an index issue when the index has no row for this snapshot', async () => {
+    const entry = make_entry();
+    given_snapshot([entry]);
+    vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue([
+      make_index(entry.file_id, ['od-snap-unrelated']),
+    ]);
+
+    const result = await verify();
+
+    expect(result.index_issues.join(' ')).toContain(SNAPSHOT_ID);
+  });
+
+  it('skips a deleted entry without reading an object', async () => {
+    given_snapshot([make_entry({ change_type: 'deleted' })]);
+
+    const result = await verify();
+
+    expect(result.total_checked).toBe(0);
+    expect(mocks.ctx.storage.get_stream).not.toHaveBeenCalled();
+  });
+
+  it('skips an entry with no storage key', async () => {
+    given_snapshot([make_entry({ storage_key: undefined, checksum: undefined })]);
+
+    const result = await verify();
+
+    expect(result.total_checked).toBe(0);
+    expect(mocks.ctx.storage.get_stream).not.toHaveBeenCalled();
+  });
+
+  it('counts mixed outcomes independently', async () => {
+    const good = make_entry({ file_id: 'file-good' });
+    const bad = make_entry({ file_id: 'file-bad', checksum: sha256(Buffer.from('other-bytes')) });
+    const deleted = make_entry({
+      file_id: 'file-del',
+      change_type: 'deleted',
+      storage_key: undefined,
+      checksum: undefined,
+    });
+    given_snapshot([good, bad, deleted]);
+    vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue([
+      make_index('file-good', [SNAPSHOT_ID]),
+      make_index('file-bad', [SNAPSHOT_ID]),
+      make_index('file-del', [SNAPSHOT_ID]),
+    ]);
+
+    const result = await verify();
+
+    expect(result.total_checked).toBe(2);
+    expect(result.failed_file_ids).toEqual(['file-bad']);
+    expect(result.passed).toBe(1);
+  });
+
+  it('reports every blob failing as zero passed', async () => {
+    given_snapshot([make_entry({ file_id: 'a' }), make_entry({ file_id: 'b' })]);
+    vi.mocked(mocks.ctx.storage.exists as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    const result = await verify();
+
+    expect(result.total_checked).toBe(2);
+    expect(result.passed).toBe(0);
+    expect(result.failed_file_ids).toEqual(['a', 'b']);
+  });
+
+  it('destroys the read-only context on the success path', async () => {
+    given_snapshot([make_entry()]);
+
+    await verify();
+
+    expect(mocks.tenant_factory.create_readonly).toHaveBeenCalledWith(TENANT_ID);
+    expect(mocks.ctx.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys the context even when the run throws', async () => {
+    given_snapshot([make_entry()]);
+    vi.mocked(mocks.indexes.list_by_owner).mockRejectedValue(new Error('index read failed'));
+
+    await expect(verify()).rejects.toThrow('index read failed');
+    // Otherwise the tenant's key material stays in the heap until GC.
+    expect(mocks.ctx.destroy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #193. Cut from `dev`. Test-only: two new files, no production code touched, so it overlaps nothing open.

## What the twin was hiding

`OneDriveVerificationService` had no test file at all: **18.3% statements, 8.3% branches**, against the SharePoint twin's 96.7%. Verification is the feature that tells an operator a backup is restorable, and both #31 and #173 were defects in exactly this logic, both reported as "verify says healthy".

Now **96.29% / 91.66%** (criterion 90/80), with `onedrive-manifest-chain.ts` pulled to 100% as a side effect. Effective parity with SharePoint.

## Two files, because the chain rules need a different fixture

The eleven single-snapshot cases and the chain rules cannot share a fixture: a chain test needs two manifests with real `created_at` ordering, and building that into the flat suite would have made every unrelated case read as if inheritance were involved. Also keeps both files under the 300-effective-line rule (244 and 184).

- **`onedrive-verification.service.test.ts`** mirrors the SharePoint suite case for case: no manifest, all intact, checksum mismatch, blob absent, auth-tag failure, no index at all, index without a row for this snapshot, deleted entries skipped, entries with no storage key skipped, mixed outcomes counted independently, every blob failing as zero passed, context destroyed on the success path and on the throwing path.
- **`onedrive-verification-chain.test.ts`** covers what #173 fixed and nothing was guarding.

## The two rules that actually matter, mutation-checked

The issue asks specifically that changing the index assertion to the verified snapshot ID makes a test fail. It does, in both directions:

| Mutation | Result |
|---|---|
| `v.snapshot_id === source_snapshot` -> `=== snapshot_id` | 2 failed \| 17 passed |
| `fold_drive_snapshot_chain(chain)` -> `([target])` | 2 failed \| 4 passed |

The first mutation is the #173 defect re-introduced: a carried-over file's index row lives under the snapshot that recorded it, not the one being verified, so comparing against the verified snapshot reports a healthy chain as missing index versions. The second is "verify only the target manifest": the fixture's target lists one entry and inherits a second, so `total_checked` drops from 2 to 1 - a carried file reported as checked while never being read.

I wrote the mirror case deliberately (`flags a carried entry whose index row is filed under the verified snapshot`), because an assertion that only ever expects zero index issues would also pass against code that accepts any snapshot id at all.

## Two judgement calls

**The pre-abort case asserts more than the issue asked.** Beyond `interrupted: true` and `total_checked: 0`, it asserts `create_readonly` was never called: aborting before the first entry should not construct a tenant context or derive key material at all. That is the current behaviour and worth pinning.

**Interrupt mid-chain asserts reads, not counters.** `should_interrupt` flips inside the first `get_stream`, so the assertion is that exactly one object read ever started. Counting `total_checked` alone would pass against code that streams a second blob and then discards the result.

## Verified

```
Tests           19 passed (13 + 6)
onedrive suite  184 passed
build 10/10 · typecheck 17/17 · test 15/15 · lint 0 errors · format clean
coverage        onedrive-verification.service.ts  96.29% stmts / 91.66% branch
                onedrive-manifest-chain.ts        100% / 100%
```

No docs: no user-visible behaviour changed.
