### PR TITLE
feat(sdk): pluggable logging, silent by default, tagged per tenant and operation

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -37,6 +37,63 @@ All config is explicit. The SDK **does not read environment variables or config 
 
 The tenant is bound at creation time, so every method operates within that tenant scope. Methods use camelCase naming, are async, and return Promises.
 
+### Logging
+
+The SDK is **silent by default**: no Atlas output reaches the host's stdout or
+stderr. Pass a `logger` to receive it.
+
+```typescript
+import pino from 'pino';
+
+const log = pino();
+
+const atlas = createAtlasInstance({
+  /* ...credentials... */
+  logger: {
+    debug: (message, fields) => log.debug(fields, message),
+    info: (message, fields) => log.info(fields, message),
+    warn: (message, fields) => log.warn(fields, message),
+    error: (message, fields) => log.error(fields, message),
+  },
+});
+```
+
+The `LogSink` interface is those four methods and nothing else, so `pino`,
+`winston`, an OpenTelemetry exporter, or `console` all satisfy it with an
+adapter of a few lines.
+
+Every line carries `fields` identifying where it came from:
+
+```json
+{ "tenant_id": "00000000-0000-0000-0000-000000000000", "operation": "backup" }
+```
+
+`operation` is the SDK method that produced the line, so one process serving
+many tenants can attribute output without correlating by timestamp. The tag is
+applied per call, and concurrent operations on separate instances never share a
+sink.
+
+There is no `success` level: those lines arrive as `info`. Progress output is
+dropped rather than logged, because it is terminal cursor control rather than a
+record. Use the [progress events](#progress-and-cancellation) for that.
+
+`debug` is passed to the sink regardless of the `DEBUG` environment variable.
+The host asked for the lines, so the host's logger decides its own level.
+
+::: tip Logs are not the only channel
+Anything operationally significant is also in the typed result:
+`summary.warnings`, `summary.errors`, `summary.excluded_folders`,
+`integrity_failures`, and the failed-item ledger. Never parse log text to find
+out what a run did.
+:::
+
+::: warning Behaviour change in 4.1.0
+Earlier SDK versions wrote chalk-coloured `[*]`, `[!]` and `[x]` lines straight
+to the console, including raw ANSI cursor control on a TTY. An embedder that
+relied on that output has to pass a `logger` to keep seeing it. The CLI is
+unaffected and its output is unchanged.
+:::
+
 ## Available Methods
 
 `createAtlasInstance` returns an `AtlasInstance` with three workload sub-APIs and cross-cutting tenant methods:

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -17,4 +17,10 @@ export { CONFIG_KEYS, find_config_key, mask_secret } from './config-keys';
 export type { ConfigKeySpec } from './config-keys';
 export { html_to_text } from './html-to-text';
 export { is_gcm_auth_failure } from './gcm-auth';
+export {
+  run_with_log_scope,
+  active_log_scope,
+  SILENT_LOG_SINK,
+  type LogScope,
+} from './log-context';
 export { mark_downloaded_from_internet } from './zone-identifier';

--- a/packages/core/src/utils/log-context.ts
+++ b/packages/core/src/utils/log-context.ts
@@ -1,0 +1,46 @@
+/**
+ * AsyncLocalStorage-based routing for Atlas log output.
+ *
+ * The core `logger` is imported as a module global by roughly 70 files and
+ * called from over 700 sites. Threading a logger parameter through all of them
+ * would be a rewrite; publishing the sink on the async context reaches every one
+ * of those call sites without touching any of them, and matches how Graph cost
+ * tracking already carries per-operation state (`graph-request-context.ts`).
+ *
+ * No scope active means no host has asked for anything, which is the CLI: the
+ * logger keeps writing chalk lines to the console exactly as before.
+ *
+ * @see issue #41
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { LogFields, LogSink } from '@wisecom/atlas-types';
+
+export interface LogScope {
+  readonly sink: LogSink;
+  /** Attached to every line, so one process can serve many tenants readably. */
+  readonly fields?: LogFields;
+}
+
+const _scope = new AsyncLocalStorage<LogScope>();
+
+/** Runs `fn` with every Atlas log line inside it routed to `scope.sink`. */
+export function run_with_log_scope<T>(scope: LogScope, fn: () => T): T {
+  return _scope.run(scope, fn);
+}
+
+/** The log scope active in the current async context, if a host installed one. */
+export function active_log_scope(): LogScope | undefined {
+  return _scope.getStore();
+}
+
+/**
+ * Discards everything. The SDK default, so an embedded Atlas writes nothing to
+ * the host's stdout unless the host asks for output.
+ */
+export const SILENT_LOG_SINK: LogSink = {
+  debug(): void {},
+  info(): void {},
+  warn(): void {},
+  error(): void {},
+};

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,37 +1,69 @@
 import chalk from 'chalk';
