### PR TITLE
docs(contributing): make the PR description convention explicit and align the pre-merge check

### DIFF
--- a/.claude/skills/write-comment/SKILL.md
+++ b/.claude/skills/write-comment/SKILL.md
@@ -131,6 +131,26 @@ machine-written one, because nobody can tell which parts to trust.
 - Match the surrounding thread. A one-line question gets a one-line answer, not
   a report.
 
+## Pull request descriptions
+
+A PR body is a comment with a fixed skeleton. Everything above applies, plus
+the sections from `.github/PULL_REQUEST_TEMPLATE.md`, which the
+`Changes explained` pre-merge check enforces:
+
+- `## Summary`: what the PR does and why, in plain sentences, with `Closes #N`
+  for the issue it fixes.
+- `## Changes`: concrete bullets, one per thing changed.
+- `## Checklist`: ticked only for what was actually run.
+
+Keep the headings as the template spells them. Extra sections under them are
+fine, and a long PR usually needs one for evidence or for the option not taken,
+but they do not replace `Summary` and `Changes`. Delete every template HTML
+comment and placeholder bullet: a leftover comment fails the check, and an
+empty section reads as a PR nobody bothered to describe.
+
+`CONTRIBUTING.md` carries the same rule for human contributors. Keep the two in
+sync when either changes.
+
 ## Never
 
 - Anything covered by **This Is a Public Repository** in `.claude/CLAUDE.md`:

--- a/.claude/skills/write-comment/SKILL.md
+++ b/.claude/skills/write-comment/SKILL.md
@@ -134,19 +134,22 @@ machine-written one, because nobody can tell which parts to trust.
 ## Pull request descriptions
 
 A PR body is a comment with a fixed skeleton. Everything above applies, plus
-the sections from `.github/PULL_REQUEST_TEMPLATE.md`, which the
-`Changes explained` pre-merge check enforces:
+the sections from `.github/PULL_REQUEST_TEMPLATE.md`:
 
 - `## Summary`: what the PR does and why, in plain sentences, with `Closes #N`
   for the issue it fixes.
 - `## Changes`: concrete bullets, one per thing changed.
 - `## Checklist`: ticked only for what was actually run.
 
-Keep the headings as the template spells them. Extra sections under them are
-fine, and a long PR usually needs one for evidence or for the option not taken,
-but they do not replace `Summary` and `Changes`. Delete every template HTML
-comment and placeholder bullet: a leftover comment fails the check, and an
-empty section reads as a PR nobody bothered to describe.
+`Summary` and `Changes` are what the `Changes explained` pre-merge check
+enforces, spelled exactly as the template spells them. The `Checklist` is not
+gated, so a body without it still passes, but a ticked box is a claim that the
+command ran and the rule against unearned claims applies to it. Extra sections
+under those are fine, and a long PR usually needs one for evidence or for the
+option not taken, though they never replace `Summary` and `Changes`. Delete
+every template HTML comment, including the one above `## Summary`, along with
+the placeholder bullets: a leftover comment fails the check, and an empty
+section reads as a PR nobody bothered to describe.
 
 `CONTRIBUTING.md` carries the same rule for human contributors. Keep the two in
 sync when either changes.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,14 +26,26 @@ reviews:
             documentation, or security.
           - Does not change the version field in any packages/*/package.json.
           - Stays a single concern; fail if it mixes unrelated changes.
-          - Adds or updates unit tests under tests/unit/ for changed behavior.
+          - Adds or updates unit tests under tests/unit/ for changed runtime
+            behavior. A PR that only touches docs, lint or build config, CI
+            workflows, or .claude/ has no runtime behavior to test, so the
+            missing tests are not a failure.
       - name: Changes explained
         mode: error
         instructions: |
-          Pass only if the PR body explains what changed and why:
-          - The Summary section states what the PR does in plain sentences.
-            Fail on an empty summary or leftover template placeholder text.
-          - The Changes section lists concrete bullets of what changed.
-            Fail on empty bullets or leftover HTML comments.
+          The baseline is the "Write the PR description" section of
+          CONTRIBUTING.md, the .claude/skills/write-comment skill, and
+          .github/PULL_REQUEST_TEMPLATE.md. This check only restates them, so
+          judge the body against those and nothing stricter.
+          Pass only if:
+          - A "## Summary" section states what the PR does and why in plain
+            sentences. Fail on an empty summary or leftover template
+            placeholder text.
+          - A "## Changes" section lists concrete bullets of what changed.
+            Fail on empty bullets or leftover template HTML comments.
           - Related issues are linked with "Closes #N" when the PR fixes a
             reported issue.
+          Extra sections beyond the template, for example evidence,
+          verification, or a rejected alternative, are expected on larger PRs.
+          Do not fail a body for having them, for section order, or for a
+          missing Checklist section.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,25 +27,29 @@ reviews:
           - Does not change the version field in any packages/*/package.json.
           - Stays a single concern; fail if it mixes unrelated changes.
           - Adds or updates unit tests under tests/unit/ for changed runtime
