### PR TITLE
fix(save): sanitize the zip entry file name at the archive boundary

### DIFF
--- a/packages/outlook/src/services/save/save-zip-writer.ts
+++ b/packages/outlook/src/services/save/save-zip-writer.ts
@@ -45,8 +45,15 @@ export function add_eml_to_archive(
 ): Promise<void> {
   // Nested mail folders become nested zip directories; each level is sanitized
   // on its own so the separator survives while illegal characters do not.
+  //
+  // The file name is sanitized here too, not just by the caller. It derives from a
+  // message subject, which is chosen by whoever sent the mail, and an entry path like
+  // `../../../.ssh/authorized_keys` escapes the destination directory in any extractor
+  // that honours entry paths. Today's callers pass a name that is already safe, so this
+  // changes no existing archive; it means a future caller passing an item or attachment
+  // name cannot reintroduce the traversal (issue #258).
   const dir_path = folder_path.split('/').map(sanitize_path_segment).join('/');
-  const entry_path = `${dir_path}/${filename}`;
+  const entry_path = `${dir_path}/${sanitize_path_segment(filename)}`;
   return new Promise<void>((resolve, reject) => {
     const on_entry = (): void => {
       archive.removeListener('error', on_error);

--- a/packages/outlook/tests/unit/save-zip-writer.test.ts
+++ b/packages/outlook/tests/unit/save-zip-writer.test.ts
@@ -7,6 +7,7 @@ import {
   add_eml_to_archive,
   finalize_archive,
 } from '@/services/save/save-zip-writer';
+import { build_eml_filename, deduplicate_filename } from '@/services/save/eml-builder';
 
 function temp_path(name: string): string {
   return join(tmpdir(), `atlas-test-${Date.now()}-${name}.zip`);
@@ -93,5 +94,72 @@ describe('save-zip-writer', () => {
     await promise;
 
     expect(entries).toEqual(['Inbox/Q1_Q2/Unknown/a.eml']);
+  });
+
+  // The file name derives from a message subject, so it is chosen by whoever sent the
+  // mail. These cases pin the sanitisation at the archive boundary rather than trusting
+  // the caller to have done it (issue #258).
+  it('strips traversal from the file name instead of nesting the entry outside the folder', async () => {
+    const path = temp_path('traversal');
+    created_files.push(path);
+
+    const { archive, promise } = create_save_archive(path);
+    const entries: string[] = [];
+    archive.on('entry', (e) => entries.push(String(e.name)));
+
+    await add_eml_to_archive(archive, 'Inbox', '../../../etc/passwd', Buffer.from('A'));
+    await finalize_archive(archive);
+    await promise;
+
+    // Separators become underscores and `..` collapses to a single dot that is then
+    // stripped from the front, so the whole name lands as one segment under the folder.
+    expect(entries).toEqual(['Inbox/_._._etc_passwd']);
+    expect(entries[0]).not.toContain('..');
+    expect(entries[0]?.split('/')).toHaveLength(2);
+  });
+
+  it('flattens separators and control characters in the file name into one entry', async () => {
+    const path = temp_path('flatten');
+    created_files.push(path);
+
+    const { archive, promise } = create_save_archive(path);
+    const entries: string[] = [];
+    archive.on('entry', (e) => entries.push(String(e.name)));
+
+    await add_eml_to_archive(archive, 'Inbox', 'a/b\\c\x01d.eml', Buffer.from('A'));
+    await finalize_archive(archive);
+    await promise;
+
+    // One folder level plus one file: the name contributes no extra depth.
+    expect(entries).toEqual(['Inbox/a_b_c_d.eml']);
+    expect(entries[0]?.split('/')).toHaveLength(2);
+  });
+
+  // The constraint on issue #258: archives stay comparable across versions, so a name
+  // that build_eml_filename produces must survive byte-identical.
+  it('leaves generated .eml file names unchanged, including the untitled fallback', async () => {
+    const path = temp_path('identity');
+    created_files.push(path);
+
+    const generated = [
+      build_eml_filename('2026-03-10T14:30:22Z', 'Meeting with client'),
+      build_eml_filename('2026-03-10T14:30:22Z', '<>:"/\\|?*'),
+      build_eml_filename(undefined, undefined),
+      deduplicate_filename(build_eml_filename('2026-03-10T14:30:22Z', 'Same'), new Set(['x'])),
+    ];
+
+    const { archive, promise } = create_save_archive(path);
+    const entries: string[] = [];
+    archive.on('entry', (e) => entries.push(String(e.name)));
+
+    for (const name of generated) {
+      await add_eml_to_archive(archive, 'Inbox', name, Buffer.from('A'));
+    }
+    await finalize_archive(archive);
+    await promise;
+
+    expect(entries).toEqual(generated.map((n) => `Inbox/${n}`));
+    expect(generated[1]).toContain('untitled');
+    expect(generated.every((n) => n.endsWith('.eml'))).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #258.

## The change

One expression in `add_eml_to_archive`:

```diff
  const dir_path = folder_path.split('/').map(sanitize_path_segment).join('/');
- const entry_path = `${dir_path}/${filename}`;
+ const entry_path = `${dir_path}/${sanitize_path_segment(filename)}`;
```

Every segment of `folder_path` was sanitized and then `filename` was interpolated raw into the same path, so traversal safety rested entirely on the caller. That input is attacker-chosen: the name derives from a message subject, which is set by whoever sent the mail, including an external sender.

## Nothing was exploitable

Both call sites build the name with `build_eml_filename`, whose `sanitize_subject` already strips separators and collapses dot runs, and the result carries a timestamp prefix. The problem was placement rather than a live hole. The guard sat a layer away from the concatenation, so a future caller passing an item name, an attachment name, or anything not routed through `build_eml_filename` would silently reintroduce an entry such as `../../../.ssh/authorized_keys`, which escapes the destination directory in any extractor that honours entry paths.

The boundary is also the cheaper place to check: one call, at the point the path is assembled, correct for every future caller without each one having to remember.

## Tests

Three cases added to `save-zip-writer.test.ts`, following the existing `archive.on('entry')` pattern:

| Input file name | Resulting entry |
|---|---|
| `../../../etc/passwd` | `Inbox/_._._etc_passwd`, one segment, no `..` |
| `a/b\c\x01d.eml` | `Inbox/a_b_c_d.eml`, no added depth |
| `build_eml_filename` output | unchanged, byte-identical |

The third case is the constraint from the issue, that archives stay comparable across versions. It covers a normal subject, an all-illegal subject that falls back to `untitled`, a missing timestamp and subject, and a deduplicated name, asserting each arrives unchanged and keeps its `.eml` extension.

Worth noting on the first row: my initial expectation was `Inbox/etcpasswd` and the test failed. The real output is `_._._etc_passwd`, because `sanitize_path_segment` maps separators to underscores rather than deleting them, and the file name is a single segment so it is never split. The code was right and the assertion was wrong. Both are safe, but the test now pins actual behaviour rather than my guess at it.

## Verification

- `save-zip-writer.test.ts`: 8 passed
- Full Outlook package: 41 files, 315 tests passed, so no existing archive layout changed
- `pnpm run typecheck`: 17 tasks successful
- `pnpm run lint`: 9 tasks successful

No CLI, SDK, or configuration surface changes, so no documentation update applies.