### PR TITLE
fix(drive): classify a download 403 by cause instead of assuming an expired URL

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -177,6 +177,30 @@ Attempting the download is not merely wasteful, it is actively harmful. Graph re
 
 The file stays reported on every run until it is removed or cleaned in the source, and the run stays `UNHEALTHY`, so an operator can always answer which files are not in the backup and why.
 
+### A 403 is acted on for the reason it was returned
+
+Three unrelated conditions answer `403` on the download path, and each now gets its own response instead of all three being read as an expired download URL.
+
+**A missing application permission stops the run.** The tenant has not granted the scope, so every item will answer the same way. Atlas fails immediately and names the grants to add, rather than re-resolving the URL and spending a second download budget per file before reporting a lost file:
+
+```
+Missing Microsoft Graph application permissions for OneDrive: Files.Read.All, Sites.Read.All.
+```
+
+**A protection or policy state is recorded against the item.** A sensitivity label, an IRM policy, or a retention rule can make the service refuse one file while the rest of the drive is readable. That is permanent for the item and not a problem with the run, so it is recorded the way a quarantined file is, with the Graph error code that explains it:
+
+```
+[!] Not backed up: Report.docx (01STBDHIPIY7N3OWY...) -- Microsoft 365 refused to release
+    Report.docx (01STBDHIPIY7N3OWY...): Graph returned 403 notAllowed. This is a protection or
+    policy state on the item, not a transient failure.; PERMANENTLY SKIPPED by service policy,
+    not retried, first failed 2026-08-11T07:58:43.224Z
+[x] Status: UNHEALTHY
+```
+
+**An expired pre-authenticated download URL is re-resolved and retried once**, which is the only one of the three where a retry is the right answer.
+
+An unrecognised `403` code is treated as a refusal of that one item rather than a reason to abort the whole backup, so a code Microsoft adds later costs one file and not a tenant run. Classification reads the HTTP status and the Graph error code only. It never matches on message text, because Microsoft documents `message` as subject to change and a substring test on `Forbidden` also matched wrapped storage and proxy errors that had nothing to do with the download.
+
 ## Snapshot Health Status
 
 Every backup prints a health status at the end:

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -148,6 +148,30 @@ Attempting the download is not merely wasteful, it is actively harmful. Graph re
 
 The file stays reported on every run until it is removed or cleaned in the source, and the run stays `UNHEALTHY`, so an operator can always answer which files are not in the backup and why.
 
+### A 403 is acted on for the reason it was returned
+
+Three unrelated conditions answer `403` on the download path, and each now gets its own response instead of all three being read as an expired download URL.
+
+**A missing application permission stops the run.** The tenant has not granted the scope, so every item will answer the same way. Atlas fails immediately and names the grants to add, rather than re-resolving the URL and spending a second download budget per file before reporting a lost file:
+
+```
+Missing Microsoft Graph application permissions for SharePoint: Sites.Read.All.
+```
+
+**A protection or policy state is recorded against the item.** A sensitivity label, an IRM policy, or a retention rule can make the service refuse one file while the rest of the drive is readable. That is permanent for the item and not a problem with the run, so it is recorded the way a quarantined file is, with the Graph error code that explains it:
+
+```
+[!] Not backed up: Report.docx (01STBDHIPIY7N3OWY...) -- Microsoft 365 refused to release
+    Report.docx (01STBDHIPIY7N3OWY...): Graph returned 403 notAllowed. This is a protection or
+    policy state on the item, not a transient failure.; PERMANENTLY SKIPPED by service policy,
+    not retried, first failed 2026-08-11T07:58:43.224Z
+[x] Status: UNHEALTHY
+```
+
+**An expired pre-authenticated download URL is re-resolved and retried once**, which is the only one of the three where a retry is the right answer.
+
+An unrecognised `403` code is treated as a refusal of that one item rather than a reason to abort the whole backup, so a code Microsoft adds later costs one file and not a tenant run. Classification reads the HTTP status and the Graph error code only. It never matches on message text, because Microsoft documents `message` as subject to change and a substring test on `Forbidden` also matched wrapped storage and proxy errors that had nothing to do with the download.
+
 ## Snapshot Health Status
 
 Every backup prints a health status at the end:

--- a/packages/m365-graph/src/graph-download-classification.ts
+++ b/packages/m365-graph/src/graph-download-classification.ts
@@ -1,0 +1,112 @@
+/**
+ * Classifies a failed drive-file download by cause, so a 403 is acted on for the
+ * reason it was returned (issue #246).
+ *
+ * Three unrelated conditions answer 403 on this path, and the previous code read
+ * all of them as an expired pre-authenticated URL:
+ *
+ * - The pre-authenticated download URL really has expired. Re-resolving and
+ *   retrying is correct, and this is the only case where it is.
+ * - The tenant has not granted the application permission. Re-resolving cannot
+ *   help, and the run should stop and name the missing grant.
+ * - The service will not release the item (IRM, sensitivity label, policy).
+ *   Neither a refresh nor a second download budget changes the answer, so the
+ *   item is recorded against the snapshot and the run continues.
+ *
+ * Classification keys on the transport the error came from and on the Graph error
+ * code, never on the message text. Microsoft's own error guidance is explicit
+ * that `message` "can change at any time" and that callers "should only code
+ * against error codes returned in `code` properties", which is why the previous
+ * substring test on `Forbidden` and `Unauthorized` is gone: it also matched
+ * wrapped storage and proxy errors that had nothing to do with the download URL.
+ */
+
+/** Cause of a failed download, as far as the error itself can be trusted to say. */
+export type DownloadFailureKind =
+  /** A pre-authenticated CDN URL that is no longer valid: re-resolve and retry. */
+  | 'expired_url'
+  /** The application lacks a required Graph permission: stop and name it. */
+  | 'missing_permission'
+  /** The service refuses to release this item and will keep refusing. */
+  | 'service_refused'
+  /** Graph rejected the credential itself, which a URL refresh cannot fix. */
+  | 'unauthorized'
+  /** Nothing in the error identifies a cause; the caller falls back as before. */
+  | 'unclassified';
+
+/**
+ * Graph error codes that mean the application is missing a grant. Only these abort
+ * a run: any other 403 code is treated as a per-item refusal, because aborting a
+ * whole tenant backup on an unrecognised code is the worse failure.
+ *
+ * Both spellings are real: driveItem returns `accessDenied`, while the Exchange
+ * backed APIs return `ErrorAccessDenied`.
+ */
+const MISSING_PERMISSION_CODES = new Set(['accessdenied', 'erroraccessdenied']);
+
+/** Thrown for a 403 the service will not reverse. Permanent for the item, not the run. */
+export class DownloadRefusedError extends Error {
+  constructor(
+    message: string,
+    readonly graph_code: string,
+  ) {
+    super(message);
+    this.name = 'DownloadRefusedError';
+  }
+}
+
+/** Thrown when a download fails because the app registration lacks a grant. */
+export class MissingGraphPermissionsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingGraphPermissionsError';
+  }
+}
+
+/** Classifies a caught download error. Never throws, whatever it is handed. */
+export function classify_download_failure(err: unknown): DownloadFailureKind {
+  if (err === null || typeof err !== 'object') return 'unclassified';
+
+  const candidate = err as { status_code?: unknown; statusCode?: unknown; code?: unknown };
+
+  // A CDN error carries `status_code` and comes from fetching the pre-authenticated
+  // URL, which is the one place a 403 does mean the URL went stale.
+  if (typeof candidate.status_code === 'number') {
+    return candidate.status_code === 401 || candidate.status_code === 403
+      ? 'expired_url'
+      : 'unclassified';
+  }
+
+  // A Graph error carries `statusCode` and comes from the API, where 401 and 403
+  // mean different things and must not share a branch.
+  if (typeof candidate.statusCode === 'number') {
+    if (candidate.statusCode === 401) return 'unauthorized';
+    if (candidate.statusCode !== 403) return 'unclassified';
+    const code = typeof candidate.code === 'string' ? candidate.code.toLowerCase() : '';
+    return MISSING_PERMISSION_CODES.has(code) ? 'missing_permission' : 'service_refused';
+  }
+
+  return 'unclassified';
+}
+
+/** Reads the Graph error code, for naming a refusal the operator has to investigate. */
+export function read_graph_error_code(err: unknown): string {
+  if (err === null || typeof err !== 'object') return 'unknown';
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'string' && code.length > 0 ? code : 'unknown';
+}
+
+/** True for a refusal that must be recorded against the item rather than retried. */
+export function is_download_refused(err: unknown): err is DownloadRefusedError {
+  return err instanceof DownloadRefusedError;
+}
+
+/** True for a missing-grant failure, which must abort the run rather than skip an item. */
+export function is_missing_graph_permissions(err: unknown): err is MissingGraphPermissionsError {
+  return err instanceof MissingGraphPermissionsError;
+}
+
+/** True when an error must reach the caller intact instead of becoming a silent skip. */
+export function is_unretryable_download_failure(err: unknown): boolean {
+  return is_download_refused(err) || is_missing_graph_permissions(err);
+}