-            behavior. A PR that only touches docs, lint or build config, CI
-            workflows, or .claude/ has no runtime behavior to test, so the
-            missing tests are not a failure.
+            behavior. A PR that only touches documentation, non-runtime
+            configuration, CI workflows, or .claude/ has no runtime behavior to
+            test, so the missing tests are not a failure.
       - name: Changes explained
         mode: error
         instructions: |
           The baseline is the "Write the PR description" section of
           CONTRIBUTING.md, the .claude/skills/write-comment skill, and
-          .github/PULL_REQUEST_TEMPLATE.md. This check only restates them, so
-          judge the body against those and nothing stricter.
+          .github/PULL_REQUEST_TEMPLATE.md. This check only restates them:
+          Summary and Changes are the enforced minimum, judged against those
+          three sources and nothing stricter.
           Pass only if:
           - A "## Summary" section states what the PR does and why in plain
             sentences. Fail on an empty summary or leftover template
             placeholder text.
           - A "## Changes" section lists concrete bullets of what changed.
-            Fail on empty bullets or leftover template HTML comments.
+            Fail on empty bullets.
+          - No leftover template HTML comment survives anywhere in the body,
+            including the one above "## Summary" in the template.
           - Related issues are linked with "Closes #N" when the PR fixes a
             reported issue.
           Extra sections beyond the template, for example evidence,
           verification, or a rejected alternative, are expected on larger PRs.
           Do not fail a body for having them, for section order, or for a
-          missing Checklist section.
+          missing Checklist section: the Checklist is for the author and this
+          check does not gate on it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,29 @@ Release notes are generated from PR labels (`enhancement`, `bug`,
 `documentation`, `security`). An unlabelled PR shows up under "Other changes", so
 label it before it is merged.
 
+### Write the PR description
+
+`.github/PULL_REQUEST_TEMPLATE.md` is the shape of every PR body:
+
+- **`## Summary`**: what the PR does and why, in plain sentences. Link the
+  issue it fixes with `Closes #N`.
+- **`## Changes`**: concrete bullets, one per thing you changed.
+- **`## Checklist`**: tick what you actually ran.
+
+Extra sections below those are welcome, and a larger PR usually wants one for
+evidence or for the option it did not take. Delete the template's HTML comments
+and placeholder bullets rather than leaving them in.
+
+Write it in the first person and keep it factual. Claim only what you ran, name
+what you did not verify, and follow the same prose rules as the docs: no em
+dashes, no `--` inside a phrase, no padding. The `write-comment` skill in
+`.claude/skills/` covers the voice in detail and applies to PR bodies too.
+
+This section and the `write-comment` skill are the baseline. The
+`Changes explained` pre-merge check in `.coderabbit.yaml` restates it, so when
+the convention changes here, update the check to match rather than the other way
+around.
+
 ## Code conventions
 
 Atlas enforces conventions via ESLint and Prettier. The linter config in `eslint.config.js` is the source of truth.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,9 +80,12 @@ label it before it is merged.
 - **`## Changes`**: concrete bullets, one per thing you changed.
 - **`## Checklist`**: tick what you actually ran.
 
