### PR TITLE
test(drive): cover the S3 manifest and cursor adapters and both status services

### DIFF
--- a/packages/onedrive/tests/unit/adapters/s3-onedrive-delta-cursor-repository.test.ts
+++ b/packages/onedrive/tests/unit/adapters/s3-onedrive-delta-cursor-repository.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { OneDriveDeltaCursor, TenantContext } from '@wisecom/atlas-types';
+import { S3OneDriveDeltaCursorRepository } from '@/adapters/s3-onedrive-delta-cursor-repository.adapter';
+
+const OWNER = 'owner-1';
+const CURSOR_KEY = 'onedrive/_meta/owner-1/delta.json';
+
+function make_cursor(overrides: Partial<OneDriveDeltaCursor> = {}): OneDriveDeltaCursor {
+  return {
+    owner_id: OWNER,
+    delta_link_by_drive: { 'drive-1': 'https://graph.microsoft.com/v1.0/delta?token=abc' },
+    previous_path_by_file_id: {},
+    previous_name_by_file_id: {},
+    previous_etag_by_file_id: {},
+    previous_kind_by_file_id: {},
+    ...overrides,
+  } as OneDriveDeltaCursor;
+}
+
+/** Storage stub holding plaintext JSON, matching the identity cipher below. */
+function make_ctx(objects: Record<string, unknown> = {}, get_error: Record<string, Error> = {}) {
+  const put = vi.fn(async (key: string, data: Buffer) => {
+    objects[key] = JSON.parse(data.toString('utf-8'));
+  });
+  const ctx = {
+    tenant_id: 'tenant-1',
+    storage: {
+      exists: vi.fn(async (key: string) => key in objects),
+      get: vi.fn(async (key: string) => {
+        const failure = get_error[key];
+        if (failure) throw failure;
+        const value = objects[key];
+        return Buffer.from(typeof value === 'string' ? value : JSON.stringify(value), 'utf-8');
+      }),
+      put,
+    },
+    encrypt: (data: Buffer) => data,
+    decrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+  return { ctx, put, objects };
+}
+
+describe('S3OneDriveDeltaCursorRepository', () => {
+  const repo = new S3OneDriveDeltaCursorRepository();
+
+  it('saves the cursor under the owner-scoped meta prefix', async () => {
+    const { ctx, objects } = make_ctx();
+
+    await repo.save(ctx, make_cursor());
+
+    expect(Object.keys(objects)).toEqual([CURSOR_KEY]);
+  });
+
+  it('lower-cases the owner segment so one owner keeps one cursor', async () => {
+    const { ctx, objects } = make_ctx();
+
+    await repo.save(ctx, make_cursor({ owner_id: 'Owner-1' }));
+
+    // Two spellings writing two cursors would re-enumerate the whole drive
+    // on the next run (issue #38).
+    expect(Object.keys(objects)).toEqual([CURSOR_KEY]);
+  });
+
+  it('round-trips the delta links it saved', async () => {
+    const { ctx } = make_ctx();
+
+    await repo.save(ctx, make_cursor());
+    const loaded = await repo.load(ctx, OWNER);
+
+    expect(loaded?.delta_link_by_drive).toEqual({
+      'drive-1': 'https://graph.microsoft.com/v1.0/delta?token=abc',
+    });
+  });
+
+  it('reports no cursor for an owner that has never been backed up', async () => {
+    const { ctx } = make_ctx();
+
+    await expect(repo.load(ctx, OWNER)).resolves.toBeUndefined();
+    // Absence is decided by exists(), so no GET is spent on a first run.
+    expect(ctx.storage.get).not.toHaveBeenCalled();
+  });
+
+  it('reads an undecryptable cursor as absent rather than throwing', async () => {
+    const { ctx } = make_ctx(
+      { [CURSOR_KEY]: make_cursor() },
+      {
+        [CURSOR_KEY]: new Error('unable to authenticate data'),
+      },
+    );
+
+    // A full re-enumeration is recoverable; a crash on every run is not.
+    await expect(repo.load(ctx, OWNER)).resolves.toBeUndefined();
+  });
+
+  it('reads an unparseable cursor as absent rather than throwing', async () => {
+    const { ctx } = make_ctx({ [CURSOR_KEY]: 'not-json' });
+
+    await expect(repo.load(ctx, OWNER)).resolves.toBeUndefined();
+  });
+
+  it('encrypts the cursor before it is stored', async () => {
+    const encrypt = vi.fn((data: Buffer) => data);
+    const { ctx } = make_ctx();
+    (ctx as unknown as { encrypt: typeof encrypt }).encrypt = encrypt;
+
+    await repo.save(ctx, make_cursor());
+
+    // The cursor carries Graph delta tokens, which are bearer-equivalent.
+    expect(encrypt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/onedrive/tests/unit/adapters/s3-onedrive-manifest-repository.test.ts
+++ b/packages/onedrive/tests/unit/adapters/s3-onedrive-manifest-repository.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { OneDriveSnapshotManifest, TenantContext } from '@wisecom/atlas-types';
+import { S3OneDriveManifestRepository } from '@/adapters/s3-onedrive-manifest-repository.adapter';
+
+const OWNER = 'owner-1';
+const OTHER_OWNER = 'owner-2';
+
+function make_manifest(
+  snapshot_id: string,
+  created_at: string,
+  owner_id = OWNER,
+): OneDriveSnapshotManifest {
+  return {
+    id: `${owner_id}-${snapshot_id}`,
+    tenant_id: 'tenant-1',
+    owner_id,
+    snapshot_id,
+    created_at: new Date(created_at),
+    total_files: 1,
+    total_size_bytes: 10,
+    entries: [],
+  };
+}
+
+/** Storage stub holding plaintext JSON, matching the identity cipher below. */
+function make_ctx(objects: Record<string, unknown> = {}, get_error: Record<string, Error> = {}) {
+  const put = vi.fn(async (key: string, data: Buffer) => {
+    objects[key] = JSON.parse(data.toString('utf-8'));
+  });
+  const ctx = {
+    tenant_id: 'tenant-1',
+    storage: {
+      list: vi.fn(async (prefix: string) =>
+        Object.keys(objects).filter((key) => key.startsWith(prefix)),
+      ),
+      get: vi.fn(async (key: string) => {
+        const failure = get_error[key];
+        if (failure) throw failure;
+        const value = objects[key];
+        return Buffer.from(typeof value === 'string' ? value : JSON.stringify(value), 'utf-8');
+      }),
+      put,
+    },
+    encrypt: (data: Buffer) => data,
+    decrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+  return { ctx, put, objects };
+}
+
+describe('S3OneDriveManifestRepository', () => {
+  const repo = new S3OneDriveManifestRepository();
+
+  it('writes a manifest under the owner-scoped manifests prefix', async () => {
+    const { ctx, objects } = make_ctx();
+
+    await repo.save(ctx, make_manifest('snap-1', '2026-03-01T00:00:00Z'));
+
+    expect(Object.keys(objects)).toEqual(['onedrive/manifests/owner-1/snap-1.json']);
+  });
+
+  it('lower-cases the owner segment so one owner never writes two prefixes', async () => {
+    const { ctx, objects } = make_ctx();
+
+    await repo.save(ctx, make_manifest('snap-1', '2026-03-01T00:00:00Z', 'Owner-1'));
+
+    // Issue #38: S3 keys are case-sensitive, Entra object IDs are not.
+    expect(Object.keys(objects)).toEqual(['onedrive/manifests/owner-1/snap-1.json']);
+  });
+
+  it('rejects a snapshot id that would escape the owner prefix', async () => {
+    const { ctx } = make_ctx();
+
+    await expect(
+      repo.save(ctx, make_manifest('../../etc/passwd', '2026-03-01T00:00:00Z')),
+    ).rejects.toThrow();
+  });
+
+  it('finds a manifest by snapshot id and revives created_at as a Date', async () => {
+    const { ctx } = make_ctx({
+      'onedrive/manifests/owner-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
+    });
+
+    const found = await repo.find_by_snapshot(ctx, OWNER, 'snap-1');
+
+    expect(found?.snapshot_id).toBe('snap-1');
+    // JSON round-trips a Date to a string, and the manifest chain sorts on
+    // created_at.getTime(): a string here breaks snapshot ordering silently.
+    expect(found?.created_at).toBeInstanceOf(Date);
+    expect(found?.created_at.toISOString()).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('returns undefined for a snapshot id that is not stored', async () => {
+    const { ctx } = make_ctx({
+      'onedrive/manifests/owner-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
+    });
+
+    await expect(repo.find_by_snapshot(ctx, OWNER, 'snap-absent')).resolves.toBeUndefined();
+  });
+
+  it('does not return another owner\u2019s manifest with the same snapshot id', async () => {
+    const { ctx } = make_ctx({
+      'onedrive/manifests/owner-2/snap-1.json': make_manifest(
+        'snap-1',
+        '2026-03-01T00:00:00Z',
+        OTHER_OWNER,
+      ),
+    });
+
+    await expect(repo.find_by_snapshot(ctx, OWNER, 'snap-1')).resolves.toBeUndefined();
+  });
+
+  it('lists an owner\u2019s snapshots newest first', async () => {
+    const { ctx } = make_ctx({
+      'onedrive/manifests/owner-1/snap-old.json': make_manifest('snap-old', '2026-03-01T00:00:00Z'),
+      'onedrive/manifests/owner-1/snap-new.json': make_manifest('snap-new', '2026-03-03T00:00:00Z'),
+      'onedrive/manifests/owner-1/snap-mid.json': make_manifest('snap-mid', '2026-03-02T00:00:00Z'),
+    });
+
+    const listed = await repo.list_snapshots_by_owner(ctx, OWNER);
+
+    expect(listed.map((m) => m.snapshot_id)).toEqual(['snap-new', 'snap-mid', 'snap-old']);
+  });
+
+  it('skips an unreadable object under the prefix instead of failing the listing', async () => {
+    const { ctx } = make_ctx(
+      {
+        'onedrive/manifests/owner-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
+        'onedrive/manifests/owner-1/snap-corrupt.json': 'not-json',
+      },
+      { 'onedrive/manifests/owner-1/snap-unreadable.json': new Error('decrypt failed') },
+    );
+
+    const listed = await repo.list_snapshots_by_owner(ctx, OWNER);
+
+    // One bad object must not hide every other snapshot the owner has.
+    expect(listed.map((m) => m.snapshot_id)).toEqual(['snap-1']);
+  });
+
+  it('throws when a manifest carries an unparseable created_at', async () => {
+    const { ctx } = make_ctx({
+      'onedrive/manifests/owner-1/snap-1.json': {
+        ...make_manifest('snap-1', '2026-03-01T00:00:00Z'),
+        created_at: 'not-a-date',
+      },
+    });
+
+    // Distinct from a corrupt object: the manifest decrypted and parsed, so
+    // skipping it would drop a real snapshot out of the chain.
+    await expect(repo.list_snapshots_by_owner(ctx, OWNER)).rejects.toThrow(/Invalid created_at/);
+  });
+
+  it('returns the newest manifest as the latest for an owner', async () => {
+    const { ctx } = make_ctx({
+      'onedrive/manifests/owner-1/snap-old.json': make_manifest('snap-old', '2026-03-01T00:00:00Z'),
+      'onedrive/manifests/owner-1/snap-new.json': make_manifest('snap-new', '2026-03-03T00:00:00Z'),
+    });
+
+    const latest = await repo.find_latest_by_owner(ctx, OWNER);
+
+    expect(latest?.snapshot_id).toBe('snap-new');
+  });
+
+  it('reports no latest manifest for an owner that has never been backed up', async () => {
+    const { ctx } = make_ctx();
+
+    await expect(repo.find_latest_by_owner(ctx, OWNER)).resolves.toBeUndefined();
+  });
+
+  it('lists every owner\u2019s manifests from the root prefix, newest first', async () => {
+    const { ctx } = make_ctx({
+      'onedrive/manifests/owner-1/snap-a.json': make_manifest('snap-a', '2026-03-01T00:00:00Z'),
+      'onedrive/manifests/owner-2/snap-b.json': make_manifest(
+        'snap-b',
+        '2026-03-02T00:00:00Z',
+        OTHER_OWNER,
+      ),
+    });
+
+    const all = await repo.list_all_manifests(ctx);
+
+    expect(all.map((m) => m.snapshot_id)).toEqual(['snap-b', 'snap-a']);
+  });
+
+  it('reads only the owner prefix, never the whole manifests root', async () => {
+    const { ctx } = make_ctx({
+      'onedrive/manifests/owner-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
+    });
+
+    await repo.find_by_snapshot(ctx, OWNER, 'snap-1');
+
+    // Issue #91: scanning the root prefix made snapshot lookup cost grow with
+    // every other owner in the bucket.
+    expect(ctx.storage.list).toHaveBeenCalledWith('onedrive/manifests/owner-1/');
+  });
+});

--- a/packages/onedrive/tests/unit/services/status/onedrive-status.service.test.ts
+++ b/packages/onedrive/tests/unit/services/status/onedrive-status.service.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  OneDriveConnector,
+  OneDriveDeltaCursorRepository,
+  OneDriveManifestRepository,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveStatusService } from '@/services/status/onedrive-status.service';
+
+const TENANT_ID = 'tenant-1';
+const OWNER_ID = '00000000-0000-0000-0000-000000000001';
+const DELTA_LINK = 'https://graph.microsoft.com/v1.0/delta?token=abc';
+
+function make_mocks() {
+  const ctx = { storage: {}, destroy: vi.fn() } as unknown as TenantContext;
+
+  const tenant_factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+    create_storage_only: vi.fn().mockResolvedValue(ctx),
+  };
+
+  const connector: OneDriveConnector = {
+    list_drives: vi.fn().mockResolvedValue([{ drive_id: 'drive-1', drive_name: 'OneDrive' }]),
+    fetch_delta: vi.fn().mockResolvedValue({ items: [], delta_link: 'next-link' }),
+  } as unknown as OneDriveConnector;
+
+  const manifests: OneDriveManifestRepository = {
+    find_latest_by_owner: vi.fn().mockResolvedValue(undefined),
+  } as unknown as OneDriveManifestRepository;
+
+  const cursors: OneDriveDeltaCursorRepository = {
+    load: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn(),
+  } as unknown as OneDriveDeltaCursorRepository;
+
+  return { ctx, tenant_factory, connector, manifests, cursors };
+}
+
+/** A saved cursor holding a delta link for each named drive. */
+const cursor_for = (...drive_ids: string[]) => ({
+  owner_id: OWNER_ID,
+  delta_link_by_drive: Object.fromEntries(drive_ids.map((id) => [id, DELTA_LINK])),
+});
+
+describe('OneDriveStatusService', () => {
+  let service: OneDriveStatusService;
+  let mocks: ReturnType<typeof make_mocks>;
+
+  beforeEach(() => {
+    mocks = make_mocks();
+    service = new OneDriveStatusService(
+      mocks.tenant_factory,
+      mocks.connector,
+      mocks.manifests,
+      mocks.cursors,
+    );
+  });
+
+  const check = (owner = OWNER_ID) => service.check_onedrive_status(TENANT_ID, owner);
+
+  it('reports no previous backup and no pending changes for an unbacked owner', async () => {
+    const result = await check();
+
+    expect(result.last_backup_at).toBeUndefined();
+    expect(result.last_snapshot_id).toBeUndefined();
+    expect(result.total_pending_changes).toBe(0);
+    expect(result.drives[0]).toMatchObject({ has_backup: false, is_up_to_date: false });
+    // No saved delta link, so nothing to peek at: Graph is not called.
+    expect(mocks.connector.fetch_delta).not.toHaveBeenCalled();
+  });
+
+  it('is not up to date when a drive has never been backed up, even with zero pending', async () => {
+    const result = await check();
+
+    // Zero pending changes on a drive that was never captured means "unknown",
+    // not "current". Reporting it as current would hide a missing drive.
+    expect(result.total_pending_changes).toBe(0);
+    expect(result.is_up_to_date).toBe(false);
+  });
+
+  it('reports the previous backup from the newest manifest', async () => {
+    vi.mocked(mocks.manifests.find_latest_by_owner).mockResolvedValue({
+      snapshot_id: 'snap-7',
+      created_at: new Date('2026-03-02T00:00:00Z'),
+    } as never);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('drive-1') as never);
+
+    const result = await check();
+
+    expect(result.last_snapshot_id).toBe('snap-7');
+    expect(result.last_backup_at?.toISOString()).toBe('2026-03-02T00:00:00.000Z');
+    expect(result.is_up_to_date).toBe(true);
+  });
+
+  it('sums pending changes across every drive', async () => {
+    vi.mocked(mocks.connector.list_drives).mockResolvedValue([
+      { drive_id: 'drive-1', drive_name: 'OneDrive' },
+      { drive_id: 'drive-2', drive_name: 'Second' },
+    ]);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('drive-1', 'drive-2') as never);
+    vi.mocked(mocks.connector.fetch_delta)
+      .mockResolvedValueOnce({ items: [{}, {}], delta_link: 'a' } as never)
+      .mockResolvedValueOnce({ items: [{}, {}, {}], delta_link: 'b' } as never);
+
+    const result = await check();
+
+    expect(result.total_drives).toBe(2);
+    expect(result.total_pending_changes).toBe(5);
+    expect(result.drives.map((d) => d.pending_changes)).toEqual([2, 3]);
+  });
+
+  it('is not up to date when any single drive has pending changes', async () => {
+    vi.mocked(mocks.connector.list_drives).mockResolvedValue([
+      { drive_id: 'drive-1', drive_name: 'OneDrive' },
+      { drive_id: 'drive-2', drive_name: 'Second' },
+    ]);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('drive-1', 'drive-2') as never);
+    vi.mocked(mocks.connector.fetch_delta)
+      .mockResolvedValueOnce({ items: [], delta_link: 'a' } as never)
+      .mockResolvedValueOnce({ items: [{}], delta_link: 'b' } as never);
+
+    const result = await check();
+
+    expect(result.is_up_to_date).toBe(false);
+    expect(result.drives.map((d) => d.is_up_to_date)).toEqual([true, false]);
+  });
+
+  it('never writes the saved cursor while peeking', async () => {
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('drive-1') as never);
+    vi.mocked(mocks.connector.fetch_delta).mockResolvedValue({
+      items: [{}, {}],
+      delta_link: 'advanced-link',
+    } as never);
+
+    await check();
+
+    // Consuming the delta link here would make the next real backup skip the
+    // very changes status just reported as pending.
+    expect(mocks.cursors.save).not.toHaveBeenCalled();
+  });
+
+  it('reads the tenant context read-only and destroys it', async () => {
+    await check();
+
+    expect(mocks.tenant_factory.create_readonly).toHaveBeenCalledWith(TENANT_ID);
+    expect(mocks.tenant_factory.create).not.toHaveBeenCalled();
+    expect(mocks.ctx.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys the context when the connector throws', async () => {
+    vi.mocked(mocks.connector.list_drives).mockRejectedValue(new Error('graph unavailable'));
+
+    await expect(check()).rejects.toThrow('graph unavailable');
+    expect(mocks.ctx.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a drive whose peek failed as backed up but not up to date', async () => {
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('drive-1') as never);
+    vi.mocked(mocks.connector.fetch_delta).mockRejectedValue(new Error('throttled'));
+
+    const result = await check();
+
+    // A failed peek is unknown, not clean: the drive has a cursor so it has a
+    // backup, but pending changes could not be counted.
+    expect(result.drives[0]).toMatchObject({
+      has_backup: true,
+      pending_changes: 0,
+      is_up_to_date: false,
+    });
+  });
+
+  it('currently rolls a failed peek up as up to date, which is wrong', async () => {
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('drive-1') as never);
+    vi.mocked(mocks.connector.fetch_delta).mockRejectedValue(new Error('throttled'));
+
+    const result = await check();
+
+    // Pins today's behaviour, it is not an endorsement. The roll-up is
+    // `total_pending === 0 && every(has_backup)`, which ignores each drive's
+    // own `is_up_to_date`, so a throttled peek counts as clean. Expected to
+    // flip to false when that is fixed; see the follow-up issue.
+    expect(result.drives[0]?.is_up_to_date).toBe(false);
+    expect(result.is_up_to_date).toBe(true);
+  });
+
+  it('does not fail the whole check when one drive of several fails to peek', async () => {
+    vi.mocked(mocks.connector.list_drives).mockResolvedValue([
+      { drive_id: 'drive-1', drive_name: 'OneDrive' },
+      { drive_id: 'drive-2', drive_name: 'Second' },
+    ]);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('drive-1', 'drive-2') as never);
+    vi.mocked(mocks.connector.fetch_delta)
+      .mockRejectedValueOnce(new Error('throttled'))
+      .mockResolvedValueOnce({ items: [{}], delta_link: 'b' } as never);
+
+    const result = await check();
+
+    expect(result.drives).toHaveLength(2);
+    expect(result.total_pending_changes).toBe(1);
+  });
+
+  it('normalises the owner id before reading storage or Graph', async () => {
+    const result = await check(OWNER_ID.toUpperCase());
+
+    // The cursor and manifest prefixes are case-sensitive in S3 (issue #38).
+    expect(result.owner_id).toBe(OWNER_ID);
+    expect(mocks.cursors.load).toHaveBeenCalledWith(expect.anything(), OWNER_ID);
+    expect(mocks.connector.list_drives).toHaveBeenCalledWith(TENANT_ID, OWNER_ID);
+  });
+
+  it('reports an owner with no drives as having nothing pending', async () => {
+    vi.mocked(mocks.connector.list_drives).mockResolvedValue([]);
+
+    const result = await check();
+
+    expect(result.total_drives).toBe(0);
+    expect(result.drives).toEqual([]);
+    // `every` on an empty list is true, so this is up to date by definition.
+    expect(result.is_up_to_date).toBe(true);
+  });
+});

--- a/packages/sharepoint/tests/unit/adapters/s3-sharepoint-delta-cursor-repository.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/s3-sharepoint-delta-cursor-repository.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SharePointDeltaCursor, TenantContext } from '@wisecom/atlas-types';
+import { S3SharePointDeltaCursorRepository } from '@/adapters/s3-sharepoint-delta-cursor-repository.adapter';
+
+const SITE = 'site-1';
+const CURSOR_KEY = 'sharepoint/_meta/site-1/delta.json';
+
+function make_cursor(overrides: Partial<SharePointDeltaCursor> = {}): SharePointDeltaCursor {
+  return {
+    site_id: SITE,
+    delta_link_by_drive: { 'drive-1': 'https://graph.microsoft.com/v1.0/delta?token=abc' },
+    previous_path_by_file_id: {},
+    previous_name_by_file_id: {},
+    previous_etag_by_file_id: {},
+    previous_kind_by_file_id: {},
+    ...overrides,
+  } as SharePointDeltaCursor;
+}
+
+/** Storage stub holding plaintext JSON, matching the identity cipher below. */
+function make_ctx(objects: Record<string, unknown> = {}, get_error: Record<string, Error> = {}) {
+  const put = vi.fn(async (key: string, data: Buffer) => {
+    objects[key] = JSON.parse(data.toString('utf-8'));
+  });
+  const ctx = {
+    tenant_id: 'tenant-1',
+    storage: {
+      exists: vi.fn(async (key: string) => key in objects),
+      get: vi.fn(async (key: string) => {
+        const failure = get_error[key];
+        if (failure) throw failure;
+        const value = objects[key];
+        return Buffer.from(typeof value === 'string' ? value : JSON.stringify(value), 'utf-8');
+      }),
+      put,
+    },
+    encrypt: (data: Buffer) => data,
+    decrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+  return { ctx, put, objects };
+}
+
+describe('S3SharePointDeltaCursorRepository', () => {
+  const repo = new S3SharePointDeltaCursorRepository();
+
+  it('saves the cursor under the site-scoped meta prefix', async () => {
+    const { ctx, objects } = make_ctx();
+
+    await repo.save(ctx, make_cursor());
+
+    expect(Object.keys(objects)).toEqual([CURSOR_KEY]);
+  });
+
+  it('lower-cases the site segment so one site keeps one cursor', async () => {
+    const { ctx, objects } = make_ctx();
+
+    await repo.save(ctx, make_cursor({ site_id: 'Site-1' }));
+
+    // Two spellings writing two cursors would re-enumerate the whole library
+    // on the next run (issue #38).
+    expect(Object.keys(objects)).toEqual([CURSOR_KEY]);
+  });
+
+  it('round-trips the delta links it saved', async () => {
+    const { ctx } = make_ctx();
+
+    await repo.save(ctx, make_cursor());
+    const loaded = await repo.load(ctx, SITE);
+
+    expect(loaded?.delta_link_by_drive).toEqual({
+      'drive-1': 'https://graph.microsoft.com/v1.0/delta?token=abc',
+    });
+  });
+
+  it('reports no cursor for a site that has never been backed up', async () => {
+    const { ctx } = make_ctx();
+
+    await expect(repo.load(ctx, SITE)).resolves.toBeUndefined();
+    // Absence is decided by exists(), so no GET is spent on a first run.
+    expect(ctx.storage.get).not.toHaveBeenCalled();
+  });
+
+  it('reads an undecryptable cursor as absent rather than throwing', async () => {
+    const { ctx } = make_ctx(
+      { [CURSOR_KEY]: make_cursor() },
+      {
+        [CURSOR_KEY]: new Error('unable to authenticate data'),
+      },
+    );
+
+    // A full re-enumeration is recoverable; a crash on every run is not.
+    await expect(repo.load(ctx, SITE)).resolves.toBeUndefined();
+  });
+
+  it('reads an unparseable cursor as absent rather than throwing', async () => {
+    const { ctx } = make_ctx({ [CURSOR_KEY]: 'not-json' });
+
+    await expect(repo.load(ctx, SITE)).resolves.toBeUndefined();
+  });
+
+  it('encrypts the cursor before it is stored', async () => {
+    const encrypt = vi.fn((data: Buffer) => data);
+    const { ctx } = make_ctx();
+    (ctx as unknown as { encrypt: typeof encrypt }).encrypt = encrypt;
+
+    await repo.save(ctx, make_cursor());
+
+    // The cursor carries Graph delta tokens, which are bearer-equivalent.
+    expect(encrypt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sharepoint/tests/unit/adapters/s3-sharepoint-manifest-repository.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/s3-sharepoint-manifest-repository.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SharePointSnapshotManifest, TenantContext } from '@wisecom/atlas-types';
+import { S3SharePointManifestRepository } from '@/adapters/s3-sharepoint-manifest-repository.adapter';
+
+const SITE = 'site-1';
+const OTHER_SITE = 'site-2';
+
+function make_manifest(
+  snapshot_id: string,
+  created_at: string,
+  site_id = SITE,
+): SharePointSnapshotManifest {
+  return {
+    id: `${site_id}-${snapshot_id}`,
+    tenant_id: 'tenant-1',
+    site_id,
+    snapshot_id,
+    created_at: new Date(created_at),
+    total_files: 1,
+    total_size_bytes: 10,
+    entries: [],
+  };
+}
+
+/** Storage stub holding plaintext JSON, matching the identity cipher below. */
+function make_ctx(objects: Record<string, unknown> = {}, get_error: Record<string, Error> = {}) {
+  const put = vi.fn(async (key: string, data: Buffer) => {
+    objects[key] = JSON.parse(data.toString('utf-8'));
+  });
+  const ctx = {
+    tenant_id: 'tenant-1',
+    storage: {
+      list: vi.fn(async (prefix: string) =>
+        Object.keys(objects).filter((key) => key.startsWith(prefix)),
+      ),
+      get: vi.fn(async (key: string) => {
+        const failure = get_error[key];
+        if (failure) throw failure;
+        const value = objects[key];
+        return Buffer.from(typeof value === 'string' ? value : JSON.stringify(value), 'utf-8');
+      }),
+      put,
+    },
+    encrypt: (data: Buffer) => data,
+    decrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+  return { ctx, put, objects };
+}
+
+describe('S3SharePointManifestRepository', () => {
+  const repo = new S3SharePointManifestRepository();
+
+  it('writes a manifest under the site-scoped manifests prefix', async () => {
+    const { ctx, objects } = make_ctx();
+
+    await repo.save(ctx, make_manifest('snap-1', '2026-03-01T00:00:00Z'));
+
+    expect(Object.keys(objects)).toEqual(['sharepoint/manifests/site-1/snap-1.json']);
+  });
+
+  it('lower-cases the site segment so one site never writes two prefixes', async () => {
+    const { ctx, objects } = make_ctx();
+
+    await repo.save(ctx, make_manifest('snap-1', '2026-03-01T00:00:00Z', 'Site-1'));
+
+    // Issue #38: S3 keys are case-sensitive, Graph site IDs are not.
+    expect(Object.keys(objects)).toEqual(['sharepoint/manifests/site-1/snap-1.json']);
+  });
+
+  it('rejects a snapshot id that would escape the site prefix', async () => {
+    const { ctx } = make_ctx();
+
+    await expect(
+      repo.save(ctx, make_manifest('../../etc/passwd', '2026-03-01T00:00:00Z')),
+    ).rejects.toThrow();
+  });
+
+  it('finds a manifest by snapshot id and revives created_at as a Date', async () => {
+    const { ctx } = make_ctx({
+      'sharepoint/manifests/site-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
+    });
+
+    const found = await repo.find_by_snapshot(ctx, SITE, 'snap-1');
+
+    expect(found?.snapshot_id).toBe('snap-1');
+    // JSON round-trips a Date to a string, and the manifest chain sorts on
+    // created_at.getTime(): a string here breaks snapshot ordering silently.
+    expect(found?.created_at).toBeInstanceOf(Date);
+    expect(found?.created_at.toISOString()).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('returns undefined for a snapshot id that is not stored', async () => {
+    const { ctx } = make_ctx({
+      'sharepoint/manifests/site-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
+    });
+
+    await expect(repo.find_by_snapshot(ctx, SITE, 'snap-absent')).resolves.toBeUndefined();
+  });
+
+  it('does not return another site\u2019s manifest with the same snapshot id', async () => {
+    const { ctx } = make_ctx({
+      'sharepoint/manifests/site-2/snap-1.json': make_manifest(
+        'snap-1',
+        '2026-03-01T00:00:00Z',
+        OTHER_SITE,
+      ),
+    });
+
+    await expect(repo.find_by_snapshot(ctx, SITE, 'snap-1')).resolves.toBeUndefined();
+  });
+
+  it('lists a site\u2019s snapshots newest first', async () => {
+    const { ctx } = make_ctx({
+      'sharepoint/manifests/site-1/snap-old.json': make_manifest(
+        'snap-old',
+        '2026-03-01T00:00:00Z',
+      ),
+      'sharepoint/manifests/site-1/snap-new.json': make_manifest(
+        'snap-new',
+        '2026-03-03T00:00:00Z',
+      ),
+      'sharepoint/manifests/site-1/snap-mid.json': make_manifest(
+        'snap-mid',
+        '2026-03-02T00:00:00Z',
+      ),
+    });
+
+    const listed = await repo.list_snapshots_by_site(ctx, SITE);
+
+    expect(listed.map((m) => m.snapshot_id)).toEqual(['snap-new', 'snap-mid', 'snap-old']);
+  });
+
+  it('skips an unreadable object under the prefix instead of failing the listing', async () => {
+    const { ctx } = make_ctx(
+      {
+        'sharepoint/manifests/site-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
+        'sharepoint/manifests/site-1/snap-corrupt.json': 'not-json',
+      },
+      { 'sharepoint/manifests/site-1/snap-unreadable.json': new Error('decrypt failed') },
+    );
+
+    const listed = await repo.list_snapshots_by_site(ctx, SITE);
+
+    // One bad object must not hide every other snapshot the site has.
+    expect(listed.map((m) => m.snapshot_id)).toEqual(['snap-1']);
+  });
+
+  it('throws when a manifest carries an unparseable created_at', async () => {
+    const { ctx } = make_ctx({
+      'sharepoint/manifests/site-1/snap-1.json': {
+        ...make_manifest('snap-1', '2026-03-01T00:00:00Z'),
+        created_at: 'not-a-date',
+      },
+    });
+
+    // Distinct from a corrupt object: the manifest decrypted and parsed, so
+    // skipping it would drop a real snapshot out of the chain.
+    await expect(repo.list_snapshots_by_site(ctx, SITE)).rejects.toThrow(/Invalid created_at/);
+  });
+
+  it('returns the newest manifest as the latest for a site', async () => {
+    const { ctx } = make_ctx({
+      'sharepoint/manifests/site-1/snap-old.json': make_manifest(
+        'snap-old',
+        '2026-03-01T00:00:00Z',
+      ),
+      'sharepoint/manifests/site-1/snap-new.json': make_manifest(
+        'snap-new',
+        '2026-03-03T00:00:00Z',
+      ),
+    });
+
+    const latest = await repo.find_latest_by_site(ctx, SITE);
+
+    expect(latest?.snapshot_id).toBe('snap-new');
+  });
+
+  it('reports no latest manifest for a site that has never been backed up', async () => {
+    const { ctx } = make_ctx();
+
+    await expect(repo.find_latest_by_site(ctx, SITE)).resolves.toBeUndefined();
+  });
+
+  it('lists every site\u2019s manifests from the root prefix, newest first', async () => {
+    const { ctx } = make_ctx({
+      'sharepoint/manifests/site-1/snap-a.json': make_manifest('snap-a', '2026-03-01T00:00:00Z'),
+      'sharepoint/manifests/site-2/snap-b.json': make_manifest(
+        'snap-b',
+        '2026-03-02T00:00:00Z',
+        OTHER_SITE,
+      ),
+    });
+
+    const all = await repo.list_all_manifests(ctx);
+
+    expect(all.map((m) => m.snapshot_id)).toEqual(['snap-b', 'snap-a']);
+  });
+
+  it('reads only the site prefix, never the whole manifests root', async () => {
+    const { ctx } = make_ctx({
+      'sharepoint/manifests/site-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
+    });
+
+    await repo.find_by_snapshot(ctx, SITE, 'snap-1');
+
+    // Issue #91: scanning the root prefix made snapshot lookup cost grow with
+    // every other site in the bucket.
+    expect(ctx.storage.list).toHaveBeenCalledWith('sharepoint/manifests/site-1/');
+  });
+});

--- a/packages/sharepoint/tests/unit/services/status/sharepoint-status.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/status/sharepoint-status.service.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  SharePointSiteConnector,
+  SharePointDeltaCursorRepository,
+  SharePointManifestRepository,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { SharePointStatusService } from '@/services/status/sharepoint-status.service';
+
+const TENANT_ID = 'tenant-1';
+const SITE_ID =
+  'contoso.sharepoint.com,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002';
+const DELTA_LINK = 'https://graph.microsoft.com/v1.0/delta?token=abc';
+
+function make_mocks() {
+  const ctx = { storage: {}, destroy: vi.fn() } as unknown as TenantContext;
+
+  const tenant_factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+    create_storage_only: vi.fn().mockResolvedValue(ctx),
+  };
+
+  const connector: SharePointSiteConnector = {
+    list_document_libraries: vi
+      .fn()
+      .mockResolvedValue([{ drive_id: 'library-1', drive_name: 'Documents' }]),
+    fetch_delta: vi.fn().mockResolvedValue({ items: [], delta_link: 'next-link' }),
+  } as unknown as SharePointSiteConnector;
+
+  const manifests: SharePointManifestRepository = {
+    find_latest_by_site: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SharePointManifestRepository;
+
+  const cursors: SharePointDeltaCursorRepository = {
+    load: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn(),
+  } as unknown as SharePointDeltaCursorRepository;
+
+  return { ctx, tenant_factory, connector, manifests, cursors };
+}
+
+/** A saved cursor holding a delta link for each named drive. */
+const cursor_for = (...library_ids: string[]) => ({
+  site_id: SITE_ID,
+  delta_link_by_drive: Object.fromEntries(library_ids.map((id) => [id, DELTA_LINK])),
+});
+
+describe('SharePointStatusService', () => {
+  let service: SharePointStatusService;
+  let mocks: ReturnType<typeof make_mocks>;
+
+  beforeEach(() => {
+    mocks = make_mocks();
+    service = new SharePointStatusService(
+      mocks.tenant_factory,
+      mocks.connector,
+      mocks.manifests,
+      mocks.cursors,
+    );
+  });
+
+  const check = (site = SITE_ID) => service.check_sharepoint_status(TENANT_ID, site);
+
+  it('reports no previous backup and no pending changes for an unbacked site', async () => {
+    const result = await check();
+
+    expect(result.last_backup_at).toBeUndefined();
+    expect(result.last_snapshot_id).toBeUndefined();
+    expect(result.total_pending_changes).toBe(0);
+    expect(result.libraries[0]).toMatchObject({ has_backup: false, is_up_to_date: false });
+    // No saved delta link, so nothing to peek at: Graph is not called.
+    expect(mocks.connector.fetch_delta).not.toHaveBeenCalled();
+  });
+
+  it('is not up to date when a library has never been backed up, even with zero pending', async () => {
+    const result = await check();
+
+    // Zero pending changes on a library that was never captured means "unknown",
+    // not "current". Reporting it as current would hide a missing library.
+    expect(result.total_pending_changes).toBe(0);
+    expect(result.is_up_to_date).toBe(false);
+  });
+
+  it('reports the previous backup from the newest manifest', async () => {
+    vi.mocked(mocks.manifests.find_latest_by_site).mockResolvedValue({
+      snapshot_id: 'snap-7',
+      created_at: new Date('2026-03-02T00:00:00Z'),
+    } as never);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('library-1') as never);
+
+    const result = await check();
+
+    expect(result.last_snapshot_id).toBe('snap-7');
+    expect(result.last_backup_at?.toISOString()).toBe('2026-03-02T00:00:00.000Z');
+    expect(result.is_up_to_date).toBe(true);
+  });
+
+  it('sums pending changes across every library', async () => {
+    vi.mocked(mocks.connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'library-1', drive_name: 'Documents' },
+      { drive_id: 'library-2', drive_name: 'Shared Documents' },
+    ]);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('library-1', 'library-2') as never);
+    vi.mocked(mocks.connector.fetch_delta)
+      .mockResolvedValueOnce({ items: [{}, {}], delta_link: 'a' } as never)
+      .mockResolvedValueOnce({ items: [{}, {}, {}], delta_link: 'b' } as never);
+
+    const result = await check();
+
+    expect(result.total_libraries).toBe(2);
+    expect(result.total_pending_changes).toBe(5);
+    expect(result.libraries.map((d) => d.pending_changes)).toEqual([2, 3]);
+  });
+
+  it('is not up to date when any single library has pending changes', async () => {
+    vi.mocked(mocks.connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'library-1', drive_name: 'Documents' },
+      { drive_id: 'library-2', drive_name: 'Shared Documents' },
+    ]);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('library-1', 'library-2') as never);
+    vi.mocked(mocks.connector.fetch_delta)
+      .mockResolvedValueOnce({ items: [], delta_link: 'a' } as never)
+      .mockResolvedValueOnce({ items: [{}], delta_link: 'b' } as never);
+
+    const result = await check();
+
+    expect(result.is_up_to_date).toBe(false);
+    expect(result.libraries.map((d) => d.is_up_to_date)).toEqual([true, false]);
+  });
+
+  it('never writes the saved cursor while peeking', async () => {
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('library-1') as never);
+    vi.mocked(mocks.connector.fetch_delta).mockResolvedValue({
+      items: [{}, {}],
+      delta_link: 'advanced-link',
+    } as never);
+
+    await check();
+
+    // Consuming the delta link here would make the next real backup skip the
+    // very changes status just reported as pending.
+    expect(mocks.cursors.save).not.toHaveBeenCalled();
+  });
+
+  it('reads the tenant context read-only and destroys it', async () => {
+    await check();
+
+    expect(mocks.tenant_factory.create_readonly).toHaveBeenCalledWith(TENANT_ID);
+    expect(mocks.tenant_factory.create).not.toHaveBeenCalled();
+    expect(mocks.ctx.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys the context when the connector throws', async () => {
+    vi.mocked(mocks.connector.list_document_libraries).mockRejectedValue(
+      new Error('graph unavailable'),
+    );
+
+    await expect(check()).rejects.toThrow('graph unavailable');
+    expect(mocks.ctx.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a library whose peek failed as backed up but not up to date', async () => {
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('library-1') as never);
+    vi.mocked(mocks.connector.fetch_delta).mockRejectedValue(new Error('throttled'));
+
+    const result = await check();
+
+    // A failed peek is unknown, not clean: the library has a cursor so it has a
+    // backup, but pending changes could not be counted.
+    expect(result.libraries[0]).toMatchObject({
+      has_backup: true,
+      pending_changes: 0,
+      is_up_to_date: false,
+    });
+  });
+
+  it('currently rolls a failed peek up as up to date, which is wrong', async () => {
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('library-1') as never);
+    vi.mocked(mocks.connector.fetch_delta).mockRejectedValue(new Error('throttled'));
+
+    const result = await check();
+
+    // Pins today's behaviour, it is not an endorsement. The roll-up is
+    // `total_pending === 0 && every(has_backup)`, which ignores each library's
+    // own `is_up_to_date`, so a throttled peek counts as clean. Expected to
+    // flip to false when that is fixed; see the follow-up issue.
+    expect(result.libraries[0]?.is_up_to_date).toBe(false);
+    expect(result.is_up_to_date).toBe(true);
+  });
+
+  it('does not fail the whole check when one library of several fails to peek', async () => {
+    vi.mocked(mocks.connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'library-1', drive_name: 'Documents' },
+      { drive_id: 'library-2', drive_name: 'Shared Documents' },
+    ]);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('library-1', 'library-2') as never);
+    vi.mocked(mocks.connector.fetch_delta)
+      .mockRejectedValueOnce(new Error('throttled'))
+      .mockResolvedValueOnce({ items: [{}], delta_link: 'b' } as never);
+
+    const result = await check();
+
+    expect(result.libraries).toHaveLength(2);
+    expect(result.total_pending_changes).toBe(1);
+  });
+
+  it('normalises the site id before reading storage or Graph', async () => {
+    const result = await check(SITE_ID.toUpperCase());
+
+    // The cursor and manifest prefixes are case-sensitive in S3 (issue #38).
+    expect(result.site_id).toBe(SITE_ID);
+    expect(mocks.cursors.load).toHaveBeenCalledWith(expect.anything(), SITE_ID);
+    expect(mocks.connector.list_document_libraries).toHaveBeenCalledWith(TENANT_ID, SITE_ID);
+  });
+
+  it('reports a site with no libraries as having nothing pending', async () => {
+    vi.mocked(mocks.connector.list_document_libraries).mockResolvedValue([]);
+
+    const result = await check();
+
+    expect(result.total_libraries).toBe(0);
+    expect(result.libraries).toEqual([]);
+    // `every` on an empty list is true, so this is up to date by definition.
+    expect(result.is_up_to_date).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #194. Cut from `dev`. Test-only, six new files, no production code touched, so it overlaps nothing open.

## The issue was partly stale, so I re-measured first

#194 was filed against `fe49b3b` and its headline behaviours no longer exist. `append_version`, `MAX_APPEND_RETRIES`, the `PreconditionFailedError` retry loop, `with_key_lock` and `find_by_file_id` were all removed when #208 rewrote the version index to one object per run. Nothing in `packages/*/src` references any of those symbols now.

The second concern, "every read failure reads as no index", has also already been fixed, deliberately and with a comment saying why: `download_indexes` now lets storage failures propagate and only skips an undecryptable payload, because an unread object is indistinguishable from a file with no history and that value decides both dedup and verification.

Re-measured on `dev` at `e43cf88`:

| File | Issue said | Actual before | Now |
|---|---|---|---|
| `*-file-version-index-repository.adapter.ts` (both) | 0% | **100%** | 100% |
| `*-manifest-repository.adapter.ts` (both) | 0% | 0% | **100%** |
| `*-delta-cursor-repository.adapter.ts` (both) | 0% | 0% | **100%** |
| `*-status.service.ts` (both) | 0% | 0% | **100%** |

So two of the eight files were already covered by #208 and needed nothing. Six were genuinely at zero. Branches are 88 to 100%, criterion was 85%.

## What the tests pin

**Manifest repositories.** Key layout; the lower-cased scope segment that stops one owner or site writing two prefixes (#38); a traversal segment rejected; `created_at` revived as a `Date`, which matters because the manifest chain sorts on `created_at.getTime()` and a JSON round-trip leaves a string; newest-first ordering; an unreadable object skipped rather than failing the whole listing; an unparseable `created_at` throwing instead of silently dropping a real snapshot; no cross-scope match; and the owner-prefix-only read from #91 rather than a root scan.

**Delta cursor repositories.** Key layout; round trip; absence decided by `exists()` so a first run spends no GET; an undecryptable or unparseable cursor read as absent, since a full re-enumeration is recoverable and a crash on every run is not; and the cursor encrypted before storage, because it carries Graph delta tokens.

**Status services.** Never-backed-up scope; pending summed across drives or libraries; `is_up_to_date` false when any is non-zero; one failing peek not failing the whole check; read-only context destroyed on both the success and the throwing path; scope id normalised before storage or Graph is touched; and an empty drive list.

The load-bearing one: **the saved cursor is asserted never to be written during a peek.** Consuming the delta link there would make the next real backup skip exactly the changes status had just reported as pending.

## One defect found, deliberately not fixed here

The top-level roll-up is:

```ts
is_up_to_date: total_pending === 0 && drive_statuses.every((d) => d.has_backup)
```

It ignores each drive's own `is_up_to_date`. A peek that throws pushes `{ has_backup: true, pending_changes: 0, is_up_to_date: false }`, so a throttled or failing peek satisfies both conjuncts and **the whole owner reports as up to date**. Identical in both drives.

`drive-status-presenter.tsx` makes it visible: `build_drive_status_row` prints that drive red as `0 change(s)` from the per-drive flag, while `print_verdict` prints the green `... is up to date -- no pending changes.` banner from the roll-up. Contradictory output, and the banner is what an operator reads.

It is not in this issue's acceptance criteria, and fixing it would make a test-only PR change user-visible behaviour. So it is **pinned as current behaviour** in a test named `currently rolls a failed peek up as up to date, which is wrong`, with a comment stating it is expected to flip. Same split as #247 and #246: the fix then lands against a test that fails when it is wrong. Draft issue is in my report, not filed yet.

## Verified

```
new tests      66 passed (13+13 manifest, 7+7 cursor, 13+13 status)
onedrive 197 passed · sharepoint 220 passed
build 10/10 · typecheck 17/17 · test 15/15 · lint 0 errors · format clean
coverage       all eight files in the issue's table at 100% statements
```

Twin check run before writing: the cursor adapters are byte-identical after normalising names, the manifest adapters differ only in comment grammar, and the status service bodies differ only in naming. One suite shape, mirrored, so a future divergence shows up as a test difference.

No docs: no user-visible behaviour changed.
