### PR TITLE
chore(deps): take inversify 8.2.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,7 @@
     "dotenv": "^17.4.2",
     "htmlparser2": "^12.0.0",
     "ink": "^7.1.1",
-    "inversify": "^7.11.0",
+    "inversify": "^8.2.3",
     "mimetext": "^3.0.28",
     "react": "^19.2.8",
     "reflect-metadata": "^0.2.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "archiver": "^7.0.1",
     "dotenv": "^17.4.2",
     "htmlparser2": "^12.0.0",
-    "inversify": "^7.11.0",
+    "inversify": "^8.2.3",
     "reflect-metadata": "^0.2.2"
   }
 }

--- a/packages/m365-graph/package.json
+++ b/packages/m365-graph/package.json
@@ -25,7 +25,7 @@
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@wisecom/atlas-core": "workspace:*",
     "@wisecom/atlas-types": "workspace:*",
-    "inversify": "^7.11.0",
+    "inversify": "^8.2.3",
     "reflect-metadata": "^0.2.2"
   }
 }

--- a/packages/onedrive/package.json
+++ b/packages/onedrive/package.json
@@ -21,11 +21,11 @@
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\""
   },
   "dependencies": {
-    "@wisecom/atlas-types": "workspace:*",
+    "@microsoft/microsoft-graph-client": "^3.0.7",
     "@wisecom/atlas-core": "workspace:*",
     "@wisecom/atlas-m365-graph": "workspace:*",
-    "@microsoft/microsoft-graph-client": "^3.0.7",
-    "inversify": "^7.11.0",
+    "@wisecom/atlas-types": "workspace:*",
+    "inversify": "^8.2.3",
     "reflect-metadata": "^0.2.2"
   }
 }

--- a/packages/outlook/package.json
+++ b/packages/outlook/package.json
@@ -26,7 +26,7 @@
     "@wisecom/atlas-m365-graph": "workspace:*",
     "@wisecom/atlas-types": "workspace:*",
     "archiver": "^7.0.1",
-    "inversify": "^7.11.0",
+    "inversify": "^8.2.3",
     "mailparser": "^3.9.17",
     "mimetext": "^3.0.28",
     "reflect-metadata": "^0.2.2"

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/client-s3": "^3.1121.0",
     "@wisecom/atlas-core": "workspace:*",
     "@wisecom/atlas-types": "workspace:*",
-    "inversify": "^7.11.0",
+    "inversify": "^8.2.3",
     "reflect-metadata": "^0.2.2"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -45,7 +45,7 @@
     "archiver": "^7.0.1",
     "dotenv": "^17.4.2",
     "htmlparser2": "^12.0.0",
-    "inversify": "^7.11.0",
+    "inversify": "^8.2.3",
     "mimetext": "^3.0.28",
     "reflect-metadata": "^0.2.2"
   },

--- a/packages/sdk/src/instance-disposal.ts
+++ b/packages/sdk/src/instance-disposal.ts
@@ -28,7 +28,11 @@ export function create_disposer(container: Container): () => Promise<void> {
       await container.get<StorageDisposer>(STORAGE_DISPOSER_TOKEN)();
     }, 'storage');
 
-    await release(() => container.unbindAll(), 'container bindings');
+    // inversify 8 made the unprefixed names synchronous: unbindAll() now
+    // returns void. unbindAllAsync() is the v7 contract, and it is what this
+    // teardown wants, so any async onDeactivation or preDestroy handler added
+    // later is still awaited rather than silently skipped (issue #42).
+    await release(() => container.unbindAllAsync(), 'container bindings');
   };
 }
 

