### PR TITLE
chore: add CodeRabbit config, review dev PRs only

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: pr-review
+description: >-
+  Open a pull request for this repository and drive it to merge-ready,
+  including triaging and answering the review comments CodeRabbit raises on it.
+when_to_use: >-
+  Use whenever the user asks to open, create, or submit a PR or pull request,
+  and whenever CodeRabbit (or any reviewer) has raised comments on a PR that
+  need to be addressed, answered, or resolved.
+---
+
+# Pull Requests and CodeRabbit Reviews
+
+The rule: **a PR targets `dev`, carries a release-notes label, and is not done
+until every review finding is either fixed or answered.** Never merge unless the
+user asked you to.
+
+## Opening the PR
+
+1. Branch from `dev`, never from `main`. The only PRs targeting `main` are
+   release and hotfix PRs, and those follow the `release` skill.
+2. Run the quality gate before pushing: `pnpm run build`, `pnpm run lint`,
+   `pnpm run format:check`, `pnpm run test`.
+3. Open the PR against `dev` with a label:
+
+```bash
+gh pr create --base dev --label bug --title "<title>" --body-file <path>
+```
+
+| Label           | Use                                  |
+| --------------- | ------------------------------------ |
+| `enhancement`   | new behavior                         |
+| `bug`           | fixes                                |
+| `documentation` | docs-only changes                    |
+| `security`      | security-relevant changes            |
+
+Release notes are generated from these labels, so an unlabelled PR lands in the
+wrong section. Mirror the sections of `.github/PULL_REQUEST_TEMPLATE.md`
+(Summary, Changes, Checklist) in the body; `gh pr create` does not expand the
+template. Use `--body-file`, not `--body`, so formatting survives. Link issues
+with `Closes #123`.
+
+The PR is a permanent public artifact: no secrets, no tenant data, no personal
+or internal system detail. The substitution table in the `write-issue` skill
+applies here unchanged.
+
+## Handling CodeRabbit's review
+
+`.coderabbit.yaml` auto-reviews every PR targeting `dev` and re-reviews on each
+push. Release PRs (`chore(release):` titles) are skipped on purpose.
+
+Wait for the walkthrough comment before triaging, then pull the inline findings:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<N>/comments \
+  --jq '.[] | {id, path, line, body}'
+```
+
+Triage every finding into exactly one bucket:
+
+- **Real** — correctness, missed callers, test gaps. Fix the root cause, not
+  the symptom; check sibling callers before editing.
+- **Wrong or nitpick** — verify the claim against the actual code first. If it
+  does not hold, reply with the technical reason instead of changing anything.
+- **Out of scope** — file it with the `write-issue` skill or add evidence to an
+  existing issue. Do not silently widen the PR.
+
+**REQUIRED SUB-SKILL:** Use `receiving-code-review` for the triage. CodeRabbit
+is wrong often enough that blind agreement ships bugs; performative agreement
+ships churn.
+
+Apply accepted fixes as focused commits, run the targeted test plus
+`pnpm run lint` and `pnpm run typecheck`, and push. CodeRabbit re-reviews each
+push automatically.
+
+## Answering and resolving threads
+
+No thread stays dangling. Reply to each one: a fixed finding gets a short reply
+naming the commit, a rejected finding gets the technical reason with file and
+symbol references. Write replies per the `write-comment` skill (first person,
+plain, no attribution).
+
+Fetch unresolved threads and resolve them once handled:
+
+```bash
+gh api graphql -f query='
+query($pr: Int!) {
+  repository(owner: "{owner}", name: "{repo}") {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 50) {
+        nodes { id isResolved comments(first: 1) { nodes { body } } }
+      }
+    }
+  }
+}' -f pr=<N> --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)'
+
+gh api graphql -f query='
+mutation($id: ID!) {
+  resolveReviewThread(input: { threadId: $id }) { thread { id } }
+}' -f id=<thread-id>
+```
+
+Reply to an inline comment in place rather than starting a loose PR comment:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<N>/comments/<comment-id>/replies -f body="<reply>"
+```
+
+## CodeRabbit commands
+
+Post as a PR comment when needed:
+
+| Command                  | Effect                                    |
+| ------------------------ | ----------------------------------------- |
+| `@coderabbitai review`   | incremental review of new commits         |
+| `@coderabbitai full review` | re-review everything from scratch      |
+| `@coderabbitai pause`    | stop automatic reviews on this PR         |
+| `@coderabbitai resume`   | restart automatic reviews                 |
+
+Normally none are needed: pushes trigger incremental reviews until the pause
+limit. Use `full review` after a rebase or large restructuring, where
+incremental context would be stale.
+
+## Ready to merge
+
+A PR is ready when CI is green, every thread is resolved or answered, and the
+description still matches the final diff. Report that and stop. Merging is the
+user's call; when asked to merge, use a merge commit (`gh pr merge --merge`),
+which matches the repository history.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -11,9 +11,10 @@ when_to_use: >-
 
 # Pull Requests and CodeRabbit Reviews
 
-The rule: **a PR targets `dev`, carries a release-notes label, and is not done
-until every review finding is either fixed or answered.** Never merge unless the
-user asked you to.
+The rule: **a normal PR targets `dev`, carries a release-notes label, and is
+not done until every review finding is either fixed or answered.** Release and
+hotfix PRs target `main` and follow the `release` skill instead. Never merge
+unless the user asked you to.
 
 ## Opening the PR
 
