### PR TITLE
feat(drive): restore stored file versions back into OneDrive and SharePoint

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -283,6 +283,18 @@ On Windows the archive is stamped with Mark-of-the-Web (`Zone.Identifier`, `Zone
 | `-f, --file <ref>`  | File ID or path               | Required       |
 | `-t, --tenant <id>` | Tenant identifier             | Config default |
 
+### `atlas onedrive restore-version`
+
+| Flag                | Description                                        | Default        |
+| ------------------- | -------------------------------------------------- | -------------- |
+| `-o, --owner <id>`  | User email or Entra object ID                      | Required       |
+| `-f, --file <ref>`  | File ID or path; required with `--version`         | Optional       |
+| `--version <id>`    | Exact stored version to restore                    | Optional       |
+| `--before <iso>`    | Newest version at or before this instant, per file | Optional       |
+| `--path <prefix>`   | Limit a `--before` rollback to one folder          | Whole drive    |
+| `--in-place`        | Upload over the original file                      | Off, writes a copy |
+| `-t, --tenant <id>` | Tenant identifier                                  | Config default |
+
 ### `atlas onedrive verify`
 
 | Flag                  | Description                   | Default        |
@@ -314,6 +326,50 @@ atlas onedrive restore -o user@company.com -s od-snap-123 --in-place
 atlas onedrive restore -o user@company.com -s od-snap-123 \
   --file-filter "/Documents/report.docx" --name report-2026-08.docx
 ```
+
+### Rolling a file back to an earlier version
+
+A snapshot restore recovers each file's state at that snapshot. A version
+restore recovers one point inside a single file's history, which is what a bad
+edit or a mass encrypt-and-sync event needs.
+
+```bash
+# See what exists first. The Version column is what --version takes.
+atlas onedrive list-versions -o user@company.com -f "/Documents/report.docx"
+
+# One file, one version, written beside the original.
+atlas onedrive restore-version -o user@company.com \
+  -f "/Documents/report.docx" --version 3.0
+
+# Roll a folder back to the state before an incident, over the live files.
+atlas onedrive restore-version -o user@company.com \
+  --before 2026-03-10T00:00:00Z --path /Projects --in-place
+```
+
+Guarantees, both for one file and for a bulk rollback:
+
+- **The bytes come from the Atlas snapshot**, decrypted and SHA-256 verified
+  against the manifest before anything is uploaded. A version whose checksum
+  fails is skipped and reported; it never reaches the drive.
+- **Nothing is destroyed.** The default writes
+  `report (restored 2026-03-01T08-15-00Z).docx` next to the original and leaves
+  the live file alone. `--in-place` uploads over the original path, and
+  Microsoft 365 records that as a new version while keeping the content it
+  replaced in the file's own history.
+- **Original timestamps survive.** The restored file carries the modification
+  time the version had, so a rolled-back document does not look like it was
+  authored during the incident.
+- **Files with no pre-cutoff version are named in the output** and counted as
+  skipped. That list is the remaining exposure: those files have no copy in the
+  backup from before the cutoff.
+- **Versions return to the drive they came from.** The version index records the
+  drive ID, so an owner with several drives needs no extra flag, and a version
+  is never restored into the wrong one.
+
+Version restore only applies in place, to the same tenant and the same drive.
+There is no cross-drive or cross-tenant form: a file restored elsewhere has no
+prior version chain to sit in. Use `atlas onedrive restore --target-owner` for
+that case, which restores snapshot state rather than history.
 
 ### Where restored files land
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -437,6 +437,9 @@ atlas onedrive restore -o user@company.com -s od-snap-123 --target-owner other@c
 atlas onedrive restore -o user@company.com -s od-snap-123 --conflict replace
 atlas onedrive list-snapshots -o user@company.com
 atlas onedrive list-versions -o user@company.com -f "Documents/report.docx"
+atlas onedrive restore-version -o user@company.com -f "Documents/report.docx" --version 3.0
+atlas onedrive restore-version -o user@company.com --before 2026-03-10T00:00:00Z
+atlas onedrive restore-version -o user@company.com --before 2026-03-10T00:00:00Z --path /Projects --in-place
 atlas onedrive verify -o user@company.com -s od-snap-1735689600000-a1b2c3
 atlas onedrive status -o user@company.com
 atlas onedrive delete -o user@company.com -s od-snap-123
@@ -449,6 +452,7 @@ atlas onedrive delete -o user@company.com -y
 | `restore`        | Restore files from a snapshot to the user's (or another user's) OneDrive |
 | `list-snapshots` | List snapshot IDs and timestamps for the owner                           |
 | `list-versions`  | List indexed versions for one file (`-f` file ID or path)                |
+| `restore-version`| Push stored file versions back into the drive, one file or a whole rollback |
 | `verify`         | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows    |
 | `status`         | Report pending Graph changes per drive without backing up                |
 | `delete`         | Delete the owner's OneDrive backups, or a single snapshot                |
@@ -512,6 +516,53 @@ Identifiers are matched case-insensitively: `--owner`, `--site`, and `--file-fil
 | `-o, --owner <id>`  | User email or Entra object ID (required) |
 | `-f, --file <ref>`  | Graph file ID or drive path (required)   |
 | `-t, --tenant <id>` | Override tenant ID from config           |
+
+**`atlas onedrive restore-version`**
+
+Restores the version bytes Atlas holds. Use it to roll a file back past a bad
+edit, or a whole folder back past a mass encrypt-and-sync event.
+
+| Option              | Description                                                                  |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `-o, --owner <id>`  | User email or Entra object ID (required)                                     |
+| `-f, --file <ref>`  | Graph file ID or drive path; required with `--version`                       |
+| `--version <id>`    | Exact stored version, as shown in the `Version` column of `list-versions`    |
+| `--before <iso>`    | Restore each file's newest version at or before this instant                  |
+| `--path <prefix>`   | Limit a `--before` rollback to this folder and below                         |
+| `--in-place`        | Upload over the original file instead of writing a copy beside it            |
+| `-t, --tenant <id>` | Override tenant ID from config                                               |
+
+Either `--file` with `--version`, or `--before`. `--version` alone is rejected
+because a version id is only unique within one file, and `--path` cannot be
+combined with `--file`, since a folder scope and a single file are two
+different requests.
+
+::: warning Nothing is overwritten unless you ask
+The default writes a sibling named `report (restored 2026-03-01T08-15-00Z).docx`
+and leaves the live file untouched, so a rollback can be inspected before it is
+adopted. `--in-place` uploads over the original path instead. Even then the
+previous content is not destroyed: Microsoft 365 records the upload as a new
+version and keeps the one it replaced in the file's own version history.
+:::
+
+Restored files keep the modification time the version had, not the time of the
+restore, so a rolled-back document does not look like it was authored during
+the incident.
+
+A file with no version stored at or before the cutoff is **reported, not
+skipped silently**, and counts toward the skipped total. Treat that list as the
+work still outstanding: those files have no pre-incident copy in the backup.
+
+::: details Why Atlas uploads its own bytes instead of calling Graph
+Microsoft Graph can promote a previous version in place with `restoreVersion`,
+and Atlas deliberately does not use it. That call only works on a version the
+service still holds, so it fails exactly when a backup is needed: history
+trimmed by a retention policy, the file deleted, or the library gone. Its result
+also cannot be checked against the manifest checksum. Atlas uploads the bytes
+it stored and verified, which is the only path that guarantees the content you
+get is the content the backup recorded. `list-versions` shows what is available
+to restore.
+:::
 
 **`atlas onedrive save`**
 
@@ -589,6 +640,8 @@ atlas sharepoint backup --site https://contoso.sharepoint.com/sites/Engineering
 atlas sharepoint backup --site https://contoso.sharepoint.com/sites/Engineering --full
 atlas sharepoint list-snapshots --site https://contoso.sharepoint.com/sites/Engineering
 atlas sharepoint list-versions --site https://contoso.sharepoint.com/sites/Engineering -f /Documents/report.docx
+atlas sharepoint restore-version --site https://contoso.sharepoint.com/sites/Engineering -f /Documents/report.docx --version 3.0
+atlas sharepoint restore-version --site https://contoso.sharepoint.com/sites/Engineering --before 2026-03-10T00:00:00Z
 atlas sharepoint restore --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-1735689600000-a1b2c3
 atlas sharepoint restore --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 --destination /DR-drill
 atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-1735689600000-a1b2c3
@@ -603,6 +656,7 @@ atlas sharepoint delete --site https://contoso.sharepoint.com/sites/Engineering 
 | `backup`         | Incremental sync; use `--full` to ignore saved delta state            |
 | `list-snapshots` | List all SharePoint snapshots for a site                              |
 | `list-versions`  | List all backed-up versions for a specific file                       |
+| `restore-version`| Push stored file versions back into the library, one file or a whole rollback |
 | `restore`        | Restore files from a snapshot back to the site's document libraries   |
 | `save`           | Decrypt and save files from a snapshot to a local zip archive         |
 | `verify`         | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows |
@@ -642,6 +696,23 @@ Graph returns only the subsites the application can read. A subsite that cannot 
 | `--site <url-or-id>` | SharePoint site URL or Graph site ID (required) |
 | `-f, --file <ref>`   | File ID or path to look up (required)           |
 | `-t, --tenant <id>`  | Override tenant ID from config                  |
+
+**`atlas sharepoint restore-version`**
+
+| Option               | Description                                                               |
+| -------------------- | ------------------------------------------------------------------------- |
+| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required)                           |
+| `-f, --file <ref>`   | File ID or path; required with `--version`                                |
+| `--version <id>`     | Exact stored version, as shown by `list-versions`                         |
+| `--before <iso>`     | Restore each file's newest version at or before this instant               |
+| `--path <prefix>`    | Limit a `--before` rollback to this folder and below                      |
+| `--in-place`         | Upload over the original file instead of writing a copy beside it         |
+| `-t, --tenant <id>`  | Override tenant ID from config                                            |
+
+Identical semantics to [`atlas onedrive restore-version`](#atlas-onedrive),
+including the copy-by-default placement and the reason Atlas uploads its own
+stored bytes rather than calling Graph's `restoreVersion`. Versions are restored
+into the document library they were captured from.
 
 **`atlas sharepoint restore`**
 

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -193,6 +193,58 @@ await atlas.onedrive.restore('owner-id', { snapshot_id, in_place: true }); // pr
 
 Deletion methods erase every version of the objects they match. `purgeTenantData()` sweeps the whole bucket, every workload and not only Outlook. The returned `DeletionResult` separates `retained_*` (blocked by Object Lock, deletable once retention expires) from `failed_*` (everything else, which will not clear on its own). See [Erasure](/security#erasure).
 
+### Version restore
+
+`restoreVersion()` pushes the file version bytes Atlas holds back into a live
+drive or library. Available on both `atlas.onedrive` and `atlas.sharepoint`.
+
+```typescript
+// One exact version, listed first so you know what exists.
+const versions = await atlas.onedrive.listFileVersions('owner-id', '/Documents/report.docx');
+const result = await atlas.onedrive.restoreVersion('owner-id', {
+  file_ref: '/Documents/report.docx',
+  version_id: versions.at(-2)?.version_id,
+});
+
+// A rollback of one folder to the state before a known instant.
+await atlas.sharepoint.restoreVersion('site-id', {
+  before: new Date('2026-03-10T00:00:00Z'),
+  path_prefix: '/Shared Documents/Projects',
+  placement: 'in-place',
+});
+```
+
+| Option        | Description                                                                    |
+| ------------- | ------------------------------------------------------------------------------ |
+| `file_ref`    | Graph item ID, rooted path, or bare filename; required with `version_id`        |
+| `version_id`  | Exact stored version, from `listFileVersions()`                                 |
+| `before`      | `Date`; restores each file's newest version at or before this instant            |
+| `path_prefix` | Limits a `before` rollback to one folder and below                              |
+| `placement`   | `'copy'` (default) writes a sibling file; `'in-place'` uploads over the original |
+
+Pass either `file_ref` with `version_id`, or `before`. The result reports
+`files_restored`, `files_skipped`, the `placement` that was applied, and a
+`restored` array of `{ file_id, version_id, last_modified_at, size_bytes, restored_to }`.
+A file with no version stored at or before the cutoff appears in `errors` and
+counts as skipped, so a caller can tell a complete rollback from a partial one:
+
+```typescript
+if (result.files_skipped > 0) {
+  for (const reason of result.errors) console.warn(reason);
+}
+```
+
+Nothing is destroyed by either placement. `'copy'` never touches the live file.
+`'in-place'` uploads over it, and Microsoft 365 records that as a new version
+while keeping the content it replaced in the file's own version history.
+Restored files carry the modification time the version had, not the restore
+time.
+
+Atlas uploads its own checksum-verified bytes rather than calling Graph's
+`restoreVersion`, which only works on a version the service still holds and
+cannot be verified against the manifest. See
+[the CLI reference](/reference/cli#atlas-onedrive) for the full reasoning.
+
 ### Folder coverage
 
 `backup()` walks every mail folder at any depth, including Drafts, Outbox, Junk Email, and folders Exchange marks hidden. Pass `exclude_junk` to skip Junk Email and its subfolders:

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -255,6 +255,41 @@ On Windows the archive is stamped with Mark-of-the-Web (`Zone.Identifier`, `Zone
 | `-f, --file <ref>`   | File ID or path to look up           | Required       |
 | `-t, --tenant <id>`  | Tenant identifier                    | Config default |
 
