### PR TITLE
ci: update the four action majors #269 recorded as current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -48,7 +48,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,7 +121,7 @@ jobs:
           ref: v${{ needs.plan.outputs.version }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -232,7 +232,7 @@ jobs:
           done
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.TAG_VERSION }}
           prerelease: ${{ contains(env.TAG_VERSION, '-') }}

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Stage 4 of #269, covering the gap I flagged when opening #275.

| Action | From | To | Uses |
| --- | --- | --- | --- |
| `pnpm/action-setup` | v4 | **v6** | 5 |
| `softprops/action-gh-release` | v2 | **v3** | 1 |
| `actions/upload-pages-artifact` | v3 | **v5** | 1 |
| `actions/deploy-pages` | v4 | **v5** | 1 |

## The issue's inventory was wrong on these four

#269 lists all four as current, and #275 left them alone on that basis. Latest is v6.0.10, v3.0.3, v5.0.0 and v5.0.0 respectively, so four of the issue's nine Actions entries were stale.

The evidence is a CI annotation rather than a version table. Before #275 it read:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: **actions/checkout@v4, astral-sh/setup-uv@v5**

After #275 it read:

> ... **pnpm/action-setup@v4**

All four of these majors are Node 24 runtime bumps, so this clears the deprecation entirely instead of leaving one behind.

All four publish moving major tags, confirmed against the tag API, so unlike `setup-uv` in #275 no full-version pin is needed here.

## pnpm/action-setup v6 is the one that needed checking

v6 adds pnpm 11 support, and **v6.0.0 through v6.0.2 had a real defect**: they ignored both the `version` input and the `packageManager` field and installed pnpm 11 beta regardless ([#225](https://github.com/pnpm/action-setup/issues/225), [#227](https://github.com/pnpm/action-setup/issues/227)).

That is precisely the mechanism this repository relies on. All five call sites pass **no** `version` input and depend entirely on `"packageManager": "pnpm@10.30.3"`. Under the defect, CI would have silently installed pnpm 11 and then hit lockfile errors.

Fixed in v6.0.3, and `@v6` resolves to v6.0.10, so it is safe today. I am not asserting that from the changelog alone: the CI run on this PR is the confirmation that pnpm 10.30.3 is still what gets installed.

## The other three

- **`softprops/action-gh-release` v3** moves the runtime Node 20 -> 24, inputs and outputs unchanged. v2.6.2 is the last Node 20 line, relevant only to self-hosted fleets; every job here is `ubuntu-latest`.
- **`actions/upload-pages-artifact` v5** moves its internal `upload-artifact` to v7, matching what #275 did directly, and adds an optional `include-hidden-files` input that is not used here.
- **`actions/deploy-pages` v5** is a Node 24 runtime bump.

## Coverage

`ci.yml` exercises `pnpm/action-setup@v6`, which is the only one of the four with a defect history and so the only one worth running.

The other three sit on paths that cannot be rehearsed from a PR: `upload-pages-artifact` and `deploy-pages` run on push to `main` under `docs/**`, and `action-gh-release` runs only on a release tag. Their changelogs are runtime bumps with no input or output changes. Combined with `configure-pages@v6` from #275, the Pages deploy path is first exercised on merge to `main`.

All five workflow files parse.

## CI result: confirmed, and the mechanism is worth recording

The run is green, and `pnpm/action-setup@v6` does honour `packageManager`. It gets there less directly than I assumed:

```
Checking for updates...
Switching pnpm from v11.19.0 to v10.30.3...
[WARN] Detected a pnpm v10 installation layout at PNPM_HOME. The pnpm shims
       at PNPM_HOME have been refreshed so the new version is active, but
       pnpm v11 expects bins in PNPM_HOME/bin. Run "pnpm setup" to migrate
       your PATH to the v11 layout.
Successfully updated pnpm to v10.30.3
```

So v6 bootstraps with pnpm **11.19.0**, reads `"packageManager": "pnpm@10.30.3"`, and switches **down** to it. The subsequent steps run on the right version, confirmed independently at the install step: `Done in 3s using pnpm v10.30.3`, and `pnpm install --frozen-lockfile` reported `Lockfile is up to date, resolution step is skipped` against `lockfileVersion: 9.0`.

The v6.0.0-6.0.2 defect is therefore genuinely fixed, not merely claimed fixed in a changelog.

The `[WARN]` is cosmetic and expected: it is emitted by the v11 bootstrap noticing a v10 layout at `PNPM_HOME`, and we deliberately end on v10.30.3, so the v10 layout is the correct one. Recording it here so the next person who sees that line in a CI log does not chase it.

One incidental confirmation for #275: the `setup-node@v4` step on this branch logs `always-auth: false` as an action default. The workflows never set it, so v7 removing that input is safe, which is what #275 argued from a grep.
