### PR TITLE
feat(outlook): back up Recoverable Items, opt-in, excluded from restore by default

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -64,6 +64,7 @@ atlas outlook backup -t <tenant-id> -m user@company.com        # explicit tenant
 | `--lock-mode <mode>`     | Object Lock mode (`governance` or `compliance`); requires `--retention-days` |
 | `-t, --tenant <id>`      | Override tenant ID from config                                            |
 | `--exclude-junk`         | Skip the Junk Email folder and its subfolders                             |
+| `--include-recoverable-items` | Also back up hard-deleted and hold-retained mail (see below)          |
 
 `--lock-mode` only means something alongside `--retention-days`: the mode selects how retention is enforced, it does not request retention on its own. Passing it alone is rejected rather than ignored, so a run that was meant to be immutable cannot exit `0` with unprotected data. Retention without a mode defaults to `governance`.
 
@@ -81,6 +82,7 @@ Every mail folder in the mailbox, at any nesting depth, including the ones Outlo
 | Hidden folders (`isHidden`) | Yes | Enumerated explicitly; Graph omits them unless asked |
 | Hidden Exchange system folders | No | A short deny-list of client-state folders such as `Conversation Action Settings`, matched only when Exchange also reports them hidden |
 | In-Place Archive mailbox | No | Graph cannot read it at all. See [In-Place Archive is out of scope](../security.md#in-place-archive-is-out-of-scope) |
+| **Recoverable Items** | Opt-in | `--include-recoverable-items`. Hard-deleted and hold-retained mail; see below |
 
 Anything skipped is reported at the end of the run and recorded in the snapshot manifest with its reason, so "was folder X captured?" is answerable from the backup rather than from whoever ran it:
 
@@ -92,6 +94,53 @@ Anything skipped is reported at the end of the run and recorded in the snapshot 
 ::: warning Drafts and Outbox are new in 4.1.0
 Earlier versions silently skipped Drafts and Outbox. New snapshots include them, which makes the first backup after upgrading larger than the previous one for mailboxes that hold unsent mail. Existing snapshots are unaffected; the content appears as those folders sync for the first time.
 :::
+
+
+#### Recoverable Items, the Exchange dumpster
+
+A message that arrives and is hard-deleted between two backups never appears in
+any delta page, so Atlas never sees it. The tenant's only copy is in the
+Recoverable Items subtree, which an ordinary backup does not read: it is not a
+child of the mailbox root Graph enumerates. Once Exchange's retention window
+expires the item is gone from the tenant and from every snapshot.
+
+```bash
+atlas outlook backup -m user@company.com --include-recoverable-items
+```
+
+| Subfolder | Backed up | Contains |
+| ------------------ | --------- | ------------------------------------------------------------- |
+| `Deletions` | Yes | Items removed from Deleted Items, user-recoverable for 14 to 30 days |
+| `Purges` | Yes | Hard-deleted items retained only by litigation hold or single item recovery |
+| `DiscoveryHolds` | Yes | Hard-deleted items retained by an In-Place Hold or retention policy |
+| `SubstrateHolds` | Yes | Original copies of held Teams messages and modified held items |
+| `Versions` | No | Pre-modification copies whose item shape is not a message |
+| `Calendar Logging` | No | Calendar change audit trail |
+| `Audits` | No | Mailbox audit log entries |
+
+Everything not captured is reported at the end of the run with its reason, and a
+subfolder Atlas does not recognise is reported rather than guessed at, so a new
+Exchange subfolder produces a visible gap instead of a silent one.
+
+Off by default on purpose. On a mailbox under litigation hold the dumpster can
+rival the mailbox in size, and that cost should be a decision. With the flag off
+the request volume is identical to a run before this existed: locating the
+subtree costs one request, and it is only spent when the flag is set.
+
+::: warning Restoring purged mail is opt-in twice
+Entries captured this way are marked in the manifest, and `restore` and `save`
+**exclude them by default**. An ordinary restore must not resurrect mail
+somebody deleted, or mail that exists only because a hold retained it. Pass
+`--include-recoverable-items` to the restore or save command as well, including
+when naming a single message with `--message`.
+
+There is no path back into Recoverable Items itself: Graph offers none.
+Recovered items land in the normal restore folder, which is what recovering a
+deleted message means in practice.
+:::
+
+Storing purged mail has compliance consequences. See
+[Recoverable Items and legal hold](../security.md#recoverable-items-and-legal-hold).
 
 ::: warning Exit codes (all backup commands: Outlook, OneDrive, SharePoint)
 `0`: complete, every folder/file/mailbox processed without error. `1`: hard failure, the run aborted (auth, storage, unhandled error). `2`: **partial**, a snapshot was saved but the run is incomplete because of per-folder/per-file errors or a soft interrupt (Ctrl+C). Failed items are listed on stderr. Schedulers should treat `1` as "page me" and `2` as "warn me": a partial backup is restorable but is missing the listed items. A run is reported complete only when every error bucket is empty (corso's fault-model contract).
@@ -175,6 +224,7 @@ atlas outlook restore -m user@company.com -T other@company.com -f Inbox
 | `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date                 |
 | `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date                |
 | `-t, --tenant <id>`         | Override tenant ID                                              |
+| `--include-recoverable-items` | Also include hard-deleted and hold-retained mail; excluded by default |
 
 Exactly one of `--snapshot` or `--mailbox` is required; passing both exits `1`, as described under [`atlas outlook`](#atlas-outlook). `-T, --target` works in either mode. In mailbox mode, entries are deduplicated across snapshots (newest version of each message wins). Cross-mailbox restores preserve the original folder names from the source mailbox. Nested source folders are recreated as nested subfolders under the `Restore-{timestamp}` root, so `Inbox/Projects/2026` restores to `Restore-.../Inbox/Projects/2026` instead of collapsing into one flat level.
 
@@ -277,6 +327,7 @@ atlas outlook save -m user@company.com --start-date 2026-01-01 --end-date 2026-0
 | `-o, --output <path>`       | Output file path (default: `Restore-<timestamp>.zip`)        |
 | `--skip-verify`             | Skip SHA-256 integrity checks (faster on low-power systems)  |
 | `-t, --tenant <id>`         | Override tenant ID                                           |
+| `--include-recoverable-items` | Also include hard-deleted and hold-retained mail; excluded by default |
 
 With both `-s` and `-m`, the named snapshot is exported and `-m` is ignored with a warning; see [`atlas outlook`](#atlas-outlook). Earlier releases silently exported the whole mailbox instead.
 

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -205,9 +205,40 @@ for (const folder of result.summary.excluded_folders) {
 }
 ```
 
-`reason` is `'junk-excluded'` or `'hidden-system-folder'`. The same list is on the manifest as `excluded_folders`, so an embedder can answer "was this folder captured?" from a stored snapshot rather than from the options whoever ran the backup happened to pass. `MailFolder.is_hidden` marks folders Exchange hides.
+`reason` is `'junk-excluded'`, `'hidden-system-folder'`,
+`'recoverable-items-not-mail'` or `'recoverable-items-unrecognised'`. The same
+list is on the manifest as `excluded_folders`, so an embedder can answer "was
+this folder captured?" from a stored snapshot rather than from the options
+whoever ran the backup happened to pass. `MailFolder.is_hidden` marks folders
+Exchange hides.
 
-Drafts and Outbox are new in 4.1.0. Earlier versions skipped them, so the first backup after upgrading is larger for mailboxes holding unsent mail.
+Drafts and Outbox are new in 4.1.0. Earlier versions skipped them, so the first
+backup after upgrading is larger for mailboxes holding unsent mail.
+
+#### Recoverable Items
+
+`include_recoverable_items` also captures hard-deleted and hold-retained mail
+from the Exchange dumpster, which no delta page ever reports. Off by default:
+
+```typescript
+await atlas.outlook.backup('user@company.com', { include_recoverable_items: true });
+```
+
+`Deletions`, `Purges`, `DiscoveryHolds` and `SubstrateHolds` are captured;
+`Versions`, `Calendar Logging` and `Audits` are reported through
+`excluded_folders` instead. Captured entries carry `recoverable_items: true` on
+the manifest entry, and `restore()` and `save()` drop them unless the same
+option is passed there:
+
+```typescript
+const restorable = manifest.entries.filter((entry) => entry.recoverable_items !== true);
+
+await atlas.outlook.restore('snapshot-id', { include_recoverable_items: true });
+```
+
+With the option off, request volume is identical to a run before it existed.
+Storing purged mail has compliance consequences: see
+[Recoverable Items and legal hold](/security#recoverable-items-and-legal-hold).
 
 ### Shared mailbox identity
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -218,6 +218,57 @@ The signal is the `Has Archive` column of the [mailbox usage report](https://lea
 
 **If archive content must be protected**, the mail has to leave the archive before Atlas can see it: adjust the retention policy so it stays in the primary mailbox, or move the content back. The Microsoft [mailbox import and export APIs](https://learn.microsoft.com/en-us/graph/mailbox-import-export-concept-overview) do cover archive mailboxes, but on a different model (job-based FastTransfer export streams and a separate `MailboxImportExport.*` permission set) that is not a drop-in for per-folder delta sync.
 
+### Recoverable Items and legal hold
+
+`atlas outlook backup --include-recoverable-items` reads the Exchange
+Recoverable Items subtree, the "dumpster". It is off by default, and turning it
+on changes what a snapshot means legally as well as what it costs.
+
+**Why it exists.** A message that arrives and is hard-deleted between two
+backups appears in no delta page, so no ordinary Atlas run can see it. Its only
+copy is in `Deletions` or `Purges`, and when Exchange's retention window expires
+it is gone from the tenant and from every snapshot. Closing that window is the
+only way a backup can cover deletion that happens between runs.
+
+**What lands in the snapshot.** `Deletions`, `Purges`, `DiscoveryHolds` and
+`SubstrateHolds`, stored as MIME under the same AES-256-GCM encryption and the
+same content-addressed layout as ordinary mail. `Versions`, `Calendar Logging`
+and `Audits` are not captured, and each is reported by name at the end of the
+run. `Purges`, `DiscoveryHolds` and `SubstrateHolds` exist **only** because a
+litigation hold, an In-Place Hold, or a retention policy retained them.
+
+::: warning What this means for compliance
+Copying hold-retained mail into an Atlas snapshot puts a second copy of legally
+held content in your storage, outside the Microsoft 365 retention machinery that
+created it, and outside whatever hold released it there. Three consequences:
+
+- **The copy outlives the hold.** Releasing a litigation hold in Microsoft 365
+  does not touch an Atlas snapshot. Deleting the copy is your retention
+  schedule's job, and `atlas outlook delete` is what performs it.
+- **The copy is discoverable.** Content that exists in your bucket can be
+  compelled from your bucket, whether or not it still exists in the tenant.
+- **Object Lock makes it undeletable on purpose.** A snapshot written under
+  `--retention-days` cannot be deleted until retention expires, including by
+  you. Combining Object Lock with purged mail is a deliberate decision, not a
+  default.
+
+Whether that is protection or exposure is a question for whoever owns the
+retention policy. Atlas marks these entries in the manifest so the answer is
+always visible from the snapshot itself, rather than depending on which flags a
+past run happened to carry.
+:::
+
+**Restore is opt-in separately.** Marked entries are excluded from `restore` and
+`save` unless `--include-recoverable-items` is passed there too, so an ordinary
+recovery cannot resurrect deleted mail by accident. Graph offers no path back
+into Recoverable Items, so recovered items land in the normal restore folder as
+visible mail. Restoring a purged message therefore makes it live again, which is
+usually the intent and is occasionally the last thing you want.
+
+**Permissions are unchanged.** The subtree is read with the same `Mail.Read`
+that ordinary mail needs, so enabling this grants Atlas nothing new against the
+tenant.
+
 ### What a drive restore rebuilds, and what it cannot
 
 A restored file is the original bytes, verified against the manifest checksum. Everything else that defines a document in Microsoft 365 is a separate question, and the answers differ:

--- a/packages/cli/src/commands/outlook-backup.handler.tsx
+++ b/packages/cli/src/commands/outlook-backup.handler.tsx
@@ -23,6 +23,7 @@ export interface OutlookBackupOptions {
   retentionDays?: string;
   lockMode?: string;
   excludeJunk?: boolean;
+  includeRecoverableItems?: boolean;
 }
 
 /** Resolves the tenant ID from CLI flag or config. */
@@ -44,6 +45,7 @@ function build_sync_options(options: OutlookBackupOptions): SyncOptions {
     object_lock_request,
     object_lock_policy,
     exclude_junk: options.excludeJunk ?? false,
+    include_recoverable_items: options.includeRecoverableItems ?? false,
   };
 }
 
@@ -123,5 +125,7 @@ const EXCLUDED_FOLDER_REPORT_LIMIT = 10;
 
 const EXCLUSION_REASONS: Record<ExcludedFolder['reason'], string> = {
   'junk-excluded': 'skipped by --exclude-junk',
+  'recoverable-items-not-mail': 'Recoverable Items subfolder holding non-mail items',
+  'recoverable-items-unrecognised': 'unrecognised Recoverable Items subfolder, not captured',
   'hidden-system-folder': 'hidden Exchange system folder, holds no mail',
 };

--- a/packages/cli/src/commands/outlook-data-ops.handler.tsx
+++ b/packages/cli/src/commands/outlook-data-ops.handler.tsx
@@ -31,6 +31,7 @@ export interface OutlookSaveOptions {
   endDate?: string;
   output?: string;
   skipVerify?: boolean;
+  includeRecoverableItems?: boolean;
 }
 
 export interface OutlookDeleteOptions {
@@ -133,6 +134,7 @@ function build_save_options(options: OutlookSaveOptions): SaveOptions {
     ...(options.message && { message_ref: options.message }),
     ...(options.output && { output_path: options.output }),
     ...(options.skipVerify && { skip_integrity_check: true }),
+    ...(options.includeRecoverableItems && { include_recoverable_items: true }),
     ...(options.startDate && { start_date: parse_date(options.startDate, '--start-date') }),
     ...(options.endDate && { end_date: parse_date(options.endDate, '--end-date') }),
     create_progress: create_transfer_progress('saved'),

--- a/packages/cli/src/commands/outlook-restore.handler.tsx
+++ b/packages/cli/src/commands/outlook-restore.handler.tsx
@@ -23,6 +23,7 @@ export interface OutlookRestoreOptions {
   message?: string;
   startDate?: string;
   endDate?: string;
+  includeRecoverableItems?: boolean;
 }
 
 /** Validates the scope flags, refusing the combinations that would restore to a guessed mailbox. */
@@ -128,6 +129,7 @@ async function execute_mailbox_restore(
 
   const restore_options: RestoreOptions = {
     ...(options.folder && { folder_name: options.folder }),
+    ...(options.includeRecoverableItems && { include_recoverable_items: true }),
     ...(start_date && { start_date }),
     ...(end_date && { end_date }),
     ...(options.target && { target_mailbox: options.target }),

--- a/packages/cli/src/commands/outlook.command.ts
+++ b/packages/cli/src/commands/outlook.command.ts
@@ -56,6 +56,10 @@ function register_outlook_backup(group: Command, get_container: ContainerFactory
     .option('-f, --folder <name...>', 'specific folder(s) to back up (e.g. -f Inbox "Sent Items")')
     .option('--full', 'force a full backup, ignoring saved delta state from prior runs')
     .option('--exclude-junk', 'skip the Junk Email folder (captured by default)')
+    .option(
+      '--include-recoverable-items',
+      'also back up hard-deleted and hold-retained mail from Recoverable Items',
+    )
     .option('-P, --page-size <n>', 'Graph API page size per delta request (1-100)', '10')
     .option('--retention-days <n>', 'apply object lock retention for N days')
     .option('--lock-mode <mode>', 'Object Lock mode: governance|compliance')
@@ -88,6 +92,10 @@ function register_outlook_restore(group: Command, get_container: ContainerFactor
     .option('--message <ref>', 'restore a single message by # from atlas list, or full ID')
     .option('--start-date <YYYY-MM-DD>', 'include snapshots created on or after this date')
     .option('--end-date <YYYY-MM-DD>', 'include snapshots created on or before this date')
+    .option(
+      '--include-recoverable-items',
+      'include hard-deleted and hold-retained mail captured from Recoverable Items',
+    )
     .action((options: OutlookRestoreOptions) => execute_outlook_restore(get_container(), options));
 }
 
@@ -127,6 +135,10 @@ function register_outlook_save(group: Command, get_container: ContainerFactory):
     .option('--end-date <YYYY-MM-DD>', 'include snapshots created on or before this date')
     .option('-o, --output <path>', 'output zip file path (default: Restore-<timestamp>.zip)')
     .option('--skip-verify', 'skip SHA-256 integrity checks (faster on low-power systems)')
+    .option(
+      '--include-recoverable-items',
+      'include hard-deleted and hold-retained mail captured from Recoverable Items',
+    )
     .action((options: OutlookSaveOptions) => execute_outlook_save(get_container(), options));
 }
 

--- a/packages/outlook/src/adapters/graph-folder-tree-enumerator.ts
+++ b/packages/outlook/src/adapters/graph-folder-tree-enumerator.ts
@@ -57,12 +57,17 @@ export type FolderChildrenFetcher = (parent_folder_id?: string) => Promise<Graph
  * Only folders reporting `childFolderCount > 0` cost an extra request. A
  * pruned folder takes its whole subtree with it, and is reported through
  * `on_excluded` so the run can record what it did not capture.
+ *
+ * `root_path` prefixes every path produced, which the Recoverable Items walk
+ * uses to keep dumpster folders distinguishable from mailbox folders of the
+ * same name (issue #141).
  */
 export async function enumerate_folder_tree(
   fetch_children: FolderChildrenFetcher,
   options: MailFolderListOptions = {},
+  seed: { root_path?: readonly string[] } = {},
 ): Promise<MailFolder[]> {
-  return walk_folder_level(fetch_children, options, undefined, [], 0);
+  return walk_folder_level(fetch_children, options, undefined, seed.root_path ?? [], 0);
 }
 
 /** Recursively collects one folder level and the levels beneath it. */

--- a/packages/outlook/src/adapters/graph-mail-folder-listing.ts
+++ b/packages/outlook/src/adapters/graph-mail-folder-listing.ts
@@ -1,5 +1,6 @@
 import type { MailFolder, MailFolderListOptions } from '@wisecom/atlas-types';
 import { enumerate_folder_tree } from '@/adapters/graph-folder-tree-enumerator';
+import { enumerate_recoverable_items, type FolderReader } from '@/adapters/graph-recoverable-items';
 import type { GraphFolderRecord } from '@/adapters/graph-mailbox-response-mappers';
 
 const FOLDER_SELECT = 'id,displayName,parentFolderId,totalItemCount,childFolderCount,isHidden';
@@ -21,13 +22,24 @@ export async function list_mail_folder_tree(
   fetch_page: FolderPageFetcher,
   owner_id: string,
   options?: MailFolderListOptions,
+  read_folder?: FolderReader,
 ): Promise<MailFolder[]> {
   // Per-page retry lives inside the fetcher; wrapping the whole enumeration
   // would put every page under one 60s timeout.
-  return await enumerate_folder_tree(
+  const visible = await enumerate_folder_tree(
     (parent_folder_id) => fetch_page(folder_url(owner_id, parent_folder_id)),
     options,
   );
+
+  // Off by default, and when off this costs not one extra request.
+  if (options?.include_recoverable_items !== true || !read_folder) return visible;
+
+  const recoverable = await enumerate_recoverable_items(
+    read_folder,
+    (parent_folder_id) => fetch_page(folder_url(owner_id, parent_folder_id)),
+    options,
+  );
+  return [...visible, ...recoverable];
 }
 
 /** Builds the folder-collection URL for the mailbox root or one parent folder. */
@@ -36,4 +48,30 @@ export function folder_url(owner_id: string, parent_folder_id?: string): string 
     ? `/users/${owner_id}/mailFolders/${parent_folder_id}/childFolders`
     : `/users/${owner_id}/mailFolders`;
   return `${collection}?includeHiddenFolders=true&$select=${FOLDER_SELECT}&$top=${FOLDER_PAGE_SIZE}`;
+}
+
+/** Builds the URL that reads one folder by id or well-known name. */
+export function folder_read_url(owner_id: string, folder_ref: string): string {
+  return `/users/${owner_id}/mailFolders/${folder_ref}?$select=id,displayName,parentFolderId`;
+}
+
+/**
+ * Wraps a raw Graph GET as a {@link FolderReader}.
+ *
+ * A mailbox with no Recoverable Items subtree answers 404 for the anchor
+ * folder, which is an answer rather than a failure, so it maps to undefined
+ * here instead of aborting a backup.
+ */
+export function create_folder_reader(
+  get_one: (url: string) => Promise<unknown>,
+  owner_id: string,
+): FolderReader {
+  return async (folder_ref: string) => {
+    try {
+      return (await get_one(folder_read_url(owner_id, folder_ref))) as GraphFolderRecord;
+    } catch (err) {
+      if ((err as Record<string, unknown>).statusCode === 404) return undefined;
+      throw err;
+    }
+  };
 }

--- a/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
+++ b/packages/outlook/src/adapters/graph-mailbox-connector.adapter.ts
@@ -27,7 +27,7 @@ import type {
   GraphAttachmentRecord,
 } from '@/adapters/graph-mailbox-response-mappers';
 import { extract_user_ids, parse_mailbox_purpose } from '@/adapters/graph-mailbox-response-mappers';
-import { list_mail_folder_tree } from '@/adapters/graph-mail-folder-listing';
+import { create_folder_reader, list_mail_folder_tree } from '@/adapters/graph-mail-folder-listing';
 import type { GraphPageResponse, GraphDeltaMessage } from '@/adapters/graph-delta-message-mapper';
 import {
   DELTA_SELECT_FIELDS,
@@ -103,6 +103,10 @@ export class GraphMailboxConnector implements MailboxConnector {
         (url) => this.collect_all_pages<GraphFolderRecord>(url),
         owner_id,
         options,
+        create_folder_reader(
+          (url) => with_graph_retry(() => this._client.api(url).get()),
+          owner_id,
+        ),
       );
     } catch (err) {
       rethrow_if_mailbox_not_licensed(err);

--- a/packages/outlook/src/adapters/graph-recoverable-items.ts
+++ b/packages/outlook/src/adapters/graph-recoverable-items.ts
@@ -1,0 +1,142 @@
+/**
+ * Enumeration of the Exchange Recoverable Items subtree, the "dumpster".
+ *
+ * It is not reachable from `/users/{id}/mailFolders`, which returns the
+ * children of the Top of Information Store. The dumpster is a sibling of that
+ * root, so a mailbox backup walking only the visible tree cannot see it, and
+ * anything hard-deleted between two runs exists nowhere else in the tenant
+ * (issue #141).
+ *
+ * The root is located through the one well-known name Microsoft documents for
+ * this subtree, `recoverableitemsdeletions`, and its `parentFolderId`.
+ * `recoverableitemsroot` and `recoverableitemspurges` do answer today but
+ * appear in no published list of well-known folder names, so relying on them
+ * would build on undocumented behaviour.
+ *
+ * @see https://learn.microsoft.com/en-us/exchange/security-and-compliance/recoverable-items-folder/recoverable-items-folder
+ */
+
+import type { ExcludedFolder, MailFolder, MailFolderListOptions } from '@wisecom/atlas-types';
+import type { GraphFolderRecord } from '@/adapters/graph-mailbox-response-mappers';
+import { enumerate_folder_tree } from '@/adapters/graph-folder-tree-enumerator';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+/** Path prefix given to every folder in the subtree, so manifests stay readable. */
+export const RECOVERABLE_ITEMS_PATH_PREFIX = 'Recoverable Items';
+
+/** The documented well-known name that anchors the subtree. */
+export const RECOVERABLE_ITEMS_ANCHOR = 'recoverableitemsdeletions';
+
+/**
+ * Subfolders holding mail items, which back up exactly like ordinary messages.
+ *
+ * `DiscoveryHolds` is included although issue #141 does not list it: it holds
+ * hard-deleted items under an In-Place Hold or a retention policy, which is the
+ * same content as `Purges` arriving through a different hold, and omitting it
+ * would leave the compliance gap the flag exists to close.
+ */
+const MAIL_SUBFOLDERS: Record<string, true> = {
+  deletions: true,
+  purges: true,
+  discoveryholds: true,
+  substrateholds: true,
+};
+
+/**
+ * Subfolders that are not mail and are deliberately not captured.
+ *
+ * `Versions` holds pre-modification copies whose item shape differs from a
+ * message, `Calendar Logging` is a calendar audit trail, and `Audits` is
+ * mailbox audit log entries. Each is reported rather than dropped quietly.
+ */
+const NON_MAIL_SUBFOLDERS: Record<string, true> = {
+  versions: true,
+  'calendar logging': true,
+  audits: true,
+};
+
+/** Reads one mail folder by id or well-known name; undefined when absent. */
+export type FolderReader = (folder_ref: string) => Promise<GraphFolderRecord | undefined>;
+
+/**
+ * Enumerates the Recoverable Items subfolders that hold mail.
+ *
+ * Returns an empty list when the subtree cannot be resolved, which is the
+ * normal answer for a mailbox that has never had one, and reports every
+ * subfolder it declined to capture through `on_excluded`.
+ */
+export async function enumerate_recoverable_items(
+  read_folder: FolderReader,
+  fetch_children: (parent_folder_id: string) => Promise<GraphFolderRecord[]>,
+  options: MailFolderListOptions = {},
+): Promise<MailFolder[]> {
+  const root_id = await resolve_recoverable_items_root(read_folder);
+  if (!root_id) return [];
+
+  const children = await fetch_children(root_id);
+  const captured: MailFolder[] = [];
+
+  for (const child of children) {
+    if (!child.id) continue;
+    const display_name = child.displayName ?? '';
+    const folder_path = `${RECOVERABLE_ITEMS_PATH_PREFIX}/${display_name}`;
+    const reason = subfolder_exclusion_reason(display_name);
+    if (reason) {
+      options.on_excluded?.({ folder_path, reason });
+      continue;
+    }
+
+    captured.push({
+      folder_id: child.id,
+      display_name,
+      folder_path,
+      parent_folder_id: root_id,
+      total_item_count: child.totalItemCount ?? 0,
+      is_recoverable_items: true,
+      ...(child.isHidden === true ? { is_hidden: true } : {}),
+    });
+
+    // Same rule as the visible tree: only a folder that reports children costs
+    // a request. Descending unconditionally would spend four per mailbox per
+    // run for subtrees that are almost always empty.
+    if ((child.childFolderCount ?? 0) === 0) continue;
+
+    const subtree = await enumerate_folder_tree(
+      (parent_folder_id) => fetch_children(parent_folder_id ?? child.id!),
+      options,
+      { root_path: [RECOVERABLE_ITEMS_PATH_PREFIX, display_name] },
+    );
+    captured.push(...subtree.map((folder) => ({ ...folder, is_recoverable_items: true })));
+  }
+
+  return captured;
+}
+
+/** Locates the subtree root through the anchor folder's parent. */
+async function resolve_recoverable_items_root(
+  read_folder: FolderReader,
+): Promise<string | undefined> {
+  const anchor = await read_folder(RECOVERABLE_ITEMS_ANCHOR);
+  if (!anchor?.parentFolderId) {
+    logger.debug(
+      'Recoverable Items root could not be resolved; the mailbox reports no Deletions folder.',
+    );
+    return undefined;
+  }
+  return anchor.parentFolderId;
+}
+
+/**
+ * Decides whether a subfolder of the dumpster is captured, and why not.
+ *
+ * An unrecognised name is reported rather than captured or ignored. These
+ * subfolder names are not localised the way Inbox and Drafts are, but that is
+ * observed behaviour rather than a documented guarantee, so a mailbox that
+ * presents different names produces a visible gap instead of a silent one.
+ */
+function subfolder_exclusion_reason(display_name: string): ExcludedFolder['reason'] | undefined {
+  const name = display_name.toLowerCase();
+  if (MAIL_SUBFOLDERS[name]) return undefined;
+  if (NON_MAIL_SUBFOLDERS[name]) return 'recoverable-items-not-mail';
+  return 'recoverable-items-unrecognised';
+}

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -81,6 +81,7 @@ export class MailboxSyncService implements BackupUseCase {
       const folder_selection = await resolve_backup_folders(this._connector, tenant_id, owner_id, {
         folder_filter: options.folder_filter,
         exclude_junk: options.exclude_junk,
+        include_recoverable_items: options.include_recoverable_items,
       });
       const folders = folder_selection.folders;
       const warnings = [...folder_selection.warnings];
@@ -253,7 +254,12 @@ export class MailboxSyncService implements BackupUseCase {
           : {}),
       });
       return {
-        entries: result.entries,
+        // Marked here rather than inside the executor: the folder knows where
+        // it came from, the message pipeline has no reason to.
+        entries:
+          folder.is_recoverable_items === true
+            ? result.entries.map((entry) => ({ ...entry, recoverable_items: true }))
+            : result.entries,
         ...(result.delta_link !== undefined ? { delta_link: result.delta_link } : {}),
         complete: result.complete,
         stored: result.stored,

--- a/packages/outlook/src/services/restore/recoverable-items-filter.ts
+++ b/packages/outlook/src/services/restore/recoverable-items-filter.ts
@@ -1,0 +1,35 @@
+import type { ManifestEntry } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+/** Whether a stored entry came from the Exchange Recoverable Items subtree. */
+export function is_recoverable_items_entry(entry: ManifestEntry): boolean {
+  return entry.recoverable_items === true;
+}
+
+/**
+ * Drops Recoverable Items entries unless the caller opted in, and says how many.
+ *
+ * Default-excluded because these are items someone deleted, or that exist only
+ * because a hold retained them. Writing them back into a live mailbox on an
+ * ordinary restore would resurrect deleted mail, which is a data-handling
+ * problem rather than a recovery (issue #141).
+ *
+ * The rule has no exceptions, including a single named message: an operator who
+ * means to recover purged mail says so with the flag, and the count logged here
+ * is how they find out the flag is what they need.
+ */
+export function apply_recoverable_items_policy(
+  entries: ManifestEntry[],
+  include: boolean | undefined,
+): ManifestEntry[] {
+  if (include === true) return entries;
+
+  const kept = entries.filter((entry) => !is_recoverable_items_entry(entry));
+  const dropped = entries.length - kept.length;
+  if (dropped > 0) {
+    logger.info(
+      `Skipping ${dropped} Recoverable Items message(s); pass --include-recoverable-items to restore them.`,
+    );
+  }
+  return kept;
+}

--- a/packages/outlook/src/services/restore/restore.service.ts
+++ b/packages/outlook/src/services/restore/restore.service.ts
@@ -11,6 +11,7 @@ import {
   filter_entries_by_folder_name,
   count_unique_folders,
 } from '@/services/restore/folder-restore-planner';
+import { apply_recoverable_items_policy } from '@/services/restore/recoverable-items-filter';
 import { filter_manifests_by_date, merge_snapshot_entries } from '@wisecom/atlas-core';
 import {
   restore_single_message,
@@ -181,11 +182,12 @@ export class RestoreService implements RestoreUseCase {
     tenant_id: string,
     options: RestoreOptions,
   ): Promise<ManifestEntry[]> {
+    const allowed = apply_recoverable_items_policy(entries, options.include_recoverable_items);
     if (options.folder_name) {
       const folder_map = await build_folder_map(this._connector, tenant_id, owner_id);
-      return filter_entries_by_folder_name(entries, options.folder_name, folder_map);
+      return filter_entries_by_folder_name(allowed, options.folder_name, folder_map);
     }
-    return entries;
+    return allowed;
   }
 
   /** Loads and validates the manifest for a given snapshot. */
@@ -203,18 +205,26 @@ export class RestoreService implements RestoreUseCase {
     tenant_id: string,
     options: RestoreOptions,
   ): Promise<ManifestEntry[]> {
+    const allowed = apply_recoverable_items_policy(
+      manifest.entries,
+      options.include_recoverable_items,
+    );
+
     if (options.message_ref) {
+      // Indexes are 1-based over the manifest, so resolve against the full list
+      // and then apply the policy, or `-r 5` would silently mean a different
+      // message once anything is filtered out.
       const entry = this.resolve_single_entry(manifest, options.message_ref);
-      return entry ? [entry] : [];
+      return entry && allowed.includes(entry) ? [entry] : [];
     }
 
     if (options.folder_name) {
-      await backfill_missing_folder_ids(ctx, manifest.entries);
+      await backfill_missing_folder_ids(ctx, allowed);
       const folder_map = await build_folder_map(this._connector, tenant_id, owner_id);
-      return filter_entries_by_folder_name(manifest.entries, options.folder_name, folder_map);
+      return filter_entries_by_folder_name(allowed, options.folder_name, folder_map);
     }
 
-    return manifest.entries;
+    return allowed;
   }
 
   /** Resolves a single entry by 1-based index or object_id. */

--- a/packages/outlook/src/services/save/save.service.ts
+++ b/packages/outlook/src/services/save/save.service.ts
@@ -15,6 +15,7 @@ import {
   filter_entries_by_folder_name,
   count_unique_folders,
 } from '@/services/restore/folder-restore-planner';
+import { apply_recoverable_items_policy } from '@/services/restore/recoverable-items-filter';
 import { filter_manifests_by_date, merge_snapshot_entries } from '@wisecom/atlas-core';
 import { backfill_missing_folder_ids } from '@/services/restore/restore-execution-orchestrator';
 import { NoopTransferProgressReporter } from '@/services/shared/noop-transfer-progress-reporter';
@@ -126,18 +127,23 @@ export class SaveService implements SaveUseCase {
     tenant_id: string,
     options: SaveOptions,
   ): Promise<ManifestEntry[]> {
+    const allowed = apply_recoverable_items_policy(
+      manifest.entries,
+      options.include_recoverable_items,
+    );
+
     if (options.message_ref) {
       const entry = this.resolve_single_entry(manifest, options.message_ref);
-      return entry ? [entry] : [];
+      return entry && allowed.includes(entry) ? [entry] : [];
     }
 
     if (options.folder_name) {
-      await backfill_missing_folder_ids(ctx, manifest.entries);
+      await backfill_missing_folder_ids(ctx, allowed);
       const folder_map = await build_folder_map(this._connector, tenant_id, owner_id);
-      return filter_entries_by_folder_name(manifest.entries, options.folder_name, folder_map);
+      return filter_entries_by_folder_name(allowed, options.folder_name, folder_map);
     }
 
-    return manifest.entries;
+    return allowed;
   }
 
   private resolve_single_entry(manifest: Manifest, ref: string): ManifestEntry | undefined {
@@ -152,11 +158,12 @@ export class SaveService implements SaveUseCase {
     tenant_id: string,
     options: SaveOptions,
   ): Promise<ManifestEntry[]> {
+    const allowed = apply_recoverable_items_policy(entries, options.include_recoverable_items);
     if (options.folder_name) {
       const folder_map = await build_folder_map(this._connector, tenant_id, owner_id);
-      return filter_entries_by_folder_name(entries, options.folder_name, folder_map);
+      return filter_entries_by_folder_name(allowed, options.folder_name, folder_map);
     }
-    return entries;
+    return allowed;
   }
 
   private async save_batch(

--- a/packages/outlook/src/services/shared/folder-selector.ts
+++ b/packages/outlook/src/services/shared/folder-selector.ts
@@ -79,11 +79,16 @@ export async function resolve_backup_folders(
   connector: MailboxConnector,
   tenant_id: string,
   owner_id: string,
-  options: { folder_filter?: string[] | undefined; exclude_junk?: boolean | undefined },
+  options: {
+    folder_filter?: string[] | undefined;
+    exclude_junk?: boolean | undefined;
+    include_recoverable_items?: boolean | undefined;
+  },
 ): Promise<ResolvedBackupFolders> {
   const excluded: ExcludedFolder[] = [];
   const all_folders = await connector.list_mail_folders(tenant_id, owner_id, {
     ...(options.exclude_junk === true ? { exclude_junk: true } : {}),
+    ...(options.include_recoverable_items === true ? { include_recoverable_items: true } : {}),
     on_excluded: (folder) => excluded.push(folder),
   });
 

--- a/packages/outlook/tests/unit/graph-recoverable-items.test.ts
+++ b/packages/outlook/tests/unit/graph-recoverable-items.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ExcludedFolder } from '@wisecom/atlas-types';
+import type { GraphFolderRecord } from '@/adapters/graph-mailbox-response-mappers';
+import {
+  enumerate_recoverable_items,
+  RECOVERABLE_ITEMS_ANCHOR,
+} from '@/adapters/graph-recoverable-items';
+
+const ROOT_ID = 'recoverable-root';
+
+/** The dumpster as Exchange presents it: the anchor names its own parent. */
+function make_reader(parent = ROOT_ID) {
+  return vi.fn(async (ref: string): Promise<GraphFolderRecord | undefined> => {
+    if (ref !== RECOVERABLE_ITEMS_ANCHOR) return undefined;
+    return { id: 'f-deletions', displayName: 'Deletions', parentFolderId: parent };
+  });
+}
+
+function folder(overrides: Partial<GraphFolderRecord>): GraphFolderRecord {
+  return { id: 'f-x', displayName: 'X', parentFolderId: ROOT_ID, totalItemCount: 0, ...overrides };
+}
+
+const FULL_DUMPSTER: GraphFolderRecord[] = [
+  folder({ id: 'f-deletions', displayName: 'Deletions', totalItemCount: 173 }),
+  folder({ id: 'f-purges', displayName: 'Purges', totalItemCount: 4 }),
+  folder({ id: 'f-discovery', displayName: 'DiscoveryHolds', totalItemCount: 2 }),
+  folder({ id: 'f-substrate', displayName: 'SubstrateHolds', totalItemCount: 7 }),
+  folder({ id: 'f-versions', displayName: 'Versions', totalItemCount: 11 }),
+  folder({ id: 'f-callog', displayName: 'Calendar Logging', totalItemCount: 26 }),
+  folder({ id: 'f-audits', displayName: 'Audits', totalItemCount: 900 }),
+];
+
+describe('enumerate_recoverable_items', () => {
+  it('locates the subtree through the documented anchor folder, not a root name', async () => {
+    const read_folder = make_reader();
+
+    await enumerate_recoverable_items(read_folder, async () => FULL_DUMPSTER);
+
+    // 'recoverableitemsroot' answers today but appears in no published list of
+    // well-known folder names.
+    expect(read_folder).toHaveBeenCalledWith(RECOVERABLE_ITEMS_ANCHOR);
+    expect(read_folder).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures the four mail subfolders', async () => {
+    const folders = await enumerate_recoverable_items(make_reader(), async () => FULL_DUMPSTER);
+
+    expect(folders.map((f) => f.display_name)).toEqual([
+      'Deletions',
+      'Purges',
+      'DiscoveryHolds',
+      'SubstrateHolds',
+    ]);
+  });
+
+  it('captures DiscoveryHolds, which issue #141 omits', async () => {
+    const folders = await enumerate_recoverable_items(make_reader(), async () => FULL_DUMPSTER);
+
+    // It holds hard-deleted items under an In-Place Hold or retention policy:
+    // the same content as Purges arriving through a different hold.
+    expect(folders.some((f) => f.display_name === 'DiscoveryHolds')).toBe(true);
+  });
+
+  it('prefixes every path so a dumpster folder is distinguishable from a mailbox folder', async () => {
+    const folders = await enumerate_recoverable_items(make_reader(), async () => FULL_DUMPSTER);
+
+    expect(folders.map((f) => f.folder_path)).toContain('Recoverable Items/Purges');
+  });
+
+  it('marks every captured folder as recoverable items', async () => {
+    const folders = await enumerate_recoverable_items(make_reader(), async () => FULL_DUMPSTER);
+
+    expect(folders.every((f) => f.is_recoverable_items === true)).toBe(true);
+  });
+
+  it('reports the non-mail subfolders as skipped rather than dropping them', async () => {
+    const excluded: ExcludedFolder[] = [];
+
+    await enumerate_recoverable_items(make_reader(), async () => FULL_DUMPSTER, {
+      on_excluded: (folder_excluded) => excluded.push(folder_excluded),
+    });
+
+    expect(excluded).toEqual([
+      { folder_path: 'Recoverable Items/Versions', reason: 'recoverable-items-not-mail' },
+      { folder_path: 'Recoverable Items/Calendar Logging', reason: 'recoverable-items-not-mail' },
+      { folder_path: 'Recoverable Items/Audits', reason: 'recoverable-items-not-mail' },
+    ]);
+  });
+
+  it('reports an unknown subfolder rather than guessing at it', async () => {
+    const excluded: ExcludedFolder[] = [];
+
+    const folders = await enumerate_recoverable_items(
+      make_reader(),
+      async () => [folder({ id: 'f-new', displayName: 'SomethingNew' })],
+      { on_excluded: (f) => excluded.push(f) },
+    );
+
+    // A localised mailbox, or a subfolder Microsoft adds later, then produces a
+    // visible gap instead of silence.
+    expect(folders).toHaveLength(0);
+    expect(excluded).toEqual([
+      { folder_path: 'Recoverable Items/SomethingNew', reason: 'recoverable-items-unrecognised' },
+    ]);
+  });
+
+  it('matches subfolder names case-insensitively', async () => {
+    const folders = await enumerate_recoverable_items(make_reader(), async () => [
+      folder({ id: 'f-p', displayName: 'PURGES' }),
+    ]);
+
+    expect(folders).toHaveLength(1);
+  });
+
+  it('returns nothing when the mailbox has no dumpster', async () => {
+    const read_folder = vi.fn(async () => undefined);
+    const fetch_children = vi.fn(async () => []);
+
+    const folders = await enumerate_recoverable_items(read_folder, fetch_children);
+
+    expect(folders).toEqual([]);
+    // No root means no listing request is spent looking for children.
+    expect(fetch_children).not.toHaveBeenCalled();
+  });
+
+  it('returns nothing when the anchor folder reports no parent', async () => {
+    const read_folder = vi.fn(async () => ({ id: 'f-deletions', displayName: 'Deletions' }));
+
+    const folders = await enumerate_recoverable_items(read_folder, async () => FULL_DUMPSTER);
+
+    expect(folders).toEqual([]);
+  });
+
+  it('walks nested folders inside a mail subfolder, keeping the prefix', async () => {
+    const fetch_children = vi.fn(async (parent_folder_id: string) => {
+      if (parent_folder_id === ROOT_ID) {
+        return [folder({ id: 'f-purges', displayName: 'Purges', childFolderCount: 1 })];
+      }
+      if (parent_folder_id === 'f-purges') {
+        return [folder({ id: 'f-nested', displayName: 'Nested', parentFolderId: 'f-purges' })];
+      }
+      return [];
+    });
+
+    const folders = await enumerate_recoverable_items(make_reader(), fetch_children);
+
+    expect(folders.map((f) => f.folder_path)).toEqual([
+      'Recoverable Items/Purges',
+      'Recoverable Items/Purges/Nested',
+    ]);
+    expect(folders.every((f) => f.is_recoverable_items === true)).toBe(true);
+  });
+
+  it('carries the item count so the run can size the work', async () => {
+    const folders = await enumerate_recoverable_items(make_reader(), async () => FULL_DUMPSTER);
+
+    expect(folders.find((f) => f.display_name === 'Deletions')?.total_item_count).toBe(173);
+  });
+});

--- a/packages/outlook/tests/unit/recoverable-items-policy.test.ts
+++ b/packages/outlook/tests/unit/recoverable-items-policy.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ManifestEntry } from '@wisecom/atlas-types';
+import {
+  apply_recoverable_items_policy,
+  is_recoverable_items_entry,
+} from '@/services/restore/recoverable-items-filter';
+import { list_mail_folder_tree } from '@/adapters/graph-mail-folder-listing';
+import type { GraphFolderRecord } from '@/adapters/graph-mailbox-response-mappers';
+
+function entry(object_id: string, recoverable?: boolean): ManifestEntry {
+  return {
+    object_id,
+    storage_key: `outlook/data/${object_id}`,
+    checksum: 'abc',
+    size_bytes: 10,
+    ...(recoverable === true ? { recoverable_items: true } : {}),
+  } as ManifestEntry;
+}
+
+describe('apply_recoverable_items_policy', () => {
+  const entries = [entry('normal-1'), entry('purged-1', true), entry('normal-2')];
+
+  it('drops recoverable items by default', () => {
+    const kept = apply_recoverable_items_policy(entries, undefined);
+
+    expect(kept.map((e) => e.object_id)).toEqual(['normal-1', 'normal-2']);
+  });
+
+  it('keeps them when the caller opts in', () => {
+    const kept = apply_recoverable_items_policy(entries, true);
+
+    expect(kept).toHaveLength(3);
+  });
+
+  it('drops them when the caller opts out explicitly', () => {
+    expect(apply_recoverable_items_policy(entries, false)).toHaveLength(2);
+  });
+
+  it('returns the same list when a snapshot holds none', () => {
+    const ordinary = [entry('a'), entry('b')];
+
+    expect(apply_recoverable_items_policy(ordinary, undefined)).toHaveLength(2);
+  });
+
+  it('identifies an entry only by its own marker, not by any path', () => {
+    // A user folder can be named "Recoverable Items", so the flag on the entry
+    // is the only trustworthy signal.
+    expect(is_recoverable_items_entry(entry('x'))).toBe(false);
+    expect(is_recoverable_items_entry(entry('x', true))).toBe(true);
+  });
+});
+
+describe('list_mail_folder_tree recoverable-items opt-in', () => {
+  const visible: GraphFolderRecord[] = [
+    { id: 'f-inbox', displayName: 'Inbox', totalItemCount: 42 },
+  ];
+
+  it('spends no extra request when the flag is off', async () => {
+    const fetch_page = vi.fn(async () => visible);
+    const read_folder = vi.fn(async () => undefined);
+
+    const folders = await list_mail_folder_tree(fetch_page, 'owner-1', {}, read_folder);
+
+    expect(folders.map((f) => f.display_name)).toEqual(['Inbox']);
+    // Issue #141 requires request volume to be unchanged with the flag off.
+    expect(read_folder).not.toHaveBeenCalled();
+    expect(fetch_page).toHaveBeenCalledTimes(1);
+  });
+
+  it('appends the dumpster folders when the flag is on', async () => {
+    const fetch_page = vi.fn(async (url: string) =>
+      url.includes('recoverable-root')
+        ? [{ id: 'f-purges', displayName: 'Purges', totalItemCount: 4 }]
+        : visible,
+    );
+    const read_folder = vi.fn(async () => ({
+      id: 'f-deletions',
+      displayName: 'Deletions',
+      parentFolderId: 'recoverable-root',
+    }));
+
+    const folders = await list_mail_folder_tree(
+      fetch_page,
+      'owner-1',
+      { include_recoverable_items: true },
+      read_folder,
+    );
+
+    expect(folders.map((f) => f.folder_path)).toEqual(['Inbox', 'Recoverable Items/Purges']);
+    expect(folders.find((f) => f.display_name === 'Purges')?.is_recoverable_items).toBe(true);
+    expect(folders.find((f) => f.display_name === 'Inbox')?.is_recoverable_items).toBeUndefined();
+  });
+
+  it('leaves the visible tree intact when the dumpster cannot be resolved', async () => {
+    const fetch_page = vi.fn(async () => visible);
+    const read_folder = vi.fn(async () => undefined);
+
+    const folders = await list_mail_folder_tree(
+      fetch_page,
+      'owner-1',
+      { include_recoverable_items: true },
+      read_folder,
+    );
+
+    // A mailbox with no dumpster is a normal answer, not a failed backup.
+    expect(folders.map((f) => f.display_name)).toEqual(['Inbox']);
+  });
+});

--- a/packages/types/src/domain/manifest.ts
+++ b/packages/types/src/domain/manifest.ts
@@ -81,4 +81,11 @@ export interface ManifestEntry {
    * payload to read `receivedDateTime` from.
    */
   readonly received_at?: string | undefined;
+  /**
+   * Captured from the Recoverable Items subtree rather than the visible
+   * mailbox. Marked on the entry, not inferred from the folder path, because a
+   * user folder can be named anything and this decides whether a restore
+   * writes the item back (issue #141).
+   */
+  readonly recoverable_items?: boolean | undefined;
 }

--- a/packages/types/src/ports/backup/use-case.port.ts
+++ b/packages/types/src/ports/backup/use-case.port.ts
@@ -62,6 +62,12 @@ export interface SyncOptions extends OperationControlOptions {
    * whether a message ever arrived.
    */
   readonly exclude_junk?: boolean | undefined;
+  /**
+   * Also back up the Exchange Recoverable Items subtree: hard-deleted mail and
+   * items retained only by a litigation hold or retention policy. Off by
+   * default because on a mailbox under hold it can rival the mailbox in size.
+   */
+  readonly include_recoverable_items?: boolean | undefined;
 }
 
 export interface BackupSyncSummary {

--- a/packages/types/src/ports/mail/connector.port.ts
+++ b/packages/types/src/ports/mail/connector.port.ts
@@ -15,6 +15,13 @@ export interface MailFolder {
    * enumerated at all.
    */
   readonly is_hidden?: boolean;
+  /**
+   * This folder lives in the Exchange Recoverable Items subtree, so its items
+   * were deleted or are held rather than sitting in the visible mailbox. Kept
+   * on the folder and on every entry it produces, because a restore must not
+   * put deleted mail back by accident (issue #141).
+   */
+  readonly is_recoverable_items?: boolean;
 }
 
 /**
@@ -24,7 +31,13 @@ export interface MailFolder {
  * - `hidden-system-folder`: an Exchange-hidden folder holding client state
  *   rather than mail, such as `Conversation Action Settings`.
  */
-export type FolderExclusionReason = 'junk-excluded' | 'hidden-system-folder';
+export type FolderExclusionReason =
+  | 'junk-excluded'
+  | 'hidden-system-folder'
+  /** A Recoverable Items subfolder whose items are not mail: Versions, Calendar Logging, Audits. */
+  | 'recoverable-items-not-mail'
+  /** A Recoverable Items subfolder Atlas does not know, reported rather than guessed at. */
+  | 'recoverable-items-unrecognised';
 
 export interface ExcludedFolder {
   /** Root-relative path, matching {@link MailFolder.folder_path}. */
@@ -45,6 +58,13 @@ export interface MailFolderListOptions {
    * whoever ran it happened to pass.
    */
   readonly on_excluded?: (excluded: ExcludedFolder) => void;
+  /**
+   * Also enumerate the Recoverable Items subtree: hard-deleted mail and items
+   * kept only by a litigation hold or retention policy. Off by default, since
+   * on a mailbox under hold the dumpster can rival the mailbox in size and
+   * that cost should be a decision rather than a surprise.
+   */
+  readonly include_recoverable_items?: boolean;
 }
 
 export interface MailMessage {

--- a/packages/types/src/ports/restore/use-case.port.ts
+++ b/packages/types/src/ports/restore/use-case.port.ts
@@ -20,6 +20,12 @@ export interface RestoreOptions extends OperationControlOptions {
   readonly folder_name?: string;
   readonly message_ref?: string;
   readonly target_mailbox?: string;
+  /**
+   * Also restore items captured from Recoverable Items. Off by default: an
+   * ordinary restore must not resurrect mail somebody deleted, or mail kept
+   * only because a hold retained it (issue #141).
+   */
+  readonly include_recoverable_items?: boolean;
   readonly start_date?: Date;
   readonly end_date?: Date;
   /** CLI presenter hook; when absent the service reports progress nowhere. */

--- a/packages/types/src/ports/save/use-case.port.ts
+++ b/packages/types/src/ports/save/use-case.port.ts
@@ -8,6 +8,11 @@ export interface SaveOptions extends OperationControlOptions {
   readonly end_date?: Date;
   readonly output_path?: string;
   readonly skip_integrity_check?: boolean;
+  /**
+   * Also export items captured from Recoverable Items. Off by default, so an
+   * ordinary export does not hand out deleted or hold-retained mail (issue #141).
+   */
+  readonly include_recoverable_items?: boolean;
   /** CLI presenter hook; when absent the service reports progress nowhere. */
   readonly create_progress?: (
     folders: { name: string; total_items: number }[],


### PR DESCRIPTION
Fixes #141. Cut from `dev`. Touches Outlook only, so it overlaps nothing open (#248 and #250 are drive tests, #249 is a skill, #251 is drive version restore).

## The gap

Atlas read nothing from the Exchange dumpster. A message that arrived and was hard-deleted between two runs appeared in no delta page, so it existed in no snapshot, and once Exchange's retention window expired it was gone from the tenant as well. For a mailbox on litigation hold, `Purges` and `SubstrateHolds` **are** the compliance record, and a "complete mailbox backup" that omits them cannot answer a hold request.

```bash
atlas outlook backup -m user@company.com --include-recoverable-items
```

## Two corrections to the issue

**The stated cause is stale.** #141 says `EXCLUDED_FOLDERS` in `graph-folder-tree-enumerator.ts:21-26` prunes `recoverableitemsdeletions`. #241 deleted that list. The real cause is the second half of the issue's own sentence: the walk starts at the mailbox root, and the dumpster is not a child of it. Nothing needed un-pruning; a second walk needed adding.

**The suggested Graph path is undocumented.** The issue proposes `/mailFolders/recoverableitemsroot/childFolders`. I checked the [well-known folder names table](https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0): it lists `recoverableitemsdeletions` and **neither `recoverableitemsroot` nor `recoverableitemspurges`**. They answer today, but building the feature on names Microsoft does not publish means a silent break later. So Atlas resolves the anchor folder by its documented name and walks its `parentFolderId`, which is ordinary documented behaviour. One request, same result.

## Coverage, and two folders the issue missed

| Subfolder | Captured | Why |
|---|---|---|
| `Deletions` | Yes | User-recoverable soft deletes |
| `Purges` | Yes | Hard deletes kept by litigation hold or single item recovery |
| **`DiscoveryHolds`** | **Yes** | **Not in the issue.** Hard deletes kept by an In-Place Hold or retention policy: the same content as `Purges` through a different hold, so omitting it leaves the gap the flag exists to close |
| `SubstrateHolds` | Yes | Held Teams messages and pre-modification copies |
| `Versions` | No, reported | Item shape is not a message |
| `Calendar Logging` | No, reported | Calendar audit trail |
| **`Audits`** | **No, reported** | **Not in the issue.** Mailbox audit log entries, same category as Calendar Logging |
| Anything unrecognised | No, reported | See below |

## The localisation trap

These subfolder names are matched case-insensitively against a known set. Unlike `Inbox` and `Drafts`, they have no locale-independent well-known name, and I could not find a documented guarantee that Exchange never localises them. Rather than assume, an **unrecognised subfolder is reported as skipped** through the existing #241 exclusion channel. A localised mailbox, or a subfolder Microsoft adds later, produces a visible gap in the run summary and the manifest instead of silence. Recorded in the module comment as observed behaviour rather than a guarantee.

## Nothing else needed changing

Per-folder delta cursors, MIME storage, encryption and manifest structure all come free: the sync loop is generic over its folder list, keyed on `folder_id`, so adding folders to the list was the whole mechanism. Criteria 2 and 3 are satisfied by not writing anything.

Marking is on the entry (`recoverable_items: true`), not the path. A user folder can be named "Recoverable Items", and this flag decides whether a restore writes deleted mail back, so it cannot rest on a string.

## Restore is opt-in twice, with no exception

`restore` and `save` drop marked entries unless the flag is passed there too, including when a single message is named with `--message`. I made the rule exceptionless on purpose: "explicitly named" is a weaker signal than it looks, and the logged skip count is how an operator discovers the flag. Index resolution still happens against the full manifest first, so `--message 5` cannot silently shift to a different message once filtering removes entries.

## Flag off costs nothing

Asserted, not assumed: with the flag off the run spends **exactly one folder request** and never mentions the dumpster. A mail subfolder is also only descended into when it reports `childFolderCount > 0`, matching the visible-tree rule. My first draft descended unconditionally and burned four requests per mailbox per run for subtrees that are almost always empty; a test caught it.

## Verified

```
new tests      20 (12 enumeration, 8 policy and request-volume)
outlook suite  312 passed
build 10/10 · typecheck 17/17 · test 15/15 · lint 0 errors · format clean · docs clean
```

**Smoke-tested against the built artefacts**, 12 assertions, all passing: flag off spends one request and never looks for the dumpster; flag on captures exactly the four mail folders and leaves `Inbox` unmarked; the three non-mail folders are reported by name; the anchor is used and `recoverableitemsroot` never appears; restore drops purged mail by default and keeps it on opt-in. All three `--help` surfaces verified on the built CLI.

`graph-mailbox-connector.adapter.ts` went 292 to 296 effective lines and `mailbox-sync.service.ts` 285 to 289, both under the 300 gate. The single-folder read moved into `graph-mail-folder-listing.ts`, where the folder URLs already live, rather than compacting the connector to fit.

## Docs

`cli.md` gets the flag, the per-subfolder table, and the double opt-in warning. `sdk.md` gets the option, the new exclusion reasons and the manifest marker. `security.md` gets **Recoverable Items and legal hold**, which is the part worth reading: storing hold-retained mail puts a second copy of legally held content in your bucket, outside the retention machinery that created it. It outlives the hold, it is discoverable from your storage, and under `--retention-days` it becomes undeletable by you as well. That is a decision for whoever owns the retention policy, and the manifest marker is what makes it auditable afterwards.