--- a/packages/m365-graph/src/index.ts
+++ b/packages/m365-graph/src/index.ts
@@ -11,6 +11,16 @@ export {
   is_content_gone_error,
   with_graph_retry,
 } from './graph-error-helpers';
+export {
+  classify_download_failure,
+  read_graph_error_code,
+  is_download_refused,
+  is_missing_graph_permissions,
+  is_unretryable_download_failure,
+  DownloadRefusedError,
+  MissingGraphPermissionsError,
+} from './graph-download-classification';
+export type { DownloadFailureKind } from './graph-download-classification';
 export { RateLimitedGraphConnector } from './rate-limited-graph-connector.adapter';
 export { bind_graph_client } from './container';
 export { GraphUserIdentityResolver } from './graph-user-identity-resolver.adapter';

--- a/packages/m365-graph/tests/unit/graph-download-classification.test.ts
+++ b/packages/m365-graph/tests/unit/graph-download-classification.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classify_download_failure,
+  read_graph_error_code,
+  is_download_refused,
+  is_missing_graph_permissions,
+  is_unretryable_download_failure,
+  DownloadRefusedError,
+  MissingGraphPermissionsError,
+} from '@/graph-download-classification';
+
+/**
+ * The shared classifier both drive download paths delegate to (issue #246). Keeping
+ * it in one place is what stops the two drives drifting apart, so the assertions
+ * here are the contract each drive relies on.
+ */
+describe('classify_download_failure', () => {
+  describe('CDN errors, which carry status_code', () => {
+    // A pre-authenticated URL that has expired is the one case where re-resolving
+    // and retrying is the right response.
+    it.each([401, 403])('reads status_code %i as an expired URL', (status) => {
+      expect(classify_download_failure({ status_code: status })).toBe('expired_url');
+    });
+
+    it.each([404, 429, 500])('leaves status_code %i unclassified', (status) => {
+      expect(classify_download_failure({ status_code: status })).toBe('unclassified');
+    });
+  });
+
+  describe('Graph errors, which carry statusCode', () => {
+    // 401 and 403 shared a branch before #246, which is why a credential problem and
+    // a permissions problem both produced a URL refresh.
+    it('reads 401 as unauthorized, never as an expired URL', () => {
+      expect(classify_download_failure({ statusCode: 401 })).toBe('unauthorized');
+    });
+
+    it.each(['accessDenied', 'ErrorAccessDenied', 'ACCESSDENIED'])(
+      'reads 403 with code %s as a missing permission',
+      (code) => {
+        expect(classify_download_failure({ statusCode: 403, code })).toBe('missing_permission');
+      },
+    );
+
+    it.each(['notAllowed', 'malwareDetected', 'someFutureCode', ''])(
+      'reads 403 with code %s as a service refusal',
+      (code) => {
+        expect(classify_download_failure({ statusCode: 403, code })).toBe('service_refused');
+      },
+    );
+
+    // Conservative on purpose: an unrecognised 403 records one item rather than
+    // aborting a whole tenant backup.
+    it('reads a 403 with no code at all as a service refusal', () => {
+      expect(classify_download_failure({ statusCode: 403 })).toBe('service_refused');
+    });
+
+    it.each([404, 429, 500])('leaves statusCode %i unclassified', (status) => {
+      expect(classify_download_failure({ statusCode: status })).toBe('unclassified');
+    });
+  });
+
+  describe('everything else', () => {
+    // The substring test on Forbidden and Unauthorized is gone. Microsoft's error
+    // guidance is that `message` can change at any time and only `code` should be
+    // relied on, and the old test also matched wrapped storage and proxy errors.
+    it.each(['Forbidden', 'Unauthorized', 'HTTP 403 Forbidden'])(
+      'does not classify by message text: %s',
+      (message) => {
+        expect(classify_download_failure(new Error(message))).toBe('unclassified');
+      },
+    );
+
+    // Previously a TypeError from reading .statusCode off the raw value (issue #263),
+    // which replaced the real download failure on the way out of the catch block.
+    it.each([undefined, null, 'string', 0, false])('classifies %s without throwing', (value) => {
+      expect(classify_download_failure(value)).toBe('unclassified');
+    });
+
+    it('ignores a status carried as a string rather than a number', () => {
+      expect(classify_download_failure({ statusCode: '403' })).toBe('unclassified');
+      expect(classify_download_failure({ status_code: '403' })).toBe('unclassified');
+    });
+  });
+});
+
+describe('read_graph_error_code', () => {
+  it('returns the code when present', () => {
+    expect(read_graph_error_code({ code: 'notAllowed' })).toBe('notAllowed');
+  });
+
+  it.each([undefined, null, {}, { code: '' }, { code: 42 }])(
+    'falls back to "unknown" for %s',
+    (value) => {
+      expect(read_graph_error_code(value)).toBe('unknown');
+    },
+  );
+});
+
+describe('error guards', () => {
+  const refused = new DownloadRefusedError('refused', 'notAllowed');
+  const missing = new MissingGraphPermissionsError('missing');
+
+  it('identifies a refusal, which is permanent for the item but not the run', () => {
+    expect(is_download_refused(refused)).toBe(true);
+    expect(is_download_refused(missing)).toBe(false);
+    expect(is_download_refused(new Error('other'))).toBe(false);
+    expect(refused.graph_code).toBe('notAllowed');
+    expect(refused.name).toBe('DownloadRefusedError');
+  });
+
+  it('identifies a missing grant, which must abort the run', () => {
+    expect(is_missing_graph_permissions(missing)).toBe(true);
+    expect(is_missing_graph_permissions(refused)).toBe(false);
+    expect(missing.name).toBe('MissingGraphPermissionsError');
+  });
+
+  // The guard the download orchestrators use to decide what must not become a
+  // silent per-file skip.
+  it('treats both as unretryable and everything else as retryable', () => {
+    expect(is_unretryable_download_failure(refused)).toBe(true);
+    expect(is_unretryable_download_failure(missing)).toBe(true);
+    expect(is_unretryable_download_failure(new Error('socket hang up'))).toBe(false);
+    expect(is_unretryable_download_failure(undefined)).toBe(false);
+  });
+});