-Extra sections below those are welcome, and a larger PR usually wants one for
-evidence or for the option it did not take. Delete the template's HTML comments
-and placeholder bullets rather than leaving them in.
+`Summary` and `Changes` are the enforced minimum, and a PR is blocked without
+them. The `Checklist` is for you, so nothing fails a PR that drops it, but a
+reviewer reads a ticked box as a command you ran. Extra sections below those are
+welcome, and a larger PR usually wants one for evidence or for the option it did
+not take. Delete every one of the template's HTML comments, including the one
+above `## Summary`, along with its placeholder bullets.
 
 Write it in the first person and keep it factual. Claim only what you ran, name
 what you did not verify, and follow the same prose rules as the docs: no em


### PR DESCRIPTION
## Summary

The `Changes explained` pre-merge check failed on #290 for missing `## Summary` and `## Changes` headings. The headings are real, they come from `.github/PULL_REQUEST_TEMPLATE.md`, but nothing outside the template said so: `CONTRIBUTING.md` documents where to target a PR and how to label it and stops there, and the `write-comment` skill covers voice without mentioning that a PR body has a fixed skeleton. The check was the only place the rule existed, which is backwards.

`CONTRIBUTING.md` and the `write-comment` skill are now the baseline and they say the same thing. `.coderabbit.yaml` restates them and nothing stricter.

## Changes

- `CONTRIBUTING.md` gains a `Write the PR description` section under the development workflow: the `Summary`, `Changes`, and `Checklist` sections from the template, extra sections explicitly welcome, template comments and placeholder bullets deleted, first person, no unearned verification claims, no em dashes.
- The `write-comment` skill gains a `Pull request descriptions` section with the same skeleton, so a body drafted through the skill lands where the check expects. Both sides carry a note to keep the other in sync.
- `Changes explained` now names `CONTRIBUTING.md`, the skill, and the template as its baseline, and no longer fails a body for extra sections, for section order, or for a missing `Checklist`.
- `Contributing guide compliance` no longer demands unit tests from a PR that only touches docs, lint or build config, CI workflows, or `.claude/`. It failed #290 on that bullet, and a lint config change has no runtime behavior to cover under `tests/unit/`.

## Checklist

- [x] Targets `dev`
- [x] No version bump
- [x] `.coderabbit.yaml` still parses, and both custom checks are still present
- [x] Labelled for release notes
- [ ] Unit tests: none, this PR changes documentation and review config only

## Verification

`.coderabbit.yaml` parses and keeps both checks:

```
$ python3 -c "import yaml;d=yaml.safe_load(open('.coderabbit.yaml'));print([c['name'] for c in d['reviews']['pre_merge_checks']['custom_checks']])"
['Contributing guide compliance', 'Changes explained']
```

The real test is CodeRabbit's review of this PR: the body follows the convention as written, so both checks should pass. `.coderabbit.yaml` and the skill file were already outside Prettier's configured globs and both had pre-existing formatting warnings, so I left them alone rather than mixing a reformat into this diff.

Related: #290, whose label I corrected from `code smell` to `documentation` after the same check flagged it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified pull request description requirements: **Summary** and **Changes** are required, while **Checklist** is optional and must remain truthful.
  * Added guidance to remove all template comments and placeholders, including comments before the Summary section.
  * Reinforced guidance on factual wording, issue-closing syntax, and consistency across contribution materials and templates.

* **Chores**
  * Updated validation rules to support documentation, configuration, workflow, and guidance-only changes.
  * Improved pull request description checks while retaining required sections and placeholder cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->