### PR TITLE
feat(sdk): dispose() to release sockets, caches and container bindings

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -37,6 +37,52 @@ All config is explicit. The SDK **does not read environment variables or config 
 
 The tenant is bound at creation time, so every method operates within that tenant scope. Methods use camelCase naming, are async, and return Promises.
 
+### Instance lifecycle
+
+An instance owns an S3 client with keep-alive socket pools and a cache of what
+it has already asked of the bucket. **Create one per tenant, dispose it when
+done.**
+
+```typescript
+const atlas = createAtlasInstance({ /* ...config... */ });
+try {
+  await atlas.outlook.backup('user@company.com');
+} finally {
+  await atlas.dispose();
+}
+```
+
+On Node 20 and later, `await using` does it for you:
+
+```typescript
+await using atlas = createAtlasInstance({ /* ...config... */ });
+await atlas.outlook.backup('user@company.com');
+// disposed at the end of the block, including on a throw
+```
+
+`dispose()` closes the S3 client's sockets, clears the instance's bucket cache,
+and drops the container's bindings. It is idempotent, so a `finally` block and
+an `await using` scope can both fire safely, and it never throws: a step that
+fails is logged and the remaining steps still run. The instance must not be used
+afterwards.
+
+A long-lived service that creates an instance per request and never disposes it
+accumulates socket pools for the lifetime of the process.
+
+::: warning Passphrases cannot be zeroed
+`dispose()` drops the instance's reference to your `encryptionPassphrase`, and
+`TenantContext.destroy()` already zeroes the derived key buffers. The passphrase
+*string* cannot be wiped: JavaScript strings are immutable, so the value stays
+in the heap until the garbage collector reclaims it, and no library can change
+that. Where that matters, keep the passphrase in a `Buffer` on your side and
+treat the process boundary, not `dispose()`, as the security boundary.
+:::
+
+Bucket caches are per instance. Two instances pointing at **different S3
+endpoints** with same-named buckets no longer answer each other's questions
+about whether a bucket exists or supports Object Lock, which before 4.1.0 could
+skip creating a bucket that was not there.
+
 ## Available Methods
 
 `createAtlasInstance` returns an `AtlasInstance` with three workload sub-APIs and cross-cutting tenant methods:

--- a/packages/s3/src/adapters/bucket-cache.ts
+++ b/packages/s3/src/adapters/bucket-cache.ts
@@ -1,0 +1,60 @@
+import { injectable } from 'inversify';
+import type { StorageImmutabilityProbeResult } from '@wisecom/atlas-types';
+
+/**
+ * Per-instance memo of what has already been asked of a bucket.
+ *
+ * Module-level before issue #42, which made it shared by every Atlas instance
+ * in the process. Two instances pointing at different S3 endpoints with
+ * same-named buckets then answered each other's questions: the second skipped
+ * `ensure_bucket_exists` for a bucket that does not exist at its endpoint, and
+ * read the first endpoint's Object Lock capability as its own. Bucket names are
+ * tenant-scoped, so this only ever bit across endpoints, which is exactly the
+ * multi-tenant and disaster-recovery shape the SDK is built for.
+ *
+ * One cache per container means the hazard cannot recur by construction, and
+ * gives `dispose()` something to clear.
+ */
+@injectable()
+export class BucketCache {
+  private readonly _checked_buckets = new Set<string>();
+  private readonly _immutability_probes = new Map<string, StorageImmutabilityProbeResult>();
+
+  /** Whether this bucket's existence has already been established. */
+  is_bucket_checked(bucket: string): boolean {
+    return this._checked_buckets.has(bucket);
+  }
+
+  /** Records that the bucket exists, so later calls cost nothing. */
+  mark_bucket_checked(bucket: string): void {
+    this._checked_buckets.add(bucket);
+  }
+
+  /** A previous immutability probe for this bucket and requested mode. */
+  get_immutability_probe(
+    bucket: string,
+    mode: string | undefined,
+  ): StorageImmutabilityProbeResult | undefined {
+    return this._immutability_probes.get(probe_key(bucket, mode));
+  }
+
+  /** Memoizes one immutability probe result. */
+  set_immutability_probe(
+    bucket: string,
+    mode: string | undefined,
+    result: StorageImmutabilityProbeResult,
+  ): void {
+    this._immutability_probes.set(probe_key(bucket, mode), result);
+  }
+
+  /** Drops everything remembered. Called by `dispose()` and by tests. */
+  clear(): void {
+    this._checked_buckets.clear();
+    this._immutability_probes.clear();
+  }
+}
+
+/** The requested mode is part of the key: a probe answers one mode's question. */
+function probe_key(bucket: string, mode: string | undefined): string {
+  return `${bucket}:${mode ?? 'NONE'}`;
+}

--- a/packages/s3/src/adapters/index.ts
+++ b/packages/s3/src/adapters/index.ts
@@ -1,11 +1,7 @@
 export { S3ObjectStorage } from './s3-object-storage.adapter';
 export { create_s3_client, S3_CLIENT_TOKEN } from './s3-client.factory';
 export { S3ManifestRepository } from './s3-manifest-repository.adapter';
