### PR TITLE
ci: update the five stale action majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: |
@@ -78,10 +78,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Lint
         working-directory: e2e
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -45,7 +45,7 @@ jobs:
         run: pnpm run docs:build
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,13 +49,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -67,7 +67,7 @@ jobs:
         run: pnpm run build
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
 
       # `down -v` first: on a self-hosted or reused runner a stale volume would carry a previous
       # run's ciphertext into this one, and the purge assertions would be judging old objects.
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload test report and scrubbed CLI transcript
         if: always() && steps.leakcheck.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-report
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: v${{ needs.plan.outputs.version }}
 
@@ -124,7 +124,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
@@ -245,7 +245,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.from }}
           fetch-depth: 0
@@ -36,7 +36,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
Stage 3 of #269. Stacked on #274, itself on #273; bases collapse to `dev` as those merge.

| Action | From | To | Uses |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v7** | 9 |
| `actions/setup-node` | v4 | **v7** | 5 |
| `actions/upload-artifact` | v4 | **v7** | 2 |
| `actions/configure-pages` | v5 | **v6** | 1 |
| `astral-sh/setup-uv` | v5 | **v10.0.1** | 2 |

`pnpm/action-setup@v4`, `softprops/action-gh-release@v2`, `actions/upload-pages-artifact@v3` and `actions/deploy-pages@v4` are current and untouched.

## setup-uv must be a full version, not `@v10`

The issue lists "v10.0.1 available", and the full version is mandatory rather than cosmetic. From v8.0.0 setup-uv publishes **immutable tags only**, so the moving major tags were never created. Verified against the tag API:

```
setup-uv v10       DOES NOT EXIST (404)
setup-uv v9        DOES NOT EXIST (404)
setup-uv v8        DOES NOT EXIST (404)
setup-uv v10.0.1   refs/tags/v10.0.1
```

Writing `@v10` would have failed to resolve at run time. The other four still publish moving majors (`refs/tags/v7`, `refs/tags/v6` all confirmed present).

## Breaking changes, checked against this repository

- **checkout v7** refuses fork PR checkouts under `pull_request_target` and `workflow_run`. No workflow here uses either trigger. Triggers in use are `pull_request`, `push`, `schedule` and `workflow_dispatch`, and the changelog states plain `pull_request` is unchanged.
- **checkout v6** moves `persist-credentials` under `$RUNNER_TEMP` (needs runner 2.329.0); **upload-artifact v6** needs 2.327.1. Every job is `ubuntu-latest`, so GitHub-hosted and current. No self-hosted runners.
- **setup-node v7** removes `always-auth`: not used anywhere. It also drops the dummy `NODE_AUTH_TOKEN` fallback, which is the one change that could touch publishing. `publish.yml` sets `NODE_AUTH_TOKEN` explicitly from `secrets.NPM_TOKEN` as step-level `env`, so the value never came from the action's fallback, and the `if [ -n "$NODE_AUTH_TOKEN" ]` provenance branch resolves the same way as before.
- **setup-node v7** auto-enables npm caching only when `package.json` names npm as the package manager. This workspace is pnpm and all five call sites already pass `cache: pnpm`.
- **upload-artifact v7** adds `archive: false` for unzipped single-file uploads, defaulting to `true`. Both call sites upload multi-path globs under a `name` and do not set it, so behaviour is unchanged. (`archive: false` would also reject their multi-file globs.)
- **setup-uv v9** stops pruning the cache by default; **v10** disables the cache for some events under the default `enable-cache: auto`. Both call sites pass no inputs and only run `uvx ruff`, so the effect is cache warmth, not behaviour.
- **configure-pages v6** is a Node 24 runtime bump, per its changelog.

## Coverage, and the one gap

This also clears a live CI annotation: `checkout@v4` and `setup-uv@v5` were being force-run on Node 24 with a Node 20 deprecation warning.

All five workflow files parse.

Opening this PR runs `ci.yml`, which exercises **four of the five**: checkout v7, setup-node v7, upload-artifact v7 and setup-uv v10.0.1, across both its jobs.

`configure-pages@v6` is the gap. It appears only in `docs.yml`, which triggers on push to `main` under `docs/**`. I did not `workflow_dispatch` it, because that job deploys to GitHub Pages and would publish docs built from this branch. Its v6 changelog is a Node 24 runtime bump with no input or output changes, and the surrounding `upload-pages-artifact@v3` and `deploy-pages@v4` are unchanged, so the risk is low, but it is genuinely first exercised on merge to `main` rather than here.

`publish.yml` and `release-start.yml` also use checkout and setup-node; both are `workflow_dispatch`/tag driven and cannot be rehearsed without cutting a release. The setup-node reasoning above is the substitute for running them.