### PR TITLE
docs(release): correct the package count and record the release-PR approval rule

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -23,7 +23,7 @@ operational procedure.
 
 1. **Never bump a version outside a release or hotfix PR.** The bump _is_ the
    release trigger. A bump merged in an ordinary PR publishes to npm on arrival.
-2. **Never hand-edit the nine `packages/*/package.json` versions.** Use
+2. **Never hand-edit the ten `packages/*/package.json` versions.** Use
    `pnpm run release:version <version>`. They move in lockstep; a partial bump
    fails the publish workflow's tag/version check.
 3. **Never delete a tag whose npm publish already succeeded.** npm versions are
@@ -74,7 +74,7 @@ gh workflow run release-start.yml -f version=2.2.0 -f from=dev
 gh run watch
 ```
 
-It creates `release/v<version>`, bumps all nine packages, commits
+It creates `release/v<version>`, bumps all ten packages, commits
 `chore(release): <version>`, and prints a prefilled compare link in the run
 summary. The organisation forbids GitHub Actions from creating pull requests, so
 open the release PR from that link:
@@ -94,7 +94,21 @@ Before merging:
   everything in the release: CLI flags, SDK methods, config variables, and
   security changes all have documentation in place.
 
-Merging the PR is the release. Then watch the pipeline:
+Merging the PR is the release, and expect to need `--admin` for it:
+
+```bash
+gh pr merge <n> --merge --admin
+```
+
+The `main` ruleset sets `require_extra_approval_for_unattributed_changes`, and
+the release commit is authored by the workflow rather than by a person, so the
+rule demands an approving review. The person who opened the release PR cannot
+supply it: GitHub refuses to let an author approve their own pull request. Every
+release therefore either takes a second person's approval or an admin merge, and
+admin is what the releases so far have used. Do not work around it by committing
+the bump by hand, which produces an unsigned commit and an unmergeable PR.
+
+Then watch the pipeline:
 
 ```bash
 gh run watch                                    # publish.yml: plan, publish, sync-dev
@@ -138,24 +152,26 @@ correct it with `npm dist-tag add`, never by republishing.
 
 ## When a release did not happen
 