@@ -24,7 +25,7 @@ user asked you to.
 3. Open the PR against `dev` with a label:
 
 ```bash
-gh pr create --base dev --label bug --title "<title>" --body-file <path>
+gh pr create --base dev --label <label> --title "<title>" --body-file <path>
 ```
 
 | Label           | Use                                  |
@@ -54,7 +55,7 @@ push. Release PRs (`chore(release):` titles) are skipped on purpose.
 Wait for the walkthrough comment before triaging, then pull the inline findings:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/<N>/comments \
+gh api --paginate repos/{owner}/{repo}/pulls/<N>/comments \
   --jq '.[] | {id, path, line, body}'
 ```
 
@@ -85,16 +86,18 @@ plain, no attribution).
 Fetch unresolved threads and resolve them once handled:
 
 ```bash
-gh api graphql -f query='
-query($pr: Int!) {
-  repository(owner: "{owner}", name: "{repo}") {
+gh api graphql --paginate -f query='
+query($owner: String!, $name: String!, $pr: Int!, $endCursor: String) {
+  repository(owner: $owner, name: $name) {
     pullRequest(number: $pr) {
-      reviewThreads(first: 50) {
+      reviewThreads(first: 50, after: $endCursor) {
         nodes { id isResolved comments(first: 1) { nodes { body } } }
+        pageInfo { hasNextPage endCursor }
       }
     }
   }
-}' -f pr=<N> --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)'
+}' -F owner=<owner> -F name=<repo> -F pr=<N> \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)'
 
 gh api graphql -f query='
 mutation($id: ID!) {

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -40,9 +40,11 @@ wrong section. Mirror the sections of `.github/PULL_REQUEST_TEMPLATE.md`
 template. Use `--body-file`, not `--body`, so formatting survives. Link issues
 with `Closes #123`.
 
-The PR is a permanent public artifact: no secrets, no tenant data, no personal
-or internal system detail. The substitution table in the `write-issue` skill
-applies here unchanged.
+The PR is a permanent public artifact: never put anything confidential in the title or body:
+no secrets, no tenant data, no personal or internal system detail. The
+substitution table in the `write-issue` skill applies here unchanged. Write the
+body per the `write-comment` skill: first person, plain, no attribution to any
+assistant or model.
 
 ## Handling CodeRabbit's review
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+reviews:
+  profile: chill
+  auto_review:
+    # main is the default branch and always reviewed; dev is where all work lands.
+    base_branches:
+      - dev
+    # Release and hotfix PRs into main are titled "chore(release): <version>"
+    # (see .claude/skills/release). Skipping them means no reviews on main.
+    ignore_title_keywords:
+      - "chore(release):"
+  path_filters:
+    - "!pnpm-lock.yaml"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,6 +2,8 @@
 language: en-US
 reviews:
   profile: chill
+  # Required so error-mode pre-merge checks actually block merging.
+  request_changes_workflow: true
   auto_review:
     # main is the default branch and always reviewed; dev is where all work lands.
     base_branches:
@@ -12,3 +14,26 @@ reviews:
       - "chore(release):"
   path_filters:
     - "!pnpm-lock.yaml"
+  pre_merge_checks:
+    custom_checks:
+      - name: Contributing guide compliance
+        mode: error
+        instructions: |
+          Pass only if the PR follows CONTRIBUTING.md:
+          - Targets dev. Fail if it targets main, unless this is a release or
+            hotfix PR titled "chore(release): <version>".
+          - Carries exactly one release-notes label: enhancement, bug,
+            documentation, or security.
+          - Does not change the version field in any packages/*/package.json.
+          - Stays a single concern; fail if it mixes unrelated changes.
+          - Adds or updates unit tests under tests/unit/ for changed behavior.
+      - name: Changes explained
+        mode: error
+        instructions: |
+          Pass only if the PR body explains what changed and why:
+          - The Summary section states what the PR does in plain sentences.
+            Fail on an empty summary or leftover template placeholder text.
+          - The Changes section lists concrete bullets of what changed.
+            Fail on empty bullets or leftover HTML comments.
+          - Related issues are linked with "Closes #N" when the PR fixes a
+            reported issue.


### PR DESCRIPTION
Adds `.coderabbit.yaml` so CodeRabbit reviews match the release flow (`dev` accumulates work, `main` only sees release and hotfix PRs).

- `auto_review.base_branches: [dev]` adds `dev` as a review target.
- `ignore_title_keywords: ["chore(release):"]` skips release and hotfix PRs into `main`, since the default branch is always included and cannot be excluded via `base_branches`. All release/hotfix PRs carry the `chore(release): <version>` title per `.claude/skills/release`.
- `path_filters` excludes `pnpm-lock.yaml` from review.

Validated against the official schema at https://coderabbit.ai/integrations/schema.v2.json. A review can still be forced on any PR with `@coderabbitai review`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added mandatory pre-merge checks for error handling and contribution-guide compliance.
  * Standardized pull request requirements, including clear descriptions, concrete change summaries, and related issue links when applicable.
  * Added a consistent review workflow covering quality checks, review follow-up, and merge readiness.

* **Documentation**
  * Added guidance for preparing, reviewing, updating, and approving pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->