--- a/packages/onedrive/src/adapters/graph-onedrive-download-helpers.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-download-helpers.ts
@@ -1,6 +1,5 @@
 import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
 import {
-  CdnHttpError,
   CHUNK_DOWNLOAD_THRESHOLD,
   compute_chunk_timeout_ms,
   download_file_chunked,
@@ -12,7 +11,14 @@ import {
 } from '@/adapters/graph-onedrive-connector-stream';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import type { Client } from '@microsoft/microsoft-graph-client';
-import { with_graph_retry } from '@wisecom/atlas-m365-graph';
+import type { DownloadFailureKind } from '@wisecom/atlas-m365-graph';
+import {
+  with_graph_retry,
+  classify_download_failure,
+  read_graph_error_code,
+  DownloadRefusedError,
+  MissingGraphPermissionsError,
+} from '@wisecom/atlas-m365-graph';
 
 interface GraphDriveItemDownload {
   '@microsoft.graph.downloadUrl'?: string;
@@ -33,7 +39,38 @@ export async function resolve_download_url(
   return response['@microsoft.graph.downloadUrl'];
 }
 
-/** Runs a download attempt with expired-URL refresh and Graph content fallback. */
+/**
+ * Throws for the two 403 causes that neither a URL refresh nor the `/content`
+ * fallback can resolve, so the caller stops instead of spending a second retry
+ * budget on a refusal (issue #246).
+ */
+function rethrow_if_unrecoverable(
+  kind: DownloadFailureKind,
+  err: unknown,
+  item: OneDriveDeltaItem,
+): void {
+  // A missing grant answers 403 on every item, so the run must stop and name it.
+  if (kind === 'missing_permission') {
+    throw_missing_permissions('read');
+  }
+
+  // The service will keep refusing this item, so it is recorded against the
+  // snapshot with the code that explains it, rather than retried.
+  if (kind === 'service_refused') {
+    const code = read_graph_error_code(err);
+    throw new DownloadRefusedError(
+      `Microsoft 365 refused to release ${item.file_name} (${item.item_id}): ` +
+        `Graph returned 403 ${code}. This is a protection or policy state on the ` +
+        `item, not a transient failure.`,
+      code,
+    );
+  }
+}
+
+/**
+ * Runs a download attempt, acting on the cause of a failure rather than assuming
+ * every 403 is a stale URL (issue #246).
+ */
 async function attempt_download_with_refresh(
   client: Client,
   item: OneDriveDeltaItem,
@@ -48,7 +85,10 @@ async function attempt_download_with_refresh(
   try {
     return await download_fn(download_url);
   } catch (err) {
-    if (is_expired_url_error(err)) {
+    const kind = classify_download_failure(err);
+    rethrow_if_unrecoverable(kind, err, item);
+
+    if (kind === 'expired_url') {
       const refreshed_url = await resolve_download_url(client, item);
       if (refreshed_url) {
         try {
@@ -110,19 +150,28 @@ export async function download_via_graph_content(
   return await stream_to_buffer(stream, drain_timeout_ms);
 }
 
+/**
+ * True only for a stale pre-authenticated URL, which is the one 403 worth retrying.
+ *
+ * Delegates to the shared classifier so both drives cannot drift, and so a nullish
+ * rejection reason is classified instead of crashing the classifier (issue #263).
+ */
 export function is_expired_url_error(err: unknown): boolean {
-  if (err instanceof CdnHttpError) {
-    return err.status_code === 401 || err.status_code === 403;
-  }
-  const graph_status = (err as { statusCode?: number }).statusCode;
-  if (typeof graph_status === 'number') return graph_status === 401 || graph_status === 403;
-  const message = err instanceof Error ? err.message : String(err);
-  return message.includes('Forbidden') || message.includes('Unauthorized');
+  return classify_download_failure(err) === 'expired_url';
 }
 
+/**
+ * Rethrows any Graph 403 as a missing grant.
+ *
+ * Deliberately broader than the download-path classification. Its callers are the
+ * enumeration paths (`list_drives`, `fetch_delta`), where a 403 has one plausible
+ * cause: there is no per-item protection state when listing a drive. The finer
+ * split between a missing grant and a service refusal belongs to the download
+ * path, where both are reachable for the same item (issue #246).
+ */
 export function rethrow_if_access_denied(err: unknown): void {
-  const graph_err = err as Record<string, unknown>;
-  if (graph_err.statusCode !== 403) return;
+  if (err === null || typeof err !== 'object') return;
+  if ((err as { statusCode?: unknown }).statusCode !== 403) return;
   throw_missing_permissions('read');
 }
 
@@ -130,5 +179,7 @@ export function throw_missing_permissions(context: 'read' | 'write' = 'read'): n
   const read_perms = 'Files.Read.All, Sites.Read.All';
   const write_perms = 'Files.ReadWrite.All, Sites.Read.All';
   const perms = context === 'write' ? write_perms : read_perms;
-  throw new Error(`Missing Microsoft Graph application permissions for OneDrive: ${perms}.`);
+  throw new MissingGraphPermissionsError(
+    `Missing Microsoft Graph application permissions for OneDrive: ${perms}.`,
+  );
 }

--- a/packages/onedrive/src/services/onedrive-backup-file-processor.ts
+++ b/packages/onedrive/src/services/onedrive-backup-file-processor.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import type { OneDriveConnector, OneDriveDeltaItem, TenantContext } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
 import { download_with_retry } from '@/services/onedrive-download-orchestrator';
 import { LARGE_FILE_THRESHOLD, process_large_file } from '@/services/onedrive-large-file-pipeline';
 import { onedrive_data_key } from '@/services/onedrive-storage-keys';
@@ -25,6 +26,9 @@ export async function process_backup_file(
     try {
       return await process_large_file(connector, item, owner_id, ctx);
     } catch (err) {
+      // A missing grant or a service refusal is not a skip: it must reach the caller
+      // so the run can name the cause instead of reporting a lost file (issue #246).
+      if (is_unretryable_download_failure(err)) throw err;
       logger.warn(
         `Skipping large file ${item.item_id} (${item.file_name}): ${err instanceof Error ? err.message : String(err)}`,
       );

--- a/packages/onedrive/src/services/onedrive-delta-item-processor.ts
+++ b/packages/onedrive/src/services/onedrive-delta-item-processor.ts
@@ -10,6 +10,7 @@ import {
   build_stored_entry,
 } from '@/services/onedrive-backup-builders';
 import { process_backup_file } from '@/services/onedrive-backup-file-processor';
+import { is_download_refused } from '@wisecom/atlas-m365-graph';
 import { classify_change_type } from '@/services/onedrive-change-classifier';
 import {
   collect_run_versions,
@@ -126,15 +127,9 @@ export async function process_delta_item(
     };
   }
 
-  const result = await process_backup_file(connector, item, owner_id, ctx);
-  if (!result) {
-    return {
-      files_stored: 0,
-      files_deduplicated: 0,
-      deleted_items: 0,
-      error: `Failed to process file ${item.file_name} (${item.item_id})`,
-    };
-  }
+  const download = await download_or_record_refusal(connector, item, owner_id, ctx);
+  if (download.outcome) return download.outcome;
+  const result = download.result;
 
   if (!result.deduplicated) {
     const version_result = await sync_file_versions(
@@ -159,4 +154,33 @@ export async function process_delta_item(
     files_deduplicated: result.deduplicated ? 1 : 0,
     deleted_items: 0,
   };
+}
+
+/**
+ * Downloads one item, converting a service refusal into a recorded outcome.
+ *
+ * A refusal is permanent for this item but not for the run, so it is recorded the
+ * way a quarantined item is. A missing grant is deliberately not caught: it applies
+ * to every item and must stop the run (issue #246).
+ */
+async function download_or_record_refusal(
+  connector: OneDriveConnector,
+  item: OneDriveDeltaItem,
+  owner_id: string,
+  ctx: TenantContext,
+): Promise<
+  | { outcome: DeltaItemOutcome; result?: undefined }
+  | { outcome?: undefined; result: NonNullable<Awaited<ReturnType<typeof process_backup_file>>> }
+> {
+  const empty = { files_stored: 0, files_deduplicated: 0, deleted_items: 0 };
+  try {
+    const result = await process_backup_file(connector, item, owner_id, ctx);
+    if (result) return { result };
+    return {
+      outcome: { ...empty, error: `Failed to process file ${item.file_name} (${item.item_id})` },
+    };
+  } catch (err) {
+    if (!is_download_refused(err)) throw err;
+    return { outcome: { ...empty, error: err.message, permanent: true } };
+  }
 }

--- a/packages/onedrive/src/services/onedrive-download-orchestrator.ts
+++ b/packages/onedrive/src/services/onedrive-download-orchestrator.ts
@@ -1,5 +1,5 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
-import { is_retryable_error } from '@wisecom/atlas-m365-graph';
+import { is_retryable_error, is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
 import type { OneDriveConnector, OneDriveDeltaItem } from '@wisecom/atlas-types';
 
 const DEFAULT_MAX_ATTEMPTS = 3;
@@ -15,6 +15,10 @@ export interface DownloadRetryOptions {
  * Wraps a connector download call in a file-level retry loop.
  * Returns undefined when all attempts are exhausted, allowing
  * the caller to skip the file without throwing.
+ *
+ * A missing grant and a service refusal are the exceptions: both are rethrown so
+ * the caller can name the cause. Swallowing them here is what turned one missing
+ * permission into a per-file retry storm reported as a skipped file (issue #246).
  */
 export async function download_with_retry(
   connector: OneDriveConnector,
@@ -29,6 +33,8 @@ export async function download_with_retry(
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       const is_last = attempt === max_attempts;
+
+      if (is_unretryable_download_failure(err)) throw err;
 
       if (is_last || !is_retryable_error(err)) {
         logger.warn(

--- a/packages/onedrive/tests/unit/adapters/download-403-classification.test.ts
+++ b/packages/onedrive/tests/unit/adapters/download-403-classification.test.ts
@@ -1,0 +1,164 @@
+import { classify_download_failure, DownloadRefusedError } from '@wisecom/atlas-m365-graph';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import type { Client } from '@microsoft/microsoft-graph-client';
+import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
+// Static: vi.mock is hoisted above imports, and the partial mock keeps CdnHttpError real.
+import { CdnHttpError } from '@/adapters/graph-onedrive-chunked-download';
+
+/**
+ * The behaviour issue #246 introduces: a 403 is acted on for the reason it was
+ * returned, instead of every 403 being read as a stale pre-authenticated URL.
+ *
+ * The suite in download-helpers.test.ts pins the classification itself. This one
+ * asserts what the download path *does* with each classification, which is where the
+ * reported symptom lived: a missing grant became a per-file retry storm reported as a
+ * skipped file.
+ */
+
+const mocks = vi.hoisted(() => ({
+  download_file_chunked: vi.fn(),
+  download_from_url: vi.fn(),
+  stream_to_buffer: vi.fn(),
+  with_timeout: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('@/adapters/graph-onedrive-chunked-download', async (import_original) => {
+  const actual = await import_original<Record<string, unknown>>();
+  return { ...actual, download_file_chunked: mocks.download_file_chunked };
+});
+
+vi.mock('@/adapters/graph-onedrive-connector-stream', () => ({
+  download_from_url: mocks.download_from_url,
+  stream_to_buffer: mocks.stream_to_buffer,
+  with_timeout: mocks.with_timeout,
+}));
+
+vi.mock('@wisecom/atlas-m365-graph', async (import_original) => {
+  const actual = await import_original<Record<string, unknown>>();
+  return { ...actual, with_graph_retry: (fn: () => unknown) => fn() };
+});
+
+vi.mock('@wisecom/atlas-core/utils/logger', () => ({
+  logger: { warn: mocks.warn, debug: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+const { download_with_fallback } = await import('@/adapters/graph-onedrive-download-helpers');
+
+const STALE_URL = 'https://cdn.example.invalid/stale';
+const CONTENT_BODY = Buffer.from('graph-content');
+
+/** A Graph error as the SDK surfaces it: statusCode plus a machine-readable code. */
+function graph_error(status: number, code: string): { statusCode: number; code: string } {
+  return { statusCode: status, code };
+}
+
+interface GraphClientMock {
+  client: Client;
+  api: Mock;
+  get: Mock;
+  get_stream: Mock;
+}
+
+function make_client(): GraphClientMock {
+  const get = vi.fn().mockResolvedValue({ '@microsoft.graph.downloadUrl': 'https://fresh' });
+  const get_stream = vi.fn().mockResolvedValue('stream-handle');
+  const select = vi.fn(() => ({ get }));
+  const api = vi.fn(() => ({ select, get, getStream: get_stream }));
+  const client = { api } as unknown as Client;
+  return { client, api, get, get_stream };
+}
+function make_item(): OneDriveDeltaItem {
+  return {
+    drive_id: 'drive-1',
+    item_id: 'item-1',
+    kind: 'file',
+    file_name: 'Report.docx',
+    parent_path: '/',
+    size_bytes: 1024,
+    deleted: false,
+    download_url: STALE_URL,
+  };
+}
+
+describe('OneDrive 403 handling by cause (issue #246)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.stream_to_buffer.mockResolvedValue(CONTENT_BODY);
+    mocks.with_timeout.mockImplementation((promise: Promise<unknown>) => promise);
+  });
+
+  it('fails fast on a missing grant, without re-resolving and without a /content fallback', async () => {
+    const mock = make_client();
+    mocks.download_from_url.mockRejectedValue(graph_error(403, 'accessDenied'));
+
+    await expect(download_with_fallback(mock.client, make_item())).rejects.toThrow(
+      'Missing Microsoft Graph application permissions for OneDrive: Files.Read.All, Sites.Read.All.',
+    );
+
+    // The whole point of the fix: neither budget is spent.
+    expect(mock.get).not.toHaveBeenCalled();
+    expect(mock.get_stream).not.toHaveBeenCalled();
+    expect(mocks.download_from_url).toHaveBeenCalledOnce();
+  });
+
+  it('records a service refusal against the item, naming the code, without a fallback', async () => {
+    const mock = make_client();
+    mocks.download_from_url.mockRejectedValue(graph_error(403, 'notAllowed'));
+
+    const error = await download_with_fallback(mock.client, make_item()).catch(
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(DownloadRefusedError);
+    expect((error as DownloadRefusedError).graph_code).toBe('notAllowed');
+    expect((error as Error).message).toContain('Report.docx');
+    expect((error as Error).message).toContain('not a transient failure');
+    expect(mock.get).not.toHaveBeenCalled();
+    expect(mock.get_stream).not.toHaveBeenCalled();
+  });
+
+  it('treats an unrecognised 403 code as a per-item refusal rather than aborting the run', async () => {
+    const mock = make_client();
+    mocks.download_from_url.mockRejectedValue(graph_error(403, 'someFutureCode'));
+
+    const error = await download_with_fallback(mock.client, make_item()).catch(
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(DownloadRefusedError);
+    expect((error as DownloadRefusedError).graph_code).toBe('someFutureCode');
+  });
+
+  it('still re-resolves and retries a genuinely expired CDN URL', async () => {
+    const mock = make_client();
+    const body = Buffer.from('after-refresh');
+    mocks.download_from_url
+      .mockRejectedValueOnce(new CdnHttpError('expired', 403))
+      .mockResolvedValueOnce(body);
+
+    await expect(download_with_fallback(mock.client, make_item())).resolves.toEqual(body);
+    expect(mock.get).toHaveBeenCalledOnce();
+    expect(mock.get_stream).not.toHaveBeenCalled();
+  });
+
+  it('falls back to /content for a Graph 401, which a URL refresh cannot fix', async () => {
+    const mock = make_client();
+    mocks.download_from_url.mockRejectedValue(graph_error(401, 'unauthenticated'));
+
+    await expect(download_with_fallback(mock.client, make_item())).resolves.toEqual(CONTENT_BODY);
+    expect(classify_download_failure(graph_error(401, 'unauthenticated'))).toBe('unauthorized');
+    expect(mock.get).not.toHaveBeenCalled();
+    expect(mock.get_stream).toHaveBeenCalledOnce();
+  });
+
+  it('no longer sends a wrapped storage error down the expired-URL path', async () => {
+    const mock = make_client();
+    mocks.download_from_url.mockRejectedValue(new Error('S3 GetObject failed: Forbidden'));
+
+    await expect(download_with_fallback(mock.client, make_item())).resolves.toEqual(CONTENT_BODY);
+    // Before #246 the substring match re-resolved the URL for this error.
+    expect(mock.get).not.toHaveBeenCalled();
+    expect(mock.get_stream).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/onedrive/tests/unit/adapters/download-helpers.test.ts
+++ b/packages/onedrive/tests/unit/adapters/download-helpers.test.ts
@@ -1,3 +1,4 @@
+import { classify_download_failure } from '@wisecom/atlas-m365-graph';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
 import type { Client } from '@microsoft/microsoft-graph-client';
@@ -42,9 +43,12 @@ vi.mock('@/adapters/graph-onedrive-connector-stream', () => ({
 }));
 
 // Retry policy is owned and tested elsewhere; here it must not multiply call counts.
-vi.mock('@wisecom/atlas-m365-graph', () => ({
-  with_graph_retry: (fn: () => unknown) => fn(),
-}));
+// Only the retry wrapper is stubbed, so it cannot multiply call counts. The download
+// classifier is real: it is the behaviour under test (issue #246).
+vi.mock('@wisecom/atlas-m365-graph', async (import_original) => {
+  const actual = await import_original<Record<string, unknown>>();
+  return { ...actual, with_graph_retry: (fn: () => unknown) => fn() };
+});
 
 vi.mock('@wisecom/atlas-core/utils/logger', () => ({
   logger: { warn: mocks.warn, debug: mocks.debug, info: vi.fn(), error: vi.fn() },
@@ -254,8 +258,24 @@ describe('OneDrive download helpers', () => {
       expect(is_expired_url_error(new CdnHttpError('other', status))).toBe(false);
     });
 
-    it.each([401, 403])('treats a Graph error with statusCode %i as an expired URL', (status) => {
-      expect(is_expired_url_error({ statusCode: status })).toBe(true);
+    // Split by #246: a CDN 401/403 is a stale URL, but a Graph 401 is a credential
+    // problem and a Graph 403 is either a missing grant or a service refusal. None of
+    // them is a URL worth re-resolving.
+    it.each([401, 403])(
+      'no longer treats a Graph error with statusCode %i as an expired URL',
+      (status) => {
+        expect(is_expired_url_error({ statusCode: status })).toBe(false);
+      },
+    );
+
+    it('classifies a Graph 401 separately from a Graph 403', () => {
+      expect(classify_download_failure({ statusCode: 401 })).toBe('unauthorized');
+      expect(classify_download_failure({ statusCode: 403, code: 'accessDenied' })).toBe(
+        'missing_permission',
+      );
+      expect(classify_download_failure({ statusCode: 403, code: 'notAllowed' })).toBe(
+        'service_refused',
+      );
     });
 
     it('does not treat a Graph error with another statusCode as an expired URL', () => {
@@ -265,10 +285,13 @@ describe('OneDrive download helpers', () => {
     // Substring classification: any wrapped error whose text happens to contain the
     // word is classified as an expired download URL, including a storage or proxy
     // error unrelated to the URL. Issue #246 removes or narrows this.
+    // Removed by #246. Microsoft's own error guidance is that `message` can change at
+    // any time and only `code` should be relied on, and the substring test also matched
+    // wrapped storage and proxy errors that had nothing to do with the download URL.
     it.each(['Forbidden', 'Unauthorized'])(
-      'classifies a message-only error containing %s as an expired URL (#246)',
+      'no longer classifies a message-only error containing %s as an expired URL',
       (word) => {
-        expect(is_expired_url_error(new Error(`S3 GetObject failed: ${word}`))).toBe(true);
+        expect(is_expired_url_error(new Error(`S3 GetObject failed: ${word}`))).toBe(false);
       },
     );
 
@@ -283,12 +306,11 @@ describe('OneDrive download helpers', () => {
     // issue. The classifier reads `.statusCode` off the raw value, so a rejection
     // carrying no reason (`Promise.reject()`) crashes the classifier instead of
     // being classified. Tracked in #263.
-    it.each([undefined, null])(
-      'currently throws a TypeError for %s rather than returning false',
-      (value) => {
-        expect(() => is_expired_url_error(value)).toThrow(TypeError);
-      },
-    );
+    // Was a TypeError before #246 replaced the raw property read (issue #263).
+    it.each([undefined, null])('classifies %s as unclassified instead of crashing', (value) => {
+      expect(is_expired_url_error(value)).toBe(false);
+      expect(classify_download_failure(value)).toBe('unclassified');
+    });
   });
 
   describe('rethrow_if_access_denied', () => {

--- a/packages/sharepoint/src/adapters/graph-sharepoint-download-helpers.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-download-helpers.ts
@@ -1,7 +1,13 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import type { SharePointDeltaItem } from '@wisecom/atlas-types';
 import type { Client } from '@microsoft/microsoft-graph-client';
-import { with_graph_retry } from '@wisecom/atlas-m365-graph';
+import {
+  with_graph_retry,
+  classify_download_failure,
+  read_graph_error_code,
+  DownloadRefusedError,
+  MissingGraphPermissionsError,
+} from '@wisecom/atlas-m365-graph';
 import {
   CdnHttpError,
   CHUNK_DOWNLOAD_THRESHOLD,
@@ -60,7 +66,10 @@ export async function download_with_fallback(
   return await download_via_graph_content(client, item);
 }
 
-/** Attempts a CDN download, refreshing expired URLs once before falling back to Graph. */
+/**
+ * Attempts a CDN download, acting on the cause of a failure rather than assuming
+ * every 403 is a stale URL (issue #246). Kept identical to the OneDrive twin.
+ */
 async function attempt_download_with_refresh(
   client: Client,
   item: SharePointDeltaItem,
@@ -71,7 +80,28 @@ async function attempt_download_with_refresh(
   try {
     return await download_fn(download_url);
   } catch (err) {
-    if (is_expired_url_error(err)) {
+    const kind = classify_download_failure(err);
+
+    // A missing grant answers 403 on every item, so re-resolving and then spending a
+    // second /content retry budget per file only delays naming the real cause.
+    if (kind === 'missing_permission') {
+      throw new MissingGraphPermissionsError(
+        'Missing Microsoft Graph application permissions for SharePoint: Sites.Read.All.',
+      );
+    }
+
+    // The service will keep refusing this item, so it is recorded against the
+    // snapshot with the code that explains it, rather than retried.
+    if (kind === 'service_refused') {
+      throw new DownloadRefusedError(
+        `Microsoft 365 refused to release ${item.file_name} (${item.item_id}): ` +
+          `Graph returned 403 ${read_graph_error_code(err)}. This is a protection or ` +
+          `policy state on the item, not a transient failure.`,
+        read_graph_error_code(err),
+      );
+    }
+
+    if (kind === 'expired_url') {
       const refreshed_url = await resolve_download_url(client, item);
       if (refreshed_url) {
         try {
@@ -107,20 +137,29 @@ export async function download_via_graph_content(
   return await stream_to_buffer(stream, drain_timeout_ms);
 }
 
+/**
+ * True only for a stale pre-authenticated URL, which is the one 403 worth retrying.
+ *
+ * Delegates to the shared classifier so both drives cannot drift, and so a nullish
+ * rejection reason is classified instead of crashing the classifier (issue #263).
+ */
 export function is_expired_url_error(err: unknown): boolean {
-  if (err instanceof CdnHttpError) {
-    return err.status_code === 401 || err.status_code === 403;
-  }
-  const graph_status = (err as { statusCode?: number }).statusCode;
-  if (typeof graph_status === 'number') return graph_status === 401 || graph_status === 403;
-  const message = err instanceof Error ? err.message : String(err);
-  return message.includes('Forbidden') || message.includes('Unauthorized');
+  return classify_download_failure(err) === 'expired_url';
 }
 
+/**
+ * Rethrows any Graph 403 as a missing grant.
+ *
+ * Deliberately broader than the download-path classification. Its callers are the
+ * enumeration paths in the connector, where a 403 has one plausible cause: there is
+ * no per-item protection state when listing a library. The finer split between a
+ * missing grant and a service refusal belongs to the download path, where both are
+ * reachable for the same item (issue #246).
+ */
 export function rethrow_if_access_denied(err: unknown): void {
-  const graph_err = err as Record<string, unknown>;
-  if (graph_err.statusCode !== 403) return;
-  throw new Error(
+  if (err === null || typeof err !== 'object') return;
+  if ((err as { statusCode?: unknown }).statusCode !== 403) return;
+  throw new MissingGraphPermissionsError(
     'Missing Microsoft Graph application permissions for SharePoint: Sites.Read.All.',
   );
 }

--- a/packages/sharepoint/src/services/sharepoint-backup-file-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-backup-file-processor.ts
@@ -5,6 +5,7 @@ import type {
   TenantContext,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
 import { download_with_retry } from '@/services/sharepoint-download-orchestrator';
 import {
   LARGE_FILE_THRESHOLD,
@@ -32,6 +33,9 @@ export async function process_backup_file(
     try {
       return await process_large_file(connector, item, site_id, ctx);
     } catch (err) {
+      // A missing grant or a service refusal is not a skip: it must reach the caller
+      // so the run can name the cause instead of reporting a lost file (issue #246).
+      if (is_unretryable_download_failure(err)) throw err;
       logger.warn(
         `Skipping large file ${item.item_id} (${item.file_name}): ${err instanceof Error ? err.message : String(err)}`,
       );

--- a/packages/sharepoint/src/services/sharepoint-download-orchestrator.ts
+++ b/packages/sharepoint/src/services/sharepoint-download-orchestrator.ts
@@ -1,5 +1,5 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
-import { is_retryable_error } from '@wisecom/atlas-m365-graph';
+import { is_retryable_error, is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
 import type { SharePointSiteConnector, SharePointDeltaItem } from '@wisecom/atlas-types';
 
 const DEFAULT_MAX_ATTEMPTS = 3;
@@ -15,6 +15,10 @@ export interface DownloadRetryOptions {
  * Wraps a connector download call in a file-level retry loop.
  * Returns undefined when all attempts are exhausted, allowing
  * the caller to skip the file without throwing.
+ *
+ * A missing grant and a service refusal are the exceptions: both are rethrown so
+ * the caller can name the cause. Swallowing them here is what turned one missing
+ * permission into a per-file retry storm reported as a skipped file (issue #246).
  */
 export async function download_with_retry(
   connector: SharePointSiteConnector,
@@ -29,6 +33,8 @@ export async function download_with_retry(
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       const is_last = attempt === max_attempts;
+
+      if (is_unretryable_download_failure(err)) throw err;
 
       if (is_last || !is_retryable_error(err)) {
         logger.warn(

--- a/packages/sharepoint/src/services/sharepoint-library-item-processor.ts
+++ b/packages/sharepoint/src/services/sharepoint-library-item-processor.ts
@@ -17,6 +17,7 @@ import {
   build_stored_entry,
 } from '@/services/sharepoint-backup-builders';
 import { process_backup_file } from '@/services/sharepoint-backup-file-processor';
+import { is_download_refused } from '@wisecom/atlas-m365-graph';
 import { classify_change_type } from '@/services/sharepoint-change-classifier';
 import {
   collect_run_versions,
@@ -110,17 +111,8 @@ export async function process_delta_item(
     return;
   }
 
-  const result = await process_backup_file(connector, item, site_id, ctx);
-  if (!result) {
-    library_state.failed_item_ids.add(item.item_id);
-    library_state.failed_items = record_item_failure(library_state.failed_items, {
-      item_id: item.item_id,
-      drive_id: item.drive_id,
-      name: item.file_name,
-      reason: 'file content could not be downloaded',
-    });
-    return;
-  }
+  const result = await download_or_record_refusal(connector, item, site_id, ctx, library_state);
+  if (!result) return;
 
   if (result.deduplicated) library_state.library_files_deduplicated++;
   if (result.stored) library_state.library_files_stored++;
@@ -249,4 +241,40 @@ function forget_item_tracking(tracking: FileTrackingState, item_id: string): voi
   delete tracking.previous_path_by_file_id[item_id];
   delete tracking.previous_name_by_file_id[item_id];
   delete tracking.previous_etag_by_file_id[item_id];
+}
+
+/**
+ * Downloads one item, recording a service refusal against it and returning
+ * undefined when there is nothing to store.
+ *
+ * A refusal is permanent for this item but not for the run, so it is recorded the
+ * way a quarantined item is. A missing grant is deliberately not caught: it applies
+ * to every item and must stop the run (issue #246). Mirrors the OneDrive twin.
+ */
+async function download_or_record_refusal(
+  connector: SharePointSiteConnector,
+  item: SharePointDeltaItem,
+  site_id: string,
+  ctx: TenantContext,
+  library_state: LibraryProcessingState,
+): Promise<Awaited<ReturnType<typeof process_backup_file>>> {
+  const record = (reason: string, permanent?: boolean): undefined => {
+    library_state.failed_item_ids.add(item.item_id);
+    library_state.failed_items = record_item_failure(library_state.failed_items, {
+      item_id: item.item_id,
+      drive_id: item.drive_id,
+      name: item.file_name,
+      reason,
+      ...(permanent === true ? { permanent: true } : {}),
+    });
+    return undefined;
+  };
+
+  try {
+    const result = await process_backup_file(connector, item, site_id, ctx);
+    return result ?? record('file content could not be downloaded');
+  } catch (err) {
+    if (!is_download_refused(err)) throw err;
+    return record(err.message, true);
+  }
 }

--- a/packages/sharepoint/tests/unit/adapters/download-403-classification.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/download-403-classification.test.ts
@@ -1,0 +1,169 @@
+import { classify_download_failure, DownloadRefusedError } from '@wisecom/atlas-m365-graph';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import type { Client } from '@microsoft/microsoft-graph-client';
+import type { SharePointDeltaItem } from '@wisecom/atlas-types';
+import { Readable } from 'node:stream';
+
+/**
+ * The SharePoint half of issue #246, asserted separately from the OneDrive half
+ * because the two download paths are not the same code: SharePoint's
+ * `download_from_url` is private and driven by `fetch`, so a Graph-shaped 403 has to
+ * be injected differently. The observable behaviour must match the twin, and these
+ * assertions are what proves it does.
+ */
+
+const mocks = vi.hoisted(() => ({
+  download_file_chunked: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('@/adapters/graph-sharepoint-chunked-download', async (import_original) => {
+  const actual = await import_original<Record<string, unknown>>();
+  return { ...actual, download_file_chunked: mocks.download_file_chunked };
+});
+
+vi.mock('@wisecom/atlas-m365-graph', async (import_original) => {
+  const actual = await import_original<Record<string, unknown>>();
+  return { ...actual, with_graph_retry: (fn: () => unknown) => fn() };
+});
+
+vi.mock('@wisecom/atlas-core/utils/logger', () => ({
+  logger: { warn: mocks.warn, debug: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+const { download_with_fallback } = await import('@/adapters/graph-sharepoint-download-helpers');
+
+const STALE_URL = 'https://cdn.example.invalid/stale';
+const CONTENT_BODY = Buffer.from('graph-content');
+
+/**
+ * SharePoint reaches the URL through `fetch`, so a Graph-shaped error (statusCode
+ * plus code) arrives only when the fetch itself rejects with one, which is what a
+ * wrapped Graph failure looks like on this path.
+ */
+function graph_error(status: number, code: string): { statusCode: number; code: string } {
+  return { statusCode: status, code };
+}
+
+interface GraphClientMock {
+  client: Client;
+  api: Mock;
+  get: Mock;
+  get_stream: Mock;
+}
+
+function make_client(): GraphClientMock {
+  const get = vi.fn().mockResolvedValue({ '@microsoft.graph.downloadUrl': 'https://fresh' });
+  const get_stream = vi.fn().mockResolvedValue(Readable.from([CONTENT_BODY]));
+  const select = vi.fn(() => ({ get }));
+  const api = vi.fn(() => ({ select, get, getStream: get_stream }));
+  const client = { api } as unknown as Client;
+  return { client, api, get, get_stream };
+}
+
+function make_item(): SharePointDeltaItem {
+  return {
+    drive_id: 'drive-1',
+    item_id: 'item-1',
+    kind: 'file',
+    file_name: 'Budget.xlsx',
+    parent_path: '/',
+    size_bytes: 1024,
+    deleted: false,
+    download_url: STALE_URL,
+  };
+}
+
+describe('SharePoint 403 handling by cause (issue #246)', () => {
+  let fetch_mock: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetch_mock = vi.fn();
+    vi.stubGlobal('fetch', fetch_mock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fails fast on a missing grant, without re-resolving and without a /content fallback', async () => {
+    const mock = make_client();
+    fetch_mock.mockRejectedValue(graph_error(403, 'accessDenied'));
+
+    await expect(download_with_fallback(mock.client, make_item())).rejects.toThrow(
+      'Missing Microsoft Graph application permissions for SharePoint: Sites.Read.All.',
+    );
+
+    expect(mock.get).not.toHaveBeenCalled();
+    expect(mock.get_stream).not.toHaveBeenCalled();
+  });
+
+  it('records a service refusal against the item, naming the code, without a fallback', async () => {
+    const mock = make_client();
+    fetch_mock.mockRejectedValue(graph_error(403, 'notAllowed'));
+
+    const error = await download_with_fallback(mock.client, make_item()).catch(
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(DownloadRefusedError);
+    expect((error as DownloadRefusedError).graph_code).toBe('notAllowed');
+    expect((error as Error).message).toContain('Budget.xlsx');
+    expect((error as Error).message).toContain('not a transient failure');
+    expect(mock.get).not.toHaveBeenCalled();
+    expect(mock.get_stream).not.toHaveBeenCalled();
+  });
+
+  it('treats an unrecognised 403 code as a per-item refusal rather than aborting the run', async () => {
+    const mock = make_client();
+    fetch_mock.mockRejectedValue(graph_error(403, 'someFutureCode'));
+
+    const error = await download_with_fallback(mock.client, make_item()).catch(
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(DownloadRefusedError);
+    expect((error as DownloadRefusedError).graph_code).toBe('someFutureCode');
+  });
+
+  it('still re-resolves and retries a genuinely expired CDN URL', async () => {
+    const body = Buffer.from('after-refresh');
+    const mock = make_client();
+    // A 403 from the CDN itself, which is what an expired pre-authenticated URL
+    // returns, and the one case worth re-resolving.
+    fetch_mock
+      .mockResolvedValueOnce({ status: 403, ok: false, headers: new Headers() })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        headers: new Headers(),
+        // Node pools small Buffers, so the view's byteOffset is not necessarily 0.
+        arrayBuffer: () =>
+          Promise.resolve(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)),
+      });
+
+    await expect(download_with_fallback(mock.client, make_item())).resolves.toEqual(body);
+    expect(mock.get).toHaveBeenCalledOnce();
+    expect(mock.get_stream).not.toHaveBeenCalled();
+  });
+
+  it('falls back to /content for a Graph 401, which a URL refresh cannot fix', async () => {
+    const mock = make_client();
+    fetch_mock.mockRejectedValue(graph_error(401, 'unauthenticated'));
+
+    await expect(download_with_fallback(mock.client, make_item())).resolves.toEqual(CONTENT_BODY);
+    expect(classify_download_failure(graph_error(401, 'unauthenticated'))).toBe('unauthorized');
+    expect(mock.get).not.toHaveBeenCalled();
+    expect(mock.get_stream).toHaveBeenCalledOnce();
+  });
+
+  it('no longer sends a wrapped storage error down the expired-URL path', async () => {
+    const mock = make_client();
+    fetch_mock.mockRejectedValue(new Error('S3 GetObject failed: Forbidden'));
+
+    await expect(download_with_fallback(mock.client, make_item())).resolves.toEqual(CONTENT_BODY);
+    expect(mock.get).not.toHaveBeenCalled();
+    expect(mock.get_stream).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/sharepoint/tests/unit/adapters/download-helpers.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/download-helpers.test.ts
@@ -1,3 +1,4 @@
+import { classify_download_failure } from '@wisecom/atlas-m365-graph';
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { Readable } from 'node:stream';
 import type { Client } from '@microsoft/microsoft-graph-client';
@@ -39,9 +40,12 @@ vi.mock('@/adapters/graph-sharepoint-chunked-download', async (import_original) 
   return { ...actual, download_file_chunked: mocks.download_file_chunked };
 });
 
-vi.mock('@wisecom/atlas-m365-graph', () => ({
-  with_graph_retry: (fn: () => unknown) => fn(),
-}));
+// Only the retry wrapper is stubbed, so it cannot multiply call counts. The download
+// classifier is real: it is the behaviour under test (issue #246).
+vi.mock('@wisecom/atlas-m365-graph', async (import_original) => {
+  const actual = await import_original<Record<string, unknown>>();
+  return { ...actual, with_graph_retry: (fn: () => unknown) => fn() };
+});
 
 vi.mock('@wisecom/atlas-core/utils/logger', () => ({
   logger: { warn: mocks.warn, debug: mocks.debug, info: vi.fn(), error: vi.fn() },
@@ -307,18 +311,37 @@ describe('SharePoint download helpers', () => {
       expect(is_expired_url_error(new CdnHttpError('other', status))).toBe(false);
     });
 
-    it.each([401, 403])('treats a Graph error with statusCode %i as an expired URL', (status) => {
-      expect(is_expired_url_error({ statusCode: status })).toBe(true);
+    // Split by #246: a CDN 401/403 is a stale URL, but a Graph 401 is a credential
+    // problem and a Graph 403 is either a missing grant or a service refusal. None of
+    // them is a URL worth re-resolving.
+    it.each([401, 403])(
+      'no longer treats a Graph error with statusCode %i as an expired URL',
+      (status) => {
+        expect(is_expired_url_error({ statusCode: status })).toBe(false);
+      },
+    );
+
+    it('classifies a Graph 401 separately from a Graph 403', () => {
+      expect(classify_download_failure({ statusCode: 401 })).toBe('unauthorized');
+      expect(classify_download_failure({ statusCode: 403, code: 'accessDenied' })).toBe(
+        'missing_permission',
+      );
+      expect(classify_download_failure({ statusCode: 403, code: 'notAllowed' })).toBe(
+        'service_refused',
+      );
     });
 
     it('does not treat a Graph error with another statusCode as an expired URL', () => {
       expect(is_expired_url_error({ statusCode: 500, message: 'Forbidden' })).toBe(false);
     });
 
+    // Removed by #246. Microsoft's own error guidance is that `message` can change at
+    // any time and only `code` should be relied on, and the substring test also matched
+    // wrapped storage and proxy errors that had nothing to do with the download URL.
     it.each(['Forbidden', 'Unauthorized'])(
-      'classifies a message-only error containing %s as an expired URL (#246)',
+      'no longer classifies a message-only error containing %s as an expired URL',
       (word) => {
-        expect(is_expired_url_error(new Error(`S3 GetObject failed: ${word}`))).toBe(true);
+        expect(is_expired_url_error(new Error(`S3 GetObject failed: ${word}`))).toBe(false);
       },
     );
 
@@ -328,12 +351,11 @@ describe('SharePoint download helpers', () => {
     });
 
     // Same latent crash as the OneDrive twin, tracked in #263 rather than fixed here.
-    it.each([undefined, null])(
-      'currently throws a TypeError for %s rather than returning false',
-      (value) => {
-        expect(() => is_expired_url_error(value)).toThrow(TypeError);
-      },
-    );
+    // Was a TypeError before #246 replaced the raw property read (issue #263).
+    it.each([undefined, null])('classifies %s as unclassified instead of crashing', (value) => {
+      expect(is_expired_url_error(value)).toBe(false);
+      expect(classify_download_failure(value)).toBe('unclassified');
+    });
   });
 
   describe('rethrow_if_access_denied', () => {


### PR DESCRIPTION
Closes #246. Closes #263.

## The defect

Three unrelated conditions answer `403` on the drive download path, and all three were read as a stale pre-authenticated URL, because `attempt_download_with_refresh` classified the error before anything else saw it. A missing grant was therefore handled as a URL refresh: re-resolve, retry, then fall through to `/content` and spend its own Graph retry budget, after which the item was recorded as a generic failure. One missing grant became a per-file retry storm reported as a skipped file, and `rethrow_if_access_denied`, twelve lines below in the same file, never got to name the cause.

## Classification

One implementation in `@wisecom/atlas-m365-graph`, so the two drives cannot drift, keyed on the transport the error arrived on plus the Graph error code:

| Error | Kind | Response |
|---|---|---|
| CDN `status_code` 401/403 | `expired_url` | Re-resolve once and retry, as before |
| Graph `statusCode` 403, code `accessDenied` | `missing_permission` | Fail immediately with the permission list. No re-resolve, no `/content` |
| Graph `statusCode` 403, any other code | `service_refused` | Record against the item with the code, continue the run |
| Graph `statusCode` 401 | `unauthorized` | Classified separately from 403, falls back rather than re-resolving |
| Anything else | `unclassified` | Existing fallback, unchanged |

An unrecognised 403 code degrades to a per-item refusal rather than aborting a tenant backup, so a code Microsoft adds later costs one file and not a run.

## The substring test is gone

The old classifier returned true for any error whose message merely contained `Forbidden` or `Unauthorized`. Microsoft's own error guidance, in the reference bundled with the msgraph skill, is explicit:

> The **message** property is a human-readable value ... Don't take any dependency on the content of this value in your code ... You should only code against error codes returned in **code** properties.

That substring also matched wrapped storage and proxy errors unrelated to the download URL, which is the #76 failure mode.

## Two swallow points had to stop swallowing

A refusal recorded as a generic skip is what hid the cause in the first place. `download_with_retry` and the large-file path in `process_backup_file` now rethrow these two kinds instead of returning `undefined`. The item processors convert a refusal into a permanent failed-item record, the same shape #53 gave a quarantined file, while a missing grant keeps propagating and stops the run.

## Scope call worth reviewing

`rethrow_if_access_denied` stays deliberately **broader** than the download path: any Graph 403 is still a missing grant. Its callers are the enumeration paths (`list_drives`, `fetch_delta`, and the SharePoint equivalents), where a 403 has one plausible cause, because there is no per-item protection state when listing a drive. Narrowing it there would have weakened a good signal, and my first attempt did exactly that before the #247 baseline caught it.

## #263 closed by the same change

The classifier no longer reads `.statusCode` off the raw value, so a nullish rejection reason is classified instead of throwing a `TypeError` that replaced the real failure. #263 asked for the guard not to be applied twice, so the assertions #247 added to pin that crash are inverted here rather than fixed separately.

## What #247's baseline caught

Exactly seven assertions failed on the first run, and every one was a behaviour this issue intends to change: Graph 401 and 403 no longer meaning expired URL, the two substring cases, the two nullish crashes, and the permission path. Nothing else moved, which is what the baseline existed to prove.

## Tests

- `graph-download-classification.test.ts` (new, 35 tests): the classifier per error shape, including string-typed statuses, absent codes, and the guards.
- `download-403-classification.test.ts` in **both** drives (new, 6 each): what the download path *does* per classification, asserted per drive as #246 requires, since SharePoint's private `download_from_url` means the two paths are not the same code.
- `download-helpers.test.ts` in both drives: the seven inverted assertions.

Verification: 1854 tests across 15 tasks, typecheck 17, lint 9, docs build clean.

Two lint findings were real and fixed by extracting functions rather than raising the threshold: the new branching pushed `attempt_download_with_refresh` and both item processors past the cognitive-complexity limit.

## Docs

`docs/onedrive-backup.md` and `docs/sharepoint-backup.md` gain a subsection next to the existing malware case, since the operator-visible output changes: a missing grant now stops the run with a named error, and a refusal appears as a permanent skip carrying the Graph code.