### PR TITLE
feat(cli): read replication secret keys from stdin with "-"

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -941,7 +941,7 @@ atlas replicate --status -o user@company.com
 | `-o, --owner <email-or-id>` | Replicate all unreplicated snapshots for a OneDrive owner  |
 | `--target-endpoint <url>`   | Target S3 endpoint URL                                     |
 | `--target-access-key <key>` | Target S3 access key                                       |
-| `--target-secret-key <key>` | Target S3 secret key                                       |
+| `--target-secret-key <key>` | Target S3 secret key; `-` reads it from stdin              |
 | `--target-region <region>`  | Target S3 region (default: `us-east-1`)                    |
 | `--target-config <path>`    | Path to JSON file with target S3 credentials               |
 | `--status`                  | Show replication status instead of replicating             |
@@ -949,6 +949,19 @@ atlas replicate --status -o user@company.com
 
 ::: tip Target Config File
 The target config file is a JSON object with `s3_endpoint`, `s3_access_key`, `s3_secret_key`, and optionally `s3_region` and `target_id`. The encryption passphrase is shared from the main Atlas configuration.
+:::
+
+::: warning Keep the secret key out of argv
+A secret passed inline is written to the shell history file and is readable in the process table by any other local user for as long as the command runs, which for a replication run over a large tenant is not a short window. Pass `-` to read it from stdin instead:
+
+```bash
+atlas replicate -m user@company.com \
+  --target-endpoint http://offsite:9000 \
+  --target-access-key <key> \
+  --target-secret-key - < target-secret.txt
+```
+
+Trailing whitespace and the trailing newline are trimmed. If stdin is empty or unreadable the command fails and names the option, rather than authenticating with an empty secret. Only the secret key accepts `-`, because only one option per invocation can read stdin and the access key ID is not a secret. `--target-config` remains available and moves the secret to a file, but that file's permissions are yours to manage, so `-` is preferable when the secret comes from a secret manager or a pipe.
 :::
 
 ## `atlas rehydrate`
@@ -980,7 +993,7 @@ atlas rehydrate -o user@company.com -s od-snap-1735689600000-a1b2c3 --source-con
 | `--all`                     | Recover every workload: Outlook, OneDrive, and SharePoint    |
 | `--source-endpoint <url>`   | Source replica S3 endpoint URL                               |
 | `--source-access-key <key>` | Source replica S3 access key                                 |
-| `--source-secret-key <key>` | Source replica S3 secret key                                 |
+| `--source-secret-key <key>` | Source replica S3 secret key; `-` reads it from stdin         |
 | `--source-region <region>`  | Source replica S3 region (default: `us-east-1`)              |
 | `--source-config <path>`    | Path to JSON file with source S3 credentials                 |
 | `-t, --tenant <id>`         | Override tenant ID                                           |
@@ -988,6 +1001,19 @@ atlas rehydrate -o user@company.com -s od-snap-1735689600000-a1b2c3 --source-con
 Scopes are matched in the order `--site`, `-o/--owner`, `-s/--snapshot`, `-m/--mailbox`, `--all`. `-s/--snapshot` works for all three workloads: the snapshot id says which one it belongs to (`od-snap-*` OneDrive, `sp-snap-*` SharePoint, `snap-*` Outlook), and the owning owner or site is resolved from storage, so it does not have to be named again. Combining `--site` or `-o/--owner` with `-s/--snapshot` addresses the same single snapshot explicitly. Owner and site identifiers are lowercased before they become storage keys, so any casing addresses the same tree.
 
 `-o/--owner` accepts an email or a raw Entra ID object ID. Recovery resolves an email through Microsoft Graph only. Unlike `atlas onedrive` commands it does not write the resolved identity back to primary, because that write would bootstrap a fresh encryption key in the target bucket and block the replica's key from being copied (see _Encryption Key Safety_ below). Pass the object ID directly when Graph is unreachable or the user has been deleted from the directory.
+
+::: warning Keep the secret key out of argv
+`--source-secret-key` accepts `-`, which reads the value from stdin so it never reaches the shell history file or the process table:
+
+```bash
+atlas rehydrate --all \
+  --source-endpoint http://offsite:9000 \
+  --source-access-key <key> \
+  --source-secret-key - < source-secret.txt
+```
+
+Behaviour matches `atlas replicate`: trailing whitespace is trimmed, and empty or unreadable stdin fails with the option named instead of authenticating with an empty secret.
+:::
 
 ::: tip What `--all` covers
 `--all` recovers all three workloads: every Outlook mailbox (`manifests/`), every OneDrive owner (`onedrive/manifests/`), and every SharePoint site (`sharepoint/manifests/`) present on the replica. The summary breaks the run down per workload, so a recovery that restored only part of the tenant is visible instead of hidden behind one aggregate status line:

