### PR TITLE
chore(lint): enforce kebab-case folders, flag relative imports and long functions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,13 +78,20 @@ Atlas enforces conventions via ESLint and Prettier. The linter config in `eslint
 | Rule                                                 | Enforced by                            |
 | ---------------------------------------------------- | -------------------------------------- |
 | `kebab-case` file names                              | `eslint-plugin-check-file`             |
+| `kebab-case` folder names                            | `eslint-plugin-check-file`             |
 | `snake_case` variables, parameters, properties       | `@typescript-eslint/naming-convention` |
 | `PascalCase` types, classes, interfaces              | `@typescript-eslint/naming-convention` |
 | `UPPER_CASE` enum members                            | `@typescript-eslint/naming-convention` |
 | Max 300 effective lines per file                     | `max-lines` ESLint rule                |
+| Max 80 effective lines per function (warning)        | `max-lines-per-function` ESLint rule   |
 | Single quotes, trailing commas, 100-char print width | Prettier                               |
-| `@/` path aliases (no relative imports)              | `tsconfig.json` paths                  |
+| `@/` path aliases, no relative imports (warning)     | `no-restricted-imports` ESLint rule    |
 | JSDoc on all exported functions                      | Convention                             |
+
+Two rules are staged as warnings because the codebase still has existing hits:
+194 relative imports and 16 oversized functions. They move to errors once those
+are cleared, so a new violation shows up in the lint output of the PR that
+introduces it rather than being silently accepted.
 
 **SDK exception:** Files under `src/sdk.ts`, `src/ports/atlas/`, and `src/adapters/sdk/` use standard ES6 `camelCase` naming to provide a familiar interface for external consumers. This is configured as an ESLint override.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,9 +14,10 @@ const sonarjs_code_smell_rules = {
 };
 
 /**
- * Structural conventions from `.claude/CLAUDE.md` that are not covered by the
- * filename, naming, or file-length rules. Staged as `warn` until the existing
- * hits are fixed, then promoted to `error`.
+ * Structural conventions from `.claude/CLAUDE.md` that nothing checked before.
+ * Folder naming is an error because the tree is already clean. The
+ * relative-import and function-length rules are warnings until their existing
+ * hits are fixed, then they are promoted to errors too.
  */
 const structural_convention_rules = {
   'no-restricted-imports': [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,30 @@ const sonarjs_code_smell_rules = {
   'sonarjs/no-unused-collection': 'error',
 };
 
+/**
+ * Structural conventions from `.claude/CLAUDE.md` that are not covered by the
+ * filename, naming, or file-length rules. Staged as `warn` until the existing
+ * hits are fixed, then promoted to `error`.
+ */
+const structural_convention_rules = {
+  'no-restricted-imports': [
+    'warn',
+    {
+      patterns: [
+        {
+          group: ['./*', '../*'],
+          message: 'Use the @/ path alias instead of a relative import.',
+        },
+      ],
+    },
+  ],
+  'check-file/folder-naming-convention': ['error', { '**/': 'KEBAB_CASE' }],
+  'max-lines-per-function': [
+    'warn',
+    { max: 80, skipBlankLines: true, skipComments: true, IIFEs: true },
+  ],
+};
+
 export default tseslint.config(
   {
     ignores: ['dist/', '**/dist/', 'node_modules/', '**/node_modules/', 'coverage/', '*.config.*'],
@@ -32,6 +56,7 @@ export default tseslint.config(
     },
     rules: {
       ...sonarjs_code_smell_rules,
+      ...structural_convention_rules,
       'max-lines': ['error', { max: 300, skipBlankLines: true, skipComments: true }],
       'check-file/filename-naming-convention': [
         'error',


### PR DESCRIPTION
## Summary

Adds the structural ESLint rules from #154 that `.claude/CLAUDE.md` documents but nothing checked, which is why the drift in the sibling layout issues went unnoticed. Rollout follows the issue: a rule with existing hits lands as a warning so it shows up in the lint output of the PR that adds a new violation, and gets promoted to an error once the sibling issues clear the backlog.

Closes #154.

## Changes

- `check-file/folder-naming-convention` for kebab-case folders, as an **error**: 0 existing hits, so it only ever fires on a new folder.
- `no-restricted-imports` for `./*` and `../*`, as a **warning**: 194 existing hits, cleared by #153 and #156.
- `max-lines-per-function` at 80 effective lines, as a **warning**: 16 existing hits.
- `CONTRIBUTING.md` conventions table lists all three with the rule that enforces them, plus a note on why two are staged as warnings.

Package lint scripts do not pass `--max-warnings`, so the staged rules do not break CI.

## Checklist

- [x] `pnpm run lint` passes with no new errors
- [x] Targets `dev`
- [x] No version bump in `packages/*/package.json`
- [x] Labelled for release notes
- [ ] Unit tests: none, this PR changes lint configuration only and has no runtime behavior to cover

## Rules I left out

`import-x/no-cycle` reports nothing on this repo. `eslint-plugin-import-x` 4.17.1 is the latest release and its peer range includes ESLint 10, but it stayed silent on a deliberately constructed two-file cycle and on a real one I inserted into `packages/core/src/utils/index.ts` importing `@/index`. Alias resolution was not the cause: with `import-x/no-unresolved` temporarily enabled, only genuinely missing externals were flagged, so `@/` resolved fine. A rule that never fires is worse than no rule, so I removed both `eslint-plugin-import-x` and `eslint-import-resolver-typescript` again rather than commit false assurance. Worth revisiting when import-x cuts a release that reports under ESLint 10.

`check-file/filename-blocklist` is conditional on the renames in #153 and #158, which have not happened. Adding it now either fails on current filenames or needs a blocklist that has to be rewritten after the renames.

`jscpd` in CI needs a new dependency, a workflow job, and a duplication threshold decision. That is a separate change from the ESLint config.

## Verification

```
$ npx eslint 'packages/*/src/**/*.{ts,tsx}'
✖ 219 problems (0 errors, 219 warnings)
```

219 = 194 relative imports + 16 long functions + 9 pre-existing warnings. Zero errors, so folder naming is clean across every package.

```
$ cd packages/core && npx eslint src/
✖ 28 problems (0 errors, 28 warnings)
exit=0
```

Run from a package directory, which is how `turbo run lint` invokes it, to confirm the folder rule does not false-positive on a package-relative cwd.

`npx prettier --check CONTRIBUTING.md eslint.config.js` is clean. The lockfile churn pnpm left behind after adding and removing import-x is not in the diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with folder naming, import path, and function size conventions.
  * Clarified which convention violations are currently warnings and may become errors after cleanup.
  * Added guidance to help maintain consistent project structure and code quality.

* **Chores**
  * Added automated checks for folder naming, preferred path aliases, relative imports, and oversized functions.
  * Existing violations are reported with appropriate warning or error levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->