### PR TITLE
fix(270): drop chalk, use util.styleText instead

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Install the CLI, point it at storage and a tenant, run a backup. Node.js 22 or later is required.
+Install the CLI, point it at storage and a tenant, run a backup. Node.js 22.8 or later is required.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepare": "husky"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.8.0"
   },
   "devDependencies": {
     "@types/archiver": "^7.0.0",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@ Protects Outlook mailboxes, OneDrive files, and SharePoint document libraries wi
 
 ## Requirements
 
-- Node.js 22 or later
+- Node.js 22.8 or later
 
 ## Install
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,6 +70,6 @@
     "ink-testing-library": "^4.0.0"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.8.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,10 +26,12 @@
     "lint": "eslint src/ tests/",
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\""
   },
+  "engines": {
+    "node": ">=22.8.0"
+  },
   "dependencies": {
     "@wisecom/atlas-types": "workspace:*",
     "archiver": "^7.0.1",
-    "chalk": "^5.6.2",
     "dotenv": "^17.3.1",
     "htmlparser2": "^12.0.0",
     "inversify": "^7.11.0",

--- a/packages/core/src/utils/log-context.ts
+++ b/packages/core/src/utils/log-context.ts
@@ -8,7 +8,7 @@
  * tracking already carries per-operation state (`graph-request-context.ts`).
  *
  * No scope active means no host has asked for anything, which is the CLI: the
- * logger keeps writing chalk lines to the console exactly as before.
+ * logger keeps writing coloured lines to the console exactly as before.
  *
  * @see issue #41
  */

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import { active_log_scope } from './log-context';
 
 /**
@@ -13,7 +13,7 @@ export const logger = {
   info(message: string): void {
     const scope = active_log_scope();
     if (scope) return scope.sink.info(message, scope.fields);
-    console.log(chalk.blue('[*]'), message);
+    console.log(styleText('blue', '[*]', { stream: process.stdout }), message);
   },
 
   success(message: string): void {
@@ -21,19 +21,19 @@ export const logger = {
     // A sink has no notion of success; it is an info line that the terminal
     // happens to render in green.
     if (scope) return scope.sink.info(message, scope.fields);
-    console.log(chalk.green('[+]'), message);
+    console.log(styleText('green', '[+]', { stream: process.stdout }), message);
   },
 
   warn(message: string): void {
     const scope = active_log_scope();
     if (scope) return scope.sink.warn(message, scope.fields);
-    console.warn(chalk.yellow('[!]'), message);
+    console.warn(styleText('yellow', '[!]', { stream: process.stderr }), message);
   },
 
   error(message: string): void {
     const scope = active_log_scope();
     if (scope) return scope.sink.error(message, scope.fields);
-    console.error(chalk.red('[x]'), message);
+    console.error(styleText('red', '[x]', { stream: process.stderr }), message);
   },
 
   debug(message: string): void {
@@ -42,16 +42,25 @@ export const logger = {
     // lines from a host that asked for them.
     if (scope) return scope.sink.debug(message, scope.fields);
     if (process.env['DEBUG']) {
-      console.debug(chalk.gray('[.]'), chalk.gray(message));
+      console.debug(
+        styleText('gray', '[.]', { stream: process.stdout }),
+        styleText('gray', message, { stream: process.stdout }),
+      );
     }
   },
 
   banner(text: string): void {
     const scope = active_log_scope();
     if (scope) return scope.sink.info(text, scope.fields);
-    const rule = chalk.cyan('---' + '-'.repeat(text.length) + '---');
+    const rule = styleText('cyan', '---' + '-'.repeat(text.length) + '---', {
+      stream: process.stdout,
+    });
     console.log(rule);
-    console.log(chalk.cyan('-- ') + chalk.bold.white(text) + chalk.cyan(' --'));
+    console.log(
+      styleText('cyan', '-- ', { stream: process.stdout }) +
+        styleText(['bold', 'white'], text, { stream: process.stdout }) +
+        styleText('cyan', ' --', { stream: process.stdout }),
+    );
     console.log(rule);
   },
 

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,6 +1,22 @@
 import { styleText } from 'node:util';
 import { active_log_scope } from './log-context';
 
+type StyleFormat = Parameters<typeof styleText>[0];
+
+/**
+ * Styles text for stdout, dropping colour when stdout is not a TTY.
+ *
+ * The `stream` option is the whole point: without it `styleText` emits escapes
+ * unconditionally and ANSI ends up in redirected logs. Binding it here means a
+ * call site cannot forget it.
+ */
+const out = (format: StyleFormat, text: string): string =>
+  styleText(format, text, { stream: process.stdout });
+
+/** Styles text for stderr, dropping colour when stderr is not a TTY. */
+const err = (format: StyleFormat, text: string): string =>
+  styleText(format, text, { stream: process.stderr });
+
 /**
  * Atlas log output.
  *
@@ -13,7 +29,7 @@ export const logger = {
   info(message: string): void {
     const scope = active_log_scope();
     if (scope) return scope.sink.info(message, scope.fields);
-    console.log(styleText('blue', '[*]', { stream: process.stdout }), message);
+    console.log(out('blue', '[*]'), message);
   },
 
   success(message: string): void {
@@ -21,19 +37,19 @@ export const logger = {
     // A sink has no notion of success; it is an info line that the terminal
     // happens to render in green.
     if (scope) return scope.sink.info(message, scope.fields);
-    console.log(styleText('green', '[+]', { stream: process.stdout }), message);
+    console.log(out('green', '[+]'), message);
   },
 
   warn(message: string): void {
     const scope = active_log_scope();
     if (scope) return scope.sink.warn(message, scope.fields);
-    console.warn(styleText('yellow', '[!]', { stream: process.stderr }), message);
+    console.warn(err('yellow', '[!]'), message);
   },
 
   error(message: string): void {
     const scope = active_log_scope();
     if (scope) return scope.sink.error(message, scope.fields);
-    console.error(styleText('red', '[x]', { stream: process.stderr }), message);
+    console.error(err('red', '[x]'), message);
   },
 
   debug(message: string): void {
@@ -42,25 +58,16 @@ export const logger = {
     // lines from a host that asked for them.
     if (scope) return scope.sink.debug(message, scope.fields);
     if (process.env['DEBUG']) {
-      console.debug(
-        styleText('gray', '[.]', { stream: process.stdout }),
-        styleText('gray', message, { stream: process.stdout }),
-      );
+      console.debug(out('gray', '[.]'), out('gray', message));
     }
   },
 
   banner(text: string): void {
     const scope = active_log_scope();
     if (scope) return scope.sink.info(text, scope.fields);
-    const rule = styleText('cyan', '---' + '-'.repeat(text.length) + '---', {
-      stream: process.stdout,
-    });
+    const rule = out('cyan', '---' + '-'.repeat(text.length) + '---');
     console.log(rule);
-    console.log(
-      styleText('cyan', '-- ', { stream: process.stdout }) +
-        styleText(['bold', 'white'], text, { stream: process.stdout }) +
-        styleText('cyan', ' --', { stream: process.stdout }),
-    );
+    console.log(out('cyan', '-- ') + out(['bold', 'white'], text) + out('cyan', ' --'));
     console.log(rule);
   },
 

--- a/packages/core/tests/unit/utils/logger.test.ts
+++ b/packages/core/tests/unit/utils/logger.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logger } from '../../../src/utils/logger';
+describe('logger', () => {
+  describe('piped output (non-TTY)', () => {
+    let originalStdoutWrite: typeof process.stdout.write;
+    let originalStderrWrite: typeof process.stderr.write;
+    let stdoutOutput: string = '';
+    let stderrOutput: string = '';
+
+    beforeEach(() => {
+      stdoutOutput = '';
+      stderrOutput = '';
+
+      // Mock process.stdout and process.stderr for non-TTY
+      originalStdoutWrite = process.stdout.write;
+      originalStderrWrite = process.stderr.write;
+
+      // Simulate piped output by setting isTTY to false and capturing writes
+      Object.defineProperty(process.stdout, 'isTTY', {
+        writable: true,
+        configurable: true,
+        value: false,
+      });
+      Object.defineProperty(process.stderr, 'isTTY', {
+        writable: true,
+        configurable: true,
+        value: false,
+      });
+
+      process.stdout.write = ((text: string) => {
+        stdoutOutput += text;
+        return true;
+      }) as any;
+
+      process.stderr.write = ((text: string) => {
+        stderrOutput += text;
+        return true;
+      }) as any;
+
+      // Mock console methods
+      vi.spyOn(console, 'log').mockImplementation((args: any) => {
+        if (typeof args === 'string') {
+          stdoutOutput += args;
+        }
+      });
+      vi.spyOn(console, 'warn').mockImplementation((args: any) => {
+        if (typeof args === 'string') {
+          stderrOutput += args;
+        }
+      });
+      vi.spyOn(console, 'error').mockImplementation((args: any) => {
+        if (typeof args === 'string') {
+          stderrOutput += args;
+        }
+      });
+      vi.spyOn(console, 'debug').mockImplementation((args: any) => {
+        if (typeof args === 'string') {
+          stdoutOutput += args;
+        }
+      });
+    });
+
+    afterEach(() => {
+      process.stdout.write = originalStdoutWrite;
+      process.stderr.write = originalStderrWrite;
+      vi.restoreAllMocks();
+    });
+
+    it('logs without ANSI codes when piped', () => {
+      logger.info('test message');
+      expect(console.log).toHaveBeenCalled();
+
+      // Verify no ANSI escape sequences in the logged content
+      const logCall = vi.mocked(console.log).mock.calls[0];
+      const loggedText = logCall.join('');
+      expect(loggedText).not.toMatch(/\x1b\[/);
+    });
+
+    it('respects NO_COLOR environment variable', () => {
+      const originalNoColor = process.env['NO_COLOR'];
+      process.env['NO_COLOR'] = '1';
+
+      try {
+        logger.info('test message');
+        const logCall = vi.mocked(console.log).mock.calls[0];
+        const loggedText = logCall.join('');
+        expect(loggedText).not.toMatch(/\x1b\[/);
+      } finally {
+        if (originalNoColor === undefined) {
+          delete process.env['NO_COLOR'];
+        } else {
+          process.env['NO_COLOR'] = originalNoColor;
+        }
+      }
+    });
+  });
+});

--- a/packages/core/tests/unit/utils/logger.test.ts
+++ b/packages/core/tests/unit/utils/logger.test.ts
@@ -1,97 +1,114 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { logger } from '../../../src/utils/logger';
-describe('logger', () => {
-  describe('piped output (non-TTY)', () => {
-    let originalStdoutWrite: typeof process.stdout.write;
-    let originalStderrWrite: typeof process.stderr.write;
-    let stdoutOutput: string = '';
-    let stderrOutput: string = '';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '@/utils/logger';
 
+const ANSI = /\x1b\[/;
+
+/** Colour env vars `styleText` reads, which turbo and CI both set. */
+const COLOUR_ENV = ['FORCE_COLOR', 'NO_COLOR', 'NODE_DISABLE_COLORS'] as const;
+
+describe('logger colour handling', () => {
+  let stdout: string[];
+  let stderr: string[];
+
+  let colour_env: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    stdout = [];
+    stderr = [];
+    colour_env = Object.fromEntries(COLOUR_ENV.map((key) => [key, process.env[key]]));
+
+    const to_stdout = (...args: unknown[]): void => {
+      stdout.push(args.join(' '));
+    };
+    const to_stderr = (...args: unknown[]): void => {
+      stderr.push(args.join(' '));
+    };
+
+    vi.spyOn(console, 'log').mockImplementation(to_stdout);
+    vi.spyOn(console, 'debug').mockImplementation(to_stdout);
+    vi.spyOn(console, 'warn').mockImplementation(to_stderr);
+    vi.spyOn(console, 'error').mockImplementation(to_stderr);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const [key, value] of Object.entries(colour_env)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    delete process.env['DEBUG'];
+  });
+
+  // Vitest pipes stdout and stderr, so this is the redirected-output case: it
+  // pins the contract that a redirected log file gets plain text and the same
+  // visible glyphs as before. It cannot isolate a dropped `stream` option,
+  // because `styleText` defaults that option to `process.stdout`, which is also
+  // piped here. The `out`/`err` helpers in logger.ts are what make omitting the
+  // stream unrepresentable.
+  describe('piped output', () => {
     beforeEach(() => {
-      stdoutOutput = '';
-      stderrOutput = '';
-
-      // Mock process.stdout and process.stderr for non-TTY
-      originalStdoutWrite = process.stdout.write;
-      originalStderrWrite = process.stderr.write;
-
-      // Simulate piped output by setting isTTY to false and capturing writes
-      Object.defineProperty(process.stdout, 'isTTY', {
-        writable: true,
-        configurable: true,
-        value: false,
-      });
-      Object.defineProperty(process.stderr, 'isTTY', {
-        writable: true,
-        configurable: true,
-        value: false,
-      });
-
-      process.stdout.write = ((text: string) => {
-        stdoutOutput += text;
-        return true;
-      }) as any;
-
-      process.stderr.write = ((text: string) => {
-        stderrOutput += text;
-        return true;
-      }) as any;
-
-      // Mock console methods
-      vi.spyOn(console, 'log').mockImplementation((args: any) => {
-        if (typeof args === 'string') {
-          stdoutOutput += args;
-        }
-      });
-      vi.spyOn(console, 'warn').mockImplementation((args: any) => {
-        if (typeof args === 'string') {
-          stderrOutput += args;
-        }
-      });
-      vi.spyOn(console, 'error').mockImplementation((args: any) => {
-        if (typeof args === 'string') {
-          stderrOutput += args;
-        }
-      });
-      vi.spyOn(console, 'debug').mockImplementation((args: any) => {
-        if (typeof args === 'string') {
-          stdoutOutput += args;
-        }
-      });
+      // Turbo sets NO_COLOR. Clearing it leaves the non-TTY stream as the only
+      // reason colour is dropped, so these assertions describe piping.
+      delete process.env['NO_COLOR'];
+      delete process.env['NODE_DISABLE_COLORS'];
     });
 
-    afterEach(() => {
-      process.stdout.write = originalStdoutWrite;
-      process.stderr.write = originalStderrWrite;
-      vi.restoreAllMocks();
+    it('emits no ANSI on any level', () => {
+      process.env['DEBUG'] = '1';
+
+      logger.info('info line');
+      logger.success('success line');
+      logger.warn('warn line');
+      logger.error('error line');
+      logger.debug('debug line');
+      logger.banner('Atlas');
+
+      expect(stdout.join('\n')).not.toMatch(ANSI);
+      expect(stderr.join('\n')).not.toMatch(ANSI);
     });
 
-    it('logs without ANSI codes when piped', () => {
-      logger.info('test message');
-      expect(console.log).toHaveBeenCalled();
+    it('keeps the visible text intact', () => {
+      logger.info('hello');
+      logger.success('done');
+      logger.warn('careful');
+      logger.error('broken');
 
-      // Verify no ANSI escape sequences in the logged content
-      const logCall = vi.mocked(console.log).mock.calls[0];
-      const loggedText = logCall.join('');
-      expect(loggedText).not.toMatch(/\x1b\[/);
+      expect(stdout).toEqual(['[*] hello', '[+] done']);
+      expect(stderr).toEqual(['[!] careful', '[x] broken']);
     });
 
-    it('respects NO_COLOR environment variable', () => {
-      const originalNoColor = process.env['NO_COLOR'];
-      process.env['NO_COLOR'] = '1';
+    it('renders the banner rule to match the text width', () => {
+      logger.banner('Atlas');
+      expect(stdout).toEqual(['-----------', '-- Atlas --', '-----------']);
+    });
+  });
 
-      try {
-        logger.info('test message');
-        const logCall = vi.mocked(console.log).mock.calls[0];
-        const loggedText = logCall.join('');
-        expect(loggedText).not.toMatch(/\x1b\[/);
-      } finally {
-        if (originalNoColor === undefined) {
-          delete process.env['NO_COLOR'];
-        } else {
-          process.env['NO_COLOR'] = originalNoColor;
-        }
-      }
+  // Positive control. Without this, the assertions above would still pass if
+  // the swap had disabled colour everywhere.
+  describe('forced colour', () => {
+    beforeEach(() => {
+      // FORCE_COLOR overrides NO_COLOR but warns when both are set, so clear it.
+      delete process.env['NO_COLOR'];
+      delete process.env['NODE_DISABLE_COLORS'];
+      process.env['FORCE_COLOR'] = '1';
+    });
+
+    it('colours stdout levels', () => {
+      logger.info('info line');
+      logger.success('success line');
+      expect(stdout.join('\n')).toMatch(ANSI);
+    });
+
+    it('colours stderr levels', () => {
+      logger.warn('warn line');
+      logger.error('error line');
+      expect(stderr.join('\n')).toMatch(ANSI);
+    });
+
+    it('applies both bold and white to the banner text', () => {
+      logger.banner('Atlas');
+      expect(stdout.join('\n')).toContain('\x1b[1m');
+      expect(stdout.join('\n')).toContain('\x1b[37m');
     });
   });
 });

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -6,7 +6,7 @@ Use this package for custom schedulers, multi-tenant SaaS, backup portals, and a
 
 ## Requirements
 
-- Node.js 22 or later
+- Node.js 22.8 or later
 
 ## Install
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -43,7 +43,6 @@
     "@azure/identity": "^4.13.0",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "archiver": "^7.0.1",
-    "chalk": "^5.6.2",
     "dotenv": "^17.3.1",
     "htmlparser2": "^12.0.0",
     "inversify": "^7.11.0",
@@ -60,6 +59,6 @@
     "@wisecom/atlas-sharepoint": "workspace:*"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.8.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,9 +156,6 @@ importers:
       archiver:
         specifier: ^7.0.1
         version: 7.0.1
-      chalk:
-        specifier: ^5.6.2
-        version: 5.6.2
       dotenv:
         specifier: ^17.3.1
         version: 17.4.2
@@ -280,9 +277,6 @@ importers:
       archiver:
         specifier: ^7.0.1
         version: 7.0.1
-      chalk:
-        specifier: ^5.6.2
-        version: 5.6.2
       dotenv:
         specifier: ^17.3.1
         version: 17.4.2


### PR DESCRIPTION
Fixes #270

Replaces the seven `chalk` call sites in `packages/core/src/utils/logger.ts` with `styleText` from `node:util`, and removes `chalk` as a direct dependency.

## Changes

- **`logger.ts`**: the `stream` option is bound once in two local helpers, `out()` and `err()`, rather than repeated at eight call sites. Omitting that option is the one way this change can silently put ANSI into a redirected log, so the helpers make it unrepresentable instead of a convention a future call site has to remember. `warn` and `error` bind `process.stderr` to match where the bytes actually go.
- **`chalk` removed** from `packages/core/package.json` and `packages/sdk/package.json` (the SDK entry was dead: nothing under `packages/sdk/src` imported it).
- **Node floor `>=22.8.0`**, the release that added the `styleText` options argument, applied to `packages/core` (which declared no `engines`), `packages/cli` (was `>=22`), `packages/sdk` and the root `package.json`.
- **Docs**: `docs/getting-started.md` and both npm-rendered READMEs said "Node.js 22 or later" and now say 22.8.
- **Tests**: `packages/core/tests/unit/utils/logger.test.ts`, 6 cases.
- Stale `chalk` mention dropped from a `log-context.ts` comment.

## Two corrections to the issue

**The "absent as a transitive dependency" criterion is not achievable, and conflicts with the issue text.** `ink` depends on `chalk`, and the issue itself argues Ink is the right tool for the CLI. So `pnpm why -r chalk` still reports:

```
chalk@5.6.2
└─┬ ink@7.1.0
  └── @wisecom/atlas-cli@4.1.0 (dependencies)
```

What is achieved, and is the substance of the supply-chain argument: `chalk` is a direct dependency of nothing, no Atlas source file imports it, and the `atlas-core` and `atlas-sdk` dependency closures are now entirely chalk-free. Only the CLI reaches it, through its UI runtime. (`chalk@1.1.3` also arrives via `nanobench` in the unpublished `atlas-perf` dev tool.)

**`NO_COLOR` is not covered by a test, and cannot be cheaply.** The issue asks for "NO_COLOR=1 produces uncoloured output on a TTY". `NO_COLOR` is handled inside `stream.hasColors()`, so exercising it requires a real colour-capable TTY. Under vitest `process.stdout.isTTY` is undefined and colour is already dropped, which means a `NO_COLOR` assertion there passes whether or not the variable is read. I removed that test rather than keep one that asserts nothing. `NO_COLOR` handling is Node's own, unchanged by this PR, and reachable only through the `stream` option the helpers now guarantee.

For the same reason the piped test cannot isolate a dropped `stream` option: `styleText` defaults that option to `process.stdout`, which is also piped under vitest. The comment in the test file says so, and the helpers are the real guarantee.

## Acceptance criteria

- `grep -rn "from 'chalk'" packages/*/src` returns nothing
- `chalk` in no `package.json`; core and sdk closures chalk-free (see correction above re: `ink`)
- every level emits the same visible glyphs, verified by exact-output assertions
- colour on a colour-capable stream, none when piped
- sink routing untouched; `log-routing.test.ts` still passes and no `styleText` call sits on a sink path
- `progress` / `progress_done` unchanged
- Node floor includes the `styleText` `stream` option, in all four manifests and the docs
- piped case covered
- ~ `NO_COLOR` test: deliberately omitted, reasoning above
- ~ chalk absent transitively: not achievable, reasoning above

## Verification

`lint`, `format:check`, `typecheck`, `build`, `test` (1998 tests), and `docs:build` all pass. CI green.

Note for #269: `chalk` 6.0.0 can come off the pending-majors list once this merges. Left to that issue rather than edited from here.