### PR TITLE
chore(deps): take typescript-language-server 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepare": "husky"
   },
   "engines": {
-    "node": ">=22.18.0"
+    "node": ">=22.22.2"
   },
   "devDependencies": {
     "@types/archiver": "^7.0.0",
@@ -43,7 +43,7 @@
     "turbo": "^2.10.12",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.68.0",
-    "typescript-language-server": "^5.3.0",
+    "typescript-language-server": "^6.0.0",
     "vitepress": "^1.6.4",
     "vitest": "^4.1.11"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^8.68.0
         version: 8.68.0(eslint@10.9.1)(typescript@5.9.3)
       typescript-language-server:
-        specifier: ^5.3.0
-        version: 5.3.0
+        specifier: ^6.0.0
+        version: 6.0.0
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.57.0)(@types/node@25.9.5)(postcss@8.5.26)(search-insights@2.17.3)(typescript@5.9.3)(yaml@2.9.0)
@@ -4007,9 +4007,9 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript-language-server@5.3.0:
-    resolution: {integrity: sha512-5puofxZHgFdAYtfNpmwCAvgtaYgg8wrUnH30m7Ze3QuguId5RNRadKASpOpyDxTyUdAF51FjhTdjntLw/EuWcQ==}
-    engines: {node: '>=20'}
+  typescript-language-server@6.0.0:
+    resolution: {integrity: sha512-LXtzY3UZGfghWA5eRU6/T5j1+YiGRgy14mR3GOKyTKlE1op1TYKQnLVxwBsmnXeDhGLuvzZyIHBAqvrekAITYQ==}
+    engines: {node: '>=22.22.2'}
     hasBin: true
 
   typescript@5.9.3:
@@ -8253,7 +8253,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript-language-server@5.3.0:
+  typescript-language-server@6.0.0:
     dependencies:
       vscode-jsonrpc: 5.0.1
       vscode-languageserver-protocol: 3.18.3


### PR DESCRIPTION
Closes #281.

## Contingency resolved

The issue made this conditional on 6.0.0 still supporting `typescript` 5.9.x, since #157 parks `typescript` at 5.9.3. It does. 6.0.0 declares **no** `peerDependencies`, and its changelog lists exactly one breaking change:

> ⚠ BREAKING CHANGES
> * Node.js >=22.22.2 is required.

Everything else in the release is two bug fixes and a yarn-to-pnpm chore. So it is not blocked on #157.

## The Node floor is the whole bump

`>=22.22.2` is the strictest floor in the workspace so far, above the `>=22.18.0` that `tsdown` 0.22 requires. Root `engines.node` moves to match.

I took this rather than avoided it. Every Node on the 22 line below 22.22.2 is missing security patches, so the constraint pushes contributors onto a patched runtime rather than costing them something. It is also dev-only: the language server is a root devDependency invoked by no script, build, test, lint or CI step, so the published `cli` and `sdk` floors are untouched.

CI is unaffected. All workflows pin `node-version: 22`, which resolves to **22.23.2**, the current latest on the line, verified against the Node dist index.

## Conflict note

#274 also edits root `engines.node`, setting `>=22.18.0` for tsdown. These conflict on that single line; resolution is the higher value, `>=22.22.2`.

## Verification

`build`, `typecheck`, `lint` and `test` green across all 15 packages. Blast radius is nil by construction, which is the point: nothing in the repository executes this package.