-| Symptom                                | Cause                                                     | Fix                                                |
-| -------------------------------------- | --------------------------------------------------------- | -------------------------------------------------- |
-| Merged to `main`, no tag               | Version was already tagged -- no bump in the merge        | Cut a real release with a higher version           |
-| `release-guard` fails on branch name   | Branch version disagrees with `packages/sdk/package.json` | `pnpm run release:version <branch version>`        |
-| `release-guard` fails on existing tag  | Version already released                                  | Pick a higher version                              |
-| Tag exists, `publish.yml` never ran    | Tag pushed by hand with `GITHUB_TOKEN`                    | `gh workflow run publish.yml -f version=<version>` |
-| No `publish.yml` run after the merge    | Event delivery is late, not dropped (issue #212)          | Wait a few minutes and re-check; only then `gh workflow run publish.yml -f version=<version> --ref main`, which tags the ref when the tag is missing |
-| Publish failed on build, lint, or test | Broken release commit                                     | Delete the tag, fix via a PR into `dev`, cut again |
-| SDK published, CLI failed              | Partial publish; npm is immutable                         | Hotfix forward at the next patch version           |
+| Symptom                                | Cause                                                     | Fix                                                                                                                                                  |
+| -------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Merged to `main`, no tag               | Version was already tagged -- no bump in the merge        | Cut a real release with a higher version                                                                                                             |
+| `release-guard` fails on branch name   | Branch version disagrees with `packages/sdk/package.json` | `pnpm run release:version <branch version>`                                                                                                          |
+| `release-guard` fails on existing tag  | Version already released                                  | Pick a higher version                                                                                                                                |
+| Tag exists, `publish.yml` never ran    | Tag pushed by hand with `GITHUB_TOKEN`                    | `gh workflow run publish.yml -f version=<version>`                                                                                                   |
+| No `publish.yml` run after the merge   | Event delivery is late, not dropped (issue #212)          | Wait a few minutes and re-check; only then `gh workflow run publish.yml -f version=<version> --ref main`, which tags the ref when the tag is missing |
+| Publish failed on build, lint, or test | Broken release commit                                     | Delete the tag, fix via a PR into `dev`, cut again                                                                                                   |
+| SDK published, CLI failed              | Partial publish; npm is immutable                         | Hotfix forward at the next patch version                                                                                                             |
 
 ## Repairing a botched bump
 
 ```bash
-pnpm run release:version 2.2.0        # explicit version, all nine packages
+pnpm run release:version 2.2.0        # explicit version, all ten packages
 pnpm run release:version patch        # or a keyword
-git diff --stat                       # expect exactly 9 package.json files
+git diff --stat                       # expect exactly 10 package.json files
 ```
 
-Nine files and nothing else. Internal dependencies are `workspace:*` and are
-rewritten by pnpm at publish time, so they never need editing. If the diff shows
-a different count, stop -- a package was added or the filter is wrong.
+Ten files and nothing else, one per workspace package. Internal dependencies are
+`workspace:*` and are rewritten by pnpm at publish time, so they never need
+editing. If the diff shows a different count, stop and check whether a package
+was added or the filter is wrong: the count is `ls -d packages/*/ | wc -l`, and
+it went from nine to ten when `packages/drive` arrived in v4.3.0.

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -199,10 +199,15 @@ gh run list --workflow e2e.yml --limit 3
 
 ## Branch protection
 
-`main` is governed by a repository **ruleset** (not classic branch protection --
-`/branches/main/protection` returns 404, the rules live under
-`/repos/:owner/:repo/rulesets`). The settings interact with the automation in ways
-that are not obvious:
+`main` is governed by two mechanisms at once, which is the part that misleads.
+Most rules live in a repository **ruleset** under
+`/repos/:owner/:repo/rulesets`, and `/branches/main/protection` returns nothing
+useful for them. Signed commits are the exception: that requirement sits in
+classic branch protection and is only visible at
+`/branches/main/protection/required_signatures`, which reports `enabled: true`
+for `main` and `false` for `dev`. Reading only the ruleset makes signing look
+optional. The settings interact with the automation in ways that are not
+obvious:
 
 | Rule                                    | State | Reason                                                                                                                                                                                                                                                                                                                                                   |
 | --------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -212,7 +217,7 @@ that are not obvious:
 | Restrict deletions                      | On    | Deleting `main` would orphan every published tag                                                                                                                                                                                                                                                                                                         |
 | Block force pushes                      | On    | A force push can strand a published tag on an orphaned commit                                                                                                                                                                                                                                                                                            |
 | **Require linear history**              | Off   | Release tags sit on PR merge commits; requiring linear history would break the release path                                                                                                                                                                                                                                                              |
-| Require signed commits                  | Off   | Optional -- the release commit is API-created and signed, so enabling it would not break the flow                                                                                                                                                                                                                                                        |
+| Require signed commits                  | On    | Enforced by classic branch protection, not by the ruleset, so it does not appear in `/rulesets`. This is why `release-start.yml` creates the bump through the GraphQL commit API: a runner-side `git commit` is unsigned and lands an unmergeable release PR                                                                                             |
 | Extra approval for unattributed changes | On    | The one rule that does bite. The release commit is created through the GraphQL commit API so it is signed, which also means it is attributed to the workflow rather than to a person, so this rule demands an approving review that the PR author cannot give. Every release PR needs either a second person's approval or `gh pr merge --merge --admin` |
 
 Tag rulesets are deliberately **not** configured: a `v*` rule can block

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -55,7 +55,7 @@ real input:
 The workflow then:
 
 1. Branches `release/v<version>` from `dev` (or `hotfix/v<version>` from `main`).
-2. Runs `pnpm run release:version <version>`, bumping all nine workspace
+2. Runs `pnpm run release:version <version>`, bumping all ten workspace
    packages in lockstep. Internal dependencies are `workspace:*`, so pnpm
    rewrites them to the exact version at publish time -- there is nothing else to
    edit.
@@ -204,15 +204,16 @@ gh run list --workflow e2e.yml --limit 3
 `/repos/:owner/:repo/rulesets`). The settings interact with the automation in ways
 that are not obvious:
 
-| Rule                       | State | Reason                                                                                               |
-| -------------------------- | ----- | ---------------------------------------------------------------------------------------------------- |
-| Require a pull request     | On    | Blocks a direct push of a version bump, which would publish to npm with no review                    |
-| Required approvals         | 0     | GitHub forbids self-approval; any higher number makes release PRs unmergeable for a solo maintainer  |
-| Require code owner review  | Off   | No `CODEOWNERS` file exists, and one naming the sole maintainer recreates the self-approval deadlock |
-| Restrict deletions         | On    | Deleting `main` would orphan every published tag                                                     |
-| Block force pushes         | On    | A force push can strand a published tag on an orphaned commit                                        |
-| **Require linear history** | Off   | Release tags sit on PR merge commits; requiring linear history would break the release path          |
-| Require signed commits     | Off   | Optional -- the release commit is API-created and signed, so enabling it would not break the flow    |
+| Rule                                    | State | Reason                                                                                                                                                                                                                                                                                                                                                   |
+| --------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Require a pull request                  | On    | Blocks a direct push of a version bump, which would publish to npm with no review                                                                                                                                                                                                                                                                        |
+| Required approvals                      | 0     | GitHub forbids self-approval; any higher number makes release PRs unmergeable for a solo maintainer                                                                                                                                                                                                                                                      |
+| Require code owner review               | Off   | No `CODEOWNERS` file exists, and one naming the sole maintainer recreates the self-approval deadlock                                                                                                                                                                                                                                                     |
+| Restrict deletions                      | On    | Deleting `main` would orphan every published tag                                                                                                                                                                                                                                                                                                         |
+| Block force pushes                      | On    | A force push can strand a published tag on an orphaned commit                                                                                                                                                                                                                                                                                            |
+| **Require linear history**              | Off   | Release tags sit on PR merge commits; requiring linear history would break the release path                                                                                                                                                                                                                                                              |
+| Require signed commits                  | Off   | Optional -- the release commit is API-created and signed, so enabling it would not break the flow                                                                                                                                                                                                                                                        |
+| Extra approval for unattributed changes | On    | The one rule that does bite. The release commit is created through the GraphQL commit API so it is signed, which also means it is attributed to the workflow rather than to a person, so this rule demands an approving review that the PR author cannot give. Every release PR needs either a second person's approval or `gh pr merge --merge --admin` |
 
 Tag rulesets are deliberately **not** configured: a `v*` rule can block
 `github-actions[bot]` from pushing the release tag, which stops every publish
@@ -229,7 +230,7 @@ pnpm run release:version 2.2.0   # explicit version
 pnpm run release:version patch   # 2.2.0 -> 2.2.1
 ```
 
-This edits all nine `packages/*/package.json` files and nothing else -- no git
+This edits all ten `packages/*/package.json` files and nothing else -- no git
 tag, no commit. Prefer the **Start release** workflow; use this only when working
 offline or repairing a botched bump.
 


### PR DESCRIPTION
## Summary

Two facts the v4.3.0 release exposed, both of which cost time to rediscover.

## Changes

- The version bump touches **ten** `package.json` files, not nine. `packages/drive` arrived in #296 and the count in the release skill and in `docs/development/releases.md` was never updated, so the stated verification ("nine files and nothing else") now fails on a correct bump. The repair section says where the number comes from, so the next package makes the count self-correcting instead of stale.
- The `main` ruleset sets `require_extra_approval_for_unattributed_changes`, which is the one rule that actually blocks a release. The release commit is created through the GraphQL commit API so that it is signed, and that same path attributes it to the workflow rather than to a person, so the rule demands an approving review. The PR author cannot give it, since GitHub refuses self-approval. v4.3.0 merged with `gh pr merge --merge --admin`, as v4.2.0 did. The skill now says so at the point of merging, and the ruleset table in the docs carries the row it was missing.

The docs table previously listed required approvals as 0 with the note that self-approval is forbidden, which reads as though nothing gates a release PR. This rule is why that is not the case.

## Checklist

- `pnpm run docs:build` succeeds.
- Documentation only, no code and no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release guidance to reflect ten workspace packages, including the addition of the Drive package.
  * Documented required approvals, administrative merge steps, and signed workflow-authored release commits.
  * Clarified branch protection requirements, including ruleset and classic protection mechanisms.
  * Added recovery guidance for delayed release event delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->