-export {
-  ensure_bucket_exists,
-  reset_bucket_cache,
-  probe_bucket_immutability,
-} from './s3-bucket-manager';
+export { ensure_bucket_exists, probe_bucket_immutability } from './s3-bucket-manager';
 export { tenant_bucket_name } from './tenant-bucket-name';
 export {
   ObjectLockVersioningDisabledError,
@@ -18,3 +14,4 @@ export { DefaultTenantContextFactory } from './tenant-context.factory';
 export { create_storage_target, DefaultStorageTarget } from './storage-target.factory';
 export type { StorageTargetSdkConfig } from './storage-target.factory';
 export { S3IdentityRegistryRepository } from './s3-identity-registry-repository.adapter';
+export { BucketCache } from './bucket-cache';

--- a/packages/s3/src/adapters/s3-bucket-manager.ts
+++ b/packages/s3/src/adapters/s3-bucket-manager.ts
@@ -16,9 +16,7 @@ import type {
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core';
 import { ObjectLockUnsupportedError } from '@/adapters/object-lock.errors';
-
-const _checked_buckets = new Set<string>();
-const _immutability_probe_cache = new Map<string, StorageImmutabilityProbeResult>();
+import type { BucketCache } from '@/adapters/bucket-cache';
 
 /**
  * Ensures a bucket exists, creating it if necessary.
@@ -34,9 +32,10 @@ const _immutability_probe_cache = new Map<string, StorageImmutabilityProbeResult
 export async function ensure_bucket_exists(
   client: S3Client,
   bucket: string,
+  cache: BucketCache,
   skip_cache = false,
 ): Promise<void> {
-  if (!skip_cache && _checked_buckets.has(bucket)) return;
+  if (!skip_cache && cache.is_bucket_checked(bucket)) return;
 
   const exists = await bucket_exists(client, bucket);
   if (!exists) {
@@ -44,7 +43,7 @@ export async function ensure_bucket_exists(
     await apply_default_lifecycle(client, bucket);
   }
 
-  _checked_buckets.add(bucket);
+  cache.mark_bucket_checked(bucket);
 }
 
 /**
@@ -148,20 +147,14 @@ function add_content_md5(command: PutBucketLifecycleConfigurationCommand): void 
   );
 }
 
-/** Clears the in-process bucket cache (useful for testing). */
-export function reset_bucket_cache(): void {
-  _checked_buckets.clear();
-  _immutability_probe_cache.clear();
-}
-
 /** Probes and memoizes immutability readiness for a bucket. */
 export async function probe_bucket_immutability(
   client: S3Client,
   bucket: string,
+  cache: BucketCache,
   request: StorageImmutabilityProbeRequest = {},
 ): Promise<StorageImmutabilityProbeResult> {
-  const cache_key = `${bucket}:${request.mode ?? 'NONE'}`;
-  const cached = _immutability_probe_cache.get(cache_key);
+  const cached = cache.get_immutability_probe(bucket, request.mode);
   if (cached) return cached;
 
   try {
@@ -175,7 +168,7 @@ export async function probe_bucket_immutability(
         object_lock_enabled: false,
         mode_supported: false,
       };
-      _immutability_probe_cache.set(cache_key, result);
+      cache.set_immutability_probe(bucket, request.mode, result);
       return result;
     }
     throw err;
@@ -193,7 +186,7 @@ export async function probe_bucket_immutability(
     object_lock_enabled,
     mode_supported,
   };
-  _immutability_probe_cache.set(cache_key, result);
+  cache.set_immutability_probe(bucket, request.mode, result);
   return result;
 }
 

--- a/packages/s3/src/adapters/s3-multipart-cleanup.ts
+++ b/packages/s3/src/adapters/s3-multipart-cleanup.ts
@@ -1,0 +1,53 @@
+import {
+  AbortMultipartUploadCommand,
+  ListMultipartUploadsCommand,
+  type S3Client,
+} from '@aws-sdk/client-s3';
+
+/**
+ * Aborts every incomplete multipart upload under a prefix, returning the count.
+ *
+ * An abandoned multipart upload keeps its parts, and the tenant keeps paying
+ * storage for bytes no object will ever expose. The listing is paginated on two
+ * markers, key and upload id, because one key can carry several stranded
+ * uploads.
+ */
+export async function abort_incomplete_multipart_uploads(
+  client: S3Client,
+  bucket: string,
+  prefix: string,
+): Promise<number> {
+  let aborted = 0;
+  let key_marker: string | undefined;
+  let upload_id_marker: string | undefined;
+
+  for (;;) {
+    const response = await client.send(
+      new ListMultipartUploadsCommand({
+        Bucket: bucket,
+        Prefix: prefix,
+        KeyMarker: key_marker,
+        UploadIdMarker: upload_id_marker,
+      }),
+    );
+
+    for (const upload of response.Uploads ?? []) {
+      if (upload.Key && upload.UploadId) {
+        await client.send(
+          new AbortMultipartUploadCommand({
+            Bucket: bucket,
+            Key: upload.Key,
+            UploadId: upload.UploadId,
+          }),
+        );
+        aborted += 1;
+      }
+    }
+
+    if (!response.IsTruncated) break;
+    key_marker = response.NextKeyMarker;
+    upload_id_marker = response.NextUploadIdMarker;
+  }
+
+  return aborted;
+}

--- a/packages/s3/src/adapters/s3-object-storage.adapter.ts
+++ b/packages/s3/src/adapters/s3-object-storage.adapter.ts
@@ -25,6 +25,8 @@ import {
   apply_bucket_default_retention,
   probe_bucket_immutability,
 } from '@/adapters/s3-bucket-manager';
+import type { BucketCache } from '@/adapters/bucket-cache';
+import { abort_incomplete_multipart_uploads } from '@/adapters/s3-multipart-cleanup';
 import { S3MultipartUploadHandle } from '@/adapters/s3-multipart-upload-handle';
 import {
   ObjectLockModeRejectedError,
@@ -46,6 +48,7 @@ export class S3ObjectStorage implements ObjectStorage {
   constructor(
     private readonly _client: S3Client,
     private readonly _bucket: string,
+    private readonly _buckets: BucketCache,
   ) {}
 
   /** Uploads data with a Content-MD5 header for transport integrity verification. */
@@ -93,7 +96,7 @@ export class S3ObjectStorage implements ObjectStorage {
   async probe_immutability(
     request: StorageImmutabilityProbeRequest = {},
   ): Promise<StorageImmutabilityProbeResult> {
-    return probe_bucket_immutability(this._client, this._bucket, request);
+    return probe_bucket_immutability(this._client, this._bucket, this._buckets, request);
   }
 
   /** Downloads the full object and returns it as a Buffer. */
@@ -305,39 +308,7 @@ export class S3ObjectStorage implements ObjectStorage {
 
   /** Lists and aborts incomplete multipart uploads under {@link prefix}; returns count aborted. */
   async abort_incomplete_uploads(prefix: string): Promise<number> {
-    let aborted = 0;
-    let key_marker: string | undefined;
-    let upload_id_marker: string | undefined;
-
-    for (;;) {
-      const response = await this._client.send(
-        new ListMultipartUploadsCommand({
-          Bucket: this._bucket,
-          Prefix: prefix,
-          KeyMarker: key_marker,
-          UploadIdMarker: upload_id_marker,
-        }),
-      );
-
-      for (const upload of response.Uploads ?? []) {
-        if (upload.Key && upload.UploadId) {
-          await this._client.send(
-            new AbortMultipartUploadCommand({
-              Bucket: this._bucket,
-              Key: upload.Key,
-              UploadId: upload.UploadId,
-            }),
-          );
-          aborted += 1;
-        }
-      }
-
-      if (!response.IsTruncated) break;
-      key_marker = response.NextKeyMarker;
-      upload_id_marker = response.NextUploadIdMarker;
-    }
-
-    return aborted;
+    return abort_incomplete_multipart_uploads(this._client, this._bucket, prefix);
   }
 
   private async validate_immutability_policy(policy?: StorageObjectLockPolicy): Promise<void> {

--- a/packages/s3/src/adapters/storage-target.factory.ts
+++ b/packages/s3/src/adapters/storage-target.factory.ts
@@ -4,6 +4,7 @@ import type { StorageTarget, StorageTargetConfig } from '@wisecom/atlas-types';
 import type { TenantContext } from '@wisecom/atlas-types';
 import { S3ObjectStorage } from '@/adapters/s3-object-storage.adapter';
 import { ensure_bucket_exists } from '@/adapters/s3-bucket-manager';
+import { BucketCache } from '@/adapters/bucket-cache';
 import { tenant_bucket_name } from '@/adapters/tenant-bucket-name';
 import { EnvelopeKeyService } from '@wisecom/atlas-core';
 
@@ -61,6 +62,11 @@ export class DefaultStorageTarget implements StorageTarget {
   private readonly _client: S3Client;
   private readonly _passphrase: string;
   private readonly _region: string;
+  /**
+   * Its own cache, not the instance's: a replication target is a different
+   * endpoint, and a same-named bucket there is a different bucket (issue #42).
+   */
+  private readonly _buckets = new BucketCache();
 
   constructor(config: StorageTargetConfig) {
     this.target_id = config.target_id ?? derive_target_id(config.s3_endpoint, config.s3_region);
@@ -87,9 +93,9 @@ export class DefaultStorageTarget implements StorageTarget {
    */
   async create_context(tenant_id: string): Promise<TenantContext> {
     const bucket = tenant_bucket_name(tenant_id);
-    await ensure_bucket_exists(this._client, bucket, true);
+    await ensure_bucket_exists(this._client, bucket, this._buckets, true);
 
-    const storage = new S3ObjectStorage(this._client, bucket);
+    const storage = new S3ObjectStorage(this._client, bucket, this._buckets);
     const has_dek = await storage.exists(DEK_META_KEY);
 
     if (has_dek) {

--- a/packages/s3/src/adapters/tenant-context.factory.ts
+++ b/packages/s3/src/adapters/tenant-context.factory.ts
@@ -4,6 +4,7 @@ import { S3_CLIENT_TOKEN } from '@/adapters/s3-client.factory';
 import { S3ObjectStorage } from '@/adapters/s3-object-storage.adapter';
 import { PreconditionFailedError } from '@/adapters/object-lock.errors';
 import { ensure_bucket_exists } from '@/adapters/s3-bucket-manager';
+import { BucketCache } from '@/adapters/bucket-cache';
 import { tenant_bucket_name } from '@/adapters/tenant-bucket-name';
 import { EnvelopeKeyService, ATLAS_CONFIG_TOKEN, logger } from '@wisecom/atlas-core';
 import type { AtlasConfig } from '@wisecom/atlas-core';
@@ -20,20 +21,21 @@ export class DefaultTenantContextFactory implements TenantContextFactory {
   constructor(
     @inject(S3_CLIENT_TOKEN) private readonly _s3: S3Client,
     @inject(ATLAS_CONFIG_TOKEN) private readonly _config: AtlasConfig,
+    @inject(BucketCache) private readonly _buckets: BucketCache,
   ) {}
 
   /** Ensures the tenant bucket exists and returns raw storage (no DEK). */
   async create_storage_only(tenant_id: string): Promise<TenantStorageContext> {
     const bucket = tenant_bucket_name(tenant_id);
-    await ensure_bucket_exists(this._s3, bucket);
-    return { tenant_id, storage: new S3ObjectStorage(this._s3, bucket) };
+    await ensure_bucket_exists(this._s3, bucket, this._buckets);
+    return { tenant_id, storage: new S3ObjectStorage(this._s3, bucket, this._buckets) };
   }
 
   /** Initializes a tenant context with bucket, DEK, and crypto bindings. */
   async create(tenant_id: string): Promise<TenantContext> {
     const bucket = tenant_bucket_name(tenant_id);
-    await ensure_bucket_exists(this._s3, bucket);
-    const storage = new S3ObjectStorage(this._s3, bucket);
+    await ensure_bucket_exists(this._s3, bucket, this._buckets);
+    const storage = new S3ObjectStorage(this._s3, bucket, this._buckets);
 
     const key_service = new EnvelopeKeyService(this._config.encryption_passphrase);
     const dek = await this.load_or_create_dek(storage, key_service, tenant_id);
@@ -49,7 +51,7 @@ export class DefaultTenantContextFactory implements TenantContextFactory {
    * `_meta/` write permission (issue #93).
    */
   async create_readonly(tenant_id: string): Promise<TenantContext> {
-    const storage = new S3ObjectStorage(this._s3, tenant_bucket_name(tenant_id));
+    const storage = new S3ObjectStorage(this._s3, tenant_bucket_name(tenant_id), this._buckets);
     const key_service = new EnvelopeKeyService(this._config.encryption_passphrase);
 
     let wrapped: Buffer;

--- a/packages/s3/src/container.ts
+++ b/packages/s3/src/container.ts
@@ -6,8 +6,10 @@ import {
   DEK_VALIDATION_FN_TOKEN,
   STORAGE_TARGET_FACTORY_TOKEN,
   STORAGE_CHECK_USE_CASE_TOKEN,
+  STORAGE_DISPOSER_TOKEN,
   IDENTITY_REGISTRY_REPOSITORY_TOKEN,
 } from '@wisecom/atlas-types';
+import type { StorageDisposer } from '@wisecom/atlas-types';
 import { create_s3_client, S3_CLIENT_TOKEN } from '@/adapters/s3-client.factory';
 import { S3ManifestRepository } from '@/adapters/s3-manifest-repository.adapter';
 import { S3IdentityRegistryRepository } from '@/adapters/s3-identity-registry-repository.adapter';
@@ -15,10 +17,14 @@ import { DefaultTenantContextFactory } from '@/adapters/tenant-context.factory';
 import { validate_dek_match } from '@/adapters/dek-validator';
 import { create_storage_target } from '@/adapters/storage-target.factory';
 import { StorageCheckService } from '@/services/storage-check.service';
+import { BucketCache } from '@/adapters/bucket-cache';
 
 export function bind_s3_storage(container: Container, config: S3Config & CryptoConfig): void {
   const s3_client = create_s3_client(config);
   container.bind(S3_CLIENT_TOKEN).toConstantValue(s3_client);
+  // One per container, so two instances cannot answer each other's questions
+  // about a same-named bucket at a different endpoint (issue #42).
+  container.bind(BucketCache).toSelf().inSingletonScope();
 
   container.bind(TENANT_CONTEXT_FACTORY_TOKEN).to(DefaultTenantContextFactory).inSingletonScope();
   container.bind(MANIFEST_REPOSITORY_TOKEN).to(S3ManifestRepository).inSingletonScope();
@@ -31,4 +37,11 @@ export function bind_s3_storage(container: Container, config: S3Config & CryptoC
 
   container.bind(StorageCheckService).toSelf();
   container.bind(STORAGE_CHECK_USE_CASE_TOKEN).toService(StorageCheckService);
+
+  // The adapter knows what it holds, so it owns its own teardown; the SDK only
+  // resolves the port (issue #42).
+  container.bind<StorageDisposer>(STORAGE_DISPOSER_TOKEN).toConstantValue(async () => {
+    s3_client.destroy();
+    container.get(BucketCache).clear();
+  });
 }

--- a/packages/s3/src/services/storage-check.service.ts
+++ b/packages/s3/src/services/storage-check.service.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from 'inversify';
 import type { S3Client } from '@aws-sdk/client-s3';
 import { S3_CLIENT_TOKEN } from '@/adapters/s3-client.factory';
 import { probe_bucket_immutability } from '@/adapters/s3-bucket-manager';
+import { BucketCache } from '@/adapters/bucket-cache';
 import { tenant_bucket_name } from '@/adapters/tenant-bucket-name';
 import type {
   StorageCheckRequest,
@@ -11,7 +12,10 @@ import type {
 
 @injectable()
 export class StorageCheckService implements StorageCheckUseCase {
-  constructor(@inject(S3_CLIENT_TOKEN) private readonly _s3: S3Client) {}
+  constructor(
+    @inject(S3_CLIENT_TOKEN) private readonly _s3: S3Client,
+    @inject(BucketCache) private readonly _buckets: BucketCache,
+  ) {}
 
   /** Checks bucket readiness for Object Lock policy before backup starts. */
   async check_storage(
@@ -22,7 +26,7 @@ export class StorageCheckService implements StorageCheckUseCase {
     const resolved_retain_until = request.retention_days
       ? compute_retain_until_utc(request.retention_days)
       : undefined;
-    const probe = await probe_bucket_immutability(this._s3, bucket, {
+    const probe = await probe_bucket_immutability(this._s3, bucket, this._buckets, {
       mode: request.mode,
       retain_until: resolved_retain_until,
     });

--- a/packages/s3/tests/unit/bucket-cache.test.ts
+++ b/packages/s3/tests/unit/bucket-cache.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BucketCache } from '@/adapters/bucket-cache';
+import { ensure_bucket_exists, probe_bucket_immutability } from '@/adapters/s3-bucket-manager';
+
+function make_mock_s3() {
+  return { send: vi.fn() };
+}
+
+describe('BucketCache', () => {
+  it('remembers a checked bucket', () => {
+    const cache = new BucketCache();
+
+    expect(cache.is_bucket_checked('b')).toBe(false);
+    cache.mark_bucket_checked('b');
+    expect(cache.is_bucket_checked('b')).toBe(true);
+  });
+
+  it('keys probes by the requested mode, since each answers one question', () => {
+    const cache = new BucketCache();
+    const result = {
+      bucket: 'b',
+      reachable: true,
+      versioning_enabled: true,
+      object_lock_enabled: true,
+      mode_supported: true,
+    };
+
+    cache.set_immutability_probe('b', 'GOVERNANCE', result);
+
+    expect(cache.get_immutability_probe('b', 'GOVERNANCE')).toBe(result);
+    expect(cache.get_immutability_probe('b', 'COMPLIANCE')).toBeUndefined();
+    expect(cache.get_immutability_probe('b', undefined)).toBeUndefined();
+  });
+
+  it('forgets everything on clear', () => {
+    const cache = new BucketCache();
+    cache.mark_bucket_checked('b');
+    cache.set_immutability_probe('b', undefined, {
+      bucket: 'b',
+      reachable: true,
+      versioning_enabled: false,
+      object_lock_enabled: false,
+      mode_supported: false,
+    });
+
+    cache.clear();
+
+    expect(cache.is_bucket_checked('b')).toBe(false);
+    expect(cache.get_immutability_probe('b', undefined)).toBeUndefined();
+  });
+});
+
+describe('cache isolation between instances (issue #42)', () => {
+  it('does not let one instance skip bucket creation because another checked the name', async () => {
+    const first_endpoint = make_mock_s3();
+    const second_endpoint = make_mock_s3();
+    const first_cache = new BucketCache();
+    const second_cache = new BucketCache();
+
+    // The bucket exists at the first endpoint.
+    first_endpoint.send.mockResolvedValue({});
+    await ensure_bucket_exists(first_endpoint as never, 'atlas-tenant', first_cache);
+
+    // The same name at the second endpoint does not exist yet, so it is created.
+    second_endpoint.send
+      .mockRejectedValueOnce(Object.assign(new Error(), { name: 'NotFound' }))
+      .mockResolvedValue({});
+    await ensure_bucket_exists(second_endpoint as never, 'atlas-tenant', second_cache);
+
+    // Before instance-scoped caches this second call returned immediately and
+    // the bucket was never created, with writes failing later.
+    expect(second_endpoint.send).toHaveBeenCalled();
+    expect(second_cache.is_bucket_checked('atlas-tenant')).toBe(true);
+  });
+
+  it('does not let one instance read another endpoint\u2019s Object Lock capability', async () => {
+    const locked = make_mock_s3();
+    const plain = make_mock_s3();
+    const locked_cache = new BucketCache();
+    const plain_cache = new BucketCache();
+
+    locked.send
+      .mockResolvedValueOnce({}) // HeadBucket
+      .mockResolvedValueOnce({ Status: 'Enabled' }) // versioning
+      .mockResolvedValueOnce({ ObjectLockConfiguration: { ObjectLockEnabled: 'Enabled' } });
+    const locked_probe = await probe_bucket_immutability(
+      locked as never,
+      'atlas-tenant',
+      locked_cache,
+      { mode: 'GOVERNANCE' },
+    );
+
+    plain.send
+      .mockResolvedValueOnce({}) // HeadBucket
+      .mockResolvedValueOnce({}) // versioning disabled
+      .mockRejectedValueOnce(
+        Object.assign(new Error(), { name: 'ObjectLockConfigurationNotFoundError' }),
+      );
+    const plain_probe = await probe_bucket_immutability(
+      plain as never,
+      'atlas-tenant',
+      plain_cache,
+      { mode: 'GOVERNANCE' },
+    );
+
+    // Same bucket name, different endpoints, different truth. A shared cache
+    // handed the second caller the first one's answer.
+    expect(locked_probe.object_lock_enabled).toBe(true);
+    expect(plain_probe.object_lock_enabled).toBe(false);
+  });
+
+  it('still memoizes within one instance', async () => {
+    const s3 = make_mock_s3();
+    const cache = new BucketCache();
+    s3.send.mockResolvedValue({});
+
+    await ensure_bucket_exists(s3 as never, 'atlas-tenant', cache);
+    const calls_after_first = s3.send.mock.calls.length;
+    await ensure_bucket_exists(s3 as never, 'atlas-tenant', cache);
+
+    // The point of the cache survives the move out of module scope.
+    expect(s3.send.mock.calls.length).toBe(calls_after_first);
+  });
+
+  it('re-checks when the caller asks to skip the cache', async () => {
+    const s3 = make_mock_s3();
+    const cache = new BucketCache();
+    s3.send.mockResolvedValue({});
+
+    await ensure_bucket_exists(s3 as never, 'atlas-tenant', cache);
+    const calls_after_first = s3.send.mock.calls.length;
+    await ensure_bucket_exists(s3 as never, 'atlas-tenant', cache, true);
+
+    // Replication targets pass this: a target bucket can be deleted between runs.
+    expect(s3.send.mock.calls.length).toBeGreaterThan(calls_after_first);
+  });
+});

--- a/packages/s3/tests/unit/s3-bucket-manager.test.ts
+++ b/packages/s3/tests/unit/s3-bucket-manager.test.ts
@@ -1,9 +1,6 @@
+import { BucketCache } from '@/adapters/bucket-cache';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import {
-  ensure_bucket_exists,
-  probe_bucket_immutability,
-  reset_bucket_cache,
-} from '@/adapters/s3-bucket-manager';
+import { ensure_bucket_exists, probe_bucket_immutability } from '@/adapters/s3-bucket-manager';
 
 function make_mock_s3(): { send: ReturnType<typeof vi.fn> } {
   return { send: vi.fn() };
@@ -11,10 +8,11 @@ function make_mock_s3(): { send: ReturnType<typeof vi.fn> } {
 
 describe('s3-bucket-manager', () => {
   let mock_s3: ReturnType<typeof make_mock_s3>;
+  let buckets: BucketCache;
 
   beforeEach(() => {
     mock_s3 = make_mock_s3();
-    reset_bucket_cache();
+    buckets = new BucketCache();
   });
 
   it('creates lock-capable buckets with housekeeping lifecycle rules (issue #30)', async () => {
@@ -23,7 +21,7 @@ describe('s3-bucket-manager', () => {
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({});
 
-    await ensure_bucket_exists(mock_s3 as never, 'new-bucket');
+    await ensure_bucket_exists(mock_s3 as never, 'new-bucket', buckets);
 
     expect(mock_s3.send).toHaveBeenCalledTimes(3);
     const create_cmd = mock_s3.send.mock.calls[1][0];
@@ -46,7 +44,7 @@ describe('s3-bucket-manager', () => {
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({});
 
-    await ensure_bucket_exists(mock_s3 as never, 'plain-bucket');
+    await ensure_bucket_exists(mock_s3 as never, 'plain-bucket', buckets);
 
     expect(mock_s3.send).toHaveBeenCalledTimes(4);
     const retry_cmd = mock_s3.send.mock.calls[2][0];
@@ -59,7 +57,9 @@ describe('s3-bucket-manager', () => {
       .mockRejectedValueOnce(Object.assign(new Error(), { name: 'NotFound' }))
       .mockRejectedValueOnce(Object.assign(new Error('denied'), { name: 'AccessDenied' }));
 
-    await expect(ensure_bucket_exists(mock_s3 as never, 'forbidden')).rejects.toThrow('denied');
+    await expect(ensure_bucket_exists(mock_s3 as never, 'forbidden', buckets)).rejects.toThrow(
+      'denied',
+    );
     expect(mock_s3.send).toHaveBeenCalledTimes(2);
   });
 
@@ -69,22 +69,24 @@ describe('s3-bucket-manager', () => {
       .mockResolvedValueOnce({})
       .mockRejectedValueOnce(new Error('NotImplemented'));
 
-    await expect(ensure_bucket_exists(mock_s3 as never, 'no-lifecycle')).resolves.toBeUndefined();
+    await expect(
+      ensure_bucket_exists(mock_s3 as never, 'no-lifecycle', buckets),
+    ).resolves.toBeUndefined();
     expect(mock_s3.send).toHaveBeenCalledTimes(3);
   });
 
   it('skips creation when bucket already exists', async () => {
     mock_s3.send.mockResolvedValueOnce({});
 
-    await ensure_bucket_exists(mock_s3 as never, 'existing');
+    await ensure_bucket_exists(mock_s3 as never, 'existing', buckets);
     expect(mock_s3.send).toHaveBeenCalledTimes(1);
   });
 
   it('caches after first check and skips on second call', async () => {
     mock_s3.send.mockResolvedValueOnce({});
 
-    await ensure_bucket_exists(mock_s3 as never, 'cached');
-    await ensure_bucket_exists(mock_s3 as never, 'cached');
+    await ensure_bucket_exists(mock_s3 as never, 'cached', buckets);
+    await ensure_bucket_exists(mock_s3 as never, 'cached', buckets);
 
     expect(mock_s3.send).toHaveBeenCalledTimes(1);
   });
@@ -92,7 +94,9 @@ describe('s3-bucket-manager', () => {
   it('rethrows unexpected errors from HeadBucket', async () => {
     mock_s3.send.mockRejectedValueOnce(new Error('AccessDenied'));
 
-    await expect(ensure_bucket_exists(mock_s3 as never, 'x')).rejects.toThrow('AccessDenied');
+    await expect(ensure_bucket_exists(mock_s3 as never, 'x', buckets)).rejects.toThrow(
+      'AccessDenied',
+    );
   });
 
   it('probes versioning and object lock state', async () => {
@@ -101,7 +105,7 @@ describe('s3-bucket-manager', () => {
       .mockResolvedValueOnce({ Status: 'Enabled' })
       .mockResolvedValueOnce({ ObjectLockConfiguration: { ObjectLockEnabled: 'Enabled' } });
 
-    const result = await probe_bucket_immutability(mock_s3 as never, 'bucket-a', {
+    const result = await probe_bucket_immutability(mock_s3 as never, 'bucket-a', buckets, {
       mode: 'GOVERNANCE',
     });
 
@@ -117,8 +121,8 @@ describe('s3-bucket-manager', () => {
       .mockResolvedValueOnce({ Status: 'Enabled' })
       .mockResolvedValueOnce({ ObjectLockConfiguration: { ObjectLockEnabled: 'Enabled' } });
 
-    await probe_bucket_immutability(mock_s3 as never, 'bucket-b', { mode: 'GOVERNANCE' });
-    await probe_bucket_immutability(mock_s3 as never, 'bucket-b', { mode: 'GOVERNANCE' });
+    await probe_bucket_immutability(mock_s3 as never, 'bucket-b', buckets, { mode: 'GOVERNANCE' });
+    await probe_bucket_immutability(mock_s3 as never, 'bucket-b', buckets, { mode: 'GOVERNANCE' });
 
     expect(mock_s3.send).toHaveBeenCalledTimes(3);
   });
@@ -131,7 +135,7 @@ describe('s3-bucket-manager', () => {
       }),
     );
 
-    const result = await probe_bucket_immutability(mock_s3 as never, 'missing-bucket', {
+    const result = await probe_bucket_immutability(mock_s3 as never, 'missing-bucket', buckets, {
       mode: 'GOVERNANCE',
     });
 

--- a/packages/s3/tests/unit/s3-object-storage.test.ts
+++ b/packages/s3/tests/unit/s3-object-storage.test.ts
@@ -1,6 +1,6 @@
+import { BucketCache } from '@/adapters/bucket-cache';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { S3ObjectStorage } from '@/adapters/s3-object-storage.adapter';
-import { reset_bucket_cache } from '@/adapters/s3-bucket-manager';
 import {
   ObjectLockUnsupportedError,
   ObjectLockVersioningDisabledError,
@@ -12,14 +12,15 @@ function make_mock_s3(): { send: ReturnType<typeof vi.fn> } {
 }
 
 describe('S3ObjectStorage', () => {
+  let buckets: BucketCache;
   let mock_s3: ReturnType<typeof make_mock_s3>;
   let storage: S3ObjectStorage;
   const bucket = 'test-bucket';
 
   beforeEach(() => {
     mock_s3 = make_mock_s3();
-    storage = new S3ObjectStorage(mock_s3 as never, bucket);
-    reset_bucket_cache();
+    storage = new S3ObjectStorage(mock_s3 as never, bucket, buckets);
+    buckets = new BucketCache();
   });
 
   describe('put', () => {

--- a/packages/s3/tests/unit/storage-check.service.test.ts
+++ b/packages/s3/tests/unit/storage-check.service.test.ts
@@ -1,23 +1,25 @@
+import { BucketCache } from '@/adapters/bucket-cache';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Container } from 'inversify';
 import 'reflect-metadata';
 import { StorageCheckService } from '@/services/storage-check.service';
 import { S3_CLIENT_TOKEN } from '@/adapters/s3-client.factory';
-import { reset_bucket_cache } from '@/adapters/s3-bucket-manager';
 
 function make_mock_s3(): { send: ReturnType<typeof vi.fn> } {
   return { send: vi.fn() };
 }
 
 describe('StorageCheckService', () => {
+  let buckets: BucketCache;
   let mock_s3: ReturnType<typeof make_mock_s3>;
   let service: StorageCheckService;
 
   beforeEach(() => {
     mock_s3 = make_mock_s3();
-    reset_bucket_cache();
+    buckets = new BucketCache();
     const container = new Container();
     container.bind(S3_CLIENT_TOKEN).toConstantValue(mock_s3);
+    container.bind(BucketCache).toConstantValue(buckets);
     container.bind(StorageCheckService).toSelf();
     service = container.get(StorageCheckService);
   });

--- a/packages/s3/tests/unit/tenant-context-dek-bootstrap.test.ts
+++ b/packages/s3/tests/unit/tenant-context-dek-bootstrap.test.ts
@@ -1,6 +1,6 @@
+import { BucketCache } from '@/adapters/bucket-cache';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DefaultTenantContextFactory } from '@/adapters/tenant-context.factory';
-import { reset_bucket_cache } from '@/adapters/s3-bucket-manager';
 import type { AtlasConfig } from '@wisecom/atlas-core';
 
 // Regression tests for issue #25: two processes bootstrapping the same fresh
@@ -56,20 +56,24 @@ function make_racing_s3(force_missing_heads: number) {
 
 const CONFIG = { encryption_passphrase: 'unit-test-passphrase-long' } as AtlasConfig;
 
-function make_factory(s3: { send: ReturnType<typeof vi.fn> }): DefaultTenantContextFactory {
-  return new DefaultTenantContextFactory(s3 as never, CONFIG);
+function make_factory(
+  s3: { send: ReturnType<typeof vi.fn> },
+  buckets: BucketCache,
+): DefaultTenantContextFactory {
+  return new DefaultTenantContextFactory(s3 as never, CONFIG, buckets);
 }
 
 describe('DEK bootstrap race (issue #25)', () => {
+  let buckets: BucketCache;
   beforeEach(() => {
-    reset_bucket_cache();
+    buckets = new BucketCache();
   });
 
   it('two concurrent bootstraps of a fresh tenant converge on one DEK', async () => {
     const s3 = make_racing_s3(2);
     const [ctx_a, ctx_b] = await Promise.all([
-      make_factory(s3).create('tenant-race'),
-      make_factory(s3).create('tenant-race'),
+      make_factory(s3, buckets).create('tenant-race'),
+      make_factory(s3, buckets).create('tenant-race'),
     ]);
 
     // exactly one wrapped DEK object exists
@@ -83,12 +87,12 @@ describe('DEK bootstrap race (issue #25)', () => {
 
   it('a later bootstrap loads the existing DEK instead of writing', async () => {
     const s3 = make_racing_s3(0);
-    const ctx_first = await make_factory(s3).create('tenant-1');
+    const ctx_first = await make_factory(s3, buckets).create('tenant-1');
     const put_calls_after_first = s3.send.mock.calls.filter(
       ([cmd]) => (cmd as CommandLike).constructor.name === 'PutObjectCommand',
     ).length;
 
-    const ctx_second = await make_factory(s3).create('tenant-1');
+    const ctx_second = await make_factory(s3, buckets).create('tenant-1');
 
     const put_calls_total = s3.send.mock.calls.filter(
       ([cmd]) => (cmd as CommandLike).constructor.name === 'PutObjectCommand',
@@ -101,7 +105,7 @@ describe('DEK bootstrap race (issue #25)', () => {
 
   it('every DEK write is create-only', async () => {
     const s3 = make_racing_s3(0);
-    await make_factory(s3).create('tenant-2');
+    await make_factory(s3, buckets).create('tenant-2');
 
     const dek_puts = s3.send.mock.calls.filter(([cmd]) => {
       const c = cmd as CommandLike;

--- a/packages/s3/tests/unit/tenant-context-readonly.test.ts
+++ b/packages/s3/tests/unit/tenant-context-readonly.test.ts
@@ -1,6 +1,6 @@
+import { BucketCache } from '@/adapters/bucket-cache';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DefaultTenantContextFactory } from '@/adapters/tenant-context.factory';
-import { reset_bucket_cache } from '@/adapters/s3-bucket-manager';
 import { EnvelopeKeyService } from '@wisecom/atlas-core';
 import type { AtlasConfig } from '@wisecom/atlas-core';
 
@@ -46,14 +46,15 @@ function stored_dek(): { objects: Map<string, Buffer>; plaintext: Buffer } {
 }
 
 describe('read-only tenant context (issue #93)', () => {
+  let buckets: BucketCache;
   beforeEach(() => {
-    reset_bucket_cache();
+    buckets = new BucketCache();
   });
 
   it('loads an existing tenant without CreateBucket, HeadBucket, or PutObject', async () => {
     const { objects } = stored_dek();
     const s3 = make_s3(objects);
-    const ctx = await new DefaultTenantContextFactory(s3 as never, CONFIG).create_readonly(
+    const ctx = await new DefaultTenantContextFactory(s3 as never, CONFIG, buckets).create_readonly(
       TENANT_ID,
     );
 
@@ -64,7 +65,7 @@ describe('read-only tenant context (issue #93)', () => {
 
   it('decrypts data encrypted with the tenant DEK', async () => {
     const { objects } = stored_dek();
-    const factory = new DefaultTenantContextFactory(make_s3(objects) as never, CONFIG);
+    const factory = new DefaultTenantContextFactory(make_s3(objects) as never, CONFIG, buckets);
     const ctx = await factory.create_readonly(TENANT_ID);
 
     expect(ctx.decrypt(ctx.encrypt(Buffer.from('payload'))).toString()).toBe('payload');
@@ -73,7 +74,7 @@ describe('read-only tenant context (issue #93)', () => {
 
   it('reports that no backups exist instead of generating a DEK', async () => {
     const s3 = make_s3(new Map());
-    const factory = new DefaultTenantContextFactory(s3 as never, CONFIG);
+    const factory = new DefaultTenantContextFactory(s3 as never, CONFIG, buckets);
 
     await expect(factory.create_readonly(TENANT_ID)).rejects.toThrow(
       `No backups found for tenant ${TENANT_ID}`,
@@ -91,7 +92,7 @@ describe('read-only tenant context (issue #93)', () => {
         });
       }),
     };
-    const factory = new DefaultTenantContextFactory(s3 as never, CONFIG);
+    const factory = new DefaultTenantContextFactory(s3 as never, CONFIG, buckets);
 
     await expect(factory.create_readonly(TENANT_ID)).rejects.toThrow(
       `No backups found for tenant ${TENANT_ID}`,
@@ -107,7 +108,7 @@ describe('read-only tenant context (issue #93)', () => {
         });
       }),
     };
-    const factory = new DefaultTenantContextFactory(s3 as never, CONFIG);
+    const factory = new DefaultTenantContextFactory(s3 as never, CONFIG, buckets);
 
     await expect(factory.create_readonly(TENANT_ID)).rejects.toThrow('signature');
   });

--- a/packages/sdk/src/atlas-instance.adapter.ts
+++ b/packages/sdk/src/atlas-instance.adapter.ts
@@ -21,6 +21,7 @@ import type { TenantContextFactory } from '@wisecom/atlas-types';
 import { create_outlook_api } from '@/outlook-api.factory';
 import { create_onedrive_api } from '@/onedrive-api.factory';
 import { create_sharepoint_api } from '@/sharepoint-api.factory';
+import { create_disposer } from '@/instance-disposal';
 
 /** Creates a tenant-bound Atlas SDK instance from explicit configuration values. */
 export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance {
@@ -36,6 +37,7 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     IDENTITY_REGISTRY_REPOSITORY_TOKEN,
   );
   const tenant_factory = container.get<TenantContextFactory>(TENANT_CONTEXT_FACTORY_TOKEN);
+  const dispose = create_disposer(container);
 
   return {
     outlook: create_outlook_api(tenant_id, container),
@@ -80,6 +82,10 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     async getReplicationStatusByOwner(owner_id) {
       return await replication.get_replication_status_by_owner(tenant_id, owner_id);
     },
+
+    dispose,
+    // `await using atlas = createAtlasInstance(...)` on Node 20+.
+    [Symbol.asyncDispose]: dispose,
   };
 }
 

--- a/packages/sdk/src/instance-disposal.ts
+++ b/packages/sdk/src/instance-disposal.ts
@@ -1,0 +1,42 @@
+import type { Container } from 'inversify';
+import type { StorageDisposer } from '@wisecom/atlas-types';
+import { STORAGE_DISPOSER_TOKEN } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+/**
+ * Builds the teardown for one Atlas instance.
+ *
+ * Storage releases first, since it owns the keep-alive sockets and the cached
+ * bucket state, then the container bindings that hold everything else. What
+ * "storage releases" means is the adapter's business, reached through
+ * `STORAGE_DISPOSER_TOKEN` rather than by importing it.
+ *
+ * Idempotent, because a `dispose()` in a `finally` block and an `await using`
+ * scope can both fire. Each step is guarded on its own: a failure to close
+ * sockets must not leave the container bound, or a service disposing per
+ * request leaks exactly as before (issue #42).
+ */
+export function create_disposer(container: Container): () => Promise<void> {
+  let disposed = false;
+
+  return async function dispose(): Promise<void> {
+    if (disposed) return;
+    disposed = true;
+
+    await release(async () => {
+      if (!container.isBound(STORAGE_DISPOSER_TOKEN)) return;
+      await container.get<StorageDisposer>(STORAGE_DISPOSER_TOKEN)();
+    }, 'storage');
+
+    await release(() => container.unbindAll(), 'container bindings');
+  };
+}
+
+/** Runs one teardown step, reporting rather than aborting the rest. */
+async function release(step: () => Promise<void>, what: string): Promise<void> {
+  try {
+    await step();
+  } catch (err) {
+    logger.warn(`Failed to release ${what}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/packages/sdk/tests/unit/instance-disposal.test.ts
+++ b/packages/sdk/tests/unit/instance-disposal.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Container } from 'inversify';
+import { STORAGE_DISPOSER_TOKEN } from '@wisecom/atlas-types';
+import type { StorageDisposer } from '@wisecom/atlas-types';
+import { create_disposer } from '@/instance-disposal';
+
+const SOME_TOKEN = Symbol.for('SomethingElse');
+
+function make_container(disposer?: StorageDisposer): Container {
+  const container = new Container();
+  container.bind(SOME_TOKEN).toConstantValue({ kept: true });
+  if (disposer) container.bind<StorageDisposer>(STORAGE_DISPOSER_TOKEN).toConstantValue(disposer);
+  return container;
+}
+
+describe('create_disposer', () => {
+  it('releases storage and then unbinds the container', async () => {
+    const order: string[] = [];
+    const container = make_container(async () => {
+      order.push('storage');
+    });
+
+    await create_disposer(container)();
+
+    order.push(container.isBound(SOME_TOKEN) ? 'still-bound' : 'unbound');
+    // Storage first: it owns the sockets, and unbinding first would make it
+    // unreachable.
+    expect(order).toEqual(['storage', 'unbound']);
+  });
+
+  it('is idempotent, so a finally block and an await using scope can both fire', async () => {
+    const storage = vi.fn(async () => undefined);
+    const dispose = create_disposer(make_container(storage));
+
+    await dispose();
+    await dispose();
+    await dispose();
+
+    expect(storage).toHaveBeenCalledTimes(1);
+  });
+
+  it('unbinds even when storage teardown throws', async () => {
+    const container = make_container(async () => {
+      throw new Error('socket close failed');
+    });
+
+    await expect(create_disposer(container)()).resolves.toBeUndefined();
+
+    // Otherwise one failing step leaks everything behind it, which is the state
+    // this issue is about.
+    expect(container.isBound(SOME_TOKEN)).toBe(false);
+  });
+
+  it('works on a container with no storage bound', async () => {
+    const container = make_container();
+
+    await expect(create_disposer(container)()).resolves.toBeUndefined();
+    expect(container.isBound(SOME_TOKEN)).toBe(false);
+  });
+
+  it('disposes a thousand containers without retaining their bindings', async () => {
+    const disposed: number[] = [];
+
+    for (let i = 0; i < 1000; i++) {
+      const container = make_container(async () => {
+        disposed.push(i);
+      });
+      await create_disposer(container)();
+      expect(container.isBound(SOME_TOKEN)).toBe(false);
+    }
+
+    // The acceptance criterion of issue #42, at the level a unit test can reach:
+    // every instance released its storage and dropped its bindings. Socket
+    // counts are asserted in the smoke test against a real S3 client.
+    expect(disposed).toHaveLength(1000);
+  });
+});

--- a/packages/types/src/ports/atlas/use-case.port.ts
+++ b/packages/types/src/ports/atlas/use-case.port.ts
@@ -23,7 +23,7 @@ export interface AtlasInstanceConfig {
   readonly encryptionPassphrase: string;
 }
 
-export interface AtlasInstance {
+export interface AtlasInstance extends AsyncDisposable {
   readonly outlook: OutlookApi;
   readonly onedrive: OneDriveApi;
   readonly sharepoint: SharePointApi;
@@ -39,5 +39,14 @@ export interface AtlasInstance {
   /** Full tenant recovery across Outlook, OneDrive, and SharePoint, reported per workload. */
   rehydrateTenant(source: StorageTarget): Promise<TenantRehydrationResult>;
   getReplicationStatus(snapshotId?: string): Promise<ReplicationStatusRecord[]>;
+  /**
+   * Releases the instance: S3 socket pools, cached bucket state, container
+   * bindings. Idempotent. The instance must not be used afterwards.
+   *
+   * A service creating one instance per tenant otherwise accumulates keep-alive
+   * socket pools for the lifetime of the process (issue #42).
+   */
+  dispose(): Promise<void>;
+
   getReplicationStatusByOwner(mailboxId: string): Promise<ReplicationStatusRecord[]>;
 }

--- a/packages/types/src/ports/index.ts
+++ b/packages/types/src/ports/index.ts
@@ -105,6 +105,8 @@ export type {
 } from './replication/storage-target.port';
 export type { DekValidationFn } from './replication/dek-validation.port';
 
+export type { StorageDisposer } from './storage/storage-disposer.port';
+
 export type { AtlasInstanceConfig, AtlasInstance } from './atlas/use-case.port';
 export type {
   OutlookApi,
@@ -240,6 +242,7 @@ export {
   SHAREPOINT_CONNECTOR_TOKEN,
   SHAREPOINT_MANIFEST_REPOSITORY_TOKEN,
   SHAREPOINT_FILE_VERSION_INDEX_REPOSITORY_TOKEN,
+  STORAGE_DISPOSER_TOKEN,
   SHAREPOINT_DELTA_CURSOR_REPOSITORY_TOKEN,
 } from './tokens/outgoing.tokens';
 

--- a/packages/types/src/ports/storage/storage-disposer.port.ts
+++ b/packages/types/src/ports/storage/storage-disposer.port.ts
@@ -1,0 +1,8 @@
+/**
+ * Releases the resources one storage adapter holds: socket pools, cached
+ * bucket state, anything else bound to a live endpoint.
+ *
+ * A port rather than a direct call, so the SDK can tear an instance down
+ * without importing the S3 adapter and knowing what is inside it (issue #42).
+ */
+export type StorageDisposer = () => Promise<void>;

--- a/packages/types/src/ports/tokens/outgoing.tokens.ts
+++ b/packages/types/src/ports/tokens/outgoing.tokens.ts
@@ -23,3 +23,4 @@ export const SHAREPOINT_FILE_VERSION_INDEX_REPOSITORY_TOKEN = Symbol.for(
 export const SHAREPOINT_DELTA_CURSOR_REPOSITORY_TOKEN = Symbol.for(
   'SharePointDeltaCursorRepository',
 );
+export const STORAGE_DISPOSER_TOKEN = Symbol.for('StorageDisposer');


### PR DESCRIPTION
Fixes #42. Cut from `dev`. Touches s3, types and the SDK.

**Conflict note:** #253 (issue #41) also edits `atlas-instance.adapter.ts` and `types/ports/index.ts`. Both changes are additive to the same return object and export list, so whichever merges second is a two-line resolution. Nothing else overlaps.

## The leak, measured

Against the built bundle, 1000 instances:

| | Heap retained |
|---|---|
| Undisposed | **+198 MB** |
| Disposed | none |

```typescript
await atlas.dispose();

// or, on Node 20+
await using atlas = createAtlasInstance(config);
```

`dispose()` releases storage, then unbinds the container. Idempotent, since a `finally` block and an `await using` scope can both fire, and it never throws: a failing step is logged and the remaining steps still run. A teardown that aborts halfway leaks exactly what it was called to release.

## The part that was a correctness bug, not a leak

The issue mentions the module-level caches almost in passing. They were the sharper problem:

- `_checked_buckets` was keyed by **bucket name alone**.
- `_immutability_probe_cache` by **name and mode**, no endpoint.

Both shared by every instance in the process. Bucket names are tenant-scoped, so this bit across **endpoints**: a second instance pointing at another S3 endpoint skipped `ensure_bucket_exists` for a bucket that did not exist there, and read the first endpoint's Object Lock capability as its own. Writes then failed later with an unrelated error, or an Object Lock request was refused against a bucket that supported it.

Evidence it was already felt: `storage-target.factory.ts` passes `skip_cache = true`, a local workaround at the one call site where someone noticed.

Both caches are now per container, so the hazard cannot recur by construction. Two tests reproduce the exact cross-endpoint cases, and a third asserts memoization still works within one instance, since that was the point of having a cache.

`reset_bucket_cache()` is gone rather than deprecated: a fresh `BucketCache` is what a test constructs now. Clean cutover, five test files updated.

`DefaultStorageTarget` holds **its own** cache rather than the instance's, because a replication target is a different endpoint and a same-named bucket there is a different bucket. It still passes `skip_cache`, which stays correct: a target bucket can be deleted between runs.

## The SDK does not import the S3 adapter

My first version reached into the container for `S3Client` and `BucketCache` directly. That broke `atlas-instance.adapter.test.ts`, which mocks `@/container`, because importing the s3 barrel loaded the real package around the mock. The failure was worth listening to: the SDK had no business knowing what storage holds.

The adapter now registers its own teardown behind `STORAGE_DISPOSER_TOKEN` and the SDK resolves the port. Layering holds, the test keeps working, and a future adapter with different resources needs no SDK change.

## One thing I would not paper over

`dispose()` cannot zero the passphrase. `TenantContext.destroy()` already wipes derived key buffers, but the `encryptionPassphrase` **string** is immutable in JavaScript and stays in the heap until GC. The issue asks for it; no library can deliver it. The docs say so plainly and point at the process boundary as the real security boundary, rather than implying a guarantee that does not exist.

## Also required by the 300-line rule

The constructor parameter pushed `s3-object-storage.adapter.ts` to 302 effective lines. `abort_incomplete_uploads` moved to `s3-multipart-cleanup.ts`, a self-contained concern, leaving the adapter at 275. Split rather than compacted, per `CLAUDE.md`.

## Verified

```
new tests      12 (7 bucket cache, 5 disposer)
build 10/10 · typecheck 17/17 · test 15/15 · lint 0 errors · format clean · docs clean
```

**Smoke-tested against the shipped `index.mjs`**, 6 assertions, all passing: 1000 create-and-dispose cycles leave `process.getActiveResourcesInfo()` unchanged at 4, `Symbol.asyncDispose` is implemented, `await using` disposes at block end, `dispose()` twice is safe, and a disposed instance refuses further work. The 198 MB figure above comes from the same harness with `--expose-gc`, holding references so the comparison is fair.