--- a/packages/sharepoint/package.json
+++ b/packages/sharepoint/package.json
@@ -21,11 +21,11 @@
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\""
   },
   "dependencies": {
-    "@wisecom/atlas-types": "workspace:*",
+    "@microsoft/microsoft-graph-client": "^3.0.7",
     "@wisecom/atlas-core": "workspace:*",
     "@wisecom/atlas-m365-graph": "workspace:*",
-    "@microsoft/microsoft-graph-client": "^3.0.7",
-    "inversify": "^7.11.0",
+    "@wisecom/atlas-types": "workspace:*",
+    "inversify": "^8.2.3",
     "reflect-metadata": "^0.2.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(@types/react@19.2.18)(react@19.2.8)
       inversify:
-        specifier: ^7.11.0
-        version: 7.11.0(reflect-metadata@0.2.2)
+        specifier: ^8.2.3
+        version: 8.2.3(reflect-metadata@0.2.2)
       mimetext:
         specifier: ^3.0.28
         version: 3.0.28
@@ -163,8 +163,8 @@ importers:
         specifier: ^12.0.0
         version: 12.0.0
       inversify:
-        specifier: ^7.11.0
-        version: 7.11.0(reflect-metadata@0.2.2)
+        specifier: ^8.2.3
+        version: 8.2.3(reflect-metadata@0.2.2)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -184,8 +184,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       inversify:
-        specifier: ^7.11.0
-        version: 7.11.0(reflect-metadata@0.2.2)
+        specifier: ^8.2.3
+        version: 8.2.3(reflect-metadata@0.2.2)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -205,8 +205,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       inversify:
-        specifier: ^7.11.0
-        version: 7.11.0(reflect-metadata@0.2.2)
+        specifier: ^8.2.3
+        version: 8.2.3(reflect-metadata@0.2.2)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -229,8 +229,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       inversify:
-        specifier: ^7.11.0
-        version: 7.11.0(reflect-metadata@0.2.2)
+        specifier: ^8.2.3
+        version: 8.2.3(reflect-metadata@0.2.2)
       mailparser:
         specifier: ^3.9.17
         version: 3.9.17
@@ -257,8 +257,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       inversify:
-        specifier: ^7.11.0
-        version: 7.11.0(reflect-metadata@0.2.2)
+        specifier: ^8.2.3
+        version: 8.2.3(reflect-metadata@0.2.2)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -284,8 +284,8 @@ importers:
         specifier: ^12.0.0
         version: 12.0.0
       inversify:
-        specifier: ^7.11.0
-        version: 7.11.0(reflect-metadata@0.2.2)
+        specifier: ^8.2.3
+        version: 8.2.3(reflect-metadata@0.2.2)
       mimetext:
         specifier: ^3.0.28
         version: 3.0.28
@@ -330,8 +330,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       inversify:
-        specifier: ^7.11.0
-        version: 7.11.0(reflect-metadata@0.2.2)
+        specifier: ^8.2.3
+        version: 8.2.3(reflect-metadata@0.2.2)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -832,25 +832,25 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  '@inversifyjs/common@1.5.2':
-    resolution: {integrity: sha512-WlzR9xGadABS9gtgZQ+luoZ8V6qm4Ii6RQfcfC9Ho2SOlE6ZuemFo7PKJvKI0ikm8cmKbU8hw5UK6E4qovH21w==}
+  '@inversifyjs/common@2.0.1':
+    resolution: {integrity: sha512-pJAR4IAcT2jkYfZ9bD9XhtUDBLJRr8QOiSjb+2XyaHru6DLvu0VD2Id2iP7+tVRKkEe3XFUwDUEdKxcYlF699Q==}
 
-  '@inversifyjs/container@1.15.0':
-    resolution: {integrity: sha512-U2xYsPrJTz5za2TExi5lg8qOWf8TEVBpN+pQM7B8BVA2rajtbRE9A66SLRHk8c1eGXmg+0K4Hdki6tWAsSQBUA==}
+  '@inversifyjs/container@3.1.3':
+    resolution: {integrity: sha512-+CZLXKzU5uwDbkY1WamY1Gnbtz0sNl62cqfd1vvI13Ei8Fe29sCwgfyEWMOzYcJhs2y2wBmYGANPDH5yq4VdTg==}
     peerDependencies:
       reflect-metadata: ~0.2.2
 
-  '@inversifyjs/core@9.2.0':
-    resolution: {integrity: sha512-Nm7BR6KmpgshIHpVQWuEDehqRVb6GBm8LFEuhc2s4kSZWrArZ15RmXQzROLk4m+hkj4kMXgvMm5Qbopot/D6Sg==}
+  '@inversifyjs/core@15.0.1':
+    resolution: {integrity: sha512-4C/hLEdYo3xG0Ez61kTP3nikINmCQz1O3OHU7dfbi9UC6Of5Qly2CLd0OSoZd6M8fumk51A0tuBxPIqs28CpNg==}
 
-  '@inversifyjs/plugin@0.2.0':
-    resolution: {integrity: sha512-R/JAdkTSD819pV1zi0HP54mWHyX+H2m8SxldXRgPQarS3ySV4KPyRdosWcfB8Se0JJZWZLHYiUNiS6JvMWSPjw==}
+  '@inversifyjs/plugin@0.3.1':
+    resolution: {integrity: sha512-ByklTw731fydBCTMwMpkmwm+lv0U+JWm9NEqRsz3n5KzAC5Om2XtLjqzEC2w+8Ote3gVC3Qxsx6YmG9XLIZpvg==}
 
-  '@inversifyjs/prototype-utils@0.1.3':
-    resolution: {integrity: sha512-EzRamZzNgE9Sn3QtZ8NncNa2lpPMZfspqbK6BWFguWnOpK8ymp2TUuH46ruFHZhrHKnknPd7fG22ZV7iF517TQ==}
+  '@inversifyjs/prototype-utils@0.2.1':
+    resolution: {integrity: sha512-53cVE3cw+RxnSkGlg+jOFNSox2owJF9Fv3HgFKe4f+4aPullscltIiio88QRkx2Sc5yo3VlqPsXQFGw2CVJZnw==}
 
-  '@inversifyjs/reflect-metadata-utils@1.4.1':
-    resolution: {integrity: sha512-Cp77C4d2wLaHXiUB7iH6Cxb7i1lD/YDuTIHLTDzKINqGSz0DCSoL/Dg2wVkW/6Qx03r/yQMLJ+32Agl32N2X8g==}
+  '@inversifyjs/reflect-metadata-utils@1.5.0':
+    resolution: {integrity: sha512-NpJVbRbuQ6Ao2vO+aw96un3oHDFCwXI0+pplsFt0Jh0gyR8DWk4m7ml/GBNMjdbeKVW/QgJ2S6NGXjk042uwqg==}
     peerDependencies:
       reflect-metadata: ~0.2.2
 
@@ -2862,8 +2862,8 @@ packages:
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
-  inversify@7.11.0:
-    resolution: {integrity: sha512-yZDprSSr8TyVeMGI/AOV4ws6gwjX22hj9Z8/oHAVpJORY6WRFTcUzhnZtibBUHEw2U8ArvHcR+i863DplQ3Cwg==}
+  inversify@8.2.3:
+    resolution: {integrity: sha512-OmTj/HB/lEV6WFaeHXBDXdUYWwtadF8QTbyEKT7LUZMzOkw5xF+Nrm1GTjIhBOrAUN4K65vtqKgxRWlSHzQH7w==}
 
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
@@ -4901,31 +4901,31 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@inversifyjs/common@1.5.2': {}
+  '@inversifyjs/common@2.0.1': {}
 
-  '@inversifyjs/container@1.15.0(reflect-metadata@0.2.2)':
+  '@inversifyjs/container@3.1.3(reflect-metadata@0.2.2)':
     dependencies:
-      '@inversifyjs/common': 1.5.2
-      '@inversifyjs/core': 9.2.0(reflect-metadata@0.2.2)
-      '@inversifyjs/plugin': 0.2.0
-      '@inversifyjs/reflect-metadata-utils': 1.4.1(reflect-metadata@0.2.2)
+      '@inversifyjs/common': 2.0.1
+      '@inversifyjs/core': 15.0.1(reflect-metadata@0.2.2)
+      '@inversifyjs/plugin': 0.3.1
+      '@inversifyjs/reflect-metadata-utils': 1.5.0(reflect-metadata@0.2.2)
       reflect-metadata: 0.2.2
 
-  '@inversifyjs/core@9.2.0(reflect-metadata@0.2.2)':
+  '@inversifyjs/core@15.0.1(reflect-metadata@0.2.2)':
     dependencies:
-      '@inversifyjs/common': 1.5.2
-      '@inversifyjs/prototype-utils': 0.1.3
-      '@inversifyjs/reflect-metadata-utils': 1.4.1(reflect-metadata@0.2.2)
+      '@inversifyjs/common': 2.0.1
+      '@inversifyjs/prototype-utils': 0.2.1
+      '@inversifyjs/reflect-metadata-utils': 1.5.0(reflect-metadata@0.2.2)
     transitivePeerDependencies:
       - reflect-metadata
 
-  '@inversifyjs/plugin@0.2.0': {}
+  '@inversifyjs/plugin@0.3.1': {}
 
-  '@inversifyjs/prototype-utils@0.1.3':
+  '@inversifyjs/prototype-utils@0.2.1':
     dependencies:
-      '@inversifyjs/common': 1.5.2
+      '@inversifyjs/common': 2.0.1
 
-  '@inversifyjs/reflect-metadata-utils@1.4.1(reflect-metadata@0.2.2)':
+  '@inversifyjs/reflect-metadata-utils@1.5.0(reflect-metadata@0.2.2)':
     dependencies:
       reflect-metadata: 0.2.2
 
@@ -6983,11 +6983,11 @@ snapshots:
 
   internmap@1.0.1: {}
 
-  inversify@7.11.0(reflect-metadata@0.2.2):
+  inversify@8.2.3(reflect-metadata@0.2.2):
     dependencies:
-      '@inversifyjs/common': 1.5.2
-      '@inversifyjs/container': 1.15.0(reflect-metadata@0.2.2)
-      '@inversifyjs/core': 9.2.0(reflect-metadata@0.2.2)
+      '@inversifyjs/common': 2.0.1
+      '@inversifyjs/container': 3.1.3(reflect-metadata@0.2.2)
+      '@inversifyjs/core': 15.0.1(reflect-metadata@0.2.2)
     transitivePeerDependencies:
       - reflect-metadata
 


### PR DESCRIPTION
Closes #276. All eight declaring packages to `^8.2.3`; `pnpm why -r inversify` reports a single resolved 8.2.3.

## Correction to the issue

I wrote #276, and it was wrong on the key point. It claimed no call site uses the methods affected by v8's sync-first rename, "in either spelling". The audit behind that grepped `packages/cli/src` and `packages/core/src` and **missed the SDK**.

`packages/sdk/src/instance-disposal.ts` calls `container.unbindAll()`, and v8 changes it:

```
v7:  unbindAll(): Promise<void>
v8:  unbindAll(): void
     unbindAllAsync(): Promise<void>
```

`typecheck` caught it immediately:

```
src/instance-disposal.ts(31,25): error TS2322:
  Type 'void' is not assignable to type 'Promise<void>'.
```

So the "two headline breaks do not apply" framing in the issue title is half wrong: the Provider removal does not apply, the sync-first rename does.

## The fix is a behavioural choice, not a type fix

Two ways to satisfy the compiler: call the now-sync `unbindAll()` and widen the `release` helper to accept a sync step, or switch to `unbindAllAsync()`.

I took `unbindAllAsync()`. They are equivalent **today**: no `onDeactivation` or `preDestroy` handler is registered anywhere in the workspace, so there is nothing async to await. It is still the right one:

- it is the v7 contract, so this bump changes no behaviour
- it is a one-word change against a helper that already expects a promise, versus widening a signature
- it stays correct if a deactivation handler is ever added

The sync call would compile, pass today, and then silently stop awaiting the first async deactivation handler someone registers. That is precisely the leak #42 built this file to prevent, so a comment records the reasoning at the call site.

## The rest of the audit held

No `ContainerModule`, no `Provider`/`ProviderBinding`, no `autoBindInjectable`, and none of the removed `toAutoFactory`/`toAutoNamedFactory`/`toConstructor`/`toFunction`. The binding surface is `.bind`, `.toSelf`, `.to`, `.toConstantValue`, all present in v8.

Decorator contract confirmed rather than assumed: inversify 8 still exports `injectable` and `inject`, checked in its own declarations.

## Verified at run time

A DI failure is a run-time error that a type check cannot see, so:

- built CLI resolves its container: `--version`, `--help`, `outlook --help` all succeed
- built SDK loads with the same **60** exports, `createAtlasInstance` present
- the five `instance-disposal` tests pass, and they construct a **real** `inversify` `Container` rather than a mock, so they actually exercise `unbindAllAsync` — including the thousand-container binding-retention case

`build`, `typecheck`, `lint`, `test` green across all 15 packages.