+import { active_log_scope } from './log-context';
 
+/**
+ * Atlas log output.
+ *
+ * With no log scope active this is the console writer it has always been, which
+ * is what the CLI wants. When a host installs a sink (`createAtlasInstance({
+ * logger })`), every line below is routed there instead and nothing reaches the
+ * host's stdout. See `log-context.ts` and issue #41.
+ */
 export const logger = {
   info(message: string): void {
+    const scope = active_log_scope();
+    if (scope) return scope.sink.info(message, scope.fields);
     console.log(chalk.blue('[*]'), message);
   },
 
   success(message: string): void {
+    const scope = active_log_scope();
+    // A sink has no notion of success; it is an info line that the terminal
+    // happens to render in green.
+    if (scope) return scope.sink.info(message, scope.fields);
     console.log(chalk.green('[+]'), message);
   },
 
   warn(message: string): void {
+    const scope = active_log_scope();
+    if (scope) return scope.sink.warn(message, scope.fields);
     console.warn(chalk.yellow('[!]'), message);
   },
 
   error(message: string): void {
+    const scope = active_log_scope();
+    if (scope) return scope.sink.error(message, scope.fields);
     console.error(chalk.red('[x]'), message);
   },
 
   debug(message: string): void {
+    const scope = active_log_scope();
+    // The sink decides its own level. Gating on DEBUG here would hide debug
+    // lines from a host that asked for them.
+    if (scope) return scope.sink.debug(message, scope.fields);
     if (process.env['DEBUG']) {
       console.debug(chalk.gray('[.]'), chalk.gray(message));
     }
   },
 
   banner(text: string): void {
+    const scope = active_log_scope();
+    if (scope) return scope.sink.info(text, scope.fields);
     const rule = chalk.cyan('---' + '-'.repeat(text.length) + '---');
     console.log(rule);
     console.log(chalk.cyan('-- ') + chalk.bold.white(text) + chalk.cyan(' --'));
     console.log(rule);
   },
 
-  /** Overwrites the current terminal line in-place (no newline). */
+  /**
+   * Overwrites the current terminal line in-place (no newline).
+   *
+   * Dropped entirely when a sink is installed: this writes raw cursor control
+   * (`\r`, `\x1b[K`) and a progress line has no meaning as a log record. A host
+   * that wants progress reads the typed progress events instead.
+   */
   progress(message: string): void {
+    if (active_log_scope()) return;
     if (process.stdout.isTTY) {
       process.stdout.write(`\r  ${message}\x1b[K`);
     }
@@ -39,6 +71,7 @@ export const logger = {
 
   /** Clears the progress line and moves to a new line. */
   progress_done(): void {
+    if (active_log_scope()) return;
     if (process.stdout.isTTY) {
       process.stdout.write('\r\x1b[K');
     }

--- a/packages/core/tests/unit/utils/log-routing.test.ts
+++ b/packages/core/tests/unit/utils/log-routing.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { LogFields, LogSink } from '@wisecom/atlas-types';
+import { logger } from '@/utils/logger';
+import { run_with_log_scope, active_log_scope, SILENT_LOG_SINK } from '@/utils/log-context';
+
+interface Recorded {
+  level: string;
+  message: string;
+  fields?: LogFields | undefined;
+}
+
+function recording_sink(): { sink: LogSink; lines: Recorded[] } {
+  const lines: Recorded[] = [];
+  const record =
+    (level: string) =>
+    (message: string, fields?: LogFields): void => {
+      lines.push({ level, message, fields });
+    };
+  return {
+    lines,
+    sink: {
+      debug: record('debug'),
+      info: record('info'),
+      warn: record('warn'),
+      error: record('error'),
+    },
+  };
+}
+
+describe('logger without a scope', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes to the console, which is what the CLI relies on', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    logger.info('an info line');
+    logger.success('a success line');
+    logger.warn('a warning');
+    logger.error('a failure');
+
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(active_log_scope()).toBeUndefined();
+  });
+
+  it('still gates debug on the DEBUG env var', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const previous = process.env['DEBUG'];
+    delete process.env['DEBUG'];
+
+    logger.debug('quiet');
+    expect(debug).not.toHaveBeenCalled();
+
+    process.env['DEBUG'] = '1';
+    logger.debug('loud');
+    expect(debug).toHaveBeenCalledTimes(1);
+
+    if (previous === undefined) delete process.env['DEBUG'];
+    else process.env['DEBUG'] = previous;
+  });
+});
+
+describe('logger inside a scope', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('routes every level to the sink and nothing to the console', () => {
+    const { sink, lines } = recording_sink();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    run_with_log_scope({ sink }, () => {
+      logger.debug('d');
+      logger.info('i');
+      logger.success('s');
+      logger.warn('w');
+      logger.error('e');
+      logger.banner('b');
+    });
+
+    expect(lines.map((l) => `${l.level}:${l.message}`)).toEqual([
+      'debug:d',
+      'info:i',
+      'info:s',
+      'warn:w',
+      'error:e',
+      'info:b',
+    ]);
+    for (const spy of [log, warn, error, debug]) expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not gate debug on DEBUG once a sink is installed', () => {
+    const { sink, lines } = recording_sink();
+    const previous = process.env['DEBUG'];
+    delete process.env['DEBUG'];
+
+    run_with_log_scope({ sink }, () => logger.debug('routed anyway'));
+
+    // The sink decides its own level; swallowing debug here would hide lines a
+    // host explicitly asked for.
+    expect(lines).toHaveLength(1);
+    if (previous !== undefined) process.env['DEBUG'] = previous;
+  });
+
+  it('attaches the scope fields to every line', () => {
+    const { sink, lines } = recording_sink();
+
+    run_with_log_scope({ sink, fields: { tenant_id: 'tenant-1', operation: 'backup' } }, () => {
+      logger.warn('skipped an attachment');
+    });
+
+    expect(lines[0]?.fields).toEqual({ tenant_id: 'tenant-1', operation: 'backup' });
+  });
+
+  it('writes no cursor control, so progress cannot corrupt a host log', () => {
+    const { sink, lines } = recording_sink();
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    run_with_log_scope({ sink }, () => {
+      logger.progress('50%');
+      logger.progress_done();
+    });
+
+    expect(write).not.toHaveBeenCalled();
+    expect(lines).toHaveLength(0);
+  });
+
+  it('survives awaits, so a log line deep inside a service still routes', async () => {
+    const { sink, lines } = recording_sink();
+
+    await run_with_log_scope({ sink, fields: { tenant_id: 't' } }, async () => {
+      await Promise.resolve();
+      await queue_microtasks(4);
+      await nested_service_call();
+    });
+
+    // This is the whole reason the scope rides on AsyncLocalStorage: the 700-odd
+    // existing call sites are reached without being touched.
+    expect(lines.map((l) => l.message)).toEqual(['from deep inside']);
+    expect(lines[0]?.fields).toEqual({ tenant_id: 't' });
+  });
+
+  it('leaves no scope behind once the call returns', () => {
+    const { sink } = recording_sink();
+
+    run_with_log_scope({ sink }, () => expect(active_log_scope()).toBeDefined());
+
+    expect(active_log_scope()).toBeUndefined();
+  });
+
+  it('keeps concurrent scopes separate', async () => {
+    const first = recording_sink();
+    const second = recording_sink();
+
+    // A deferred rather than a sleep, so the interleaving is exact: 'a' is
+    // suspended mid-scope while 'b' runs to completion in its own scope.
+    let release_first: () => void = () => {};
+    const first_gate = new Promise<void>((resolve) => {
+      release_first = resolve;
+    });
+
+    const a = run_with_log_scope({ sink: first.sink, fields: { tenant_id: 'a' } }, async () => {
+      await first_gate;
+      logger.info('for a');
+    });
+    const b = run_with_log_scope({ sink: second.sink, fields: { tenant_id: 'b' } }, async () => {
+      logger.info('for b');
+    });
+    await b;
+    release_first();
+    await a;
+
+    expect(first.lines.map((l) => l.message)).toEqual(['for a']);
+    expect(second.lines.map((l) => l.message)).toEqual(['for b']);
+  });
+
+  it('writes nothing at all through the silent sink', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    run_with_log_scope({ sink: SILENT_LOG_SINK }, () => {
+      logger.info('dropped');
+      logger.warn('also dropped');
+    });
+
+    expect(log).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+/** Stands in for a service function that logs from several awaits down. */
+async function nested_service_call(): Promise<void> {
+  await Promise.resolve();
+  logger.info('from deep inside');
+}
+
+/** Advances past several microtask turns without touching the clock. */
+async function queue_microtasks(turns: number): Promise<void> {
+  for (let i = 0; i < turns; i++) await Promise.resolve();
+}

--- a/packages/sdk/src/atlas-instance.adapter.ts
+++ b/packages/sdk/src/atlas-instance.adapter.ts
@@ -21,6 +21,7 @@ import type { TenantContextFactory } from '@wisecom/atlas-types';
 import { create_outlook_api } from '@/outlook-api.factory';
 import { create_onedrive_api } from '@/onedrive-api.factory';
 import { create_sharepoint_api } from '@/sharepoint-api.factory';
+import { resolve_log_sink, scope_api_logging } from '@/log-scope';
 
 /** Creates a tenant-bound Atlas SDK instance from explicit configuration values. */
 export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance {
@@ -36,11 +37,13 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     IDENTITY_REGISTRY_REPOSITORY_TOKEN,
   );
   const tenant_factory = container.get<TenantContextFactory>(TENANT_CONTEXT_FACTORY_TOKEN);
+  const sink = resolve_log_sink(config.logger);
+  const scoped = <T extends object>(api: T): T => scope_api_logging(api, tenant_id, sink);
 
-  return {
-    outlook: create_outlook_api(tenant_id, container),
-    onedrive: create_onedrive_api(tenant_id, container),
-    sharepoint: create_sharepoint_api(tenant_id, container),
+  return scoped({
+    outlook: scoped(create_outlook_api(tenant_id, container)),
+    onedrive: scoped(create_onedrive_api(tenant_id, container)),
+    sharepoint: scoped(create_sharepoint_api(tenant_id, container)),
 
     async checkStorage(request) {
       return await storage_check.check_storage(tenant_id, request);
@@ -80,7 +83,7 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     async getReplicationStatusByOwner(owner_id) {
       return await replication.get_replication_status_by_owner(tenant_id, owner_id);
     },
-  };
+  });
 }
 
 function normalizeConfig(config: AtlasInstanceConfig): AtlasConfig {

--- a/packages/sdk/src/log-scope.ts
+++ b/packages/sdk/src/log-scope.ts
@@ -1,0 +1,35 @@
+import {
+  run_with_log_scope,
+  SILENT_LOG_SINK,
+  type LogScope,
+} from '@wisecom/atlas-core/utils/log-context';
+import type { LogSink } from '@wisecom/atlas-types';
+
+/**
+ * Wraps every method of an SDK namespace so its log output is routed and tagged.
+ *
+ * Applied once per namespace at construction rather than per method, so a new
+ * SDK method is covered by existing code instead of needing to remember this.
+ * Methods are closures over their factory, never `this`, so rebinding them is
+ * safe (issue #41).
+ */
+export function scope_api_logging<T extends object>(api: T, tenant_id: string, sink: LogSink): T {
+  const scoped: Record<string, unknown> = {};
+
+  for (const [name, value] of Object.entries(api)) {
+    if (typeof value !== 'function') {
+      scoped[name] = value;
+      continue;
+    }
+    const scope: LogScope = { sink, fields: { tenant_id, operation: name } };
+    scoped[name] = (...args: unknown[]): unknown =>
+      run_with_log_scope(scope, () => (value as (...a: unknown[]) => unknown)(...args));
+  }
+
+  return scoped as T;
+}
+
+/** The sink an instance uses: the host's, or silence. */
+export function resolve_log_sink(logger: LogSink | undefined): LogSink {
+  return logger ?? SILENT_LOG_SINK;
+}

--- a/packages/sdk/tests/unit/log-sink.test.ts
+++ b/packages/sdk/tests/unit/log-sink.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { LogFields, LogSink } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import { resolve_log_sink, scope_api_logging } from '@/log-scope';
+
+function recording_sink(): {
+  sink: LogSink;
+  lines: { level: string; message: string; fields?: LogFields | undefined }[];
+} {
+  const lines: { level: string; message: string; fields?: LogFields | undefined }[] = [];
+  const record =
+    (level: string) =>
+    (message: string, fields?: LogFields): void => {
+      lines.push({ level, message, fields });
+    };
+  return {
+    lines,
+    sink: {
+      debug: record('debug'),
+      info: record('info'),
+      warn: record('warn'),
+      error: record('error'),
+    },
+  };
+}
+
+/** Stands in for an SDK namespace: async methods that log from inside a service. */
+function fake_api() {
+  return {
+    async backup(mailbox: string): Promise<string> {
+      await Promise.resolve();
+      logger.warn(`skipped an attachment for ${mailbox}`);
+      return 'done';
+    },
+    async verify(): Promise<void> {
+      logger.info('verified');
+    },
+    not_a_function: 42,
+  };
+}
+
+describe('resolve_log_sink', () => {
+  it('falls back to silence when the host passes no logger', () => {
+    const sink = resolve_log_sink(undefined);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    sink.info('nothing');
+    sink.error('also nothing');
+
+    expect(write).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('uses the host sink when given one', () => {
+    const { sink } = recording_sink();
+
+    expect(resolve_log_sink(sink)).toBe(sink);
+  });
+});
+
+describe('scope_api_logging', () => {
+  it('routes a method\u2019s log output to the sink', async () => {
+    const { sink, lines } = recording_sink();
+    const api = scope_api_logging(fake_api(), 'tenant-1', sink);
+
+    await api.backup('user@example.com');
+
+    expect(lines).toEqual([
+      {
+        level: 'warn',
+        message: 'skipped an attachment for user@example.com',
+        fields: { tenant_id: 'tenant-1', operation: 'backup' },
+      },
+    ]);
+  });
+
+  it('tags each line with the method that produced it', async () => {
+    const { sink, lines } = recording_sink();
+    const api = scope_api_logging(fake_api(), 'tenant-1', sink);
+
+    await api.backup('a@example.com');
+    await api.verify();
+
+    expect(lines.map((l) => l.fields?.['operation'])).toEqual(['backup', 'verify']);
+  });
+
+  it('keeps two instances apart, which a module-global logger cannot', async () => {
+    const first = recording_sink();
+    const second = recording_sink();
+    const api_a = scope_api_logging(fake_api(), 'tenant-a', first.sink);
+    const api_b = scope_api_logging(fake_api(), 'tenant-b', second.sink);
+
+    await Promise.all([api_a.verify(), api_b.verify()]);
+
+    expect(first.lines.map((l) => l.fields?.['tenant_id'])).toEqual(['tenant-a']);
+    expect(second.lines.map((l) => l.fields?.['tenant_id'])).toEqual(['tenant-b']);
+  });
+
+  it('preserves the return value and rejects as the method does', async () => {
+    const { sink } = recording_sink();
+    const api = scope_api_logging(
+      {
+        async ok(): Promise<string> {
+          return 'value';
+        },
+        async boom(): Promise<never> {
+          throw new Error('from the service');
+        },
+      },
+      'tenant-1',
+      sink,
+    );
+
+    await expect(api.ok()).resolves.toBe('value');
+    await expect(api.boom()).rejects.toThrow('from the service');
+  });
+
+  it('passes every argument through untouched', async () => {
+    const { sink } = recording_sink();
+    const spy = vi.fn(async (..._args: unknown[]) => undefined);
+    const api = scope_api_logging({ run: spy }, 'tenant-1', sink);
+
+    await api.run('a', 2, { c: true }, undefined);
+
+    expect(spy).toHaveBeenCalledWith('a', 2, { c: true }, undefined);
+  });
+
+  it('leaves non-function properties alone', () => {
+    const { sink } = recording_sink();
+    const api = scope_api_logging(fake_api(), 'tenant-1', sink);
+
+    // The instance nests sub-API objects next to its own methods.
+    expect(api.not_a_function).toBe(42);
+  });
+
+  it('writes nothing to the console for an instance with no logger', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const api = scope_api_logging(fake_api(), 'tenant-1', resolve_log_sink(undefined));
+
+    await api.backup('user@example.com');
+    await api.verify();
+
+    // The acceptance criterion of issue #41: with no logger, SDK operations
+    // write nothing to stdout.
+    expect(log).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/types/src/ports/atlas/log-sink.port.ts
+++ b/packages/types/src/ports/atlas/log-sink.port.ts
@@ -1,0 +1,17 @@
+/** Structured fields attached to one log line. */
+export type LogFields = Record<string, unknown>;
+
+/**
+ * Where Atlas sends its log output.
+ *
+ * Deliberately the four levels every host logger already has, so a `pino` or
+ * `winston` instance satisfies it as-is and an adapter is a few lines at most.
+ * There is no `success` or `progress`: the first is an `info`, and the second is
+ * terminal cursor control that means nothing to a structured logger.
+ */
+export interface LogSink {
+  debug(message: string, fields?: LogFields): void;
+  info(message: string, fields?: LogFields): void;
+  warn(message: string, fields?: LogFields): void;
+  error(message: string, fields?: LogFields): void;
+}

--- a/packages/types/src/ports/atlas/use-case.port.ts
+++ b/packages/types/src/ports/atlas/use-case.port.ts
@@ -1,3 +1,4 @@
+import type { LogSink } from '@/ports/atlas/log-sink.port';
 import type { StorageCheckRequest, StorageCheckResult } from '@/ports/storage-check/use-case.port';
 import type { BucketStats } from '@/domain/stats';
 import type {
@@ -21,6 +22,11 @@ export interface AtlasInstanceConfig {
   readonly s3SecretKey: string;
   readonly s3Region?: string;
   readonly encryptionPassphrase: string;
+  /**
+   * Where Atlas sends log output. Omitted means silent: an embedded Atlas
+   * writes nothing to the host's stdout unless the host asks for it (issue #41).
+   */
+  readonly logger?: LogSink;
 }
 
 export interface AtlasInstance {

--- a/packages/types/src/ports/index.ts
+++ b/packages/types/src/ports/index.ts
@@ -106,6 +106,7 @@ export type {
 export type { DekValidationFn } from './replication/dek-validation.port';
 
 export type { AtlasInstanceConfig, AtlasInstance } from './atlas/use-case.port';
+export type { LogSink, LogFields } from './atlas/log-sink.port';
 export type {
   OutlookApi,
   OutlookBackupOptions,


### PR DESCRIPTION
Fixes #41. Cut from `dev`. Touches core logging, types and the SDK, so it overlaps nothing open.

## The problem

Every SDK operation wrote chalk-coloured `[*]`, `[!]` and `[x]` lines straight to the host application's console, plus raw ANSI cursor control on a TTY. An embedded Atlas could not be silenced, could not be routed to `pino` or `winston`, and could not attribute a line to a tenant, because all instances shared one module global.

```typescript
createAtlasInstance({ ...credentials, logger: myPinoAdapter });
```

`LogSink` is four methods, `debug`/`info`/`warn`/`error`, each taking a message and optional structured fields. A host logger satisfies it with a four-line adapter.

## Why AsyncLocalStorage, not DI

The issue proposes threading the sink through the Inversify container instead of the module-global import. I measured first: the core logger is imported by **71 files and called from 733 sites**, most of them free functions rather than injectable classes. Threading a parameter through all of them is a rewrite with no behavioural gain, and it is not reviewable.

The scope rides on `AsyncLocalStorage` instead, which reaches all 733 call sites without touching any of them. This is not an invention: `packages/core/src/services/shared/graph-request-context.ts` already carries per-operation Graph cost state exactly this way, so it is the house pattern.

## Behaviour

| Context | Output |
|---|---|
| No scope (the CLI) | Console writer, unchanged and byte-identical |
| SDK, no `logger` | Silent. Nothing reaches stdout or stderr |
| SDK with `logger` | Every line to the sink, tagged `{ tenant_id, operation }` |

The CLI does not call `createAtlasInstance`, which I verified before choosing silence as the SDK default, so there is no risk of muting it.

Three mapping decisions worth reviewing:

- **`success` arrives as `info`.** A structured sink has no success level; it was only ever an info line the terminal rendered green.
- **`progress` and `progress_done` are dropped, not logged.** They write `\r` and `\x1b[K`; as a log record they are noise, and injecting cursor control into a host's log stream would corrupt it. Progress belongs in the typed progress events, and the docs say so.
- **`debug` reaches the sink regardless of `DEBUG`.** The host asked for the lines and its own logger decides the level. Gating on an env var would hide lines an embedder explicitly requested.

Wrapping is applied **once per namespace at construction**, not per method, so a new SDK method is covered without anyone remembering to wrap it.

## One bullet was already done

The issue's third bullet asks that operationally significant lines also appear in typed results. That predates this PR: `summary.warnings`, `summary.errors`, `summary.excluded_folders`, `integrity_failures` and the failed-item ledger already carry it, from #241 and #32. I checked rather than claiming credit. **No result shape changed.**

## Verified

```
new tests      19 (10 core routing, 9 SDK wrapper)
build 10/10 · typecheck 17/17 · test 15/15 · lint 0 errors · format clean · docs clean
```

Core tests cover the parts that would fail silently: the scope survives `await` chains, two concurrent scopes stay separate, no cursor control escapes, and the CLI path still prints when no scope exists.

**Smoke-tested against the built artefacts and the shipped `index.mjs` bundle**, 10 assertions, all passing: a silent instance writes nothing to either stream, a host sink receives lines logged several awaits deep, no ANSI escapes reach the sink, `progress` is dropped, levels survive, every line is tagged, the CLI path still prints with no scope, and constructing an instance prints nothing. I patched `process.stdout.write` and `process.stderr.write` to catch anything escaping rather than trusting the sink's own count.

Per the no-real-timers rule, the concurrency test uses an explicit deferred rather than a sleep, so the interleaving is exact: one scope is suspended mid-operation while the other runs to completion.

## Docs

`sdk.md` gets a Logging section with the pino adapter, the field shape, the three mapping decisions, and a **behaviour-change warning for 4.1.0**: an embedder who relied on console output has to pass a `logger` to keep seeing it. That is the one thing in this PR that can surprise an existing user.