--- a/packages/cli/src/commands/rehydrate.command.tsx
+++ b/packages/cli/src/commands/rehydrate.command.tsx
@@ -28,6 +28,7 @@ import { format_bytes } from '@/command-formatters';
 import { logger, GRAPH_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-core';
 import type { UserIdentityResolver } from '@wisecom/atlas-types';
 import { resolve_site_id } from '@/commands/sharepoint-command.handlers';
+import { resolve_secret_option } from '@/utils/secret-option';
 
 /**
  * Resolves an owner for recovery without touching primary storage.
@@ -81,7 +82,7 @@ export function register_rehydrate_command(
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option('--source-endpoint <url>', 'source replica S3 endpoint URL')
     .option('--source-access-key <key>', 'source replica S3 access key')
-    .option('--source-secret-key <key>', 'source replica S3 secret key')
+    .option('--source-secret-key <key>', 'source replica S3 secret key; "-" reads it from stdin')
     .option('--source-region <region>', 'source replica S3 region')
     .option('--source-config <path>', 'path to JSON file with source S3 credentials')
     .action((options: RehydrateOptions) => execute_rehydrate(get_container(), options));
@@ -205,7 +206,11 @@ function build_source(container: Container, options: RehydrateOptions): StorageT
     });
   }
 
-  if (!options.sourceEndpoint || !options.sourceAccessKey || !options.sourceSecretKey) {
+  // Resolved before the presence check so `--source-secret-key -` with empty stdin reports
+  // that, rather than the misleading "credentials required" (issue #256).
+  const source_secret_key = resolve_secret_option(options.sourceSecretKey, '--source-secret-key');
+
+  if (!options.sourceEndpoint || !options.sourceAccessKey || !source_secret_key) {
     throw new Error(
       'Source credentials required: provide --source-endpoint, --source-access-key, --source-secret-key ' +
         'or --source-config <path>',
@@ -215,7 +220,7 @@ function build_source(container: Container, options: RehydrateOptions): StorageT
   return create_storage_target({
     s3_endpoint: options.sourceEndpoint,
     s3_access_key: options.sourceAccessKey,
-    s3_secret_key: options.sourceSecretKey,
+    s3_secret_key: source_secret_key,
     ...(options.sourceRegion !== undefined ? { s3_region: options.sourceRegion } : {}),
     encryption_passphrase: config.encryption_passphrase,
   });

--- a/packages/cli/src/commands/replicate.command.tsx
+++ b/packages/cli/src/commands/replicate.command.tsx
@@ -26,6 +26,7 @@ import { format_bytes } from '@/command-formatters';
 import { logger } from '@wisecom/atlas-core';
 import { resolve_owner } from '@/commands/onedrive-command.handlers';
 import { resolve_site_id } from '@/commands/sharepoint-command.handlers';
+import { resolve_secret_option } from '@/utils/secret-option';
 
 type ContainerFactory = () => Container;
 
@@ -61,7 +62,7 @@ export function register_replicate_command(
     .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option('--target-endpoint <url>', 'target S3 endpoint URL')
     .option('--target-access-key <key>', 'target S3 access key')
-    .option('--target-secret-key <key>', 'target S3 secret key')
+    .option('--target-secret-key <key>', 'target S3 secret key; "-" reads it from stdin')
     .option('--target-region <region>', 'target S3 region')
     .option('--target-config <path>', 'path to JSON file with target S3 credentials')
     .option('--status', 'show replication status instead of replicating')
@@ -184,7 +185,11 @@ function build_target(container: Container, options: ReplicateOptions): StorageT
     });
   }
 
-  if (!options.targetEndpoint || !options.targetAccessKey || !options.targetSecretKey) {
+  // Resolved before the presence check so `--target-secret-key -` with empty stdin reports
+  // that, rather than the misleading "credentials required" (issue #256).
+  const target_secret_key = resolve_secret_option(options.targetSecretKey, '--target-secret-key');
+
+  if (!options.targetEndpoint || !options.targetAccessKey || !target_secret_key) {
     throw new Error(
       'Target credentials required: provide --target-endpoint, --target-access-key, --target-secret-key ' +
         'or --target-config <path>',
@@ -194,7 +199,7 @@ function build_target(container: Container, options: ReplicateOptions): StorageT
   return create_storage_target({
     s3_endpoint: options.targetEndpoint,
     s3_access_key: options.targetAccessKey,
-    s3_secret_key: options.targetSecretKey,
+    s3_secret_key: target_secret_key,
     ...(options.targetRegion !== undefined ? { s3_region: options.targetRegion } : {}),
     encryption_passphrase: config.encryption_passphrase,
   });

--- a/packages/cli/src/utils/secret-option.ts
+++ b/packages/cli/src/utils/secret-option.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+
+/** Option value that means "read the real value from stdin". */
+const STDIN_SENTINEL = '-';
+
+/**
+ * Resolves a credential option, reading stdin when the value is `-`.
+ *
+ * A secret passed inline is written to the shell history file and is readable in
+ * the process table by any other local user for as long as the command runs,
+ * which for a replication run over a large tenant is not a short window. `-`
+ * keeps it out of both. Mirrors the `-` form `atlas config` already accepts.
+ *
+ * Only one option per invocation can read stdin, which is why `-` is offered on
+ * the secret key rather than on the access key ID, which is not a secret.
+ */
+export function resolve_secret_option(
+  value: string | undefined,
+  option: string,
+): string | undefined {
+  if (value !== STDIN_SENTINEL) return value;
+
+  const from_stdin = read_stdin_or_throw(option);
+  if (from_stdin.length === 0) {
+    throw new Error(
+      `${option} was given "-", which reads the value from stdin, but stdin was empty. ` +
+        `Pipe the secret in, for example: ${option} - < secret.txt`,
+    );
+  }
+  return from_stdin;
+}
+
+/** Reads all of stdin, failing loudly rather than yielding an empty secret. */
+function read_stdin_or_throw(option: string): string {
+  try {
+    return readFileSync(0, 'utf-8').trim();
+  } catch (err) {
+    // Closed or unreadable stdin lands here (EBADF, EAGAIN). Silently treating it
+    // as an empty value would authenticate with an empty secret.
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `${option} was given "-", which reads the value from stdin, but stdin could not be read: ${reason}`,
+    );
+  }
+}

