### PR TITLE
fix(e2e): stop leaving a default restore root in the drive test account

### DIFF
--- a/e2e/atlas_e2e/cleanup.py
+++ b/e2e/atlas_e2e/cleanup.py
@@ -34,13 +34,25 @@ def sweep_drive(graph: Graph, drive_id: str, marker: str) -> list[str]:
         if marker not in name and not is_stale(parse_graph_time(item.get("createdDateTime"))):
             log.info("Leaving foreign, non-stale drive folder %s", name)
             continue
-        try:
-            drive.delete_item(graph, drive_id, str(item["id"]))
-            removed.append(name)
-            log.info("Cleaned up drive folder %s", name)
-        except GraphError as err:
-            log.warning("Could not delete drive folder %s: %s", name, err)
+        _delete_drive_item(graph, drive_id, str(item["id"]), name, removed)
+
+    # A restore that took the default destination nests under `Restore-{timestamp}` at the drive
+    # root, which carries no marker, so it is identified by holding a marked descendant instead.
+    for root in drive.restore_roots_containing(graph, drive_id, marker):
+        _delete_drive_item(graph, drive_id, str(root["id"]), str(root.get("name", "")), removed)
     return removed
+
+
+def _delete_drive_item(
+    graph: Graph, drive_id: str, item_id: str, name: str, removed: list[str]
+) -> None:
+    """Deletes one drive item, recording it; a failure is logged, never raised out of teardown."""
+    try:
+        drive.delete_item(graph, drive_id, item_id)
+        removed.append(name)
+        log.info("Cleaned up drive folder %s", name)
+    except GraphError as err:
+        log.warning("Could not delete drive folder %s: %s", name, err)
 
 
 def surviving_drive_artifacts(graph: Graph, drive_id: str, marker: str) -> list[str]:
