### PR TITLE
chore(deps): bump mailparser to 3.9.17 to close GHSA-ggr8-5vv4-36mx

### DIFF
--- a/packages/outlook/package.json
+++ b/packages/outlook/package.json
@@ -21,13 +21,13 @@
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\""
   },
   "dependencies": {
-    "@wisecom/atlas-types": "workspace:*",
+    "@microsoft/microsoft-graph-client": "^3.0.7",
     "@wisecom/atlas-core": "workspace:*",
     "@wisecom/atlas-m365-graph": "workspace:*",
-    "@microsoft/microsoft-graph-client": "^3.0.7",
+    "@wisecom/atlas-types": "workspace:*",
     "archiver": "^7.0.1",
     "inversify": "^7.11.0",
-    "mailparser": "^3.9.15",
+    "mailparser": "^3.9.17",
     "mimetext": "^3.0.28",
     "reflect-metadata": "^0.2.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,8 +235,8 @@ importers:
         specifier: ^7.11.0
         version: 7.11.0(reflect-metadata@0.2.2)
       mailparser:
-        specifier: ^3.9.15
-        version: 3.9.15
+        specifier: ^3.9.17
+        version: 3.9.17
       mimetext:
         specifier: ^3.0.28
         version: 3.0.28
@@ -2056,9 +2056,9 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.6:
-    resolution: {integrity: sha512-gQhL1ksGBLQbHeAo47YU6cs2ahd3Pv+8PFYoWogNZbQnNwQyOh9Ad5kbeHFiWwbKdeWQJ5Z7Y7mwb9ew2hXBLw==}
-    engines: {node: '>=16.0.0'}
+  deepmerge-ts@8.0.2:
+    resolution: {integrity: sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==}
+    engines: {node: '>=16.9.0'}
 
   default-browser-id@5.0.1:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
@@ -2544,8 +2544,8 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  html-to-text@10.0.0:
-    resolution: {integrity: sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==}
+  html-to-text@10.0.1:
+    resolution: {integrity: sha512-GiVhRI1BatGARSCmlXWNCjDT0cWrwBWoeduLoV0WSKAgaV/wa+hUWy5LiQLUs4UwiUrE52ZCMfBGiKD87TDPrg==}
     engines: {node: '>=20.19.0'}
 
   html-void-elements@3.0.0:
@@ -2917,8 +2917,8 @@ packages:
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
-  mailparser@3.9.15:
-    resolution: {integrity: sha512-/5hgybKDMKFS05jAh8OPeEE7N53lj8nF6ywlo89VPjF2TtwqIQbjaxumQWnJIkmaagnJ6u1eansMOViHFxIXwQ==}
+  mailparser@3.9.17:
+    resolution: {integrity: sha512-ELSD5aeFPS/1227UqkmbbmBqy4SFpvADYTbVImQ5m8KoM7ZLG3PcnHF6+16MTgg2AeNGIcKzfBW8n6XrHZJGeg==}
 
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -3066,8 +3066,8 @@ packages:
   no-case@2.3.2:
     resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
 
-  nodemailer@9.0.5:
-    resolution: {integrity: sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==}
+  nodemailer@9.0.6:
+    resolution: {integrity: sha512-IQUGFdhdGwI9+AWX+FpUt4DLmvFaOjTMEoneTIWX/RXxuy1TdenPwWrvFMSfLkPKl+HQEXWuSAxEMMbPYXtBmg==}
     engines: {node: '>=6.0.0'}
 
   normalize-html-whitespace@0.2.0:
@@ -5984,7 +5984,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.6: {}
+  deepmerge-ts@8.0.2: {}
 
   default-browser-id@5.0.1: {}
 
@@ -6533,10 +6533,10 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-to-text@10.0.0:
+  html-to-text@10.0.1:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.12.0(selderee@0.12.0)
-      deepmerge-ts: 7.1.6
+      deepmerge-ts: 8.0.2
       dom-serializer: 2.0.0
       htmlparser2: 10.1.0
       selderee: 0.12.0
@@ -6935,16 +6935,16 @@ snapshots:
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
-  mailparser@3.9.15:
+  mailparser@3.9.17:
     dependencies:
       '@zone-eu/mailsplit': 5.4.15
       encoding-japanese: 2.2.0
       he: 1.2.0
-      html-to-text: 10.0.0
+      html-to-text: 10.0.1
       iconv-lite: 0.7.3
       libmime: 5.4.2
       linkify-it: 5.0.2
-      nodemailer: 9.0.5
+      nodemailer: 9.0.6
       punycode.js: 2.3.1
       tlds: 1.261.0
 
@@ -7117,7 +7117,7 @@ snapshots:
     dependencies:
       lower-case: 1.1.4
 
-  nodemailer@9.0.5: {}
+  nodemailer@9.0.6: {}
 
   normalize-html-whitespace@0.2.0: {}
 


### PR DESCRIPTION
Stage 1 of #269, kept to one dependency so a regression is attributable.

## Change

`mailparser` `^3.9.15` -> `^3.9.17` in `packages/outlook`. That pins `html-to-text` 10.0.1, which requires `deepmerge-ts ^8.0.1`, so the resolved tree moves off the vulnerable version with no `pnpm.overrides` entry:

```
before: deepmerge-ts@7.1.6 <- html-to-text@10.0.0 <- mailparser@3.9.15
after:  deepmerge-ts@8.0.2 <- html-to-text@10.0.1 <- mailparser@3.9.17
```

Dependabot alert GHSA-ggr8-5vv4-36mx (high, stack exhaustion on recursive object graphs) should close as fixed.

## Exposure note

The issue describes the vulnerable merge as running on `html-to-text` formatter options "which Atlas supplies itself". Slight correction: Atlas supplies none. `parse_mime_message` calls `simpleParser(mime)` with no options argument, so the merged options are mailparser's own defaults. The conclusion is unchanged and if anything firmer: the merge input is never derived from message content, so untrusted mail could not reach it.

`html-to-text` does process message HTML to produce `parsed.text`, but that is content passing through the formatter, not options passing through the merge.

## Incidental diff

`pnpm update` alphabetised the `dependencies` block in `packages/outlook/package.json`, moving three lines that are otherwise unchanged. Left as-is: it is inert key ordering that pnpm will reapply on the next bump in this package.

## Verification

- `pnpm why -r deepmerge-ts` reports a single `8.0.2`
- Outlook suite: 315 passed, including the 7 `parse_mime_message` cases; `decodes both body alternatives` is the one that exercises the `html-to-text` path
- `build`, `typecheck`, `test` green across all 15 packages
- no `pnpm.overrides` entry added

Stages 2 (patch and minor set) and 3 (stale Actions majors) follow as separate PRs.