+### `atlas sharepoint restore-version`
+
+| Flag                 | Description                                        | Default            |
+| -------------------- | -------------------------------------------------- | ------------------ |
+| `--site <url-or-id>` | SharePoint site URL or Graph site ID               | Required           |
+| `-f, --file <ref>`   | File ID or path; required with `--version`         | Optional           |
+| `--version <id>`     | Exact stored version to restore                    | Optional           |
+| `--before <iso>`     | Newest version at or before this instant, per file | Optional           |
+| `--path <prefix>`    | Limit a `--before` rollback to one folder          | Whole site         |
+| `--in-place`         | Upload over the original file                      | Off, writes a copy |
+| `-t, --tenant <id>`  | Tenant identifier                                  | Config default     |
+
+```bash
+atlas sharepoint list-versions --site https://contoso.sharepoint.com/sites/Engineering \
+  -f "/Shared Documents/report.docx"
+
+atlas sharepoint restore-version --site https://contoso.sharepoint.com/sites/Engineering \
+  -f "/Shared Documents/report.docx" --version 3.0
+
+atlas sharepoint restore-version --site https://contoso.sharepoint.com/sites/Engineering \
+  --before 2026-03-10T00:00:00Z --path "/Shared Documents/Projects" --in-place
+```
+
+Same guarantees as the OneDrive command, listed under
+[Rolling a file back to an earlier version](./onedrive-backup.md#rolling-a-file-back-to-an-earlier-version):
+bytes come from the verified snapshot, the default writes a `(restored ...)`
+copy rather than touching the live file, original modification times survive,
+and files with no pre-cutoff version are reported rather than skipped quietly.
+
+Versions return to the document library they were captured from, recorded per
+version in the index, so a site with several libraries needs no extra flag.
+Version restore has no cross-site form: a file restored into another site has
+no prior version chain to join. Use `atlas sharepoint restore --target-site`
+for that, which restores snapshot state rather than history.
+
 ### `atlas sharepoint verify`
 
 | Flag                  | Description                          | Default        |

--- a/packages/cli/src/commands/drive-version-restore.handlers.tsx
+++ b/packages/cli/src/commands/drive-version-restore.handlers.tsx
@@ -1,0 +1,163 @@
+import type { Container } from 'inversify';
+import { logger } from '@wisecom/atlas-core';
+import type {
+  DriveVersionRestoreOptions,
+  DriveVersionRestoreResult,
+  OneDriveVersionRestoreUseCase,
+  SharePointVersionRestoreUseCase,
+} from '@wisecom/atlas-types';
+import {
+  ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN,
+  SHAREPOINT_VERSION_RESTORE_USE_CASE_TOKEN,
+} from '@wisecom/atlas-types';
+import {
+  resolve_owner,
+  resolve_tenant_id,
+  type OneDriveTenantOptions,
+} from '@/commands/onedrive-command.handlers';
+import {
+  resolve_site_id,
+  resolve_tenant_id as resolve_sharepoint_tenant_id,
+  type SharePointTenantOptions,
+} from '@/commands/sharepoint-command.handlers';
+import { format_bytes } from '@/command-formatters';
+import { Banner } from '@/ui/components/banner';
+import { DataTable, type TableColumn } from '@/ui/components/data-table';
+import { render_static_view } from '@/ui/render';
+
+/** Flags shared by both drives; only the scope flag differs. */
+interface VersionRestoreFlags {
+  file?: string;
+  version?: string;
+  before?: string;
+  path?: string;
+  inPlace?: boolean;
+}
+
+export interface OneDriveRestoreVersionOptions extends OneDriveTenantOptions, VersionRestoreFlags {
+  owner: string;
+}
+
+export interface SharePointRestoreVersionOptions
+  extends SharePointTenantOptions, VersionRestoreFlags {
+  site: string;
+}
+
+interface RestoredRow {
+  path: string;
+  version: string;
+  modified: string;
+  size: string;
+}
+
+const restored_columns: TableColumn<RestoredRow>[] = [
+  { key: 'path', header: 'Restored to' },
+  { key: 'version', header: 'Version' },
+  { key: 'modified', header: 'Modified' },
+  { key: 'size', header: 'Size', align: 'right' },
+];
+
+/** Turns CLI flags into service options, rejecting combinations that cannot mean anything. */
+export function build_version_restore_options(
+  flags: VersionRestoreFlags,
+): DriveVersionRestoreOptions {
+  if (flags.version !== undefined && flags.file === undefined) {
+    throw new Error('--version needs --file: a version id is only unique within one file');
+  }
+  if (flags.file === undefined && flags.before === undefined) {
+    throw new Error('Pass --file with --version, or --before for a bulk rollback');
+  }
+  if (flags.path !== undefined && flags.file !== undefined) {
+    throw new Error('--path scopes a bulk rollback and cannot be combined with --file');
+  }
+
+  let before: Date | undefined;
+  if (flags.before !== undefined) {
+    before = new Date(flags.before);
+    if (Number.isNaN(before.getTime())) {
+      throw new Error(`--before is not a valid date: '${flags.before}'`);
+    }
+  }
+
+  return {
+    ...(flags.file !== undefined ? { file_ref: flags.file } : {}),
+    ...(flags.version !== undefined ? { version_id: flags.version } : {}),
+    ...(before !== undefined ? { before } : {}),
+    ...(flags.path !== undefined ? { path_prefix: flags.path } : {}),
+    placement: flags.inPlace === true ? 'in-place' : 'copy',
+  };
+}
+
+/** Runs `atlas onedrive restore-version`. */
+export async function execute_onedrive_restore_version(
+  container: Container,
+  options: OneDriveRestoreVersionOptions,
+): Promise<void> {
+  const tenant_id = resolve_tenant_id(container, options);
+  const owner = await resolve_owner(container, tenant_id, options.owner);
+  const use_case = container.get<OneDriveVersionRestoreUseCase>(
+    ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN,
+  );
+  const result = await use_case.restore_onedrive_version(
+    tenant_id,
+    owner.object_id,
+    build_version_restore_options(options),
+  );
+  await report_version_restore('Atlas OneDrive Version Restore', result);
+}
+
+/** Runs `atlas sharepoint restore-version`. */
+export async function execute_sharepoint_restore_version(
+  container: Container,
+  options: SharePointRestoreVersionOptions,
+): Promise<void> {
+  const tenant_id = resolve_sharepoint_tenant_id(container, options);
+  const site_id = await resolve_site_id(container, tenant_id, options.site);
+  const use_case = container.get<SharePointVersionRestoreUseCase>(
+    SHAREPOINT_VERSION_RESTORE_USE_CASE_TOKEN,
+  );
+  const result = await use_case.restore_sharepoint_version(
+    tenant_id,
+    site_id,
+    build_version_restore_options(options),
+  );
+  await report_version_restore('Atlas SharePoint Version Restore', result);
+}
+
+/** Prints what was written, then what was not, then the placement guarantee. */
+async function report_version_restore(
+  title: string,
+  result: DriveVersionRestoreResult,
+): Promise<void> {
+  await render_static_view(<Banner title={title} />);
+
+  if (result.restored.length > 0) {
+    const rows: RestoredRow[] = result.restored.map((item) => ({
+      path: item.restored_to,
+      version: item.version_id ?? '(current)',
+      modified: item.last_modified_at ?? '-',
+      size: format_bytes(item.size_bytes),
+    }));
+    await render_static_view(<DataTable columns={restored_columns} rows={rows} />);
+  }
+
+  // Skips are the load-bearing output of a rollback: a file with no pre-cutoff
+  // version was not rolled back, and a silent run would read as complete.
+  for (const failure of result.errors) logger.warn(failure);
+
+  if (result.files_restored === 0) {
+    logger.warn(`Nothing restored. ${result.files_skipped} file(s) skipped.`);
+  } else {
+    logger.success(
+      `Restored ${result.files_restored} version(s), skipped ${result.files_skipped}.`,
+    );
+  }
+
+  logger.info(
+    result.placement === 'in-place'
+      ? 'Uploaded over the original path. The previous content is kept as an earlier version by Microsoft 365.'
+      : 'Written alongside the originals as "(restored ...)" copies. No live file was modified.',
+  );
+
+  if (result.interrupted) logger.warn('Run was interrupted before every version was restored.');
+}

--- a/packages/cli/src/commands/onedrive-catalog-command.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-catalog-command.handlers.tsx
@@ -1,3 +1,4 @@
+import { format_bytes } from '@/command-formatters';
 import type { Container } from 'inversify';
 import { logger } from '@wisecom/atlas-core';
 import type { OneDriveCatalogUseCase } from '@wisecom/atlas-types';
@@ -33,6 +34,9 @@ const snapshot_columns: TableColumn<SnapshotRow>[] = [
 ];
 
 interface FileVersionRow {
+  version: string;
+  modified: string;
+  size: string;
   backup_at: string;
   snapshot_id: string;
   change_type: string;
@@ -40,6 +44,11 @@ interface FileVersionRow {
 }
 
 const file_version_columns: TableColumn<FileVersionRow>[] = [
+  // Version and Modified come first: they are what `restore-version` consumes,
+  // and a listing that omits the id cannot be acted on.
+  { key: 'version', header: 'Version' },
+  { key: 'modified', header: 'Modified' },
+  { key: 'size', header: 'Size' },
   { key: 'backup_at', header: 'Backed up' },
   { key: 'snapshot_id', header: 'Snapshot' },
   { key: 'change_type', header: 'Change' },
@@ -87,6 +96,9 @@ export async function execute_onedrive_list_versions(
     return;
   }
   const rows: FileVersionRow[] = versions.map((ver) => ({
+    version: ver.version_id ?? '(current)',
+    modified: ver.last_modified_at ?? '-',
+    size: format_bytes(ver.size_bytes),
     backup_at: ver.backup_at,
     snapshot_id: ver.snapshot_id,
     change_type: ver.change_type,

--- a/packages/cli/src/commands/onedrive.command.ts
+++ b/packages/cli/src/commands/onedrive.command.ts
@@ -18,6 +18,10 @@ import {
   type OneDriveListVersionsOptions,
 } from '@/commands/onedrive-catalog-command.handlers';
 import {
+  execute_onedrive_restore_version,
+  type OneDriveRestoreVersionOptions,
+} from '@/commands/drive-version-restore.handlers';
+import {
   execute_onedrive_delete,
   execute_onedrive_status,
   type OneDriveDeleteOptions,
@@ -36,6 +40,7 @@ export function register_onedrive_command(program: Command, get_container: Conta
   register_onedrive_save(group, get_container);
   register_onedrive_list_snapshots(group, get_container);
   register_onedrive_list_versions(group, get_container);
+  register_onedrive_restore_version(group, get_container);
   register_onedrive_verify(group, get_container);
   register_onedrive_status(group, get_container);
   register_onedrive_delete(group, get_container);
@@ -122,6 +127,22 @@ function register_onedrive_list_versions(group: Command, get_container: Containe
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .action((options: OneDriveListVersionsOptions) =>
       execute_onedrive_list_versions(get_container(), options),
+    );
+}
+
+function register_onedrive_restore_version(group: Command, get_container: ContainerFactory): void {
+  group
+    .command('restore-version')
+    .description('Restore stored file versions back into OneDrive')
+    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
+    .option('-f, --file <ref>', 'file ID or path; required with --version')
+    .option('--version <id>', 'exact stored version to restore')
+    .option('--before <iso>', "restore each file's last version at or before this instant")
+    .option('--path <prefix>', 'limit a bulk rollback to this folder and below')
+    .option('--in-place', 'upload over the original file instead of writing a copy beside it')
+    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .action((options: OneDriveRestoreVersionOptions) =>
+      execute_onedrive_restore_version(get_container(), options),
     );
 }
 

--- a/packages/cli/src/commands/sharepoint-catalog.command.tsx
+++ b/packages/cli/src/commands/sharepoint-catalog.command.tsx
@@ -1,3 +1,4 @@
+import { format_bytes } from '@/command-formatters';
 import type { Command } from 'commander';
 import type { Container } from 'inversify';
 import type { AtlasConfig } from '@wisecom/atlas-core';
@@ -75,6 +76,9 @@ const snapshot_columns: TableColumn<SnapshotRow>[] = [
 ];
 
 interface FileVersionRow {
+  version: string;
+  modified: string;
+  size: string;
   backup_at: string;
   snapshot_id: string;
   change_type: string;
@@ -82,6 +86,11 @@ interface FileVersionRow {
 }
 
 const file_version_columns: TableColumn<FileVersionRow>[] = [
+  // Version and Modified come first: they are what `restore-version` consumes,
+  // and a listing that omits the id cannot be acted on.
+  { key: 'version', header: 'Version' },
+  { key: 'modified', header: 'Modified' },
+  { key: 'size', header: 'Size' },
   { key: 'backup_at', header: 'Backed up' },
   { key: 'snapshot_id', header: 'Snapshot' },
   { key: 'change_type', header: 'Change' },
@@ -131,6 +140,9 @@ async function execute_sharepoint_list_versions(
     return;
   }
   const rows: FileVersionRow[] = versions.map((ver) => ({
+    version: ver.version_id ?? '(current)',
+    modified: ver.last_modified_at ?? '-',
+    size: format_bytes(ver.size_bytes),
     backup_at: ver.backup_at,
     snapshot_id: ver.snapshot_id,
     change_type: ver.change_type,

--- a/packages/cli/src/commands/sharepoint.command.ts
+++ b/packages/cli/src/commands/sharepoint.command.ts
@@ -18,6 +18,10 @@ import {
   register_sharepoint_list_versions,
 } from '@/commands/sharepoint-catalog.command';
 import {
+  execute_sharepoint_restore_version,
+  type SharePointRestoreVersionOptions,
+} from '@/commands/drive-version-restore.handlers';
+import {
   execute_sharepoint_delete,
   execute_sharepoint_status,
   type SharePointDeleteOptions,
@@ -37,12 +41,32 @@ export function register_sharepoint_command(
   register_sharepoint_list_sites(group, get_container);
   register_sharepoint_list_snapshots(group, get_container);
   register_sharepoint_list_versions(group, get_container);
+  register_sharepoint_restore_version(group, get_container);
   register_sharepoint_backup(group, get_container);
   register_sharepoint_restore(group, get_container);
   register_sharepoint_save(group, get_container);
   register_sharepoint_verify(group, get_container);
   register_sharepoint_status(group, get_container);
   register_sharepoint_delete(group, get_container);
+}
+
+function register_sharepoint_restore_version(
+  group: Command,
+  get_container: ContainerFactory,
+): void {
+  group
+    .command('restore-version')
+    .description('Restore stored file versions back into a SharePoint library')
+    .requiredOption('--site <url-or-id>', 'SharePoint site URL or site ID')
+    .option('-f, --file <ref>', 'file ID or path; required with --version')
+    .option('--version <id>', 'exact stored version to restore')
+    .option('--before <iso>', "restore each file's last version at or before this instant")
+    .option('--path <prefix>', 'limit a bulk rollback to this folder and below')
+    .option('--in-place', 'upload over the original file instead of writing a copy beside it')
+    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
+    .action((options: SharePointRestoreVersionOptions) =>
+      execute_sharepoint_restore_version(get_container(), options),
+    );
 }
 
 function register_sharepoint_list_sites(group: Command, get_container: ContainerFactory): void {

--- a/packages/cli/tests/unit/drive-version-restore-options.test.ts
+++ b/packages/cli/tests/unit/drive-version-restore-options.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { build_version_restore_options } from '@/commands/drive-version-restore.handlers';
+
+describe('build_version_restore_options', () => {
+  it('maps a single-version restore', () => {
+    expect(
+      build_version_restore_options({ file: '/Documents/Report.docx', version: '3.0' }),
+    ).toEqual({
+      file_ref: '/Documents/Report.docx',
+      version_id: '3.0',
+      placement: 'copy',
+    });
+  });
+
+  it('defaults to the copy placement', () => {
+    const options = build_version_restore_options({ before: '2026-03-10T00:00:00Z' });
+
+    // The destructive-looking option has to be asked for by name.
+    expect(options.placement).toBe('copy');
+  });
+
+  it('selects in-place only when the flag is present', () => {
+    const options = build_version_restore_options({
+      before: '2026-03-10T00:00:00Z',
+      inPlace: true,
+    });
+
+    expect(options.placement).toBe('in-place');
+  });
+
+  it('parses the cutoff into a Date', () => {
+    const options = build_version_restore_options({ before: '2026-03-10T00:00:00Z' });
+
+    expect(options.before?.toISOString()).toBe('2026-03-10T00:00:00.000Z');
+  });
+
+  it('rejects a cutoff that is not a date', () => {
+    expect(() => build_version_restore_options({ before: 'last tuesday' })).toThrow(
+      /not a valid date/,
+    );
+  });
+
+  it('rejects --version without --file', () => {
+    // Version ids are per file, so '3.0' alone names nothing.
+    expect(() => build_version_restore_options({ version: '3.0' })).toThrow(
+      /--version needs --file/,
+    );
+  });
+
+  it('rejects a run with neither a file nor a cutoff', () => {
+    expect(() => build_version_restore_options({})).toThrow(/--file with --version, or --before/);
+  });
+
+  it('rejects --path combined with --file', () => {
+    // A folder scope and a single file are two different requests, and
+    // silently ignoring one of them would restore the wrong set.
+    expect(() =>
+      build_version_restore_options({ file: '/a.docx', version: '1.0', path: '/Documents' }),
+    ).toThrow(/cannot be combined with --file/);
+  });
+
+  it('omits absent flags rather than passing undefined through', () => {
+    const options = build_version_restore_options({ before: '2026-03-10T00:00:00Z' });
+
+    // exactOptionalPropertyTypes is on: an explicit undefined is not the same
+    // as an absent key for the service's option checks.
+    expect('file_ref' in options).toBe(false);
+    expect('version_id' in options).toBe(false);
+    expect('path_prefix' in options).toBe(false);
+  });
+});

--- a/packages/onedrive/src/container.ts
+++ b/packages/onedrive/src/container.ts
@@ -6,6 +6,7 @@ import {
   ONEDRIVE_DELTA_CURSOR_REPOSITORY_TOKEN,
   ONEDRIVE_BACKUP_USE_CASE_TOKEN,
   ONEDRIVE_CATALOG_USE_CASE_TOKEN,
+  ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN,
   ONEDRIVE_VERIFICATION_USE_CASE_TOKEN,
   ONEDRIVE_RESTORE_USE_CASE_TOKEN,
   ONEDRIVE_SAVE_USE_CASE_TOKEN,
@@ -19,6 +20,7 @@ import { S3OneDriveFileVersionIndexRepository } from '@/adapters/s3-onedrive-fil
 import { OneDriveBackupService } from '@/services/onedrive-backup.service';
 import { OneDriveRestoreService } from '@/services/onedrive-restore.service';
 import { OneDriveSaveService } from '@/services/onedrive-save.service';
+import { OneDriveVersionRestoreService } from '@/services/onedrive-version-restore.service';
 import { OneDriveCatalogService } from '@/services/onedrive-catalog.service';
 import { OneDriveVerificationService } from '@/services/onedrive-verification.service';
 import { OneDriveStatusService } from '@/services/status/onedrive-status.service';
@@ -46,6 +48,10 @@ export function bind_onedrive(container: Container): void {
     .inSingletonScope();
   container.bind(ONEDRIVE_BACKUP_USE_CASE_TOKEN).to(OneDriveBackupService).inSingletonScope();
   container.bind(ONEDRIVE_CATALOG_USE_CASE_TOKEN).to(OneDriveCatalogService).inSingletonScope();
+  container
+    .bind(ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN)
+    .to(OneDriveVersionRestoreService)
+    .inSingletonScope();
   container
     .bind(ONEDRIVE_VERIFICATION_USE_CASE_TOKEN)
     .to(OneDriveVerificationService)

--- a/packages/onedrive/src/services/index.ts
+++ b/packages/onedrive/src/services/index.ts
@@ -1,5 +1,6 @@
 export { OneDriveBackupService } from './onedrive-backup.service';
 export { OneDriveRestoreService } from './onedrive-restore.service';
+export { OneDriveVersionRestoreService } from './onedrive-version-restore.service';
 export { OneDriveSaveService } from './onedrive-save.service';
 export { sync_file_versions } from './onedrive-version-sync';
 export { classify_change_type } from './onedrive-change-classifier';

--- a/packages/onedrive/src/services/onedrive-blob-restore.ts
+++ b/packages/onedrive/src/services/onedrive-blob-restore.ts
@@ -1,0 +1,91 @@
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import { is_gcm_auth_failure } from '@wisecom/atlas-core/utils/gcm-auth';
+import type { StoredBlobRef, TenantContext } from '@wisecom/atlas-types';
+import {
+  should_stream_restore,
+  stream_decrypt_from_storage,
+  verify_streaming_checksum,
+} from '@/services/onedrive-restore-streaming';
+import {
+  OneDriveDecryptAuthError,
+  plaintext_sha256_equals_expected,
+} from '@/services/onedrive-restore-integrity';
+
+/**
+ * Fetches and decrypts one stored blob, or undefined when it cannot be trusted.
+ *
+ * Returning undefined rather than throwing lets a bulk restore skip one bad
+ * object and report it, instead of losing the whole run. An AES-GCM auth
+ * failure is thrown instead of swallowed, so a caller can tell "wrong key or
+ * tampered ciphertext" from "one unreadable object" rather than reporting the
+ * first as the second (issue #76).
+ */
+export async function download_and_decrypt_blob(
+  ctx: TenantContext,
+  ref: StoredBlobRef,
+): Promise<Buffer | undefined> {
+  if (!ref.storage_key) return undefined;
+  return should_stream_restore(ref)
+    ? stream_download_and_decrypt(ctx, ref)
+    : buffered_download_and_decrypt(ctx, ref);
+}
+
+/** Streaming path: avoids holding the full ciphertext in memory for large files. */
+async function stream_download_and_decrypt(
+  ctx: TenantContext,
+  ref: StoredBlobRef,
+): Promise<Buffer | undefined> {
+  try {
+    const { content, sha256_hex } = await stream_decrypt_from_storage(ctx, ref.storage_key!);
+    if (!verify_streaming_checksum(ref, sha256_hex)) return undefined;
+    return content;
+  } catch (err) {
+    if (is_gcm_auth_failure(err)) {
+      throw new OneDriveDecryptAuthError(`AES-GCM authentication failed for ${ref.file_name}`, {
+        cause: err,
+      });
+    }
+    logger.warn(
+      `Streaming decrypt failed for ${ref.file_name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+}
+
+/** Buffered path: simple and safe for small files at or below the stream threshold. */
+async function buffered_download_and_decrypt(
+  ctx: TenantContext,
+  ref: StoredBlobRef,
+): Promise<Buffer | undefined> {
+  let encrypted: Buffer;
+  try {
+    encrypted = await ctx.storage.get(ref.storage_key!);
+  } catch (err) {
+    logger.warn(
+      `Missing or unreadable blob for ${ref.file_name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+  try {
+    const content = ctx.decrypt(encrypted);
+    if (!ref.checksum || !plaintext_sha256_equals_expected(content, ref.checksum)) {
+      logger.warn(
+        ref.checksum
+          ? `Checksum mismatch after decrypt for ${ref.file_name}; skipping restore`
+          : `Missing checksum for ${ref.file_name}; skipping restore`,
+      );
+      return undefined;
+    }
+    return content;
+  } catch (err) {
+    if (is_gcm_auth_failure(err)) {
+      throw new OneDriveDecryptAuthError(`AES-GCM authentication failed for ${ref.file_name}`, {
+        cause: err,
+      });
+    }
+    logger.warn(
+      `Failed to decrypt ${ref.file_name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+}

--- a/packages/onedrive/src/services/onedrive-catalog.service.ts
+++ b/packages/onedrive/src/services/onedrive-catalog.service.ts
@@ -1,8 +1,8 @@
+import { resolve_file_id } from '@/services/onedrive-version-reference';
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {
   OneDriveCatalogUseCase,
-  OneDriveFileVersionIndex,
   OneDriveFileVersionIndexRepository,
   OneDriveFileVersionRecord,
   OneDriveManifestRepository,
@@ -60,64 +60,4 @@ export class OneDriveCatalogService implements OneDriveCatalogUseCase {
       ctx.destroy();
     }
   }
-}
-
-/** Maps a CLI file reference (Graph item id or rooted path) to a file id, if known. */
-function resolve_file_id(
-  indexes: OneDriveFileVersionIndex[],
-  file_ref: string,
-): string | undefined {
-  const trimmed = file_ref.trim();
-  if (!looks_like_path(trimmed)) {
-    if (indexes.some((idx) => idx.file_id === trimmed)) return trimmed;
-    return match_by_file_name(indexes, trimmed);
-  }
-  const want = normalize_path_ref(trimmed);
-  for (const idx of indexes) {
-    for (const v of idx.versions) {
-      if (normalize_path_ref(version_logical_path(v)) === want) return idx.file_id;
-    }
-  }
-  return undefined;
-}
-
-/**
- * Matches a bare filename against every indexed version of the owner's files.
- * Throws with the candidate paths when the name maps to more than one file.
- */
-function match_by_file_name(
-  indexes: OneDriveFileVersionIndex[],
-  file_name: string,
-): string | undefined {
-  const matches = new Map<string, string>();
-  for (const idx of indexes) {
-    for (const v of idx.versions) {
-      if (v.file_name === file_name) matches.set(idx.file_id, version_logical_path(v));
-    }
-  }
-  if (matches.size > 1) {
-    const candidates = [...new Set(matches.values())].sort().join(', ');
-    throw new Error(
-      `'${file_name}' matches ${matches.size} files: ${candidates}. Pass a full path instead.`,
-    );
-  }
-  return [...matches.keys()][0];
-}
-
-/** Paths contain a slash; Graph ids do not. */
-function looks_like_path(ref: string): boolean {
-  return ref.includes('/') || ref.includes('\\');
-}
-
-/** NFC-normalized path string comparable to stored manifest/index paths. */
-function normalize_path_ref(raw: string): string {
-  const unified = raw.replace(/\\/g, '/').trim();
-  const with_slash = unified.startsWith('/') ? unified : `/${unified}`;
-  return with_slash.normalize('NFC');
-}
-
-function version_logical_path(v: OneDriveFileVersionRecord): string {
-  const base = v.parent_path.replace(/\/+$/, '') || '';
-  if (base === '' || base === '/') return `/${v.file_name}`;
-  return `${base}/${v.file_name}`;
 }

--- a/packages/onedrive/src/services/onedrive-restore-streaming.ts
+++ b/packages/onedrive/src/services/onedrive-restore-streaming.ts
@@ -1,4 +1,3 @@
-import type { OneDriveManifestEntry } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
 export {
@@ -10,13 +9,13 @@ export {
 const STREAM_THRESHOLD_BYTES = 4 * 1024 * 1024;
 
 /** Checks whether a file should use stream-based restore. */
-export function should_stream_restore(entry: OneDriveManifestEntry): boolean {
+export function should_stream_restore(entry: { size_bytes: number }): boolean {
   return entry.size_bytes > STREAM_THRESHOLD_BYTES;
 }
 
 /** Verifies the computed SHA-256 against the manifest entry. */
 export function verify_streaming_checksum(
-  entry: OneDriveManifestEntry,
+  entry: { checksum?: string | undefined; file_name: string },
   sha256_hex: string,
 ): boolean {
   if (!entry.checksum) {

--- a/packages/onedrive/src/services/onedrive-restore.service.ts
+++ b/packages/onedrive/src/services/onedrive-restore.service.ts
@@ -21,16 +21,8 @@ import {
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
-import {
-  should_stream_restore,
-  stream_decrypt_from_storage,
-  verify_streaming_checksum,
-} from '@/services/onedrive-restore-streaming';
-import { is_gcm_auth_failure } from '@wisecom/atlas-core/utils/gcm-auth';
-import {
-  OneDriveDecryptAuthError,
-  plaintext_sha256_equals_expected,
-} from '@/services/onedrive-restore-integrity';
+import { download_and_decrypt_blob } from '@/services/onedrive-blob-restore';
+import { OneDriveDecryptAuthError } from '@/services/onedrive-restore-integrity';
 import { filter_onedrive_entries } from '@/services/onedrive-entry-filter';
 import {
   load_onedrive_chain_entries,
@@ -182,7 +174,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
         return { restored: false, error: `Could not create folder path: ${target_path}` };
       }
 
-      const content = await this.download_and_decrypt(ctx, entry);
+      const content = await download_and_decrypt_blob(ctx, entry);
       if (!content) {
         return { restored: false };
       }
@@ -222,80 +214,6 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       const msg = `${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`;
       logger.warn(`Skipped ${entry.file_name}: ${msg}`);
       return { restored: false, error: msg };
-    }
-  }
-
-  private async download_and_decrypt(
-    ctx: TenantContext,
-    entry: OneDriveManifestEntry,
-  ): Promise<Buffer | undefined> {
-    if (!entry.storage_key) return undefined;
-
-    if (should_stream_restore(entry)) {
-      return this.stream_download_and_decrypt(ctx, entry);
-    }
-
-    return this.buffered_download_and_decrypt(ctx, entry);
-  }
-
-  /** Streaming path: avoids holding the full ciphertext in memory for large files. */
-  private async stream_download_and_decrypt(
-    ctx: TenantContext,
-    entry: OneDriveManifestEntry,
-  ): Promise<Buffer | undefined> {
-    try {
-      const { content, sha256_hex } = await stream_decrypt_from_storage(ctx, entry.storage_key!);
-      if (!verify_streaming_checksum(entry, sha256_hex)) return undefined;
-      return content;
-    } catch (err) {
-      if (is_gcm_auth_failure(err)) {
-        throw new OneDriveDecryptAuthError(`AES-GCM authentication failed for ${entry.file_name}`, {
-          cause: err,
-        });
-      }
-      logger.warn(
-        `Streaming decrypt failed for ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-
-  /** Buffered path: simple and safe for small files at or below SMALL_FILE_LIMIT. */
-  private async buffered_download_and_decrypt(
-    ctx: TenantContext,
-    entry: OneDriveManifestEntry,
-  ): Promise<Buffer | undefined> {
-    let encrypted: Buffer;
-    try {
-      encrypted = await ctx.storage.get(entry.storage_key!);
-    } catch (err) {
-      logger.warn(
-        `Missing or unreadable blob for ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-    try {
-      const content = ctx.decrypt(encrypted);
-      const expected = entry.checksum;
-      if (!expected || !plaintext_sha256_equals_expected(content, expected)) {
-        logger.warn(
-          expected
-            ? `Checksum mismatch after decrypt for ${entry.file_name}; skipping restore`
-            : `Missing checksum for ${entry.file_name}; skipping restore`,
-        );
-        return undefined;
-      }
-      return content;
-    } catch (err) {
-      if (is_gcm_auth_failure(err)) {
-        throw new OneDriveDecryptAuthError(`AES-GCM authentication failed for ${entry.file_name}`, {
-          cause: err,
-        });
-      }
-      logger.warn(
-        `Failed to decrypt ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
     }
   }
 }

--- a/packages/onedrive/src/services/onedrive-version-placement.ts
+++ b/packages/onedrive/src/services/onedrive-version-placement.ts
@@ -1,0 +1,42 @@
+import type { DriveVersionPlacement, OneDriveFileVersionRecord } from '@wisecom/atlas-types';
+
+/** Splits a rooted file path into its parent path and file name. */
+export function split_parent_path(path: string): { parent_path: string; file_name: string } {
+  const cut = path.lastIndexOf('/');
+  if (cut <= 0) return { parent_path: '/', file_name: path.slice(cut + 1) };
+  return { parent_path: path.slice(0, cut), file_name: path.slice(cut + 1) };
+}
+
+/**
+ * Names the file the restored bytes are written to.
+ *
+ * `in-place` keeps the original name, so the service records a new current
+ * version of the same file. `copy` appends the version's own modification
+ * time before the extension, which keeps the restored file adjacent to the
+ * original in a sorted listing and states which point in time it came from.
+ */
+export function build_restored_file_name(
+  version: OneDriveFileVersionRecord,
+  placement: DriveVersionPlacement,
+): string {
+  if (placement === 'in-place') return version.file_name;
+
+  const stamp = restored_stamp(version);
+  const dot = version.file_name.lastIndexOf('.');
+  // A leading dot is the whole name of a dotfile, not an extension.
+  if (dot <= 0) return `${version.file_name} (restored ${stamp})`;
+  return `${version.file_name.slice(0, dot)} (restored ${stamp})${version.file_name.slice(dot)}`;
+}
+
+/**
+ * Filename-safe instant for the restored copy, in UTC.
+ *
+ * Colons are legal in OneDrive but break the file on export to Windows, and
+ * Atlas exports archives, so they never enter a name it creates.
+ */
+function restored_stamp(version: OneDriveFileVersionRecord): string {
+  const raw = version.last_modified_at ?? version.backup_at;
+  const parsed = new Date(raw);
+  const iso = Number.isNaN(parsed.getTime()) ? raw : parsed.toISOString();
+  return iso.replace(/\.\d+Z$/, 'Z').replace(/[:]/g, '-');
+}

--- a/packages/onedrive/src/services/onedrive-version-reference.ts
+++ b/packages/onedrive/src/services/onedrive-version-reference.ts
@@ -1,0 +1,61 @@
+import type { OneDriveFileVersionIndex, OneDriveFileVersionRecord } from '@wisecom/atlas-types';
+
+/** Maps a CLI file reference (Graph item id or rooted path) to a file id, if known. */
+export function resolve_file_id(
+  indexes: OneDriveFileVersionIndex[],
+  file_ref: string,
+): string | undefined {
+  const trimmed = file_ref.trim();
+  if (!looks_like_path(trimmed)) {
+    if (indexes.some((idx) => idx.file_id === trimmed)) return trimmed;
+    return match_by_file_name(indexes, trimmed);
+  }
+  const want = normalize_path_ref(trimmed);
+  for (const idx of indexes) {
+    for (const v of idx.versions) {
+      if (normalize_path_ref(version_logical_path(v)) === want) return idx.file_id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Matches a bare filename against every indexed version of the owner's files.
+ * Throws with the candidate paths when the name maps to more than one file.
+ */
+function match_by_file_name(
+  indexes: OneDriveFileVersionIndex[],
+  file_name: string,
+): string | undefined {
+  const matches = new Map<string, string>();
+  for (const idx of indexes) {
+    for (const v of idx.versions) {
+      if (v.file_name === file_name) matches.set(idx.file_id, version_logical_path(v));
+    }
+  }
+  if (matches.size > 1) {
+    const candidates = [...new Set(matches.values())].sort().join(', ');
+    throw new Error(
+      `'${file_name}' matches ${matches.size} files: ${candidates}. Pass a full path instead.`,
+    );
+  }
+  return [...matches.keys()][0];
+}
+
+/** Paths contain a slash; Graph ids do not. */
+function looks_like_path(ref: string): boolean {
+  return ref.includes('/') || ref.includes('\\');
+}
+
+/** NFC-normalized path string comparable to stored manifest/index paths. */
+function normalize_path_ref(raw: string): string {
+  const unified = raw.replace(/\\/g, '/').trim();
+  const with_slash = unified.startsWith('/') ? unified : `/${unified}`;
+  return with_slash.normalize('NFC');
+}
+
+export function version_logical_path(v: OneDriveFileVersionRecord): string {
+  const base = v.parent_path.replace(/\/+$/, '') || '';
+  if (base === '' || base === '/') return `/${v.file_name}`;
+  return `${base}/${v.file_name}`;
+}

--- a/packages/onedrive/src/services/onedrive-version-restore.service.ts
+++ b/packages/onedrive/src/services/onedrive-version-restore.service.ts
@@ -1,0 +1,229 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
+import { inject, injectable } from 'inversify';
+import type {
+  DriveRestoredVersion,
+  DriveVersionPlacement,
+  DriveVersionRestoreOptions,
+  DriveVersionRestoreResult,
+  OneDriveConnector,
+  OneDriveFileVersionIndexRepository,
+  OneDriveVersionRestoreUseCase,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import {
+  ONEDRIVE_CONNECTOR_TOKEN,
+  ONEDRIVE_FILE_VERSION_INDEX_REPOSITORY_TOKEN,
+  TENANT_CONTEXT_FACTORY_TOKEN,
+} from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import { download_and_decrypt_blob } from '@/services/onedrive-blob-restore';
+import { ensure_onedrive_folder_path } from '@/services/onedrive-restore-folder-path';
+import {
+  select_versions_to_restore,
+  type SelectedVersion,
+} from '@/services/onedrive-version-selection';
+import { build_restored_file_name, split_parent_path } from '@/services/onedrive-version-placement';
+
+const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
+
+/**
+ * Pushes stored OneDrive version bytes back into a live drive.
+ *
+ * Uploads the bytes Atlas holds rather than calling Graph's `restoreVersion`.
+ * `restoreVersion` promotes a version the *service* still has, so it cannot
+ * help once version history is trimmed or the file is gone, and its result
+ * cannot be checked against the manifest checksum. Uploading a verified copy
+ * is the only path that guarantees the operator gets what the backup recorded.
+ */
+@injectable()
+export class OneDriveVersionRestoreService implements OneDriveVersionRestoreUseCase {
+  constructor(
+    @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
+    @inject(ONEDRIVE_CONNECTOR_TOKEN) private readonly _connector: OneDriveConnector,
+    @inject(ONEDRIVE_FILE_VERSION_INDEX_REPOSITORY_TOKEN)
+    private readonly _indexes: OneDriveFileVersionIndexRepository,
+  ) {}
+
+  /** Restores one stored version, or every file's last version before a cutoff. */
+  async restore_onedrive_version(
+    tenant_id: string,
+    owner_id: string,
+    options: DriveVersionRestoreOptions,
+  ): Promise<DriveVersionRestoreResult> {
+    owner_id = normalize_owner_id(owner_id);
+    const placement: DriveVersionPlacement = options.placement ?? 'copy';
+
+    if (begin_operation_progress(options, 'restore', 'onedrive')) {
+      finish_operation_progress(options, 'restore', 'onedrive', 0, 0);
+      return empty_version_result(placement);
+    }
+
+    const ctx = await this._tenant_factory.create(tenant_id);
+    try {
+      const indexes = await this._indexes.list_by_owner(ctx, owner_id);
+      const selection = select_versions_to_restore(indexes, options);
+
+      // The version row records the drive it came from, so a version restore
+      // needs no drive lookup and stays correct for an owner with several
+      // drives, where "the first drive" would be a guess.
+      const folder_ids_by_drive = new Map<string, Map<string, string>>();
+      const restored: DriveRestoredVersion[] = [];
+      const errors: string[] = [...selection.skipped];
+      let files_skipped = selection.skipped.length;
+
+      emit_operation_progress(options, {
+        operation: 'restore',
+        workload: 'onedrive',
+        phase: 'processing',
+        processed: 0,
+        total: selection.selected.length,
+      });
+
+      for (const [index, candidate] of selection.selected.entries()) {
+        if (options.should_interrupt?.() === true) break;
+        const outcome = await this.restore_one_version(
+          tenant_id,
+          owner_id,
+          ctx,
+          folder_ids_by_drive,
+          candidate,
+          placement,
+        );
+        if (outcome.restored) restored.push(outcome.restored);
+        else {
+          files_skipped++;
+          if (outcome.error) errors.push(outcome.error);
+        }
+        emit_operation_progress(options, {
+          operation: 'restore',
+          workload: 'onedrive',
+          phase: 'processing',
+          processed: index + 1,
+          total: selection.selected.length,
+          current: candidate.version.file_name,
+        });
+      }
+
+      const interrupted = finish_operation_progress(
+        options,
+        'restore',
+        'onedrive',
+        restored.length + files_skipped,
+        selection.selected.length + selection.skipped.length,
+        restored.length + files_skipped < selection.selected.length,
+      );
+
+      return {
+        files_restored: restored.length,
+        files_skipped,
+        restored,
+        errors,
+        interrupted,
+        placement,
+      };
+    } finally {
+      ctx.destroy();
+    }
+  }
+
+  /** Fetches one stored version and uploads it, honouring the placement choice. */
+  private async restore_one_version(
+    tenant_id: string,
+    owner_id: string,
+    ctx: TenantContext,
+    folder_ids_by_drive: Map<string, Map<string, string>>,
+    candidate: SelectedVersion,
+    placement: DriveVersionPlacement,
+  ): Promise<{ restored?: DriveRestoredVersion; error?: string }> {
+    const { version, original_path } = candidate;
+    const drive_id = version.drive_id;
+    try {
+      const content = await download_and_decrypt_blob(ctx, version);
+      if (!content) {
+        return { error: `${original_path}: stored version could not be read or verified` };
+      }
+
+      // Folder ids are cached per drive: the same path exists in more than one
+      // drive of the same owner and means a different folder in each.
+      let folder_ids = folder_ids_by_drive.get(drive_id);
+      if (!folder_ids) {
+        folder_ids = new Map<string, string>([['/', 'root']]);
+        folder_ids_by_drive.set(drive_id, folder_ids);
+      }
+
+      const { parent_path } = split_parent_path(original_path);
+      const parent_id = await ensure_onedrive_folder_path(
+        this._connector,
+        tenant_id,
+        owner_id,
+        drive_id,
+        parent_path,
+        folder_ids,
+      );
+      if (!parent_id) {
+        return { error: `${original_path}: could not resolve or create ${parent_path}` };
+      }
+
+      const file_name = build_restored_file_name(version, placement);
+      // 'replace' on the original path becomes a new service version and
+      // leaves the old current one in history; 'fail' guarantees a sibling
+      // copy never silently overwrites something already there.
+      const conflict = placement === 'in-place' ? 'replace' : 'fail';
+      // Issue #242: without this the service stamps the restore time, and the
+      // rolled-back file looks like it was authored during the incident.
+      const file_system_info = version.last_modified_at
+        ? { last_modified_at: version.last_modified_at }
+        : undefined;
+      const args = [
+        tenant_id,
+        owner_id,
+        drive_id,
+        parent_id,
+        file_name,
+        content,
+        conflict,
+        file_system_info,
+      ] as const;
+      if (content.length <= SMALL_FILE_LIMIT) {
+        await this._connector.upload_small_file(...args);
+      } else {
+        await this._connector.upload_large_file(...args);
+      }
+
+      const restored_to = parent_path === '/' ? `/${file_name}` : `${parent_path}/${file_name}`;
+      logger.info(
+        `Restored version ${version.version_id ?? '(current-state row)'} to ${restored_to}`,
+      );
+      return {
+        restored: {
+          file_id: candidate.file_id,
+          version_id: version.version_id,
+          last_modified_at: version.last_modified_at,
+          size_bytes: version.size_bytes,
+          restored_to,
+        },
+      };
+    } catch (err) {
+      const msg = `${original_path}: ${err instanceof Error ? err.message : String(err)}`;
+      logger.warn(`Skipped ${msg}`);
+      return { error: msg };
+    }
+  }
+}
+
+function empty_version_result(placement: DriveVersionPlacement): DriveVersionRestoreResult {
+  return {
+    files_restored: 0,
+    files_skipped: 0,
+    restored: [],
+    errors: [],
+    interrupted: true,
+    placement,
+  };
+}

--- a/packages/onedrive/src/services/onedrive-version-selection.ts
+++ b/packages/onedrive/src/services/onedrive-version-selection.ts
@@ -1,0 +1,179 @@
+import type {
+  DriveVersionRestoreOptions,
+  OneDriveFileVersionIndex,
+  OneDriveFileVersionRecord,
+} from '@wisecom/atlas-types';
+import { resolve_file_id, version_logical_path } from '@/services/onedrive-version-reference';
+
+export interface SelectedVersion {
+  readonly file_id: string;
+  readonly version: OneDriveFileVersionRecord;
+  /** Original rooted path of the file, e.g. `/Documents/Report.docx`. */
+  readonly original_path: string;
+}
+
+export interface VersionSelection {
+  readonly selected: SelectedVersion[];
+  /** Files in scope that had no restorable version, with the reason. */
+  readonly skipped: string[];
+}
+
+/**
+ * The instant a stored version's content was last modified in Microsoft 365.
+ *
+ * Rows written by version sync carry `last_modified_at`; rows copied from a
+ * manifest entry may not, and then the backup time is the only thing known.
+ * A rollback is expressed in service time ("before the attack"), so service
+ * time is what the cutoff compares against wherever it exists.
+ */
+function version_instant(version: OneDriveFileVersionRecord): string {
+  return version.last_modified_at ?? version.backup_at;
+}
+
+/** A version is restorable only when its bytes were stored and can be verified. */
+function has_restorable_blob(version: OneDriveFileVersionRecord): boolean {
+  return Boolean(version.storage_key) && Boolean(version.checksum);
+}
+
+/**
+ * Picks which stored versions to push back, from the owner's whole version index.
+ *
+ * Three modes, all resolved here so the service stays orchestration only:
+ * one exact version, the newest version of one file before a cutoff, or the
+ * newest version of every file in scope before a cutoff.
+ */
+export function select_versions_to_restore(
+  indexes: OneDriveFileVersionIndex[],
+  options: DriveVersionRestoreOptions,
+): VersionSelection {
+  if (options.file_ref === undefined && options.before === undefined) {
+    throw new Error('Pass a file reference with --version, or --before for a bulk rollback');
+  }
+
+  if (options.file_ref !== undefined) {
+    return select_for_one_file(indexes, options);
+  }
+  return select_before_cutoff(indexes, options);
+}
+
+/** Single-file mode: an exact `version_id`, or the newest version before a cutoff. */
+function select_for_one_file(
+  indexes: OneDriveFileVersionIndex[],
+  options: DriveVersionRestoreOptions,
+): VersionSelection {
+  const file_ref = options.file_ref!;
+  const file_id = resolve_file_id(indexes, file_ref);
+  if (!file_id) {
+    throw new Error(`No stored versions found for '${file_ref}'`);
+  }
+  const versions = indexes.find((idx) => idx.file_id === file_id)?.versions ?? [];
+
+  if (options.version_id !== undefined) {
+    const wanted = versions.find((v) => v.version_id === options.version_id);
+    if (!wanted) {
+      const known = versions
+        .map((v) => v.version_id)
+        .filter((id): id is string => id !== undefined);
+      throw new Error(
+        known.length > 0
+          ? `Version '${options.version_id}' not stored for '${file_ref}'. Stored: ${known.join(', ')}`
+          : `No identified versions stored for '${file_ref}'; only current-state rows`,
+      );
+    }
+    if (!has_restorable_blob(wanted)) {
+      throw new Error(
+        `Version '${options.version_id}' of '${file_ref}' has no stored content to restore`,
+      );
+    }
+    return {
+      selected: [{ file_id, version: wanted, original_path: version_logical_path(wanted) }],
+      skipped: [],
+    };
+  }
+
+  if (options.before === undefined) {
+    throw new Error(
+      `Pass --version or --before to choose which version of '${file_ref}' to restore`,
+    );
+  }
+  const newest = newest_before(versions, options.before);
+  if (!newest) {
+    return { selected: [], skipped: [`${file_ref}: no stored version at or before the cutoff`] };
+  }
+  return {
+    selected: [{ file_id, version: newest, original_path: version_logical_path(newest) }],
+    skipped: [],
+  };
+}
+
+/** Bulk mode: the newest pre-cutoff version of every file under the path scope. */
+function select_before_cutoff(
+  indexes: OneDriveFileVersionIndex[],
+  options: DriveVersionRestoreOptions,
+): VersionSelection {
+  const cutoff = options.before!;
+  const prefix = normalize_prefix(options.path_prefix);
+  const selected: SelectedVersion[] = [];
+  const skipped: string[] = [];
+
+  for (const idx of indexes) {
+    const in_scope = idx.versions.filter((v) => path_in_scope(version_logical_path(v), prefix));
+    if (in_scope.length === 0) continue;
+
+    const newest = newest_before(in_scope, cutoff);
+    if (!newest) {
+      // Every version of this file is newer than the cutoff, so Atlas holds
+      // nothing from before the event. Naming it matters: an operator must not
+      // read a clean run as "every file rolled back".
+      const path = version_logical_path(in_scope[in_scope.length - 1]!);
+      skipped.push(`${path}: no stored version at or before the cutoff`);
+      continue;
+    }
+    selected.push({
+      file_id: idx.file_id,
+      version: newest,
+      original_path: version_logical_path(newest),
+    });
+  }
+
+  return { selected, skipped };
+}
+
+/** Newest restorable version at or before the cutoff, or undefined when none is. */
+function newest_before(
+  versions: readonly OneDriveFileVersionRecord[],
+  cutoff: Date,
+): OneDriveFileVersionRecord | undefined {
+  const limit = cutoff.getTime();
+  let best: OneDriveFileVersionRecord | undefined;
+  let best_time = -Infinity;
+  for (const version of versions) {
+    if (!has_restorable_blob(version)) continue;
+    const time = new Date(version_instant(version)).getTime();
+    if (Number.isNaN(time) || time > limit) continue;
+    // `>=` keeps the last row at an identical timestamp: Graph timestamps have
+    // second precision, and the index is already ordered oldest first.
+    if (time >= best_time) {
+      best = version;
+      best_time = time;
+    }
+  }
+  return best;
+}
+
+/** Rooted, NFC-normalized prefix with no trailing slash; undefined means the whole drive. */
+function normalize_prefix(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  const unified = raw.replace(/\\/g, '/').trim();
+  const rooted = unified.startsWith('/') ? unified : `/${unified}`;
+  const trimmed = rooted.replace(/\/+$/, '');
+  return (trimmed === '' ? '/' : trimmed).normalize('NFC');
+}
+
+/** Whether a file path sits at or under the scope prefix. */
+function path_in_scope(path: string, prefix: string | undefined): boolean {
+  if (prefix === undefined || prefix === '/') return true;
+  const normalized = path.normalize('NFC');
+  // Segment-boundary match, so `/Docs` never captures `/Docs Archive`.
+  return normalized === prefix || normalized.startsWith(`${prefix}/`);
+}

--- a/packages/onedrive/tests/unit/services/version-placement.test.ts
+++ b/packages/onedrive/tests/unit/services/version-placement.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
+import type { OneDriveFileVersionRecord } from '@wisecom/atlas-types';
+import { build_restored_file_name, split_parent_path } from '@/services/onedrive-version-placement';
+
+function version(overrides: Overrides<OneDriveFileVersionRecord> = {}): OneDriveFileVersionRecord {
+  return apply_overrides<OneDriveFileVersionRecord>(
+    {
+      snapshot_id: 'snap-1',
+      backup_at: '2026-03-02T09:30:00.000Z',
+      drive_id: 'drive-1',
+      file_name: 'Report.docx',
+      parent_path: '/Documents',
+      size_bytes: 10,
+      change_type: 'updated',
+      last_modified_at: '2026-03-01T08:15:00.000Z',
+    } as OneDriveFileVersionRecord,
+    overrides,
+  );
+}
+
+describe('split_parent_path', () => {
+  it('splits a nested path', () => {
+    expect(split_parent_path('/Documents/Reports/Q1.docx')).toEqual({
+      parent_path: '/Documents/Reports',
+      file_name: 'Q1.docx',
+    });
+  });
+
+  it('treats a file at the drive root as living in the root folder', () => {
+    expect(split_parent_path('/Report.docx')).toEqual({
+      parent_path: '/',
+      file_name: 'Report.docx',
+    });
+  });
+});
+
+describe('build_restored_file_name', () => {
+  it('keeps the original name in place', () => {
+    expect(build_restored_file_name(version(), 'in-place')).toBe('Report.docx');
+  });
+
+  it('stamps the version time before the extension for a copy', () => {
+    // The extension has to survive, or Office refuses to open the recovery.
+    expect(build_restored_file_name(version(), 'copy')).toBe(
+      'Report (restored 2026-03-01T08-15-00Z).docx',
+    );
+  });
+
+  it('never puts a colon in a name it creates', () => {
+    const name = build_restored_file_name(version(), 'copy');
+
+    // Colons are legal in OneDrive and illegal on Windows, and Atlas exports
+    // these files into zip archives that land on Windows.
+    expect(name).not.toContain(':');
+  });
+
+  it('falls back to the backup time when no modification time was recorded', () => {
+    const name = build_restored_file_name(version({ last_modified_at: undefined }), 'copy');
+
+    expect(name).toBe('Report (restored 2026-03-02T09-30-00Z).docx');
+  });
+
+  it('appends to a name with no extension', () => {
+    expect(build_restored_file_name(version({ file_name: 'README' }), 'copy')).toBe(
+      'README (restored 2026-03-01T08-15-00Z)',
+    );
+  });
+
+  it('treats a dotfile name as having no extension', () => {
+    // '.gitignore' is the whole name, so splitting on the dot would produce
+    // ' (restored ...).gitignore' with an empty stem.
+    expect(build_restored_file_name(version({ file_name: '.gitignore' }), 'copy')).toBe(
+      '.gitignore (restored 2026-03-01T08-15-00Z)',
+    );
+  });
+
+  it('uses the last dot in a multi-extension name', () => {
+    expect(build_restored_file_name(version({ file_name: 'backup.tar.gz' }), 'copy')).toBe(
+      'backup.tar (restored 2026-03-01T08-15-00Z).gz',
+    );
+  });
+
+  it('keeps an unparseable timestamp verbatim rather than printing Invalid Date', () => {
+    const name = build_restored_file_name(
+      version({ last_modified_at: 'garbage', backup_at: 'garbage' }),
+      'copy',
+    );
+
+    expect(name).toBe('Report (restored garbage).docx');
+    expect(name).not.toContain('Invalid');
+  });
+});

--- a/packages/onedrive/tests/unit/services/version-restore.service.test.ts
+++ b/packages/onedrive/tests/unit/services/version-restore.service.test.ts
@@ -1,0 +1,250 @@
+import { createHash } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
+import type {
+  OneDriveConnector,
+  OneDriveFileVersionIndex,
+  OneDriveFileVersionIndexRepository,
+  OneDriveFileVersionRecord,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { stub_encrypted_object_store } from '@wisecom/atlas-types/testing/stub-encrypted-object-store';
+import { OneDriveVersionRestoreService } from '@/services/onedrive-version-restore.service';
+
+const TENANT_ID = 'tenant-1';
+const OWNER_ID = '00000000-0000-0000-0000-000000000001';
+const CUTOFF = new Date('2026-03-10T00:00:00Z');
+const CONTENT = Buffer.from('pre-attack content');
+const CHECKSUM = createHash('sha256').update(CONTENT).digest('hex');
+
+function version(overrides: Overrides<OneDriveFileVersionRecord> = {}): OneDriveFileVersionRecord {
+  return apply_overrides<OneDriveFileVersionRecord>(
+    {
+      snapshot_id: 'snap-1',
+      backup_at: '2026-03-01T00:00:00.000Z',
+      drive_id: 'drive-1',
+      file_name: 'Report.docx',
+      parent_path: '/Documents',
+      size_bytes: CONTENT.length,
+      storage_key: 'onedrive/data/owner/abc',
+      checksum: CHECKSUM,
+      change_type: 'updated',
+      last_modified_at: '2026-03-01T08:15:00.000Z',
+      version_id: '1.0',
+    } as OneDriveFileVersionRecord,
+    overrides,
+  );
+}
+
+function make_mocks() {
+  const ctx = {
+    storage: { get: vi.fn().mockResolvedValue(Buffer.from('ciphertext')) },
+    decrypt: vi.fn().mockReturnValue(CONTENT),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const tenant_factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+    create_storage_only: vi.fn().mockResolvedValue(ctx),
+  };
+
+  const connector: OneDriveConnector = {
+    list_drives: vi.fn().mockResolvedValue([{ drive_id: 'drive-1', drive_name: 'OneDrive' }]),
+    create_folder: vi.fn().mockResolvedValue('folder-1'),
+    upload_small_file: vi.fn().mockResolvedValue(undefined),
+    upload_large_file: vi.fn().mockResolvedValue(undefined),
+  } as unknown as OneDriveConnector;
+
+  const indexes: OneDriveFileVersionIndexRepository = {
+    list_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveFileVersionIndexRepository;
+
+  return { ctx, tenant_factory, connector, indexes };
+}
+
+describe('OneDriveVersionRestoreService', () => {
+  let service: OneDriveVersionRestoreService;
+  let mocks: ReturnType<typeof make_mocks>;
+
+  beforeEach(() => {
+    mocks = make_mocks();
+    service = new OneDriveVersionRestoreService(
+      mocks.tenant_factory,
+      mocks.connector,
+      mocks.indexes,
+    );
+  });
+
+  const given_versions = (...indexes: OneDriveFileVersionIndex[]): void => {
+    vi.mocked(mocks.indexes.list_by_owner).mockResolvedValue(indexes);
+  };
+
+  const restore = (options: Parameters<typeof service.restore_onedrive_version>[2]) =>
+    service.restore_onedrive_version(TENANT_ID, OWNER_ID, options);
+
+  it('writes a sibling copy by default and never touches the live file', async () => {
+    given_versions({ file_id: 'file-1', owner_id: OWNER_ID, versions: [version()] });
+
+    const result = await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    expect(result.files_restored).toBe(1);
+    expect(result.placement).toBe('copy');
+    const [call] = vi.mocked(mocks.connector.upload_small_file).mock.calls;
+    expect(call?.[4]).toBe('Report (restored 2026-03-01T08-15-00Z).docx');
+    // 'fail' rather than 'replace': a copy must never overwrite a real file.
+    expect(call?.[6]).toBe('fail');
+  });
+
+  it('uploads over the original path only when in-place is asked for', async () => {
+    given_versions({ file_id: 'file-1', owner_id: OWNER_ID, versions: [version()] });
+
+    const result = await restore({
+      file_ref: 'file-1',
+      version_id: '1.0',
+      placement: 'in-place',
+    });
+
+    const [call] = vi.mocked(mocks.connector.upload_small_file).mock.calls;
+    expect(call?.[4]).toBe('Report.docx');
+    // Microsoft 365 records this as a new version and keeps the poisoned one,
+    // so nothing is destroyed even here.
+    expect(call?.[6]).toBe('replace');
+    expect(result.restored[0]?.restored_to).toBe('/Documents/Report.docx');
+  });
+
+  it('carries the version\u2019s own modification time to the upload', async () => {
+    given_versions({ file_id: 'file-1', owner_id: OWNER_ID, versions: [version()] });
+
+    await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    // Issue #242: without this the restored file is stamped with the restore
+    // time and looks authored during the incident.
+    const [call] = vi.mocked(mocks.connector.upload_small_file).mock.calls;
+    expect(call?.[7]).toEqual({ last_modified_at: '2026-03-01T08:15:00.000Z' });
+  });
+
+  it('restores to the drive the version was recorded in, without listing drives', async () => {
+    given_versions({
+      file_id: 'file-1',
+      owner_id: OWNER_ID,
+      versions: [version({ drive_id: 'drive-second' })],
+    });
+
+    await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    const [call] = vi.mocked(mocks.connector.upload_small_file).mock.calls;
+    expect(call?.[2]).toBe('drive-second');
+    expect(mocks.connector.list_drives).not.toHaveBeenCalled();
+  });
+
+  it('skips a version whose stored bytes fail their checksum', async () => {
+    given_versions({ file_id: 'file-1', owner_id: OWNER_ID, versions: [version()] });
+    vi.mocked(mocks.ctx.decrypt).mockReturnValue(Buffer.from('tampered'));
+
+    const result = await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    expect(result.files_restored).toBe(0);
+    expect(result.files_skipped).toBe(1);
+    expect(result.errors[0]).toMatch(/could not be read or verified/);
+    // Nothing may reach the live drive when the bytes cannot be trusted.
+    expect(mocks.connector.upload_small_file).not.toHaveBeenCalled();
+  });
+
+  it('never calls Graph restoreVersion', async () => {
+    given_versions({ file_id: 'file-1', owner_id: OWNER_ID, versions: [version()] });
+
+    await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    // The connector has no restoreVersion method by design: promoting a
+    // service-side version cannot be checked against the manifest checksum,
+    // and it is gone once history is trimmed.
+    expect('restore_version' in mocks.connector).toBe(false);
+  });
+
+  it('rolls back every file in scope and reports those with no pre-cutoff version', async () => {
+    given_versions(
+      { file_id: 'file-1', owner_id: OWNER_ID, versions: [version()] },
+      {
+        file_id: 'file-2',
+        owner_id: OWNER_ID,
+        versions: [
+          version({
+            file_name: 'Later.docx',
+            last_modified_at: '2026-03-20T00:00:00.000Z',
+            version_id: '4.0',
+          }),
+        ],
+      },
+    );
+
+    const result = await restore({ before: CUTOFF });
+
+    expect(result.files_restored).toBe(1);
+    expect(result.files_skipped).toBe(1);
+    expect(result.errors[0]).toMatch(/Later\.docx: no stored version at or before the cutoff/);
+  });
+
+  it('uses the resumable upload path above the small-file limit', async () => {
+    // Above 4 MB the blob is decrypted as a stream, so this needs a real
+    // key-bound cipher rather than a decrypt() stub.
+    const big = Buffer.alloc(5 * 1024 * 1024, 7);
+    const big_checksum = createHash('sha256').update(big).digest('hex');
+    const store = stub_encrypted_object_store();
+    const stored = store.encrypt(big);
+    const streaming_ctx = {
+      storage: { get_stream: vi.fn(async () => store.stream(stored)) },
+      create_decipher: store.create_decipher,
+      destroy: vi.fn(),
+    } as unknown as TenantContext;
+    vi.mocked(mocks.tenant_factory.create).mockResolvedValue(streaming_ctx);
+    given_versions({
+      file_id: 'file-1',
+      owner_id: OWNER_ID,
+      versions: [version({ size_bytes: big.length, checksum: big_checksum })],
+    });
+
+    await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    expect(mocks.connector.upload_large_file).toHaveBeenCalledTimes(1);
+    expect(mocks.connector.upload_small_file).not.toHaveBeenCalled();
+  });
+
+  it('stops at an interrupt and reports the run as interrupted', async () => {
+    given_versions(
+      { file_id: 'file-1', owner_id: OWNER_ID, versions: [version()] },
+      { file_id: 'file-2', owner_id: OWNER_ID, versions: [version({ file_name: 'B.docx' })] },
+    );
+    let uploaded = 0;
+    vi.mocked(mocks.connector.upload_small_file).mockImplementation(async () => {
+      uploaded++;
+    });
+
+    const result = await restore({ before: CUTOFF, should_interrupt: () => uploaded >= 1 });
+
+    expect(uploaded).toBe(1);
+    expect(result.interrupted).toBe(true);
+  });
+
+  it('destroys the tenant context on the success and the failure path', async () => {
+    given_versions({ file_id: 'file-1', owner_id: OWNER_ID, versions: [version()] });
+    await restore({ file_ref: 'file-1', version_id: '1.0' });
+    expect(mocks.ctx.destroy).toHaveBeenCalledTimes(1);
+
+    vi.mocked(mocks.indexes.list_by_owner).mockRejectedValue(new Error('index unreadable'));
+    await expect(restore({ before: CUTOFF })).rejects.toThrow('index unreadable');
+    expect(mocks.ctx.destroy).toHaveBeenCalledTimes(2);
+  });
+
+  it('normalises the owner id before reading the index', async () => {
+    given_versions({ file_id: 'file-1', owner_id: OWNER_ID, versions: [version()] });
+
+    await service.restore_onedrive_version(TENANT_ID, OWNER_ID.toUpperCase(), {
+      file_ref: 'file-1',
+      version_id: '1.0',
+    });
+
+    expect(mocks.indexes.list_by_owner).toHaveBeenCalledWith(expect.anything(), OWNER_ID);
+  });
+});

--- a/packages/onedrive/tests/unit/services/version-selection.test.ts
+++ b/packages/onedrive/tests/unit/services/version-selection.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
+import type { OneDriveFileVersionIndex, OneDriveFileVersionRecord } from '@wisecom/atlas-types';
+import { select_versions_to_restore } from '@/services/onedrive-version-selection';
+
+const OWNER = 'owner-1';
+const ATTACK = new Date('2026-03-10T00:00:00Z');
+
+function version(overrides: Overrides<OneDriveFileVersionRecord> = {}): OneDriveFileVersionRecord {
+  return apply_overrides<OneDriveFileVersionRecord>(
+    {
+      snapshot_id: 'snap-1',
+      backup_at: '2026-03-01T00:00:00.000Z',
+      drive_id: 'drive-1',
+      file_name: 'Report.docx',
+      parent_path: '/Documents',
+      size_bytes: 100,
+      storage_key: 'onedrive/data/owner-1/abc',
+      checksum: 'abc',
+      change_type: 'updated',
+      last_modified_at: '2026-03-01T00:00:00.000Z',
+      version_id: '1.0',
+    } as OneDriveFileVersionRecord,
+    overrides,
+  );
+}
+
+function index(file_id: string, versions: OneDriveFileVersionRecord[]): OneDriveFileVersionIndex {
+  return { file_id, owner_id: OWNER, versions };
+}
+
+describe('select_versions_to_restore', () => {
+  it('requires either a file reference or a cutoff', () => {
+    expect(() => select_versions_to_restore([], {})).toThrow(/file reference|--before/);
+  });
+
+  it('selects one exact version by id', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '1.0' }),
+        version({ version_id: '2.0', last_modified_at: '2026-03-05T00:00:00.000Z' }),
+      ]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, {
+      file_ref: '/Documents/Report.docx',
+      version_id: '1.0',
+    });
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.version.version_id).toBe('1.0');
+    expect(selected[0]?.original_path).toBe('/Documents/Report.docx');
+  });
+
+  it('lists the stored version ids when the requested one is absent', () => {
+    const indexes = [index('file-1', [version({ version_id: '1.0' })])];
+
+    expect(() =>
+      select_versions_to_restore(indexes, { file_ref: 'file-1', version_id: '9.0' }),
+    ).toThrow(/Stored: 1\.0/);
+  });
+
+  it('refuses an exact version whose content was never stored', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '1.0', storage_key: undefined, checksum: undefined }),
+      ]),
+    ];
+
+    // Graph lists versions Atlas could not download; selecting one would fail
+    // later with a confusing decrypt error instead of an honest refusal.
+    expect(() =>
+      select_versions_to_restore(indexes, { file_ref: 'file-1', version_id: '1.0' }),
+    ).toThrow(/no stored content/);
+  });
+
+  it('rejects an unknown file reference', () => {
+    expect(() =>
+      select_versions_to_restore([index('file-1', [version()])], { file_ref: '/nope.docx' }),
+    ).toThrow(/No stored versions found/);
+  });
+
+  it('requires a version or a cutoff once a file is named', () => {
+    expect(() =>
+      select_versions_to_restore([index('file-1', [version()])], { file_ref: 'file-1' }),
+    ).toThrow(/--version or --before/);
+  });
+
+  it('picks the newest version at or before the cutoff', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '1.0', last_modified_at: '2026-03-01T00:00:00.000Z' }),
+        version({ version_id: '2.0', last_modified_at: '2026-03-09T23:59:59.000Z' }),
+        version({ version_id: '3.0', last_modified_at: '2026-03-10T00:00:01.000Z' }),
+      ]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    // 3.0 is the poisoned one, a second past the cutoff.
+    expect(selected[0]?.version.version_id).toBe('2.0');
+  });
+
+  it('includes a version exactly at the cutoff', () => {
+    const indexes = [
+      index('file-1', [version({ version_id: '1.0', last_modified_at: ATTACK.toISOString() })]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    expect(selected).toHaveLength(1);
+  });
+
+  it('reports a file whose every version is newer than the cutoff', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '9.0', last_modified_at: '2026-03-20T00:00:00.000Z' }),
+      ]),
+    ];
+
+    const { selected, skipped } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    // Silence here would read as "everything rolled back" when this file has
+    // no pre-attack copy at all.
+    expect(selected).toHaveLength(0);
+    expect(skipped).toEqual(['/Documents/Report.docx: no stored version at or before the cutoff']);
+  });
+
+  it('falls back to the backup time when a row carries no modification time', () => {
+    const indexes = [
+      index('file-1', [
+        version({
+          version_id: undefined,
+          last_modified_at: undefined,
+          backup_at: '2026-03-02T00:00:00.000Z',
+        }),
+      ]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    // Rows copied from a manifest entry carry no version id or service time.
+    expect(selected).toHaveLength(1);
+  });
+
+  it('skips a version with an unparseable timestamp rather than restoring it', () => {
+    const indexes = [
+      index('file-1', [version({ last_modified_at: 'not-a-date', backup_at: 'also-not' })]),
+    ];
+
+    const { selected, skipped } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    expect(selected).toHaveLength(0);
+    expect(skipped).toHaveLength(1);
+  });
+
+  it('rolls back every file in the drive when no path scope is given', () => {
+    const indexes = [
+      index('file-1', [version({ file_name: 'A.docx' })]),
+      index('file-2', [version({ file_name: 'B.docx', parent_path: '/Other' })]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    expect(selected).toHaveLength(2);
+  });
+
+  it('limits a rollback to the path scope', () => {
+    const indexes = [
+      index('file-1', [version({ parent_path: '/Documents' })]),
+      index('file-2', [version({ parent_path: '/Pictures' })]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, {
+      before: ATTACK,
+      path_prefix: '/Documents',
+    });
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.file_id).toBe('file-1');
+  });
+
+  it('does not let a path scope capture a sibling with a shared prefix', () => {
+    const indexes = [
+      index('file-1', [version({ parent_path: '/Docs' })]),
+      index('file-2', [version({ parent_path: '/Docs Archive' })]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, {
+      before: ATTACK,
+      path_prefix: '/Docs',
+    });
+
+    // '/Docs Archive' starts with '/Docs' as a string but is a different folder.
+    expect(selected.map((s) => s.file_id)).toEqual(['file-1']);
+  });
+
+  it('accepts a path scope without a leading slash or with backslashes', () => {
+    const indexes = [index('file-1', [version({ parent_path: '/Documents' })])];
+
+    for (const path_prefix of ['Documents', '\\Documents', '/Documents/']) {
+      const { selected } = select_versions_to_restore(indexes, { before: ATTACK, path_prefix });
+      expect(selected, path_prefix).toHaveLength(1);
+    }
+  });
+
+  it('ignores versions with no stored bytes when picking the newest', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '1.0', last_modified_at: '2026-03-01T00:00:00.000Z' }),
+        version({
+          version_id: '2.0',
+          last_modified_at: '2026-03-05T00:00:00.000Z',
+          storage_key: undefined,
+        }),
+      ]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    // 2.0 is newer but its bytes were never captured, so it cannot be restored.
+    expect(selected[0]?.version.version_id).toBe('1.0');
+  });
+
+  it('selects one file by reference and cutoff together', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '1.0', last_modified_at: '2026-03-01T00:00:00.000Z' }),
+        version({ version_id: '5.0', last_modified_at: '2026-03-30T00:00:00.000Z' }),
+      ]),
+      index('file-2', [version({ parent_path: '/Other', file_name: 'B.docx' })]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, {
+      file_ref: '/Documents/Report.docx',
+      before: ATTACK,
+    });
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.version.version_id).toBe('1.0');
+  });
+});

--- a/packages/sdk/src/onedrive-api.factory.ts
+++ b/packages/sdk/src/onedrive-api.factory.ts
@@ -5,6 +5,7 @@ import type {
   OneDriveVerificationUseCase,
   OneDriveCatalogUseCase,
   OneDriveRestoreUseCase,
+  OneDriveVersionRestoreUseCase,
   OneDriveSaveUseCase,
   OneDriveDeletionUseCase,
   OneDriveReplicationUseCase,
@@ -18,6 +19,7 @@ import {
   ONEDRIVE_VERIFICATION_USE_CASE_TOKEN,
   ONEDRIVE_CATALOG_USE_CASE_TOKEN,
   ONEDRIVE_RESTORE_USE_CASE_TOKEN,
+  ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN,
   ONEDRIVE_SAVE_USE_CASE_TOKEN,
   ONEDRIVE_DELETION_USE_CASE_TOKEN,
   ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
@@ -34,6 +36,9 @@ export function create_onedrive_api(tenant_id: string, container: Container): On
     ONEDRIVE_VERIFICATION_USE_CASE_TOKEN,
   );
   const catalog = container.get<OneDriveCatalogUseCase>(ONEDRIVE_CATALOG_USE_CASE_TOKEN);
+  const version_restore = container.get<OneDriveVersionRestoreUseCase>(
+    ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN,
+  );
   const restore = container.get<OneDriveRestoreUseCase>(ONEDRIVE_RESTORE_USE_CASE_TOKEN);
   const save = container.get<OneDriveSaveUseCase>(ONEDRIVE_SAVE_USE_CASE_TOKEN);
   const deletion = container.get<OneDriveDeletionUseCase>(ONEDRIVE_DELETION_USE_CASE_TOKEN);
@@ -84,6 +89,14 @@ export function create_onedrive_api(tenant_id: string, container: Container): On
         tenant_id,
         owner_id,
         adapt_required_operation_options(options, 'onedrive.restore()'),
+      );
+    },
+    async restoreVersion(owner_input, options) {
+      const owner_id = await resolve_owner_id(owner_input);
+      return await version_restore.restore_onedrive_version(
+        tenant_id,
+        owner_id,
+        adapt_required_operation_options(options, 'onedrive.restoreVersion()'),
       );
     },
     async save(owner_input, options) {

--- a/packages/sdk/src/sharepoint-api.factory.ts
+++ b/packages/sdk/src/sharepoint-api.factory.ts
@@ -5,6 +5,7 @@ import type {
   SharePointCatalogUseCase,
   SharePointReplicationUseCase,
   SharePointRestoreUseCase,
+  SharePointVersionRestoreUseCase,
   SharePointSaveUseCase,
   SharePointVerificationUseCase,
   SharePointDeletionUseCase,
@@ -17,6 +18,7 @@ import {
   SHAREPOINT_CATALOG_USE_CASE_TOKEN,
   SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
   SHAREPOINT_RESTORE_USE_CASE_TOKEN,
+  SHAREPOINT_VERSION_RESTORE_USE_CASE_TOKEN,
   SHAREPOINT_SAVE_USE_CASE_TOKEN,
   SHAREPOINT_VERIFICATION_USE_CASE_TOKEN,
   SHAREPOINT_DELETION_USE_CASE_TOKEN,
@@ -36,6 +38,9 @@ export function create_sharepoint_api(tenant_id: string, container: Container): 
   );
   const replication = container.get<SharePointReplicationUseCase>(
     SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
+  );
+  const version_restore = container.get<SharePointVersionRestoreUseCase>(
+    SHAREPOINT_VERSION_RESTORE_USE_CASE_TOKEN,
   );
   const restore = container.get<SharePointRestoreUseCase>(SHAREPOINT_RESTORE_USE_CASE_TOKEN);
   const save = container.get<SharePointSaveUseCase>(SHAREPOINT_SAVE_USE_CASE_TOKEN);
@@ -73,6 +78,14 @@ export function create_sharepoint_api(tenant_id: string, container: Container): 
         tenant_id,
         site_id,
         adapt_required_operation_options(options, 'sharepoint.restore()'),
+      );
+    },
+    async restoreVersion(site_input, options) {
+      const site_id = await resolve_site_id(site_input);
+      return await version_restore.restore_sharepoint_version(
+        tenant_id,
+        site_id,
+        adapt_required_operation_options(options, 'sharepoint.restoreVersion()'),
       );
     },
     async save(site_input, options) {

--- a/packages/sharepoint/src/container.ts
+++ b/packages/sharepoint/src/container.ts
@@ -10,6 +10,7 @@ import {
   SHAREPOINT_RESTORE_USE_CASE_TOKEN,
   SHAREPOINT_SAVE_USE_CASE_TOKEN,
   SHAREPOINT_CATALOG_USE_CASE_TOKEN,
+  SHAREPOINT_VERSION_RESTORE_USE_CASE_TOKEN,
   SHAREPOINT_STATUS_USE_CASE_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
@@ -22,6 +23,7 @@ import { SharePointSiteTreeBackupService } from '@/services/sharepoint-site-tree
 import { SharePointVerificationService } from '@/services/sharepoint-verification.service';
 import { SharePointRestoreService } from '@/services/sharepoint-restore.service';
 import { SharePointSaveService } from '@/services/sharepoint-save.service';
+import { SharePointVersionRestoreService } from '@/services/sharepoint-version-restore.service';
 import { SharePointCatalogService } from '@/services/sharepoint-catalog.service';
 import { SharePointStatusService } from '@/services/status/sharepoint-status.service';
 
@@ -58,5 +60,9 @@ export function bind_sharepoint(container: Container): void {
   container.bind(SHAREPOINT_RESTORE_USE_CASE_TOKEN).to(SharePointRestoreService).inSingletonScope();
   container.bind(SHAREPOINT_SAVE_USE_CASE_TOKEN).to(SharePointSaveService).inSingletonScope();
   container.bind(SHAREPOINT_CATALOG_USE_CASE_TOKEN).to(SharePointCatalogService).inSingletonScope();
+  container
+    .bind(SHAREPOINT_VERSION_RESTORE_USE_CASE_TOKEN)
+    .to(SharePointVersionRestoreService)
+    .inSingletonScope();
   container.bind(SHAREPOINT_STATUS_USE_CASE_TOKEN).to(SharePointStatusService).inSingletonScope();
 }

--- a/packages/sharepoint/src/services/index.ts
+++ b/packages/sharepoint/src/services/index.ts
@@ -2,3 +2,4 @@ export { SharePointBackupService } from './sharepoint-backup.service';
 export { SharePointRestoreService } from './sharepoint-restore.service';
 export { SharePointSaveService } from './sharepoint-save.service';
 export { SharePointVerificationService } from './sharepoint-verification.service';
+export { SharePointVersionRestoreService } from './sharepoint-version-restore.service';

--- a/packages/sharepoint/src/services/sharepoint-catalog.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-catalog.service.ts
@@ -1,8 +1,8 @@
+import { resolve_file_id } from '@/services/sharepoint-version-reference';
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {
   SharePointCatalogUseCase,
-  SharePointFileVersionIndex,
   SharePointFileVersionIndexRepository,
   SharePointFileVersionRecord,
   SharePointManifestRepository,
@@ -60,64 +60,4 @@ export class SharePointCatalogService implements SharePointCatalogUseCase {
       ctx.destroy();
     }
   }
-}
-
-/** Maps a CLI file reference (Graph item id or rooted path) to a file id, if known. */
-function resolve_file_id(
-  indexes: SharePointFileVersionIndex[],
-  file_ref: string,
-): string | undefined {
-  const trimmed = file_ref.trim();
-  if (!looks_like_path(trimmed)) {
-    if (indexes.some((idx) => idx.file_id === trimmed)) return trimmed;
-    return match_by_file_name(indexes, trimmed);
-  }
-  const want = normalize_path_ref(trimmed);
-  for (const idx of indexes) {
-    for (const v of idx.versions) {
-      if (normalize_path_ref(version_logical_path(v)) === want) return idx.file_id;
-    }
-  }
-  return undefined;
-}
-
-/**
- * Matches a bare filename against every indexed version of the site's files.
- * Throws with the candidate paths when the name maps to more than one file.
- */
-function match_by_file_name(
-  indexes: SharePointFileVersionIndex[],
-  file_name: string,
-): string | undefined {
-  const matches = new Map<string, string>();
-  for (const idx of indexes) {
-    for (const v of idx.versions) {
-      if (v.file_name === file_name) matches.set(idx.file_id, version_logical_path(v));
-    }
-  }
-  if (matches.size > 1) {
-    const candidates = [...new Set(matches.values())].sort().join(', ');
-    throw new Error(
-      `'${file_name}' matches ${matches.size} files: ${candidates}. Pass a full path instead.`,
-    );
-  }
-  return [...matches.keys()][0];
-}
-
-/** Paths contain a slash; Graph ids do not. */
-function looks_like_path(ref: string): boolean {
-  return ref.includes('/') || ref.includes('\\');
-}
-
-/** NFC-normalized path string comparable to stored manifest/index paths. */
-function normalize_path_ref(raw: string): string {
-  const unified = raw.replace(/\\/g, '/').trim();
-  const with_slash = unified.startsWith('/') ? unified : `/${unified}`;
-  return with_slash.normalize('NFC');
-}
-
-function version_logical_path(v: SharePointFileVersionRecord): string {
-  const base = v.parent_path.replace(/\/+$/, '') || '';
-  if (base === '' || base === '/') return `/${v.file_name}`;
-  return `${base}/${v.file_name}`;
 }

--- a/packages/sharepoint/src/services/sharepoint-restore-content.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore-content.ts
@@ -11,7 +11,7 @@
  */
 
 import { createHash, timingSafeEqual } from 'node:crypto';
-import type { SharePointManifestEntry, TenantContext } from '@wisecom/atlas-types';
+import type { StoredBlobRef, TenantContext } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import { is_gcm_auth_failure } from '@wisecom/atlas-core/utils/gcm-auth';
 import {
@@ -31,7 +31,7 @@ export class SharePointDecryptAuthError extends Error {
 /** Returns the entry's verified plaintext, or undefined when it cannot be restored. */
 export async function download_and_decrypt(
   ctx: TenantContext,
-  entry: SharePointManifestEntry,
+  entry: StoredBlobRef,
 ): Promise<Buffer | undefined> {
   if (!entry.storage_key) return undefined;
 
@@ -42,7 +42,7 @@ export async function download_and_decrypt(
 
 async function stream_download_and_decrypt(
   ctx: TenantContext,
-  entry: SharePointManifestEntry,
+  entry: StoredBlobRef,
 ): Promise<Buffer | undefined> {
   try {
     const { content, sha256_hex } = await stream_decrypt_from_storage(ctx, entry.storage_key!);
@@ -63,7 +63,7 @@ async function stream_download_and_decrypt(
 
 async function buffered_download_and_decrypt(
   ctx: TenantContext,
-  entry: SharePointManifestEntry,
+  entry: StoredBlobRef,
 ): Promise<Buffer | undefined> {
   let encrypted: Buffer;
   try {

--- a/packages/sharepoint/src/services/sharepoint-restore-streaming.ts
+++ b/packages/sharepoint/src/services/sharepoint-restore-streaming.ts
@@ -1,4 +1,3 @@
-import type { SharePointManifestEntry } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
 export {
@@ -10,13 +9,13 @@ export {
 const STREAM_THRESHOLD_BYTES = 4 * 1024 * 1024;
 
 /** Checks whether a file should use stream-based restore. */
-export function should_stream_restore(entry: SharePointManifestEntry): boolean {
+export function should_stream_restore(entry: { size_bytes: number }): boolean {
   return entry.size_bytes > STREAM_THRESHOLD_BYTES;
 }
 
 /** Verifies the computed SHA-256 against the manifest entry. */
 export function verify_streaming_checksum(
-  entry: SharePointManifestEntry,
+  entry: { checksum?: string | undefined; file_name: string },
   sha256_hex: string,
 ): boolean {
   if (!entry.checksum) {

--- a/packages/sharepoint/src/services/sharepoint-version-placement.ts
+++ b/packages/sharepoint/src/services/sharepoint-version-placement.ts
@@ -1,0 +1,42 @@
+import type { DriveVersionPlacement, SharePointFileVersionRecord } from '@wisecom/atlas-types';
+
+/** Splits a rooted file path into its parent path and file name. */
+export function split_parent_path(path: string): { parent_path: string; file_name: string } {
+  const cut = path.lastIndexOf('/');
+  if (cut <= 0) return { parent_path: '/', file_name: path.slice(cut + 1) };
+  return { parent_path: path.slice(0, cut), file_name: path.slice(cut + 1) };
+}
+
+/**
+ * Names the file the restored bytes are written to.
+ *
+ * `in-place` keeps the original name, so the service records a new current
+ * version of the same file. `copy` appends the version's own modification
+ * time before the extension, which keeps the restored file adjacent to the
+ * original in a sorted listing and states which point in time it came from.
+ */
+export function build_restored_file_name(
+  version: SharePointFileVersionRecord,
+  placement: DriveVersionPlacement,
+): string {
+  if (placement === 'in-place') return version.file_name;
+
+  const stamp = restored_stamp(version);
+  const dot = version.file_name.lastIndexOf('.');
+  // A leading dot is the whole name of a dotfile, not an extension.
+  if (dot <= 0) return `${version.file_name} (restored ${stamp})`;
+  return `${version.file_name.slice(0, dot)} (restored ${stamp})${version.file_name.slice(dot)}`;
+}
+
+/**
+ * Filename-safe instant for the restored copy, in UTC.
+ *
+ * Colons are legal in OneDrive but break the file on export to Windows, and
+ * Atlas exports archives, so they never enter a name it creates.
+ */
+function restored_stamp(version: SharePointFileVersionRecord): string {
+  const raw = version.last_modified_at ?? version.backup_at;
+  const parsed = new Date(raw);
+  const iso = Number.isNaN(parsed.getTime()) ? raw : parsed.toISOString();
+  return iso.replace(/\.\d+Z$/, 'Z').replace(/[:]/g, '-');
+}

--- a/packages/sharepoint/src/services/sharepoint-version-reference.ts
+++ b/packages/sharepoint/src/services/sharepoint-version-reference.ts
@@ -1,0 +1,61 @@
+import type { SharePointFileVersionIndex, SharePointFileVersionRecord } from '@wisecom/atlas-types';
+
+/** Maps a CLI file reference (Graph item id or rooted path) to a file id, if known. */
+export function resolve_file_id(
+  indexes: SharePointFileVersionIndex[],
+  file_ref: string,
+): string | undefined {
+  const trimmed = file_ref.trim();
+  if (!looks_like_path(trimmed)) {
+    if (indexes.some((idx) => idx.file_id === trimmed)) return trimmed;
+    return match_by_file_name(indexes, trimmed);
+  }
+  const want = normalize_path_ref(trimmed);
+  for (const idx of indexes) {
+    for (const v of idx.versions) {
+      if (normalize_path_ref(version_logical_path(v)) === want) return idx.file_id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Matches a bare filename against every indexed version of the site's files.
+ * Throws with the candidate paths when the name maps to more than one file.
+ */
+function match_by_file_name(
+  indexes: SharePointFileVersionIndex[],
+  file_name: string,
+): string | undefined {
+  const matches = new Map<string, string>();
+  for (const idx of indexes) {
+    for (const v of idx.versions) {
+      if (v.file_name === file_name) matches.set(idx.file_id, version_logical_path(v));
+    }
+  }
+  if (matches.size > 1) {
+    const candidates = [...new Set(matches.values())].sort().join(', ');
+    throw new Error(
+      `'${file_name}' matches ${matches.size} files: ${candidates}. Pass a full path instead.`,
+    );
+  }
+  return [...matches.keys()][0];
+}
+
+/** Paths contain a slash; Graph ids do not. */
+function looks_like_path(ref: string): boolean {
+  return ref.includes('/') || ref.includes('\\');
+}
+
+/** NFC-normalized path string comparable to stored manifest/index paths. */
+function normalize_path_ref(raw: string): string {
+  const unified = raw.replace(/\\/g, '/').trim();
+  const with_slash = unified.startsWith('/') ? unified : `/${unified}`;
+  return with_slash.normalize('NFC');
+}
+
+export function version_logical_path(v: SharePointFileVersionRecord): string {
+  const base = v.parent_path.replace(/\/+$/, '') || '';
+  if (base === '' || base === '/') return `/${v.file_name}`;
+  return `${base}/${v.file_name}`;
+}

--- a/packages/sharepoint/src/services/sharepoint-version-restore.service.ts
+++ b/packages/sharepoint/src/services/sharepoint-version-restore.service.ts
@@ -1,0 +1,232 @@
+import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
+import {
+  begin_operation_progress,
+  emit_operation_progress,
+  finish_operation_progress,
+} from '@wisecom/atlas-core/services/shared/operation-progress';
+import { inject, injectable } from 'inversify';
+import type {
+  DriveRestoredVersion,
+  DriveVersionPlacement,
+  DriveVersionRestoreOptions,
+  DriveVersionRestoreResult,
+  SharePointSiteConnector,
+  SharePointFileVersionIndexRepository,
+  SharePointVersionRestoreUseCase,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import {
+  SHAREPOINT_CONNECTOR_TOKEN,
+  SHAREPOINT_FILE_VERSION_INDEX_REPOSITORY_TOKEN,
+  TENANT_CONTEXT_FACTORY_TOKEN,
+} from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import { download_and_decrypt } from '@/services/sharepoint-restore-content';
+import { ensure_sharepoint_folder_path } from '@/services/sharepoint-restore-folder-path';
+import {
+  select_versions_to_restore,
+  type SelectedVersion,
+} from '@/services/sharepoint-version-selection';
+import {
+  build_restored_file_name,
+  split_parent_path,
+} from '@/services/sharepoint-version-placement';
+
+const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
+
+/**
+ * Pushes stored SharePoint version bytes back into a live drive.
+ *
+ * Uploads the bytes Atlas holds rather than calling Graph's `restoreVersion`.
+ * `restoreVersion` promotes a version the *service* still has, so it cannot
+ * help once version history is trimmed or the file is gone, and its result
+ * cannot be checked against the manifest checksum. Uploading a verified copy
+ * is the only path that guarantees the operator gets what the backup recorded.
+ */
+@injectable()
+export class SharePointVersionRestoreService implements SharePointVersionRestoreUseCase {
+  constructor(
+    @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
+    @inject(SHAREPOINT_CONNECTOR_TOKEN) private readonly _connector: SharePointSiteConnector,
+    @inject(SHAREPOINT_FILE_VERSION_INDEX_REPOSITORY_TOKEN)
+    private readonly _indexes: SharePointFileVersionIndexRepository,
+  ) {}
+
+  /** Restores one stored version, or every file's last version before a cutoff. */
+  async restore_sharepoint_version(
+    tenant_id: string,
+    site_id: string,
+    options: DriveVersionRestoreOptions,
+  ): Promise<DriveVersionRestoreResult> {
+    site_id = normalize_owner_id(site_id);
+    const placement: DriveVersionPlacement = options.placement ?? 'copy';
+
+    if (begin_operation_progress(options, 'restore', 'sharepoint')) {
+      finish_operation_progress(options, 'restore', 'sharepoint', 0, 0);
+      return empty_version_result(placement);
+    }
+
+    const ctx = await this._tenant_factory.create(tenant_id);
+    try {
+      const indexes = await this._indexes.list_by_site(ctx, site_id);
+      const selection = select_versions_to_restore(indexes, options);
+
+      // The version row records the drive it came from, so a version restore
+      // needs no drive lookup and stays correct for an owner with several
+      // libraries, where "the first library" would be a guess.
+      const folder_ids_by_drive = new Map<string, Map<string, string>>();
+      const restored: DriveRestoredVersion[] = [];
+      const errors: string[] = [...selection.skipped];
+      let files_skipped = selection.skipped.length;
+
+      emit_operation_progress(options, {
+        operation: 'restore',
+        workload: 'sharepoint',
+        phase: 'processing',
+        processed: 0,
+        total: selection.selected.length,
+      });
+
+      for (const [index, candidate] of selection.selected.entries()) {
+        if (options.should_interrupt?.() === true) break;
+        const outcome = await this.restore_one_version(
+          tenant_id,
+          site_id,
+          ctx,
+          folder_ids_by_drive,
+          candidate,
+          placement,
+        );
+        if (outcome.restored) restored.push(outcome.restored);
+        else {
+          files_skipped++;
+          if (outcome.error) errors.push(outcome.error);
+        }
+        emit_operation_progress(options, {
+          operation: 'restore',
+          workload: 'sharepoint',
+          phase: 'processing',
+          processed: index + 1,
+          total: selection.selected.length,
+          current: candidate.version.file_name,
+        });
+      }
+
+      const interrupted = finish_operation_progress(
+        options,
+        'restore',
+        'sharepoint',
+        restored.length + files_skipped,
+        selection.selected.length + selection.skipped.length,
+        restored.length + files_skipped < selection.selected.length,
+      );
+
+      return {
+        files_restored: restored.length,
+        files_skipped,
+        restored,
+        errors,
+        interrupted,
+        placement,
+      };
+    } finally {
+      ctx.destroy();
+    }
+  }
+
+  /** Fetches one stored version and uploads it, honouring the placement choice. */
+  private async restore_one_version(
+    tenant_id: string,
+    site_id: string,
+    ctx: TenantContext,
+    folder_ids_by_drive: Map<string, Map<string, string>>,
+    candidate: SelectedVersion,
+    placement: DriveVersionPlacement,
+  ): Promise<{ restored?: DriveRestoredVersion; error?: string }> {
+    const { version, original_path } = candidate;
+    const drive_id = version.drive_id;
+    try {
+      const content = await download_and_decrypt(ctx, version);
+      if (!content) {
+        return { error: `${original_path}: stored version could not be read or verified` };
+      }
+
+      // Folder ids are cached per drive: the same path exists in more than one
+      // library of the same site and means a different folder in each.
+      let folder_ids = folder_ids_by_drive.get(drive_id);
+      if (!folder_ids) {
+        folder_ids = new Map<string, string>([['/', 'root']]);
+        folder_ids_by_drive.set(drive_id, folder_ids);
+      }
+
+      const { parent_path } = split_parent_path(original_path);
+      const parent_id = await ensure_sharepoint_folder_path(
+        this._connector,
+        tenant_id,
+        site_id,
+        drive_id,
+        parent_path,
+        folder_ids,
+      );
+      if (!parent_id) {
+        return { error: `${original_path}: could not resolve or create ${parent_path}` };
+      }
+
+      const file_name = build_restored_file_name(version, placement);
+      // 'replace' on the original path becomes a new service version and
+      // leaves the old current one in history; 'fail' guarantees a sibling
+      // copy never silently overwrites something already there.
+      const conflict = placement === 'in-place' ? 'replace' : 'fail';
+      // Issue #242: without this the service stamps the restore time, and the
+      // rolled-back file looks like it was authored during the incident.
+      const file_system_info = version.last_modified_at
+        ? { last_modified_at: version.last_modified_at }
+        : undefined;
+      const args = [
+        tenant_id,
+        site_id,
+        drive_id,
+        parent_id,
+        file_name,
+        content,
+        conflict,
+        file_system_info,
+      ] as const;
+      if (content.length <= SMALL_FILE_LIMIT) {
+        await this._connector.upload_small_file(...args);
+      } else {
+        await this._connector.upload_large_file(...args);
+      }
+
+      const restored_to = parent_path === '/' ? `/${file_name}` : `${parent_path}/${file_name}`;
+      logger.info(
+        `Restored version ${version.version_id ?? '(current-state row)'} to ${restored_to}`,
+      );
+      return {
+        restored: {
+          file_id: candidate.file_id,
+          version_id: version.version_id,
+          last_modified_at: version.last_modified_at,
+          size_bytes: version.size_bytes,
+          restored_to,
+        },
+      };
+    } catch (err) {
+      const msg = `${original_path}: ${err instanceof Error ? err.message : String(err)}`;
+      logger.warn(`Skipped ${msg}`);
+      return { error: msg };
+    }
+  }
+}
+
+function empty_version_result(placement: DriveVersionPlacement): DriveVersionRestoreResult {
+  return {
+    files_restored: 0,
+    files_skipped: 0,
+    restored: [],
+    errors: [],
+    interrupted: true,
+    placement,
+  };
+}

--- a/packages/sharepoint/src/services/sharepoint-version-selection.ts
+++ b/packages/sharepoint/src/services/sharepoint-version-selection.ts
@@ -1,0 +1,179 @@
+import type {
+  DriveVersionRestoreOptions,
+  SharePointFileVersionIndex,
+  SharePointFileVersionRecord,
+} from '@wisecom/atlas-types';
+import { resolve_file_id, version_logical_path } from '@/services/sharepoint-version-reference';
+
+export interface SelectedVersion {
+  readonly file_id: string;
+  readonly version: SharePointFileVersionRecord;
+  /** Original rooted path of the file, e.g. `/Documents/Report.docx`. */
+  readonly original_path: string;
+}
+
+export interface VersionSelection {
+  readonly selected: SelectedVersion[];
+  /** Files in scope that had no restorable version, with the reason. */
+  readonly skipped: string[];
+}
+
+/**
+ * The instant a stored version's content was last modified in Microsoft 365.
+ *
+ * Rows written by version sync carry `last_modified_at`; rows copied from a
+ * manifest entry may not, and then the backup time is the only thing known.
+ * A rollback is expressed in service time ("before the attack"), so service
+ * time is what the cutoff compares against wherever it exists.
+ */
+function version_instant(version: SharePointFileVersionRecord): string {
+  return version.last_modified_at ?? version.backup_at;
+}
+
+/** A version is restorable only when its bytes were stored and can be verified. */
+function has_restorable_blob(version: SharePointFileVersionRecord): boolean {
+  return Boolean(version.storage_key) && Boolean(version.checksum);
+}
+
+/**
+ * Picks which stored versions to push back, from the owner's whole version index.
+ *
+ * Three modes, all resolved here so the service stays orchestration only:
+ * one exact version, the newest version of one file before a cutoff, or the
+ * newest version of every file in scope before a cutoff.
+ */
+export function select_versions_to_restore(
+  indexes: SharePointFileVersionIndex[],
+  options: DriveVersionRestoreOptions,
+): VersionSelection {
+  if (options.file_ref === undefined && options.before === undefined) {
+    throw new Error('Pass a file reference with --version, or --before for a bulk rollback');
+  }
+
+  if (options.file_ref !== undefined) {
+    return select_for_one_file(indexes, options);
+  }
+  return select_before_cutoff(indexes, options);
+}
+
+/** Single-file mode: an exact `version_id`, or the newest version before a cutoff. */
+function select_for_one_file(
+  indexes: SharePointFileVersionIndex[],
+  options: DriveVersionRestoreOptions,
+): VersionSelection {
+  const file_ref = options.file_ref!;
+  const file_id = resolve_file_id(indexes, file_ref);
+  if (!file_id) {
+    throw new Error(`No stored versions found for '${file_ref}'`);
+  }
+  const versions = indexes.find((idx) => idx.file_id === file_id)?.versions ?? [];
+
+  if (options.version_id !== undefined) {
+    const wanted = versions.find((v) => v.version_id === options.version_id);
+    if (!wanted) {
+      const known = versions
+        .map((v) => v.version_id)
+        .filter((id): id is string => id !== undefined);
+      throw new Error(
+        known.length > 0
+          ? `Version '${options.version_id}' not stored for '${file_ref}'. Stored: ${known.join(', ')}`
+          : `No identified versions stored for '${file_ref}'; only current-state rows`,
+      );
+    }
+    if (!has_restorable_blob(wanted)) {
+      throw new Error(
+        `Version '${options.version_id}' of '${file_ref}' has no stored content to restore`,
+      );
+    }
+    return {
+      selected: [{ file_id, version: wanted, original_path: version_logical_path(wanted) }],
+      skipped: [],
+    };
+  }
+
+  if (options.before === undefined) {
+    throw new Error(
+      `Pass --version or --before to choose which version of '${file_ref}' to restore`,
+    );
+  }
+  const newest = newest_before(versions, options.before);
+  if (!newest) {
+    return { selected: [], skipped: [`${file_ref}: no stored version at or before the cutoff`] };
+  }
+  return {
+    selected: [{ file_id, version: newest, original_path: version_logical_path(newest) }],
+    skipped: [],
+  };
+}
+
+/** Bulk mode: the newest pre-cutoff version of every file under the path scope. */
+function select_before_cutoff(
+  indexes: SharePointFileVersionIndex[],
+  options: DriveVersionRestoreOptions,
+): VersionSelection {
+  const cutoff = options.before!;
+  const prefix = normalize_prefix(options.path_prefix);
+  const selected: SelectedVersion[] = [];
+  const skipped: string[] = [];
+
+  for (const idx of indexes) {
+    const in_scope = idx.versions.filter((v) => path_in_scope(version_logical_path(v), prefix));
+    if (in_scope.length === 0) continue;
+
+    const newest = newest_before(in_scope, cutoff);
+    if (!newest) {
+      // Every version of this file is newer than the cutoff, so Atlas holds
+      // nothing from before the event. Naming it matters: an operator must not
+      // read a clean run as "every file rolled back".
+      const path = version_logical_path(in_scope[in_scope.length - 1]!);
+      skipped.push(`${path}: no stored version at or before the cutoff`);
+      continue;
+    }
+    selected.push({
+      file_id: idx.file_id,
+      version: newest,
+      original_path: version_logical_path(newest),
+    });
+  }
+
+  return { selected, skipped };
+}
+
+/** Newest restorable version at or before the cutoff, or undefined when none is. */
+function newest_before(
+  versions: readonly SharePointFileVersionRecord[],
+  cutoff: Date,
+): SharePointFileVersionRecord | undefined {
+  const limit = cutoff.getTime();
+  let best: SharePointFileVersionRecord | undefined;
+  let best_time = -Infinity;
+  for (const version of versions) {
+    if (!has_restorable_blob(version)) continue;
+    const time = new Date(version_instant(version)).getTime();
+    if (Number.isNaN(time) || time > limit) continue;
+    // `>=` keeps the last row at an identical timestamp: Graph timestamps have
+    // second precision, and the index is already ordered oldest first.
+    if (time >= best_time) {
+      best = version;
+      best_time = time;
+    }
+  }
+  return best;
+}
+
+/** Rooted, NFC-normalized prefix with no trailing slash; undefined means the whole library. */
+function normalize_prefix(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  const unified = raw.replace(/\\/g, '/').trim();
+  const rooted = unified.startsWith('/') ? unified : `/${unified}`;
+  const trimmed = rooted.replace(/\/+$/, '');
+  return (trimmed === '' ? '/' : trimmed).normalize('NFC');
+}
+
+/** Whether a file path sits at or under the scope prefix. */
+function path_in_scope(path: string, prefix: string | undefined): boolean {
+  if (prefix === undefined || prefix === '/') return true;
+  const normalized = path.normalize('NFC');
+  // Segment-boundary match, so `/Docs` never captures `/Docs Archive`.
+  return normalized === prefix || normalized.startsWith(`${prefix}/`);
+}

--- a/packages/sharepoint/tests/unit/services/version-placement.test.ts
+++ b/packages/sharepoint/tests/unit/services/version-placement.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
+import type { SharePointFileVersionRecord } from '@wisecom/atlas-types';
+import {
+  build_restored_file_name,
+  split_parent_path,
+} from '@/services/sharepoint-version-placement';
+
+function version(
+  overrides: Overrides<SharePointFileVersionRecord> = {},
+): SharePointFileVersionRecord {
+  return apply_overrides<SharePointFileVersionRecord>(
+    {
+      snapshot_id: 'snap-1',
+      backup_at: '2026-03-02T09:30:00.000Z',
+      drive_id: 'drive-1',
+      file_name: 'Report.docx',
+      parent_path: '/Documents',
+      size_bytes: 10,
+      change_type: 'updated',
+      last_modified_at: '2026-03-01T08:15:00.000Z',
+    } as SharePointFileVersionRecord,
+    overrides,
+  );
+}
+
+describe('split_parent_path', () => {
+  it('splits a nested path', () => {
+    expect(split_parent_path('/Documents/Reports/Q1.docx')).toEqual({
+      parent_path: '/Documents/Reports',
+      file_name: 'Q1.docx',
+    });
+  });
+
+  it('treats a file at the library root as living in the root folder', () => {
+    expect(split_parent_path('/Report.docx')).toEqual({
+      parent_path: '/',
+      file_name: 'Report.docx',
+    });
+  });
+});
+
+describe('build_restored_file_name', () => {
+  it('keeps the original name in place', () => {
+    expect(build_restored_file_name(version(), 'in-place')).toBe('Report.docx');
+  });
+
+  it('stamps the version time before the extension for a copy', () => {
+    // The extension has to survive, or Office refuses to open the recovery.
+    expect(build_restored_file_name(version(), 'copy')).toBe(
+      'Report (restored 2026-03-01T08-15-00Z).docx',
+    );
+  });
+
+  it('never puts a colon in a name it creates', () => {
+    const name = build_restored_file_name(version(), 'copy');
+
+    // Colons are legal in OneDrive and illegal on Windows, and Atlas exports
+    // these files into zip archives that land on Windows.
+    expect(name).not.toContain(':');
+  });
+
+  it('falls back to the backup time when no modification time was recorded', () => {
+    const name = build_restored_file_name(version({ last_modified_at: undefined }), 'copy');
+
+    expect(name).toBe('Report (restored 2026-03-02T09-30-00Z).docx');
+  });
+
+  it('appends to a name with no extension', () => {
+    expect(build_restored_file_name(version({ file_name: 'README' }), 'copy')).toBe(
+      'README (restored 2026-03-01T08-15-00Z)',
+    );
+  });
+
+  it('treats a dotfile name as having no extension', () => {
+    // '.gitignore' is the whole name, so splitting on the dot would produce
+    // ' (restored ...).gitignore' with an empty stem.
+    expect(build_restored_file_name(version({ file_name: '.gitignore' }), 'copy')).toBe(
+      '.gitignore (restored 2026-03-01T08-15-00Z)',
+    );
+  });
+
+  it('uses the last dot in a multi-extension name', () => {
+    expect(build_restored_file_name(version({ file_name: 'backup.tar.gz' }), 'copy')).toBe(
+      'backup.tar (restored 2026-03-01T08-15-00Z).gz',
+    );
+  });
+
+  it('keeps an unparseable timestamp verbatim rather than printing Invalid Date', () => {
+    const name = build_restored_file_name(
+      version({ last_modified_at: 'garbage', backup_at: 'garbage' }),
+      'copy',
+    );
+
+    expect(name).toBe('Report (restored garbage).docx');
+    expect(name).not.toContain('Invalid');
+  });
+});

--- a/packages/sharepoint/tests/unit/services/version-restore.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/version-restore.service.test.ts
@@ -1,0 +1,255 @@
+import { createHash } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
+import type {
+  SharePointSiteConnector,
+  SharePointFileVersionIndex,
+  SharePointFileVersionIndexRepository,
+  SharePointFileVersionRecord,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { stub_encrypted_object_store } from '@wisecom/atlas-types/testing/stub-encrypted-object-store';
+import { SharePointVersionRestoreService } from '@/services/sharepoint-version-restore.service';
+
+const TENANT_ID = 'tenant-1';
+const SITE_ID =
+  'contoso.sharepoint.com,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002';
+const CUTOFF = new Date('2026-03-10T00:00:00Z');
+const CONTENT = Buffer.from('pre-attack content');
+const CHECKSUM = createHash('sha256').update(CONTENT).digest('hex');
+
+function version(
+  overrides: Overrides<SharePointFileVersionRecord> = {},
+): SharePointFileVersionRecord {
+  return apply_overrides<SharePointFileVersionRecord>(
+    {
+      snapshot_id: 'snap-1',
+      backup_at: '2026-03-01T00:00:00.000Z',
+      drive_id: 'drive-1',
+      file_name: 'Report.docx',
+      parent_path: '/Documents',
+      size_bytes: CONTENT.length,
+      storage_key: 'sharepoint/data/site/abc',
+      checksum: CHECKSUM,
+      change_type: 'updated',
+      last_modified_at: '2026-03-01T08:15:00.000Z',
+      version_id: '1.0',
+    } as SharePointFileVersionRecord,
+    overrides,
+  );
+}
+
+function make_mocks() {
+  const ctx = {
+    storage: { get: vi.fn().mockResolvedValue(Buffer.from('ciphertext')) },
+    decrypt: vi.fn().mockReturnValue(CONTENT),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const tenant_factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+    create_storage_only: vi.fn().mockResolvedValue(ctx),
+  };
+
+  const connector: SharePointSiteConnector = {
+    list_document_libraries: vi
+      .fn()
+      .mockResolvedValue([{ drive_id: 'drive-1', drive_name: 'OneDrive' }]),
+    create_folder: vi.fn().mockResolvedValue('folder-1'),
+    upload_small_file: vi.fn().mockResolvedValue(undefined),
+    upload_large_file: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SharePointSiteConnector;
+
+  const indexes: SharePointFileVersionIndexRepository = {
+    list_by_site: vi.fn().mockResolvedValue([]),
+  } as unknown as SharePointFileVersionIndexRepository;
+
+  return { ctx, tenant_factory, connector, indexes };
+}
+
+describe('SharePointVersionRestoreService', () => {
+  let service: SharePointVersionRestoreService;
+  let mocks: ReturnType<typeof make_mocks>;
+
+  beforeEach(() => {
+    mocks = make_mocks();
+    service = new SharePointVersionRestoreService(
+      mocks.tenant_factory,
+      mocks.connector,
+      mocks.indexes,
+    );
+  });
+
+  const given_versions = (...indexes: SharePointFileVersionIndex[]): void => {
+    vi.mocked(mocks.indexes.list_by_site).mockResolvedValue(indexes);
+  };
+
+  const restore = (options: Parameters<typeof service.restore_sharepoint_version>[2]) =>
+    service.restore_sharepoint_version(TENANT_ID, SITE_ID, options);
+
+  it('writes a sibling copy by default and never touches the live file', async () => {
+    given_versions({ file_id: 'file-1', site_id: SITE_ID, versions: [version()] });
+
+    const result = await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    expect(result.files_restored).toBe(1);
+    expect(result.placement).toBe('copy');
+    const [call] = vi.mocked(mocks.connector.upload_small_file).mock.calls;
+    expect(call?.[4]).toBe('Report (restored 2026-03-01T08-15-00Z).docx');
+    // 'fail' rather than 'replace': a copy must never overwrite a real file.
+    expect(call?.[6]).toBe('fail');
+  });
+
+  it('uploads over the original path only when in-place is asked for', async () => {
+    given_versions({ file_id: 'file-1', site_id: SITE_ID, versions: [version()] });
+
+    const result = await restore({
+      file_ref: 'file-1',
+      version_id: '1.0',
+      placement: 'in-place',
+    });
+
+    const [call] = vi.mocked(mocks.connector.upload_small_file).mock.calls;
+    expect(call?.[4]).toBe('Report.docx');
+    // Microsoft 365 records this as a new version and keeps the poisoned one,
+    // so nothing is destroyed even here.
+    expect(call?.[6]).toBe('replace');
+    expect(result.restored[0]?.restored_to).toBe('/Documents/Report.docx');
+  });
+
+  it('carries the version\u2019s own modification time to the upload', async () => {
+    given_versions({ file_id: 'file-1', site_id: SITE_ID, versions: [version()] });
+
+    await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    // Issue #242: without this the restored file is stamped with the restore
+    // time and looks authored during the incident.
+    const [call] = vi.mocked(mocks.connector.upload_small_file).mock.calls;
+    expect(call?.[7]).toEqual({ last_modified_at: '2026-03-01T08:15:00.000Z' });
+  });
+
+  it('restores to the library the version was recorded in, without listing libraries', async () => {
+    given_versions({
+      file_id: 'file-1',
+      site_id: SITE_ID,
+      versions: [version({ drive_id: 'drive-second' })],
+    });
+
+    await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    const [call] = vi.mocked(mocks.connector.upload_small_file).mock.calls;
+    expect(call?.[2]).toBe('drive-second');
+    expect(mocks.connector.list_document_libraries).not.toHaveBeenCalled();
+  });
+
+  it('skips a version whose stored bytes fail their checksum', async () => {
+    given_versions({ file_id: 'file-1', site_id: SITE_ID, versions: [version()] });
+    vi.mocked(mocks.ctx.decrypt).mockReturnValue(Buffer.from('tampered'));
+
+    const result = await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    expect(result.files_restored).toBe(0);
+    expect(result.files_skipped).toBe(1);
+    expect(result.errors[0]).toMatch(/could not be read or verified/);
+    // Nothing may reach the live drive when the bytes cannot be trusted.
+    expect(mocks.connector.upload_small_file).not.toHaveBeenCalled();
+  });
+
+  it('never calls Graph restoreVersion', async () => {
+    given_versions({ file_id: 'file-1', site_id: SITE_ID, versions: [version()] });
+
+    await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    // The connector has no restoreVersion method by design: promoting a
+    // service-side version cannot be checked against the manifest checksum,
+    // and it is gone once history is trimmed.
+    expect('restore_version' in mocks.connector).toBe(false);
+  });
+
+  it('rolls back every file in scope and reports those with no pre-cutoff version', async () => {
+    given_versions(
+      { file_id: 'file-1', site_id: SITE_ID, versions: [version()] },
+      {
+        file_id: 'file-2',
+        site_id: SITE_ID,
+        versions: [
+          version({
+            file_name: 'Later.docx',
+            last_modified_at: '2026-03-20T00:00:00.000Z',
+            version_id: '4.0',
+          }),
+        ],
+      },
+    );
+
+    const result = await restore({ before: CUTOFF });
+
+    expect(result.files_restored).toBe(1);
+    expect(result.files_skipped).toBe(1);
+    expect(result.errors[0]).toMatch(/Later\.docx: no stored version at or before the cutoff/);
+  });
+
+  it('uses the resumable upload path above the small-file limit', async () => {
+    // Above 4 MB the blob is decrypted as a stream, so this needs a real
+    // key-bound cipher rather than a decrypt() stub.
+    const big = Buffer.alloc(5 * 1024 * 1024, 7);
+    const big_checksum = createHash('sha256').update(big).digest('hex');
+    const store = stub_encrypted_object_store();
+    const stored = store.encrypt(big);
+    const streaming_ctx = {
+      storage: { get_stream: vi.fn(async () => store.stream(stored)) },
+      create_decipher: store.create_decipher,
+      destroy: vi.fn(),
+    } as unknown as TenantContext;
+    vi.mocked(mocks.tenant_factory.create).mockResolvedValue(streaming_ctx);
+    given_versions({
+      file_id: 'file-1',
+      site_id: SITE_ID,
+      versions: [version({ size_bytes: big.length, checksum: big_checksum })],
+    });
+
+    await restore({ file_ref: 'file-1', version_id: '1.0' });
+
+    expect(mocks.connector.upload_large_file).toHaveBeenCalledTimes(1);
+    expect(mocks.connector.upload_small_file).not.toHaveBeenCalled();
+  });
+
+  it('stops at an interrupt and reports the run as interrupted', async () => {
+    given_versions(
+      { file_id: 'file-1', site_id: SITE_ID, versions: [version()] },
+      { file_id: 'file-2', site_id: SITE_ID, versions: [version({ file_name: 'B.docx' })] },
+    );
+    let uploaded = 0;
+    vi.mocked(mocks.connector.upload_small_file).mockImplementation(async () => {
+      uploaded++;
+    });
+
+    const result = await restore({ before: CUTOFF, should_interrupt: () => uploaded >= 1 });
+
+    expect(uploaded).toBe(1);
+    expect(result.interrupted).toBe(true);
+  });
+
+  it('destroys the tenant context on the success and the failure path', async () => {
+    given_versions({ file_id: 'file-1', site_id: SITE_ID, versions: [version()] });
+    await restore({ file_ref: 'file-1', version_id: '1.0' });
+    expect(mocks.ctx.destroy).toHaveBeenCalledTimes(1);
+
+    vi.mocked(mocks.indexes.list_by_site).mockRejectedValue(new Error('index unreadable'));
+    await expect(restore({ before: CUTOFF })).rejects.toThrow('index unreadable');
+    expect(mocks.ctx.destroy).toHaveBeenCalledTimes(2);
+  });
+
+  it('normalises the site id before reading the index', async () => {
+    given_versions({ file_id: 'file-1', site_id: SITE_ID, versions: [version()] });
+
+    await service.restore_sharepoint_version(TENANT_ID, SITE_ID.toUpperCase(), {
+      file_ref: 'file-1',
+      version_id: '1.0',
+    });
+
+    expect(mocks.indexes.list_by_site).toHaveBeenCalledWith(expect.anything(), SITE_ID);
+  });
+});

--- a/packages/sharepoint/tests/unit/services/version-selection.test.ts
+++ b/packages/sharepoint/tests/unit/services/version-selection.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
+import type { SharePointFileVersionIndex, SharePointFileVersionRecord } from '@wisecom/atlas-types';
+import { select_versions_to_restore } from '@/services/sharepoint-version-selection';
+
+const SITE = 'site-1';
+const ATTACK = new Date('2026-03-10T00:00:00Z');
+
+function version(
+  overrides: Overrides<SharePointFileVersionRecord> = {},
+): SharePointFileVersionRecord {
+  return apply_overrides<SharePointFileVersionRecord>(
+    {
+      snapshot_id: 'snap-1',
+      backup_at: '2026-03-01T00:00:00.000Z',
+      drive_id: 'drive-1',
+      file_name: 'Report.docx',
+      parent_path: '/Documents',
+      size_bytes: 100,
+      storage_key: 'sharepoint/data/site-1/abc',
+      checksum: 'abc',
+      change_type: 'updated',
+      last_modified_at: '2026-03-01T00:00:00.000Z',
+      version_id: '1.0',
+    } as SharePointFileVersionRecord,
+    overrides,
+  );
+}
+
+function index(
+  file_id: string,
+  versions: SharePointFileVersionRecord[],
+): SharePointFileVersionIndex {
+  return { file_id, site_id: SITE, versions };
+}
+
+describe('select_versions_to_restore', () => {
+  it('requires either a file reference or a cutoff', () => {
+    expect(() => select_versions_to_restore([], {})).toThrow(/file reference|--before/);
+  });
+
+  it('selects one exact version by id', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '1.0' }),
+        version({ version_id: '2.0', last_modified_at: '2026-03-05T00:00:00.000Z' }),
+      ]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, {
+      file_ref: '/Documents/Report.docx',
+      version_id: '1.0',
+    });
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.version.version_id).toBe('1.0');
+    expect(selected[0]?.original_path).toBe('/Documents/Report.docx');
+  });
+
+  it('lists the stored version ids when the requested one is absent', () => {
+    const indexes = [index('file-1', [version({ version_id: '1.0' })])];
+
+    expect(() =>
+      select_versions_to_restore(indexes, { file_ref: 'file-1', version_id: '9.0' }),
+    ).toThrow(/Stored: 1\.0/);
+  });
+
+  it('refuses an exact version whose content was never stored', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '1.0', storage_key: undefined, checksum: undefined }),
+      ]),
+    ];
+
+    // Graph lists versions Atlas could not download; selecting one would fail
+    // later with a confusing decrypt error instead of an honest refusal.
+    expect(() =>
+      select_versions_to_restore(indexes, { file_ref: 'file-1', version_id: '1.0' }),
+    ).toThrow(/no stored content/);
+  });
+
+  it('rejects an unknown file reference', () => {
+    expect(() =>
+      select_versions_to_restore([index('file-1', [version()])], { file_ref: '/nope.docx' }),
+    ).toThrow(/No stored versions found/);
+  });
+
+  it('requires a version or a cutoff once a file is named', () => {
+    expect(() =>
+      select_versions_to_restore([index('file-1', [version()])], { file_ref: 'file-1' }),
+    ).toThrow(/--version or --before/);
+  });
+
+  it('picks the newest version at or before the cutoff', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '1.0', last_modified_at: '2026-03-01T00:00:00.000Z' }),
+        version({ version_id: '2.0', last_modified_at: '2026-03-09T23:59:59.000Z' }),
+        version({ version_id: '3.0', last_modified_at: '2026-03-10T00:00:01.000Z' }),
+      ]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    // 3.0 is the poisoned one, a second past the cutoff.
+    expect(selected[0]?.version.version_id).toBe('2.0');
+  });
+
+  it('includes a version exactly at the cutoff', () => {
+    const indexes = [
+      index('file-1', [version({ version_id: '1.0', last_modified_at: ATTACK.toISOString() })]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    expect(selected).toHaveLength(1);
+  });
+
+  it('reports a file whose every version is newer than the cutoff', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '9.0', last_modified_at: '2026-03-20T00:00:00.000Z' }),
+      ]),
+    ];
+
+    const { selected, skipped } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    // Silence here would read as "everything rolled back" when this file has
+    // no pre-attack copy at all.
+    expect(selected).toHaveLength(0);
+    expect(skipped).toEqual(['/Documents/Report.docx: no stored version at or before the cutoff']);
+  });
+
+  it('falls back to the backup time when a row carries no modification time', () => {
+    const indexes = [
+      index('file-1', [
+        version({
+          version_id: undefined,
+          last_modified_at: undefined,
+          backup_at: '2026-03-02T00:00:00.000Z',
+        }),
+      ]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    // Rows copied from a manifest entry carry no version id or service time.
+    expect(selected).toHaveLength(1);
+  });
+
+  it('skips a version with an unparseable timestamp rather than restoring it', () => {
+    const indexes = [
+      index('file-1', [version({ last_modified_at: 'not-a-date', backup_at: 'also-not' })]),
+    ];
+
+    const { selected, skipped } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    expect(selected).toHaveLength(0);
+    expect(skipped).toHaveLength(1);
+  });
+
+  it('rolls back every file in the site when no path scope is given', () => {
+    const indexes = [
+      index('file-1', [version({ file_name: 'A.docx' })]),
+      index('file-2', [version({ file_name: 'B.docx', parent_path: '/Other' })]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    expect(selected).toHaveLength(2);
+  });
+
+  it('limits a rollback to the path scope', () => {
+    const indexes = [
+      index('file-1', [version({ parent_path: '/Documents' })]),
+      index('file-2', [version({ parent_path: '/Pictures' })]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, {
+      before: ATTACK,
+      path_prefix: '/Documents',
+    });
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.file_id).toBe('file-1');
+  });
+
+  it('does not let a path scope capture a sibling with a shared prefix', () => {
+    const indexes = [
+      index('file-1', [version({ parent_path: '/Docs' })]),
+      index('file-2', [version({ parent_path: '/Docs Archive' })]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, {
+      before: ATTACK,
+      path_prefix: '/Docs',
+    });
+
+    // '/Docs Archive' starts with '/Docs' as a string but is a different folder.
+    expect(selected.map((s) => s.file_id)).toEqual(['file-1']);
+  });
+
+  it('accepts a path scope without a leading slash or with backslashes', () => {
+    const indexes = [index('file-1', [version({ parent_path: '/Documents' })])];
+
+    for (const path_prefix of ['Documents', '\\Documents', '/Documents/']) {
+      const { selected } = select_versions_to_restore(indexes, { before: ATTACK, path_prefix });
+      expect(selected, path_prefix).toHaveLength(1);
+    }
+  });
+
+  it('ignores versions with no stored bytes when picking the newest', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '1.0', last_modified_at: '2026-03-01T00:00:00.000Z' }),
+        version({
+          version_id: '2.0',
+          last_modified_at: '2026-03-05T00:00:00.000Z',
+          storage_key: undefined,
+        }),
+      ]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, { before: ATTACK });
+
+    // 2.0 is newer but its bytes were never captured, so it cannot be restored.
+    expect(selected[0]?.version.version_id).toBe('1.0');
+  });
+
+  it('selects one file by reference and cutoff together', () => {
+    const indexes = [
+      index('file-1', [
+        version({ version_id: '1.0', last_modified_at: '2026-03-01T00:00:00.000Z' }),
+        version({ version_id: '5.0', last_modified_at: '2026-03-30T00:00:00.000Z' }),
+      ]),
+      index('file-2', [version({ parent_path: '/Other', file_name: 'B.docx' })]),
+    ];
+
+    const { selected } = select_versions_to_restore(indexes, {
+      file_ref: '/Documents/Report.docx',
+      before: ATTACK,
+    });
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.version.version_id).toBe('1.0');
+  });
+});

--- a/packages/types/src/domain/drive-item-metadata.ts
+++ b/packages/types/src/domain/drive-item-metadata.ts
@@ -32,3 +32,17 @@ export interface DriveFileSystemInfo {
   /** ISO 8601 UTC. Graph `fileSystemInfo.lastModifiedDateTime`. */
   readonly last_modified_at?: string;
 }
+
+/**
+ * The fields needed to fetch one stored blob back out of object storage.
+ *
+ * A manifest entry and a version index row both satisfy this. That is the
+ * point: restoring a historical version is the same operation as restoring a
+ * file, differing only in which bytes are named.
+ */
+export interface StoredBlobRef {
+  readonly storage_key?: string | undefined;
+  readonly checksum?: string | undefined;
+  readonly file_name: string;
+  readonly size_bytes: number;
+}

--- a/packages/types/src/domain/index.ts
+++ b/packages/types/src/domain/index.ts
@@ -69,4 +69,8 @@ export type {
   IdentityServiceLimits,
 } from './graph-service-limits';
 export { GRAPH_SERVICE_LIMITS } from './graph-service-limits-values';
-export type { DriveItemIdentity, DriveFileSystemInfo } from '@/domain/drive-item-metadata';
+export type {
+  DriveItemIdentity,
+  DriveFileSystemInfo,
+  StoredBlobRef,
+} from '@/domain/drive-item-metadata';

--- a/packages/types/src/ports/atlas/onedrive-api.port.ts
+++ b/packages/types/src/ports/atlas/onedrive-api.port.ts
@@ -1,4 +1,8 @@
 import type {
+  DriveVersionRestoreOptions,
+  DriveVersionRestoreResult,
+} from '@/ports/drive/version-restore.port';
+import type {
   OneDriveBackupOptions,
   OneDriveBackupResult,
   OneDriveVerificationResult,
@@ -32,6 +36,11 @@ export type OneDriveSdkRestoreOptions = Omit<
   'on_progress' | 'should_interrupt'
 > &
   SdkOperationOptions;
+export type OneDriveSdkVersionRestoreOptions = Omit<
+  DriveVersionRestoreOptions,
+  'on_progress' | 'should_interrupt'
+> &
+  SdkOperationOptions;
 export type OneDriveSdkSaveOptions = Omit<FileSaveOptions, 'on_progress' | 'should_interrupt'> &
   SdkOperationOptions;
 
@@ -43,6 +52,11 @@ export interface OneDriveApi {
     options?: OneDriveSdkVerificationOptions,
   ): Promise<OneDriveVerificationResult>;
   restore(ownerId: string, options: OneDriveSdkRestoreOptions): Promise<OneDriveRestoreResult>;
+  /** Restores stored file version bytes back into OneDrive. */
+  restoreVersion(
+    ownerId: string,
+    options: OneDriveSdkVersionRestoreOptions,
+  ): Promise<DriveVersionRestoreResult>;
   save(ownerId: string, options: OneDriveSdkSaveOptions): Promise<FileSaveResult>;
   listSnapshots(ownerId: string): Promise<OneDriveSnapshotManifest[]>;
   listFileVersions(ownerId: string, fileRef: string): Promise<OneDriveFileVersionRecord[]>;

--- a/packages/types/src/ports/atlas/sharepoint-api.port.ts
+++ b/packages/types/src/ports/atlas/sharepoint-api.port.ts
@@ -1,4 +1,8 @@
 import type {
+  DriveVersionRestoreOptions,
+  DriveVersionRestoreResult,
+} from '@/ports/drive/version-restore.port';
+import type {
   SharePointBackupOptions,
   SharePointBackupResult,
   SharePointVerificationResult,
@@ -36,6 +40,11 @@ export type SharePointSdkRestoreOptions = Omit<
   'on_progress' | 'should_interrupt'
 > &
   SdkOperationOptions;
+export type SharePointSdkVersionRestoreOptions = Omit<
+  DriveVersionRestoreOptions,
+  'on_progress' | 'should_interrupt'
+> &
+  SdkOperationOptions;
 export type SharePointSdkSaveOptions = Omit<FileSaveOptions, 'on_progress' | 'should_interrupt'> &
   SdkOperationOptions;
 
@@ -53,6 +62,11 @@ export interface SharePointApi {
     options?: SharePointSdkVerificationOptions,
   ): Promise<SharePointVerificationResult>;
   restore(siteId: string, options: SharePointSdkRestoreOptions): Promise<SharePointRestoreResult>;
+  /** Restores stored file version bytes back into a SharePoint library. */
+  restoreVersion(
+    siteId: string,
+    options: SharePointSdkVersionRestoreOptions,
+  ): Promise<DriveVersionRestoreResult>;
   save(siteId: string, options: SharePointSdkSaveOptions): Promise<FileSaveResult>;
   listSnapshots(siteId: string): Promise<SharePointSnapshotManifest[]>;
   listFileVersions(siteId: string, fileRef: string): Promise<SharePointFileVersionRecord[]>;

--- a/packages/types/src/ports/drive/version-restore.port.ts
+++ b/packages/types/src/ports/drive/version-restore.port.ts
@@ -1,0 +1,50 @@
+import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
+
+/**
+ * Where restored version bytes land.
+ *
+ * `copy` writes a sibling file and never touches the live one: the safe default
+ * for a rollback whose correctness the operator has not confirmed yet.
+ *
+ * `in-place` uploads over the original path. The service keeps the previous
+ * current version in its own version history, so the poisoned copy stays
+ * recoverable, but the file users open changes immediately.
+ */
+export type DriveVersionPlacement = 'copy' | 'in-place';
+
+export interface DriveVersionRestoreOptions extends OperationControlOptions {
+  /** Graph item id or rooted path, e.g. `/Documents/Report.docx`. */
+  readonly file_ref?: string | undefined;
+  /** Exact stored version to restore. Requires `file_ref`. */
+  readonly version_id?: string | undefined;
+  /**
+   * Bulk rollback: for every file in scope, restore the newest version Atlas
+   * recorded at or before this instant. The point of the feature: a mass
+   * encrypt-and-sync event has a known start time, not a known version id.
+   */
+  readonly before?: Date | undefined;
+  /** Bulk rollback: limit to files under this rooted path prefix. */
+  readonly path_prefix?: string | undefined;
+  /** Defaults to `copy`. */
+  readonly placement?: DriveVersionPlacement | undefined;
+}
+
+export interface DriveRestoredVersion {
+  readonly file_id: string;
+  /** Absent for a version row copied from a manifest entry rather than version sync. */
+  readonly version_id: string | undefined;
+  /** When the restored bytes were last modified in Microsoft 365. */
+  readonly last_modified_at: string | undefined;
+  readonly size_bytes: number;
+  /** Path the bytes were written to, which differs from the original under `copy`. */
+  readonly restored_to: string;
+}
+
+export interface DriveVersionRestoreResult {
+  readonly files_restored: number;
+  readonly files_skipped: number;
+  readonly restored: DriveRestoredVersion[];
+  readonly errors: string[];
+  readonly interrupted: boolean;
+  readonly placement: DriveVersionPlacement;
+}

--- a/packages/types/src/ports/index.ts
+++ b/packages/types/src/ports/index.ts
@@ -118,6 +118,7 @@ export type {
   OneDriveSdkBackupOptions,
   OneDriveSdkVerificationOptions,
   OneDriveSdkRestoreOptions,
+  OneDriveSdkVersionRestoreOptions,
   OneDriveSdkSaveOptions,
 } from './atlas/onedrive-api.port';
 export type {
@@ -125,6 +126,7 @@ export type {
   SharePointSdkBackupOptions,
   SharePointSdkVerificationOptions,
   SharePointSdkRestoreOptions,
+  SharePointSdkVersionRestoreOptions,
   SharePointSdkSaveOptions,
 } from './atlas/sharepoint-api.port';
 export type {
@@ -179,6 +181,16 @@ export type {
   OneDriveRestoreOptions,
   OneDriveRestoreConflictBehavior,
 } from './onedrive/restore.port';
+
+export type { OneDriveVersionRestoreUseCase } from './onedrive/use-case.port';
+export type { SharePointVersionRestoreUseCase } from './sharepoint/use-case.port';
+
+export type {
+  DriveVersionPlacement,
+  DriveVersionRestoreOptions,
+  DriveRestoredVersion,
+  DriveVersionRestoreResult,
+} from './drive/version-restore.port';
 
 export type {
   SharePointSiteConnector,
@@ -257,6 +269,8 @@ export {
   REPLICATION_USE_CASE_TOKEN,
   ONEDRIVE_BACKUP_USE_CASE_TOKEN,
   ONEDRIVE_CATALOG_USE_CASE_TOKEN,
+  ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN,
+  SHAREPOINT_VERSION_RESTORE_USE_CASE_TOKEN,
   ONEDRIVE_VERIFICATION_USE_CASE_TOKEN,
   ONEDRIVE_RESTORE_USE_CASE_TOKEN,
   ONEDRIVE_SAVE_USE_CASE_TOKEN,

--- a/packages/types/src/ports/onedrive/use-case.port.ts
+++ b/packages/types/src/ports/onedrive/use-case.port.ts
@@ -5,6 +5,10 @@ import type {
 import type { BackupProgressReporter, ObjectLockRequest } from '../backup/use-case.port';
 import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
 import type { VerificationOptions } from '@/ports/verification/use-case.port';
+import type {
+  DriveVersionRestoreOptions,
+  DriveVersionRestoreResult,
+} from '@/ports/drive/version-restore.port';
 
 export interface OneDriveBackupSummary {
   readonly drives_scanned: number;
@@ -64,6 +68,22 @@ export interface OneDriveCatalogUseCase {
     owner_id: string,
     file_ref: string,
   ): Promise<OneDriveFileVersionRecord[]>;
+}
+
+export interface OneDriveVersionRestoreUseCase {
+  /**
+   * Restores stored version bytes back into OneDrive.
+   *
+   * Reads the bytes Atlas holds rather than promoting a version in the
+   * service: after a mass encrypt-and-sync the live version history may be
+   * trimmed or gone, and only a checksum-verified copy proves the operator
+   * gets what the backup recorded.
+   */
+  restore_onedrive_version(
+    tenant_id: string,
+    owner_id: string,
+    options: DriveVersionRestoreOptions,
+  ): Promise<DriveVersionRestoreResult>;
 }
 
 export interface OneDriveBackupUseCase {

--- a/packages/types/src/ports/sharepoint/use-case.port.ts
+++ b/packages/types/src/ports/sharepoint/use-case.port.ts
@@ -5,6 +5,10 @@ import type {
 import type { ObjectLockRequest } from '../backup/use-case.port';
 import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
 import type { VerificationOptions } from '@/ports/verification/use-case.port';
+import type {
+  DriveVersionRestoreOptions,
+  DriveVersionRestoreResult,
+} from '@/ports/drive/version-restore.port';
 
 export interface SharePointBackupSummary {
   readonly libraries_scanned: number;
@@ -99,4 +103,20 @@ export interface SharePointCatalogUseCase {
     site_id: string,
     file_ref: string,
   ): Promise<SharePointFileVersionRecord[]>;
+}
+
+export interface SharePointVersionRestoreUseCase {
+  /**
+   * Restores stored version bytes back into a SharePoint library.
+   *
+   * Reads the bytes Atlas holds rather than promoting a version in the
+   * service: after a mass encrypt-and-sync the live version history may be
+   * trimmed or gone, and only a checksum-verified copy proves the operator
+   * gets what the backup recorded.
+   */
+  restore_sharepoint_version(
+    tenant_id: string,
+    site_id: string,
+    options: DriveVersionRestoreOptions,
+  ): Promise<DriveVersionRestoreResult>;
 }

--- a/packages/types/src/ports/tokens/use-case.tokens.ts
+++ b/packages/types/src/ports/tokens/use-case.tokens.ts
@@ -28,3 +28,7 @@ export const ONEDRIVE_REPLICATION_USE_CASE_TOKEN = Symbol.for('OneDriveReplicati
 export const ONEDRIVE_STATUS_USE_CASE_TOKEN = Symbol.for('OneDriveStatusUseCase');
 export const SHAREPOINT_DELETION_USE_CASE_TOKEN = Symbol.for('SharePointDeletionUseCase');
 export const SHAREPOINT_STATUS_USE_CASE_TOKEN = Symbol.for('SharePointStatusUseCase');
+export const ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN = Symbol.for('OneDriveVersionRestoreUseCase');
+export const SHAREPOINT_VERSION_RESTORE_USE_CASE_TOKEN = Symbol.for(
+  'SharePointVersionRestoreUseCase',
+);

--- a/packages/types/src/testing/apply-overrides.ts
+++ b/packages/types/src/testing/apply-overrides.ts
@@ -1,0 +1,17 @@
+/**
+ * Fixture overrides that may blank an optional field.
+ *
+ * `Partial<T>` is not enough under `exactOptionalPropertyTypes`: passing
+ * `{ checksum: undefined }` is rejected, even though "this fixture has no
+ * checksum" is exactly what a test needs to express.
+ */
+export type Overrides<T> = { [K in keyof T]?: T[K] | undefined };
+
+/** Applies fixture overrides, where an explicit `undefined` drops the key entirely. */
+export function apply_overrides<T extends object>(base: T, overrides: Overrides<T>): T {
+  const merged: Record<string, unknown> = { ...base, ...overrides };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete merged[key];
+  }
+  return merged as T;
+}


### PR DESCRIPTION
Fixes #140. Cut from `dev`. Overlaps nothing open: #248, #249 and #250 are test-only or docs.

## The gap

Atlas captured version history and could restore none of it. `onedrive-version-sync.ts` and the SharePoint equivalent store every historical version's bytes with a checksum; neither restore service referenced them. The versions were pure storage cost, and the ransomware rollback the capture exists for was unreachable.

## What ships

`restore-version` on both drives, three modes:

```bash
atlas onedrive restore-version -o user@company.com -f /Documents/report.docx --version 3.0
atlas onedrive restore-version -o user@company.com --before 2026-03-10T00:00:00Z --path /Projects
atlas sharepoint restore-version --site <url> --before 2026-03-10T00:00:00Z --in-place
```

SDK: `atlas.onedrive.restoreVersion()` and `atlas.sharepoint.restoreVersion()`.

`list-versions` now shows **Version, Modified and Size**. It previously omitted the version id, so its output could not be acted on. The issue's first criterion was only half met.

## I did not use Graph `restoreVersion`, and that is deliberate

The issue asks for "`restoreVersion` where supported and upload fallback otherwise". I inverted it and implemented only the upload path. Three reasons, and I checked the API docs rather than assuming:

1. **It only works on a version the service still holds.** Confirmed in the v1.0 reference: it promotes an existing `driveItemVersion`. So it fails precisely when a backup is needed: history trimmed by a retention policy, the file deleted, the library gone. In the cases where it does work, Microsoft's own Files Restore already covers the operator without a backup product.
2. **Its result cannot be verified.** Atlas holds a SHA-256 for the bytes it stored. Promoting a service-side version yields content Atlas never checked, and a recorded `version_id` may no longer denote the same bytes after trimming. For a backup tool, "restored something, cannot confirm what" is the wrong trade.
3. **It would be a second code path** with different failure modes, guarding a bandwidth optimisation.

Happy to add it as a fast path if you want the bandwidth saving, but it should be opt-in and verified, not the default. Flagging clearly because it contradicts the issue text.

## Guarantees, and the tests that hold them

- **Verified before upload.** Blobs are decrypted and SHA-256 checked; a failing version is skipped and reported and never reaches the drive.
- **Nothing is destroyed.** Default `copy` writes `report (restored 2026-03-01T08-15-00Z).docx` beside the original with `conflictBehavior: fail`. `--in-place` uploads over the original with `replace`, which Microsoft 365 records as a new version while keeping the content it replaced. That satisfies criterion 4 with a non-destructive default rather than a prompt.
- **Original timestamps survive** via `file_system_info` (#242), so a rolled-back document does not look authored during the incident.
- **Partial rollbacks cannot read as complete.** A file with no version at or before the cutoff is named in `errors` and counted in `files_skipped`.
- **Versions return to the drive they came from**, read off the version row, so a multi-drive owner needs no flag and no `list_drives` call is spent. Asserted by a test that fails if `list_drives` is called at all.

Selection details worth review: the cutoff compares `last_modified_at` (service time, which is how an incident is described) and falls back to `backup_at` for rows copied from a manifest entry; a version whose timestamp will not parse is skipped rather than restored; versions with no stored bytes are ignored when picking the newest, so a newer-but-uncaptured version cannot mask an older restorable one; and the path scope matches on segment boundaries, so `/Docs` never captures `/Docs Archive`.

## Reuse instead of a fourth copy

The blob fetch, decrypt and checksum path became one module per drive over a shared `StoredBlobRef` in `packages/types`, which both manifest entries and version rows satisfy. File reference resolution moved out of the catalog services into `*-version-reference.ts` so both callers share one implementation. Net effect: `onedrive-restore.service.ts` drops from **277 to 202 effective lines**, and the streaming helpers were narrowed to the three fields they actually read rather than demanding a full manifest entry.

Twin check run first: the cursor adapters and both selection modules are structurally identical across drives, so the suites are mirrored and a future divergence shows up as a test difference.

## Verified

```
new tests      85 passed (38 onedrive, 38 sharepoint, 9 CLI option guards)
build 10/10 · typecheck 17/17 · test 15/15 · lint 0 errors · format clean · docs clean
```

**Smoke-tested end to end against the built artefacts**, not the source: a two-file ransomware scenario where `Q1.docx` has a clean `2.0` at 2026-03-05 and a poisoned `3.0` at 2026-03-11, and `New.docx` exists only after the cutoff. All eleven assertions pass, including that `2.0` is chosen, the uploaded bytes equal the pre-attack content, the `.docx` extension survives the `(restored ...)` rename, `conflict=fail` is used, the original modified time is carried, and `New.docx` is reported rather than silently dropped. Both `--help` surfaces verified on the built CLI.

Three lint warnings remain in `graph-*-connector.adapter.ts` and `graph-sharepoint-download-helpers.ts`. I confirmed by stashing that they pre-exist on `dev` and are untouched here. The two my extraction did create, orphaned type imports, are fixed.

Docs: `reference/cli.md` for both commands, `reference/sdk.md` with a Version restore section, and the guarantees plus the in-place constraint in `onedrive-backup.md` and `sharepoint-backup.md`, per the issue's last criterion.