@@ -55,7 +67,11 @@ def surviving_drive_artifacts(graph: Graph, drive_id: str, marker: str) -> list[
     except GraphError as err:
         log.warning("Could not verify drive cleanup: %s", err)
         return []
-    return [str(i.get("name", "")) for i in items if marker in str(i.get("name", ""))]
+    leftovers = [str(i.get("name", "")) for i in items if marker in str(i.get("name", ""))]
+    leftovers.extend(
+        str(r.get("name", "")) for r in drive.restore_roots_containing(graph, drive_id, marker)
+    )
+    return leftovers
 
 
 def sweep_mailbox(graph: Graph, mailbox: str, marker: str) -> list[str]:

--- a/e2e/atlas_e2e/drive.py
+++ b/e2e/atlas_e2e/drive.py
@@ -240,3 +240,27 @@ def fixture_items(graph: Graph, drive_id: str, prefix: str) -> list[dict[str, An
         except GraphError as err:
             log.debug("Could not list %s: %s", path, err)
     return marked
+
+
+def restore_roots_containing(graph: Graph, drive_id: str, marker: str) -> list[dict[str, Any]]:
+    """Drive-root `Restore-*` folders holding this run's fixture tree.
+
+    A restore that takes the default destination writes `/Restore-<timestamp>/E2E/<marker>/...` at
+    the drive root, outside the marker namespace `fixture_items` scans, so nothing deleted it and
+    every nightly run left an empty tree behind. The root carries no marker of ours, so ownership is
+    decided by a marked child, never by the name alone: an operator's own restore must survive.
+    """
+    roots: list[dict[str, Any]] = []
+    try:
+        top = list(graph.paged(f"/drives/{drive_id}/root/children", **{"$select": "id,name"}))
+    except GraphError as err:
+        log.debug("Could not list drive root: %s", err)
+        return roots
+    for item in top:
+        name = str(item.get("name", ""))
+        if not name.startswith("Restore-"):
+            continue
+        inner = children(graph, drive_id, f"{name}/{FIXTURE_ROOT}")
+        if any(marker in str(c.get("name", "")) for c in inner):
+            roots.append(item)
+    return roots

--- a/e2e/atlas_e2e/self_check.py
+++ b/e2e/atlas_e2e/self_check.py
@@ -205,6 +205,37 @@ def check_cleanup_spares_a_concurrent_run() -> None:
     assert cleanup.sweep_drive(stale, "d1", f"{PREFIX}-run-1") == [f"{PREFIX}-run-2"]  # type: ignore[arg-type]
 
 
+def _fake_drive_with_restore_root(inner: list[dict[str, object]]) -> _FakeGraph:
+    return _FakeGraph(
+        {
+            f"/drives/d1/root:/{drive.FIXTURE_ROOT}:/children": [],
+            "/drives/d1/root/children": [_drive_item("Restore-2026-01-01T00-00-00", "id-root")],
+            f"/drives/d1/root:/Restore-2026-01-01T00-00-00/{drive.FIXTURE_ROOT}:/children": inner,
+        }
+    )
+
+
+def check_cleanup_removes_a_default_restore_root() -> None:
+    """A restore that took the default destination must not survive teardown.
+
+    `Restore-{timestamp}` at the drive root carries no marker, so the marker-name sweep never saw
+    it and every nightly run left an empty tree in the tenant's OneDrive.
+    """
+    this_run = f"{PREFIX}-run-1"
+    graph = _fake_drive_with_restore_root([_drive_item(this_run, "id-marked")])
+
+    assert cleanup.sweep_drive(graph, "d1", this_run) == ["Restore-2026-01-01T00-00-00"]  # type: ignore[arg-type]
+    assert graph.deleted == ["id-root"]
+
+
+def check_cleanup_spares_an_operator_restore_root() -> None:
+    """A `Restore-*` folder with no marked descendant is the operator's, and stays."""
+    graph = _fake_drive_with_restore_root([_drive_item("Contract.docx", "id-real")])
+
+    assert cleanup.sweep_drive(graph, "d1", f"{PREFIX}-run-1") == []  # type: ignore[arg-type]
+    assert graph.deleted == []
+
+
 CHECKS = (
     check_settings_repr_hides_secrets,
     check_scrub_redacts_every_secret,
@@ -214,6 +245,8 @@ CHECKS = (
     check_fixture_discovery_only_returns_marked,
     check_cleanup_still_removes_this_run,
     check_cleanup_spares_a_concurrent_run,
+    check_cleanup_removes_a_default_restore_root,
+    check_cleanup_spares_an_operator_restore_root,
 )
 
 

--- a/e2e/tests/test_35_regressions.py
+++ b/e2e/tests/test_35_regressions.py
@@ -19,7 +19,7 @@ import subprocess
 import uuid
 from typing import Any
 
-from atlas_e2e import storage
+from atlas_e2e import drive, storage
 from atlas_e2e.atlas import Cli
 from atlas_e2e.config import REPO_ROOT, Settings
 
@@ -50,7 +50,7 @@ def test_01_readonly_commands_provision_nothing(cli: Cli, s3: Any) -> None:
 
 
 def test_02_corrupt_ciphertext_is_reported_as_tampering(
-    cli: Cli, settings: Settings, s3: Any
+    cli: Cli, settings: Settings, s3: Any, run_marker: str
 ) -> None:
     """A blob that fails its AES-GCM tag check is classified as authentication failure (issue #76).
 
@@ -96,6 +96,12 @@ def test_02_corrupt_ciphertext_is_reported_as_tampering(
             snapshots[0],
             "--conflict",
             "rename",
+            # A failing restore still creates its destination folders before the first decrypt
+            # fails, so this must stay inside the marker namespace cleanup owns. Taking the
+            # default `/Restore-<timestamp>` root left an empty tree at the drive root after
+            # every nightly run, which nothing was allowed to delete.
+            "--destination",
+            drive.restore_destination(run_marker),
         )
         assert result.code != 0, (
             f"restore of tampered ciphertext reported success\n{result.describe()}"


### PR DESCRIPTION
Closes #267.

The nightly suite left one empty folder tree in the OneDrive test account per run. `test_35_regressions.py::test_02_corrupt_ciphertext_is_reported_as_tampering` ran `onedrive restore` without `--destination`, so it took the product default `/Restore-<timestamp>` at the drive root. A failing restore still creates its destination folders before the first AES-GCM tag check fails, which is what the test asserts, so the tree was created and then abandoned.

Teardown could not remove it. `cleanup.sweep_drive` discovers candidates through `drive.fixture_items`, which only returns names carrying the `atlas-e2e-` marker prefix, and the restore root carries no marker. `surviving_drive_artifacts` used the same discovery, so the leak was invisible to the run that caused it.

## Changes

- `tests/test_35_regressions.py`: the restore now passes `--destination drive.restore_destination(run_marker)`, keeping its output inside the marker namespace cleanup owns.
- `atlas_e2e/drive.py`: new `restore_roots_containing`, the drive-side counterpart of `probe.restore_roots_containing`. A drive-root `Restore-*` folder counts as the run's only when it holds a marked descendant, never by name, so an operator's own restore survives.
- `atlas_e2e/cleanup.py`: `sweep_drive` deletes those roots too, and `surviving_drive_artifacts` reports them, so a future default-root restore fails the run instead of accumulating silently. Deletion of a single drive item moved into `_delete_drive_item`.
- `atlas_e2e/self_check.py`: two offline checks, one per direction. The run's restore root is deleted; an unmarked one is spared.

SharePoint was never affected. `test_20_onedrive.py::test_06` and `test_30_sharepoint.py::test_07` already passed `--destination`, and the Outlook default root is already swept by `cleanup.sweep_mailbox`.

## Verification

`uv run python -m atlas_e2e.self_check` passes all 10 checks, `uvx ruff check`, `uvx ruff format --check` and `uv run mypy` are clean, and `pytest --collect-only tests/test_35_regressions.py` confirms the new `run_marker` fixture resolves.

The six folders already in the tenant predate this change and need one manual delete. Cleanup catches any that reappear.

`restore_roots_containing` checks `Restore-*/E2E` rather than walking the whole subtree, because every fixture the suite seeds lives at that path. A test that restores a source tree rooted elsewhere would need the recursive walk.
