### PR TITLE
test(drive): cover both download-helper modules and pin the 403 ambiguity

### DIFF
--- a/packages/onedrive/tests/unit/adapters/download-helpers.test.ts
+++ b/packages/onedrive/tests/unit/adapters/download-helpers.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
+import type { Client } from '@microsoft/microsoft-graph-client';
+import { CdnHttpError, CHUNK_DOWNLOAD_THRESHOLD } from '@/adapters/graph-onedrive-chunked-download';
+import {
+  resolve_download_url,
+  download_with_fallback,
+  download_via_graph_content,
+  is_expired_url_error,
+  rethrow_if_access_denied,
+  throw_missing_permissions,
+} from '@/adapters/graph-onedrive-download-helpers';
+
+/**
+ * Pins the current behaviour of the OneDrive download helpers (issue #247). It does
+ * not assert that the behaviour is correct: the 403 classification is contradictory
+ * by design here, and issue #246 changes it. Tests that describe behaviour expected
+ * to change say so and name #246, so that PR gets a failing baseline rather than an
+ * assumption.
+ */
+
+const mocks = vi.hoisted(() => ({
+  download_file_chunked: vi.fn(),
+  download_from_url: vi.fn(),
+  stream_to_buffer: vi.fn(),
+  with_timeout: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+}));
+
+// CdnHttpError stays real: is_expired_url_error branches on `instanceof`, so a stubbed
+// class would silently take the wrong branch and the test would prove nothing.
+vi.mock('@/adapters/graph-onedrive-chunked-download', async (import_original) => {
+  const actual = await import_original<Record<string, unknown>>();
+  return { ...actual, download_file_chunked: mocks.download_file_chunked };
+});
+
+vi.mock('@/adapters/graph-onedrive-connector-stream', () => ({
+  download_from_url: mocks.download_from_url,
+  stream_to_buffer: mocks.stream_to_buffer,
+  with_timeout: mocks.with_timeout,
+}));
+
+// Retry policy is owned and tested elsewhere; here it must not multiply call counts.
+vi.mock('@wisecom/atlas-m365-graph', () => ({
+  with_graph_retry: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('@wisecom/atlas-core/utils/logger', () => ({
+  logger: { warn: mocks.warn, debug: mocks.debug, info: vi.fn(), error: vi.fn() },
+}));
+
+const URL_BODY = Buffer.from('url-download');
+const CHUNK_BODY = Buffer.from('chunked-download');
+const CONTENT_BODY = Buffer.from('graph-content');
+const FRESH_URL = 'https://cdn.example.invalid/fresh';
+const STALE_URL = 'https://cdn.example.invalid/stale';
+
+interface GraphClientMock {
+  /** The fake, shaped for the helpers' parameter type so call sites need no cast. */
+  client: Client;
+  api: Mock;
+  get: Mock;
+  get_stream: Mock;
+  select: Mock;
+}
+
+/** Fake Graph client exposing the fluent chain these helpers use. */
+function make_client(overrides: { download_url?: string | undefined } = {}): GraphClientMock {
+  const get = vi
+    .fn()
+    .mockResolvedValue(
+      'download_url' in overrides
+        ? { '@microsoft.graph.downloadUrl': overrides.download_url }
+        : { '@microsoft.graph.downloadUrl': FRESH_URL },
+    );
+  const get_stream = vi.fn().mockResolvedValue('stream-handle');
+  const select = vi.fn(() => ({ get }));
+  const api = vi.fn(() => ({ select, get, getStream: get_stream }));
+  // The real Client has a large surface; these helpers touch only api/select/get/getStream.
+  const client = { api } as unknown as Client;
+  return { client, api, get, get_stream, select };
+}
+
+function make_item(overrides: Partial<OneDriveDeltaItem> = {}): OneDriveDeltaItem {
+  return {
+    drive_id: 'drive-1',
+    item_id: 'item-1',
+    name: 'Report.docx',
+    size_bytes: 1024,
+    ...overrides,
+  } as OneDriveDeltaItem;
+}
+
+describe('OneDrive download helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.download_from_url.mockResolvedValue(URL_BODY);
+    mocks.download_file_chunked.mockResolvedValue(CHUNK_BODY);
+    mocks.stream_to_buffer.mockResolvedValue(CONTENT_BODY);
+    mocks.with_timeout.mockImplementation((promise: Promise<unknown>) => promise);
+  });
+
+  describe('resolve_download_url', () => {
+    it('returns the @microsoft.graph.downloadUrl value', async () => {
+      const mock = make_client();
+
+      await expect(resolve_download_url(mock.client, make_item())).resolves.toBe(FRESH_URL);
+      expect(mock.api).toHaveBeenCalledWith('/drives/drive-1/items/item-1');
+      expect(mock.select).toHaveBeenCalledWith('@microsoft.graph.downloadUrl');
+    });
+
+    it('returns undefined when Graph omits the property', async () => {
+      const mock = make_client({ download_url: undefined });
+
+      await expect(resolve_download_url(mock.client, make_item())).resolves.toBeUndefined();
+    });
+  });
+
+  describe('download_with_fallback routing', () => {
+    it("uses the item's existing download_url without re-resolving", async () => {
+      const mock = make_client();
+
+      const body = await download_with_fallback(
+        mock.client,
+        make_item({ download_url: STALE_URL }),
+      );
+
+      expect(body).toEqual(URL_BODY);
+      expect(mocks.download_from_url).toHaveBeenCalledWith(STALE_URL, 1024, 'item-1');
+      expect(mock.api).not.toHaveBeenCalled();
+    });
+
+    it('takes the chunked path above the threshold and the direct path below it', async () => {
+      const big = make_item({
+        download_url: STALE_URL,
+        size_bytes: CHUNK_DOWNLOAD_THRESHOLD + 1,
+      });
+      await expect(download_with_fallback(make_client().client, big)).resolves.toEqual(CHUNK_BODY);
+      expect(mocks.download_file_chunked).toHaveBeenCalledOnce();
+      expect(mocks.download_from_url).not.toHaveBeenCalled();
+
+      vi.clearAllMocks();
+      mocks.download_from_url.mockResolvedValue(URL_BODY);
+
+      const small = make_item({
+        download_url: STALE_URL,
+        size_bytes: CHUNK_DOWNLOAD_THRESHOLD,
+      });
+      await expect(download_with_fallback(make_client().client, small)).resolves.toEqual(URL_BODY);
+      expect(mocks.download_from_url).toHaveBeenCalledOnce();
+      expect(mocks.download_file_chunked).not.toHaveBeenCalled();
+    });
+
+    it('goes to /content without attempting a URL download when no URL resolves', async () => {
+      const mock = make_client({ download_url: undefined });
+
+      const body = await download_with_fallback(mock.client, make_item());
+
+      expect(body).toEqual(CONTENT_BODY);
+      expect(mocks.download_from_url).not.toHaveBeenCalled();
+      expect(mock.get_stream).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('expired-URL refresh', () => {
+    it('re-resolves exactly once and retries with the refreshed URL', async () => {
+      const mock = make_client();
+      mocks.download_from_url
+        .mockRejectedValueOnce(new CdnHttpError('gone', 401))
+        .mockResolvedValueOnce(URL_BODY);
+
+      const body = await download_with_fallback(
+        mock.client,
+        make_item({ download_url: STALE_URL }),
+      );
+
+      expect(body).toEqual(URL_BODY);
+      expect(mock.get).toHaveBeenCalledOnce();
+      expect(mocks.download_from_url).toHaveBeenNthCalledWith(1, STALE_URL, 1024, 'item-1');
+      expect(mocks.download_from_url).toHaveBeenNthCalledWith(2, FRESH_URL, 1024, 'item-1');
+      expect(mock.get_stream).not.toHaveBeenCalled();
+    });
+
+    it('falls back to /content when the refreshed URL also fails, without surfacing the original error', async () => {
+      const mock = make_client();
+      mocks.download_from_url
+        .mockRejectedValueOnce(new CdnHttpError('stale', 401))
+        .mockRejectedValueOnce(new CdnHttpError('still stale', 401));
+
+      const body = await download_with_fallback(
+        mock.client,
+        make_item({ download_url: STALE_URL }),
+      );
+
+      expect(body).toEqual(CONTENT_BODY);
+      expect(mock.get_stream).toHaveBeenCalledOnce();
+      expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining('retry failed for item-1'));
+    });
+
+    it('goes straight to /content without re-resolving for a non-expired failure', async () => {
+      const mock = make_client();
+      mocks.download_from_url.mockRejectedValue(new CdnHttpError('server error', 500));
+
+      const body = await download_with_fallback(
+        mock.client,
+        make_item({ download_url: STALE_URL }),
+      );
+
+      expect(body).toEqual(CONTENT_BODY);
+      expect(mock.get).not.toHaveBeenCalled();
+      expect(mocks.download_from_url).toHaveBeenCalledOnce();
+      expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining('falling back'));
+    });
+
+    it('skips the retry and falls back when the refreshed URL cannot be resolved', async () => {
+      const mock = make_client({ download_url: undefined });
+      mocks.download_from_url.mockRejectedValue(new CdnHttpError('gone', 403));
+
+      await expect(
+        download_with_fallback(mock.client, make_item({ download_url: STALE_URL })),
+      ).resolves.toEqual(CONTENT_BODY);
+      expect(mocks.download_from_url).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('download_via_graph_content', () => {
+    it('requests /content and drains the stream', async () => {
+      const mock = make_client();
+
+      await expect(download_via_graph_content(mock.client, make_item())).resolves.toEqual(
+        CONTENT_BODY,
+      );
+      expect(mock.api).toHaveBeenCalledWith('/drives/drive-1/items/item-1/content');
+      // Drain budget is twice the request budget.
+      expect(mocks.stream_to_buffer).toHaveBeenCalledWith('stream-handle', 60_000);
+      expect(mocks.with_timeout).toHaveBeenCalledWith(
+        expect.anything(),
+        30_000,
+        'Graph content request timed out for file item-1',
+      );
+    });
+  });
+
+  describe('is_expired_url_error', () => {
+    // 403 is also what a missing Files.Read.All grant and a label-protected item
+    // return, so this branch currently swallows two unrelated causes. Issue #246
+    // splits them; these assertions are expected to change with it.
+    it.each([401, 403])('treats CdnHttpError %i as an expired URL (see #246 for 403)', (status) => {
+      expect(is_expired_url_error(new CdnHttpError('denied', status))).toBe(true);
+    });
+
+    it.each([404, 429, 500])('does not treat CdnHttpError %i as an expired URL', (status) => {
+      expect(is_expired_url_error(new CdnHttpError('other', status))).toBe(false);
+    });
+
+    it.each([401, 403])('treats a Graph error with statusCode %i as an expired URL', (status) => {
+      expect(is_expired_url_error({ statusCode: status })).toBe(true);
+    });
+
+    it('does not treat a Graph error with another statusCode as an expired URL', () => {
+      expect(is_expired_url_error({ statusCode: 500, message: 'Forbidden' })).toBe(false);
+    });
+
+    // Substring classification: any wrapped error whose text happens to contain the
+    // word is classified as an expired download URL, including a storage or proxy
+    // error unrelated to the URL. Issue #246 removes or narrows this.
+    it.each(['Forbidden', 'Unauthorized'])(
+      'classifies a message-only error containing %s as an expired URL (#246)',
+      (word) => {
+        expect(is_expired_url_error(new Error(`S3 GetObject failed: ${word}`))).toBe(true);
+      },
+    );
+
+    it('returns false for an unrelated error', () => {
+      expect(is_expired_url_error(new Error('ECONNRESET'))).toBe(false);
+      expect(is_expired_url_error('plain string')).toBe(false);
+      expect(is_expired_url_error(0)).toBe(false);
+    });
+
+    // Found while writing this suite, and left unfixed on purpose: issue #247 pins
+    // behaviour and rules that anything beyond the 403 classification gets its own
+    // issue. The classifier reads `.statusCode` off the raw value, so a rejection
+    // carrying no reason (`Promise.reject()`) crashes the classifier instead of
+    // being classified. Tracked in #263.
+    it.each([undefined, null])(
+      'currently throws a TypeError for %s rather than returning false',
+      (value) => {
+        expect(() => is_expired_url_error(value)).toThrow(TypeError);
+      },
+    );
+  });
+
+  describe('rethrow_if_access_denied', () => {
+    it('throws only on statusCode 403, naming the permissions to grant', () => {
+      expect(() => rethrow_if_access_denied({ statusCode: 403 })).toThrow(
+        'Missing Microsoft Graph application permissions for OneDrive: Files.Read.All, Sites.Read.All.',
+      );
+    });
+
+    it.each([401, 404, 500, undefined])('is a no-op for statusCode %s', (status) => {
+      expect(() => rethrow_if_access_denied({ statusCode: status })).not.toThrow();
+    });
+
+    it('is a no-op for a CdnHttpError carrying 403, because it reads statusCode only', () => {
+      // The CDN error uses status_code, not statusCode, so the permission path never
+      // sees a CDN refusal. Recorded rather than endorsed (#246).
+      expect(() => rethrow_if_access_denied(new CdnHttpError('denied', 403))).not.toThrow();
+    });
+  });
+
+  describe('throw_missing_permissions', () => {
+    it('names read permissions by default and write permissions on request', () => {
+      expect(() => throw_missing_permissions()).toThrow(/Files\.Read\.All, Sites\.Read\.All/);
+      expect(() => throw_missing_permissions('write')).toThrow(
+        /Files\.ReadWrite\.All, Sites\.Read\.All/,
+      );
+    });
+  });
+});

--- a/packages/sharepoint/tests/unit/adapters/download-helpers.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/download-helpers.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { Readable } from 'node:stream';
+import type { Client } from '@microsoft/microsoft-graph-client';
+import type { SharePointDeltaItem } from '@wisecom/atlas-types';
+import {
+  CdnHttpError,
+  CHUNK_DOWNLOAD_THRESHOLD,
+} from '@/adapters/graph-sharepoint-chunked-download';
+import {
+  resolve_download_url,
+  download_with_fallback,
+  download_via_graph_content,
+  is_expired_url_error,
+  rethrow_if_access_denied,
+} from '@/adapters/graph-sharepoint-download-helpers';
+
+/**
+ * Pins the current behaviour of the SharePoint download helpers (issue #247).
+ *
+ * The SharePoint twin is not a copy of the OneDrive one: it owns a private
+ * `download_from_url` with its own 429 retry loop honouring `Retry-After`, and its
+ * permission error names a different scope. Both differences are asserted here rather
+ * than avoided, because divergence between the two drive pipelines is what let the
+ * replication gate drift through in #190.
+ *
+ * The 403 classification is contradictory in this file too, and issue #246 changes it.
+ */
+
+const mocks = vi.hoisted(() => ({
+  download_file_chunked: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+}));
+
+// CdnHttpError and compute_chunk_timeout_ms stay real: the first is matched with
+// `instanceof`, the second sets the timeout the retry loop runs under.
+vi.mock('@/adapters/graph-sharepoint-chunked-download', async (import_original) => {
+  const actual = await import_original<Record<string, unknown>>();
+  return { ...actual, download_file_chunked: mocks.download_file_chunked };
+});
+
+vi.mock('@wisecom/atlas-m365-graph', () => ({
+  with_graph_retry: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('@wisecom/atlas-core/utils/logger', () => ({
+  logger: { warn: mocks.warn, debug: mocks.debug, info: vi.fn(), error: vi.fn() },
+}));
+
+const URL_BODY = Buffer.from('url-download');
+const CHUNK_BODY = Buffer.from('chunked-download');
+const CONTENT_BODY = Buffer.from('graph-content');
+const FRESH_URL = 'https://cdn.example.invalid/fresh';
+const STALE_URL = 'https://cdn.example.invalid/stale';
+
+/** MAX_URL_RETRIES is private; 3 retries means 4 attempts in total. */
+const MAX_URL_ATTEMPTS = 4;
+
+interface GraphClientMock {
+  /** The fake, shaped for the helpers' parameter type so call sites need no cast. */
+  client: Client;
+  api: Mock;
+  get: Mock;
+  get_stream: Mock;
+  select: Mock;
+}
+
+function make_client(overrides: { download_url?: string | undefined } = {}): GraphClientMock {
+  const get = vi
+    .fn()
+    .mockResolvedValue(
+      'download_url' in overrides
+        ? { '@microsoft.graph.downloadUrl': overrides.download_url }
+        : { '@microsoft.graph.downloadUrl': FRESH_URL },
+    );
+  const get_stream = vi.fn().mockResolvedValue(Readable.from([CONTENT_BODY]));
+  const select = vi.fn(() => ({ get }));
+  const api = vi.fn(() => ({ select, get, getStream: get_stream }));
+  // The real Client has a large surface; these helpers touch only api/select/get/getStream.
+  const client = { api } as unknown as Client;
+  return { client, api, get, get_stream, select };
+}
+
+function make_item(overrides: Partial<SharePointDeltaItem> = {}): SharePointDeltaItem {
+  return {
+    drive_id: 'drive-1',
+    item_id: 'item-1',
+    name: 'Budget.xlsx',
+    size_bytes: 1024,
+    ...overrides,
+  } as SharePointDeltaItem;
+}
+
+/** Minimal fetch Response stand-in: only the fields download_from_url reads. */
+function make_response(init: { status: number; body?: Buffer; retry_after?: string }): Response {
+  const headers = new Headers();
+  if (init.retry_after !== undefined) headers.set('Retry-After', init.retry_after);
+  const body = init.body ?? URL_BODY;
+  const response = {
+    status: init.status,
+    ok: init.status >= 200 && init.status < 300,
+    headers,
+    arrayBuffer: () =>
+      Promise.resolve(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)),
+  };
+  return response as unknown as Response;
+}
+
+describe('SharePoint download helpers', () => {
+  let fetch_mock: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.download_file_chunked.mockResolvedValue(CHUNK_BODY);
+    fetch_mock = vi.fn().mockResolvedValue(make_response({ status: 200 }));
+    vi.stubGlobal('fetch', fetch_mock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('resolve_download_url', () => {
+    it('returns the @microsoft.graph.downloadUrl value', async () => {
+      const mock = make_client();
+
+      await expect(resolve_download_url(mock.client, make_item())).resolves.toBe(FRESH_URL);
+      expect(mock.api).toHaveBeenCalledWith('/drives/drive-1/items/item-1');
+      expect(mock.select).toHaveBeenCalledWith('@microsoft.graph.downloadUrl');
+    });
+
+    it('returns undefined when Graph omits the property', async () => {
+      const mock = make_client({ download_url: undefined });
+
+      await expect(resolve_download_url(mock.client, make_item())).resolves.toBeUndefined();
+    });
+  });
+
+  describe('download_with_fallback routing', () => {
+    it("uses the item's existing download_url without re-resolving", async () => {
+      const mock = make_client();
+
+      const body = await download_with_fallback(
+        mock.client,
+        make_item({ download_url: STALE_URL }),
+      );
+
+      expect(body).toEqual(URL_BODY);
+      expect(fetch_mock).toHaveBeenCalledWith(STALE_URL, expect.anything());
+      expect(mock.api).not.toHaveBeenCalled();
+    });
+
+    it('takes the chunked path above the threshold and the direct path below it', async () => {
+      const big = make_item({ download_url: STALE_URL, size_bytes: CHUNK_DOWNLOAD_THRESHOLD + 1 });
+      await expect(download_with_fallback(make_client().client, big)).resolves.toEqual(CHUNK_BODY);
+      expect(mocks.download_file_chunked).toHaveBeenCalledOnce();
+      expect(fetch_mock).not.toHaveBeenCalled();
+
+      const small = make_item({ download_url: STALE_URL, size_bytes: CHUNK_DOWNLOAD_THRESHOLD });
+      await expect(download_with_fallback(make_client().client, small)).resolves.toEqual(URL_BODY);
+      expect(fetch_mock).toHaveBeenCalledOnce();
+      expect(mocks.download_file_chunked).toHaveBeenCalledOnce();
+    });
+
+    it('goes to /content without attempting a URL download when no URL resolves', async () => {
+      const mock = make_client({ download_url: undefined });
+
+      const body = await download_with_fallback(mock.client, make_item());
+
+      expect(body).toEqual(CONTENT_BODY);
+      expect(fetch_mock).not.toHaveBeenCalled();
+      expect(mock.get_stream).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('expired-URL refresh', () => {
+    it('re-resolves exactly once and retries with the refreshed URL', async () => {
+      const mock = make_client();
+      fetch_mock
+        .mockResolvedValueOnce(make_response({ status: 401 }))
+        .mockResolvedValueOnce(make_response({ status: 200 }));
+
+      const body = await download_with_fallback(
+        mock.client,
+        make_item({ download_url: STALE_URL }),
+      );
+
+      expect(body).toEqual(URL_BODY);
+      expect(mock.get).toHaveBeenCalledOnce();
+      expect(fetch_mock).toHaveBeenNthCalledWith(1, STALE_URL, expect.anything());
+      expect(fetch_mock).toHaveBeenNthCalledWith(2, FRESH_URL, expect.anything());
+      expect(mock.get_stream).not.toHaveBeenCalled();
+    });
+
+    it('falls back to /content when the refreshed URL also fails', async () => {
+      const mock = make_client();
+      fetch_mock.mockResolvedValue(make_response({ status: 403 }));
+
+      const body = await download_with_fallback(
+        mock.client,
+        make_item({ download_url: STALE_URL }),
+      );
+
+      expect(body).toEqual(CONTENT_BODY);
+      expect(mock.get_stream).toHaveBeenCalledOnce();
+      expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining('retry failed for item-1'));
+    });
+
+    it('goes straight to /content without re-resolving for a non-expired failure', async () => {
+      const mock = make_client();
+      fetch_mock.mockResolvedValue(make_response({ status: 500 }));
+
+      const body = await download_with_fallback(
+        mock.client,
+        make_item({ download_url: STALE_URL }),
+      );
+
+      expect(body).toEqual(CONTENT_BODY);
+      expect(mock.get).not.toHaveBeenCalled();
+      expect(fetch_mock).toHaveBeenCalledOnce();
+      expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining('falling back'));
+    });
+  });
+
+  // This loop is SharePoint's own. OneDrive imports download_from_url from
+  // graph-onedrive-connector-stream and has no equivalent 429 handling here, which is
+  // the divergence issue #247 requires asserting rather than hiding.
+  describe('download_from_url 429 handling (SharePoint only)', () => {
+    it('retries 429 honouring Retry-After and then succeeds', async () => {
+      fetch_mock
+        .mockResolvedValueOnce(make_response({ status: 429, retry_after: '0' }))
+        .mockResolvedValueOnce(make_response({ status: 200 }));
+
+      const body = await download_with_fallback(
+        make_client().client,
+        make_item({ download_url: STALE_URL }),
+      );
+
+      expect(body).toEqual(URL_BODY);
+      expect(fetch_mock).toHaveBeenCalledTimes(2);
+      expect(mocks.debug).toHaveBeenCalledWith(expect.stringContaining('HTTP 429'));
+    });
+
+    it('gives up after MAX_URL_RETRIES and raises CdnHttpError carrying 429', async () => {
+      fetch_mock.mockResolvedValue(make_response({ status: 429, retry_after: '0' }));
+      const mock = make_client();
+
+      // The CdnHttpError surfaces into attempt_download_with_refresh, which classifies
+      // 429 as not-expired and falls back to /content rather than propagating it.
+      const body = await download_with_fallback(
+        mock.client,
+        make_item({ download_url: STALE_URL }),
+      );
+
+      expect(body).toEqual(CONTENT_BODY);
+      expect(fetch_mock).toHaveBeenCalledTimes(MAX_URL_ATTEMPTS);
+      expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining('HTTP 429'));
+      expect(mock.get).not.toHaveBeenCalled();
+    });
+
+    // A 429 with no Retry-After header falls back to exponential backoff. Asserted on
+    // the final attempt, which throws without sleeping, so the suite pays no delay.
+    it('omits retry_after_ms on the raised error when the header is absent', async () => {
+      fetch_mock
+        .mockResolvedValueOnce(make_response({ status: 429, retry_after: '0' }))
+        .mockResolvedValueOnce(make_response({ status: 429, retry_after: '0' }))
+        .mockResolvedValueOnce(make_response({ status: 429, retry_after: '0' }))
+        .mockResolvedValueOnce(make_response({ status: 429 }));
+      const mock = make_client();
+
+      await download_with_fallback(mock.client, make_item({ download_url: STALE_URL }));
+
+      expect(fetch_mock).toHaveBeenCalledTimes(MAX_URL_ATTEMPTS);
+      expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining('HTTP 429'));
+    });
+
+    it('raises CdnHttpError carrying the status for a non-ok response', async () => {
+      fetch_mock.mockResolvedValue(make_response({ status: 404 }));
+      const mock = make_client();
+
+      await download_with_fallback(mock.client, make_item({ download_url: STALE_URL }));
+
+      expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining('HTTP 404'));
+      expect(fetch_mock).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('download_via_graph_content', () => {
+    it('requests /content and drains the stream', async () => {
+      const mock = make_client();
+
+      await expect(download_via_graph_content(mock.client, make_item())).resolves.toEqual(
+        CONTENT_BODY,
+      );
+      expect(mock.api).toHaveBeenCalledWith('/drives/drive-1/items/item-1/content');
+    });
+  });
+
+  describe('is_expired_url_error', () => {
+    // Identical to the OneDrive classifier, including reading 403 as an expired URL
+    // when it is also what a missing grant and a label-protected item return (#246).
+    it.each([401, 403])('treats CdnHttpError %i as an expired URL (see #246 for 403)', (status) => {
+      expect(is_expired_url_error(new CdnHttpError('denied', status))).toBe(true);
+    });
+
+    it.each([404, 429, 500])('does not treat CdnHttpError %i as an expired URL', (status) => {
+      expect(is_expired_url_error(new CdnHttpError('other', status))).toBe(false);
+    });
+
+    it.each([401, 403])('treats a Graph error with statusCode %i as an expired URL', (status) => {
+      expect(is_expired_url_error({ statusCode: status })).toBe(true);
+    });
+
+    it('does not treat a Graph error with another statusCode as an expired URL', () => {
+      expect(is_expired_url_error({ statusCode: 500, message: 'Forbidden' })).toBe(false);
+    });
+
+    it.each(['Forbidden', 'Unauthorized'])(
+      'classifies a message-only error containing %s as an expired URL (#246)',
+      (word) => {
+        expect(is_expired_url_error(new Error(`S3 GetObject failed: ${word}`))).toBe(true);
+      },
+    );
+
+    it('returns false for an unrelated error', () => {
+      expect(is_expired_url_error(new Error('ECONNRESET'))).toBe(false);
+      expect(is_expired_url_error('plain string')).toBe(false);
+    });
+
+    // Same latent crash as the OneDrive twin, tracked in #263 rather than fixed here.
+    it.each([undefined, null])(
+      'currently throws a TypeError for %s rather than returning false',
+      (value) => {
+        expect(() => is_expired_url_error(value)).toThrow(TypeError);
+      },
+    );
+  });
+
+  describe('rethrow_if_access_denied', () => {
+    // Divergence: SharePoint names Sites.Read.All only, where OneDrive names
+    // Files.Read.All plus Sites.Read.All through throw_missing_permissions, which
+    // SharePoint does not have.
+    it('throws only on statusCode 403, naming the SharePoint scope', () => {
+      expect(() => rethrow_if_access_denied({ statusCode: 403 })).toThrow(
+        'Missing Microsoft Graph application permissions for SharePoint: Sites.Read.All.',
+      );
+    });
+
+    it.each([401, 404, 500, undefined])('is a no-op for statusCode %s', (status) => {
+      expect(() => rethrow_if_access_denied({ statusCode: status })).not.toThrow();
+    });
+
+    it('is a no-op for a CdnHttpError carrying 403, because it reads statusCode only', () => {
+      expect(() => rethrow_if_access_denied(new CdnHttpError('denied', 403))).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Closes #247.

## Coverage

| Module | Statements before | after |
|---|---|---|
| `graph-onedrive-download-helpers.ts` | 0.0% | **100%** |
| `graph-sharepoint-download-helpers.ts` | 1.2% | **95.12%** |

62 tests, no production code changed, per the issue's final criterion.

## Pinning, not endorsing

The point is to give #246 a baseline that fails when its change is wrong, rather than an assumption about current behaviour. Where a test describes behaviour that looks wrong, it says so and names #246:

- `403` classified as an expired URL, which is also what a missing `Files.Read.All` grant and a label-protected item return.
- Substring classification: any wrapped error whose text merely contains `Forbidden` or `Unauthorized` is treated as an expired download URL, including a storage error unrelated to the URL.
- `rethrow_if_access_denied` reads `statusCode` only, so a `CdnHttpError` carrying `403` never reaches the permission path at all. That one is worth a look when #246 is designed, because it means the CDN refusal case cannot currently be named.

`CdnHttpError` is deliberately left real in both suites rather than stubbed: `is_expired_url_error` branches on `instanceof`, so a fake class would quietly take the wrong branch and the assertions would prove nothing.

## Divergences asserted, not avoided

Divergent coverage between the drive pipelines is what let the replication gate drift through in #190, so each difference is asserted explicitly:

| | OneDrive | SharePoint |
|---|---|---|
| `download_from_url` | imported from `graph-onedrive-connector-stream` | private, with its own 429 loop honouring `Retry-After`, giving up after `MAX_URL_RETRIES` |
| Permission error | `Files.Read.All, Sites.Read.All` via `throw_missing_permissions` | `Sites.Read.All` only, no such helper |
| Unresolvable URL | reaches `/content` through `attempt_download_with_refresh` | reaches it by an explicit branch in `download_with_fallback` |

## A defect found while writing the suite

`is_expired_url_error` reads `.statusCode` off the raw value, so `undefined` or `null` throws `TypeError: Cannot read properties of undefined` instead of classifying. Because it runs inside `catch (err)`, that `TypeError` then replaces the real download failure, and the item fails naming a property rather than falling back to `/content`. Every other input shape survives: a string, a number, and a boolean all read as `undefined` and fall through.

This issue's constraint is that anything beyond the `403` classification gets its own issue rather than a fix here, so it is filed as #263 and pinned in both drives with `expect(() => is_expired_url_error(undefined)).toThrow(TypeError)`, to be inverted by the fix.

## Remaining uncovered

Four statements in the SharePoint module, all timer callbacks (`AbortController` abort, `with_timeout` reject, `stream_to_buffer` destroy-and-reject). Those paths are already exercised by the chunk-download timeout suites, and reaching them here would need timer manipulation for no additional signal.

## Verification

- OneDrive package: 36 files, 285 tests passed
- SharePoint package: 37 files, 330 tests passed
- `pnpm run typecheck`: 17 tasks, `pnpm run lint`: 9 tasks
- `git status` confirms the diff is two test files and nothing else