--- a/packages/cli/tests/unit/replication-secret-stdin.test.ts
+++ b/packages/cli/tests/unit/replication-secret-stdin.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { Command } from 'commander';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { ATLAS_CONFIG_TOKEN, GRAPH_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-core';
+import {
+  REPLICATION_USE_CASE_TOKEN,
+  SHAREPOINT_REPLICATION_USE_CASE_TOKEN,
+  ONEDRIVE_REPLICATION_USE_CASE_TOKEN,
+  USER_IDENTITY_RESOLVER_TOKEN,
+  ReplicationStatus,
+  ReplicationVerificationStatus,
+} from '@wisecom/atlas-types';
+import type { ReplicationResult } from '@wisecom/atlas-types';
+import { register_replicate_command } from '@/commands/replicate.command';
+import { register_rehydrate_command } from '@/commands/rehydrate.command';
+
+/**
+ * Obviously fake, and carrying trailing whitespace and a newline because that is
+ * what `--target-secret-key - < secret.txt` actually delivers.
+ */
+const STDIN_SECRET = 'FAKE-stdin-s3-secret-do-not-use-6Hn3';
+const STDIN_PAYLOAD = `${STDIN_SECRET}  \n`;
+const INLINE_SECRET = 'FAKE-inline-s3-secret-do-not-use-2Pq8';
+
+const mocks = vi.hoisted(() => ({
+  read_file_sync: vi.fn(),
+  create_storage_target: vi.fn(),
+}));
+
+// Only readFileSync is replaced: the point is to control what stdin (fd 0) yields
+// without the test runner's own stdin taking part.
+vi.mock('node:fs', async (import_original) => {
+  const actual = await import_original<Record<string, unknown>>();
+  return { ...actual, readFileSync: mocks.read_file_sync };
+});
+
+// Captures the credential object the command assembles. The real factory builds an
+// S3 client and hides the secret behind a private field, so the assertion needs the
+// input, not the constructed target.
+vi.mock('@wisecom/atlas-s3', () => ({
+  create_storage_target: mocks.create_storage_target,
+}));
+
+const RESULT: ReplicationResult = {
+  snapshot_id: 'od-snap-1',
+  target_id: 'replica',
+  status: ReplicationStatus.COMPLETED,
+  objects_total: 1,
+  objects_copied: 1,
+  objects_skipped: 0,
+  objects_failed: 0,
+  bytes_copied: 64,
+  elapsed_ms: 3,
+  errors: [],
+  verification_status: ReplicationVerificationStatus.PASSED,
+};
+
+/** The secret the command handed to the storage factory, or undefined when none was built. */
+function captured_secret(): string | undefined {
+  const call = (mocks.create_storage_target as Mock).mock.calls[0];
+  return call?.[0]?.s3_secret_key as string | undefined;
+}
+
+describe('replicate/rehydrate secret key from stdin (issue #256)', () => {
+  let container: Container;
+  let program: Command;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    mocks.create_storage_target.mockImplementation((config: { s3_endpoint: string }) => ({
+      target_id: 'replica',
+      endpoint: config.s3_endpoint,
+    }));
+    mocks.read_file_sync.mockImplementation((fd: unknown) => {
+      if (fd === 0) return STDIN_PAYLOAD;
+      throw new Error(`unexpected readFileSync of ${String(fd)}`);
+    });
+
+    container = new Container();
+    const onedrive = {
+      replicate_owner: vi.fn().mockResolvedValue([RESULT]),
+      replicate_all_owner_snapshots: vi.fn().mockResolvedValue([RESULT]),
+      rehydrate_owner_snapshot: vi.fn().mockResolvedValue(RESULT),
+      rehydrate_owner: vi.fn().mockResolvedValue(RESULT),
+    };
+    const identity = {
+      resolve_user: vi.fn().mockResolvedValue({
+        object_id: '75a21b57-4d82-4f42-9ccc-7c231c30f78c',
+        email: 'user@example.com',
+        display_name: 'Example User',
+      }),
+    };
+    container.bind(ONEDRIVE_REPLICATION_USE_CASE_TOKEN).toConstantValue(onedrive);
+    container.bind(REPLICATION_USE_CASE_TOKEN).toConstantValue({
+      replicate_snapshot: vi.fn().mockResolvedValue([RESULT]),
+      get_replication_status: vi.fn().mockResolvedValue([]),
+      get_replication_status_by_owner: vi.fn().mockResolvedValue([]),
+      rehydrate_tenant: vi.fn().mockResolvedValue({ total: RESULT, workloads: [] }),
+    });
+    container.bind(SHAREPOINT_REPLICATION_USE_CASE_TOKEN).toConstantValue({});
+    container.bind(USER_IDENTITY_RESOLVER_TOKEN).toConstantValue(identity);
+    container.bind(GRAPH_IDENTITY_RESOLVER_TOKEN).toConstantValue(identity);
+    container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({
+      tenant_id: 'test-tenant',
+      encryption_passphrase: 'pass',
+    });
+
+    program = new Command();
+    program.exitOverride();
+    register_replicate_command(program, () => container);
+    register_rehydrate_command(program, () => container);
+  });
+
+  it('reads the replicate target secret from stdin and trims trailing whitespace', async () => {
+    const argv = [
+      'replicate',
+      '-o',
+      'user@example.com',
+      '--target-endpoint',
+      'http://replica:9000',
+      '--target-access-key',
+      'FAKEACCESSKEYID12345',
+      '--target-secret-key',
+      '-',
+    ];
+
+    await program.parseAsync(argv, { from: 'user' });
+
+    expect(mocks.read_file_sync).toHaveBeenCalledWith(0, 'utf-8');
+    expect(captured_secret()).toBe(STDIN_SECRET);
+    // The whole point: the secret is nowhere in the command line.
+    expect(argv).toContain('-');
+    expect(argv.join(' ')).not.toContain(STDIN_SECRET);
+  });
+
+  it('reads the rehydrate source secret from stdin', async () => {
+    await program.parseAsync(
+      [
+        'rehydrate',
+        '-o',
+        'user@example.com',
+        '--source-endpoint',
+        'http://replica:9000',
+        '--source-access-key',
+        'FAKEACCESSKEYID12345',
+        '--source-secret-key',
+        '-',
+      ],
+      { from: 'user' },
+    );
+
+    expect(mocks.read_file_sync).toHaveBeenCalledWith(0, 'utf-8');
+    expect(captured_secret()).toBe(STDIN_SECRET);
+  });
+
+  it('still accepts an inline secret without touching stdin', async () => {
+    await program.parseAsync(
+      [
+        'replicate',
+        '-o',
+        'user@example.com',
+        '--target-endpoint',
+        'http://replica:9000',
+        '--target-access-key',
+        'FAKEACCESSKEYID12345',
+        '--target-secret-key',
+        INLINE_SECRET,
+      ],
+      { from: 'user' },
+    );
+
+    expect(captured_secret()).toBe(INLINE_SECRET);
+    expect(mocks.read_file_sync).not.toHaveBeenCalledWith(0, 'utf-8');
+  });
+
+  it('fails clearly on empty stdin instead of authenticating with an empty secret', async () => {
+    mocks.read_file_sync.mockImplementation((fd: unknown) => (fd === 0 ? '   \n' : ''));
+
+    await expect(
+      program.parseAsync(
+        [
+          'replicate',
+          '-o',
+          'user@example.com',
+          '--target-endpoint',
+          'http://replica:9000',
+          '--target-access-key',
+          'FAKEACCESSKEYID12345',
+          '--target-secret-key',
+          '-',
+        ],
+        { from: 'user' },
+      ),
+    ).rejects.toThrow(/--target-secret-key was given "-".*stdin was empty/s);
+
+    expect(mocks.create_storage_target).not.toHaveBeenCalled();
+  });
+
+  it('fails clearly when stdin cannot be read', async () => {
+    mocks.read_file_sync.mockImplementation(() => {
+      throw Object.assign(new Error('EBADF: bad file descriptor, read'), { code: 'EBADF' });
+    });
+
+    await expect(
+      program.parseAsync(
+        [
+          'rehydrate',
+          '-o',
+          'user@example.com',
+          '--source-endpoint',
+          'http://replica:9000',
+          '--source-access-key',
+          'FAKEACCESSKEYID12345',
+          '--source-secret-key',
+          '-',
+        ],
+        { from: 'user' },
+      ),
+    ).rejects.toThrow(/--source-secret-key was given "-".*stdin could not be read.*EBADF/s);
+
+    expect(mocks.create_storage_target).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #256.

## The problem

`--target-secret-key` on `replicate` and `--source-secret-key` on `rehydrate` could only be passed inline, so the value landed in the shell history file and was readable in the process table by any other local user for as long as the command ran. A replication run over a large tenant is not a short window, and a CI runner that echoes its step is worse.

`atlas config` already solved this at `config.command.ts:52`, with a comment saying exactly why. The replication commands never inherited it.

## The change

```bash
atlas replicate -m user@company.com \
  --target-endpoint http://offsite:9000 \
  --target-access-key <key> \
  --target-secret-key - < target-secret.txt
```

One helper, `packages/cli/src/utils/secret-option.ts`, resolves `-` by reading stdin, trims trailing whitespace, and refuses to continue when stdin is empty or unreadable. Treating either as an empty string would authenticate with an empty secret.

Resolution happens **before** the credentials-required check, so `-` with empty stdin reports that specifically rather than the misleading `Target credentials required`.

Only the secret key accepts `-`: one option per invocation can read stdin, and the access key ID is not a secret, which `config-keys.ts` already encodes as `secret: false`.

## What I deliberately did not change

`atlas config` keeps its inline one-liner. I checked whether it shared the empty-stdin hole and it does not: `execute_set` runs `spec.validate(value)` before storing, and every secret key's validator rejects an empty value. Routing it through the helper would have been churn for no behaviour change.

`--target-config` and `--source-config` stay as they are. They do avoid argv, but they trade it for a credentials file whose permissions Atlas neither sets nor checks, so the docs now point at `-` when the secret comes from a pipe or a secret manager.

## Tests

New `replication-secret-stdin.test.ts` drives both real commands through commander with a mocked container, mocking only `readFileSync` (to control fd 0) and `create_storage_target` (to capture the credential object, since the real target hides the secret behind a private field):

| Case | Asserted |
|---|---|
| `replicate --target-secret-key -` | Secret arrives from stdin, trailing whitespace and newline trimmed |
| `rehydrate --source-secret-key -` | Same, on the source side |
| Inline secret | Still works, and stdin is never read |
| Empty stdin | Throws naming the option, and no storage target is constructed |
| Unreadable stdin (`EBADF`) | Throws naming the option and the cause, no target constructed |

The first case also asserts the secret appears nowhere in the argv array, which is the whole point of the change.

One incidental confirmation: the rendered command output in the test run shows only the endpoint and target id, never the secret, which covers the issue's requirement that it not reach a log line.

## Verification

- CLI package: 27 files, 173 tests passed
- Full monorepo suite: 15 tasks successful
- `pnpm run typecheck`: 17 tasks, `pnpm run lint`: 9 tasks
- `pnpm run docs:build`: clean, no dead links

## Docs

`docs/reference/cli.md`: both option tables note the `-` form, and each command gains a warning container explaining the argv exposure, the trimming, the failure modes, and why only the secret key takes `-`. Container fences use the file's existing 3-colon convention.