### PR TITLE
fix(e2e): pass the suite dispatch input through env, not into the shell

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,6 +91,12 @@ jobs:
         id: suite
         working-directory: e2e
         env:
+          # Through `env`, never interpolated into `run:`. A dispatch input is attacker-controlled
+          # text, GitHub expands `${{ }}` before the shell parses the line, and this step holds
+          # every E2E secret, so an inline expansion is a command-injection path (issue #257).
+          # `${SUITE:+-k "$SUITE"}` omits `-k` entirely when the input is empty, which is what a
+          # scheduled run gets.
+          SUITE: ${{ inputs.suite }}
           E2E_TENANT_ID: ${{ secrets.E2E_TENANT_ID }}
           E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
           E2E_CLIENT_SECRET: ${{ secrets.E2E_CLIENT_SECRET }}
@@ -98,7 +104,7 @@ jobs:
           E2E_MAILBOX: ${{ secrets.E2E_MAILBOX }}
           E2E_ONEDRIVE_OWNER: ${{ secrets.E2E_ONEDRIVE_OWNER }}
           E2E_SHAREPOINT_SITE: ${{ secrets.E2E_SHAREPOINT_SITE }}
-        run: uv run pytest ${{ inputs.suite && format('-k "{0}"', inputs.suite) || '' }}
+        run: uv run pytest ${SUITE:+-k "$SUITE"}
 
       # Status is readable from the run page itself, so a red badge can be triaged without
       # opening logs. The XML holds test names only -- no tenant data.


### PR DESCRIPTION
Closes #257.

## The problem

GitHub expands `${{ }}` before the shell parses the line, so the old step passed a dispatch input as source text rather than as an argument:

```yaml
run: uv run pytest ${{ inputs.suite && format('-k "{0}"', inputs.suite) || '' }}
```

That step holds every E2E secret. A dispatch value such as `a"; env > out; echo "` ran as a separate command with those credentials in scope, and the mask on line 88 covers only `atlas-$E2E_TENANT_ID`, not the secret values themselves.

## The fix

The input arrives as an environment variable and the shell quotes it:

```yaml
        env:
          SUITE: ${{ inputs.suite }}
          # ... existing secrets
        run: uv run pytest ${SUITE:+-k "$SUITE"}
```

`${SUITE:+-k "$SUITE"}` omits `-k` entirely when the value is empty, which is what the nightly schedule passes, so scheduled runs keep running the full suite.

## Verification

Expansion behaviour was measured with an argv probe that prints one line per argument, rather than reasoned about:

| `SUITE` | argv reaching pytest |
|---|---|
| `''` | none |
| `test_10_outlook` | `[-k]` `[test_10_outlook]` |
| `a"; id; echo "` | `[-k]` `[a"; id; echo "]` |
| `x$(id)y` | `[-k]` `[x$(id)y]` |
| ``x`id`y`` | ``[-k]`` ``[x`id`y]`` |
| `a and not b` | `[-k]` `[a and not b]` |

A canary case with `touch /tmp/INJECTED` confirmed the file was never created, so nothing executed. The multi-word row matters separately from the security fix: a real `-k` expression contains spaces and must still arrive as one argument.

The workflow was also parsed with PyYAML to confirm the step keeps all 7 `E2E_*` variables and that `run:` no longer contains `${{`. A repository-wide scan of every workflow's `run:` blocks for `github.*`, `inputs.*`, or `needs.*` interpolation now returns nothing, which was the last acceptance criterion on the issue.

## Scope

CI only. No shipped code, no CLI or SDK surface, so no documentation change applies.