### PR TITLE
test: make the drive adapter failure injections reach the branch under test

### DIFF
--- a/packages/onedrive/tests/unit/adapters/s3-delta-cursor-repository.test.ts
+++ b/packages/onedrive/tests/unit/adapters/s3-delta-cursor-repository.test.ts
@@ -82,14 +82,23 @@ describe('S3OneDriveDeltaCursorRepository', () => {
   });
 
   it('reads an undecryptable cursor as absent rather than throwing', async () => {
-    const { ctx } = make_ctx(
-      { [CURSOR_KEY]: make_cursor() },
-      {
-        [CURSOR_KEY]: new Error('unable to authenticate data'),
-      },
-    );
+    const { ctx } = make_ctx({ [CURSOR_KEY]: make_cursor() });
+    // The object reads back fine and fails to decrypt, which is the case a wrong or rotated key
+    // produces. Failing the read instead would exercise the storage path, not this one.
+    (ctx as unknown as { decrypt: () => Buffer }).decrypt = () => {
+      throw new Error('unable to authenticate data');
+    };
 
     // A full re-enumeration is recoverable; a crash on every run is not.
+    await expect(repo.load(ctx, OWNER)).resolves.toBeUndefined();
+  });
+
+  it('reads a cursor whose object cannot be fetched as absent rather than throwing', async () => {
+    const { ctx } = make_ctx(
+      { [CURSOR_KEY]: make_cursor() },
+      { [CURSOR_KEY]: new Error('connection reset') },
+    );
+
     await expect(repo.load(ctx, OWNER)).resolves.toBeUndefined();
   });
 

--- a/packages/onedrive/tests/unit/adapters/s3-manifest-repository.test.ts
+++ b/packages/onedrive/tests/unit/adapters/s3-manifest-repository.test.ts
@@ -127,6 +127,12 @@ describe('S3OneDriveManifestRepository', () => {
       {
         'onedrive/manifests/owner-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
         'onedrive/manifests/owner-1/snap-corrupt.json': 'not-json',
+        // Listed so the injected get() failure below is actually reached: list() is derived
+        // from the stored keys, so a key present only in get_error is never read.
+        'onedrive/manifests/owner-1/snap-unreadable.json': make_manifest(
+          'snap-unreadable',
+          '2026-03-02T00:00:00Z',
+        ),
       },
       { 'onedrive/manifests/owner-1/snap-unreadable.json': new Error('decrypt failed') },
     );

--- a/packages/onedrive/tests/unit/services/save/save.service.test.ts
+++ b/packages/onedrive/tests/unit/services/save/save.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
 import { Container } from 'inversify';
 import 'reflect-metadata';
 import { OneDriveSaveService } from '@/services/save/save.service';
@@ -13,17 +14,6 @@ import type {
   TenantContext,
   TenantContextFactory,
 } from '@wisecom/atlas-types';
-
-/** Fixture overrides may blank an optional field; an explicit `undefined` drops the key. */
-type Overrides<T> = { [K in keyof T]?: T[K] | undefined };
-
-function apply_overrides<T extends object>(base: T, overrides: Overrides<T>): T {
-  const merged: Record<string, unknown> = { ...base, ...overrides };
-  for (const [key, value] of Object.entries(overrides)) {
-    if (value === undefined) delete merged[key];
-  }
-  return merged as T;
-}
 
 vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
   const mock_archive = {

--- a/packages/onedrive/tests/unit/services/verification/verification.service.test.ts
+++ b/packages/onedrive/tests/unit/services/verification/verification.service.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type {
   OneDriveFileVersionIndex,
@@ -11,17 +12,6 @@ import type {
 } from '@wisecom/atlas-types';
 import { stub_encrypted_object_store } from '@wisecom/atlas-types/testing/stub-encrypted-object-store';
 import { OneDriveVerificationService } from '@/services/verification/verification.service';
-
-/** Fixture overrides may blank an optional field; an explicit `undefined` drops the key. */
-type Overrides<T> = { [K in keyof T]?: T[K] | undefined };
-
-function apply_overrides<T extends object>(base: T, overrides: Overrides<T>): T {
-  const merged: Record<string, unknown> = { ...base, ...overrides };
-  for (const [key, value] of Object.entries(overrides)) {
-    if (value === undefined) delete merged[key];
-  }
-  return merged as T;
-}
 
 const TENANT_ID = 'tenant-1';
 const OWNER_ID = '00000000-0000-0000-0000-000000000001';

--- a/packages/sharepoint/tests/unit/adapters/s3-delta-cursor-repository.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/s3-delta-cursor-repository.test.ts
@@ -82,14 +82,23 @@ describe('S3SharePointDeltaCursorRepository', () => {
   });
 
   it('reads an undecryptable cursor as absent rather than throwing', async () => {
-    const { ctx } = make_ctx(
-      { [CURSOR_KEY]: make_cursor() },
-      {
-        [CURSOR_KEY]: new Error('unable to authenticate data'),
-      },
-    );
+    const { ctx } = make_ctx({ [CURSOR_KEY]: make_cursor() });
+    // The object reads back fine and fails to decrypt, which is the case a wrong or rotated key
+    // produces. Failing the read instead would exercise the storage path, not this one.
+    (ctx as unknown as { decrypt: () => Buffer }).decrypt = () => {
+      throw new Error('unable to authenticate data');
+    };
 
     // A full re-enumeration is recoverable; a crash on every run is not.
+    await expect(repo.load(ctx, SITE)).resolves.toBeUndefined();
+  });
+
+  it('reads a cursor whose object cannot be fetched as absent rather than throwing', async () => {
+    const { ctx } = make_ctx(
+      { [CURSOR_KEY]: make_cursor() },
+      { [CURSOR_KEY]: new Error('connection reset') },
+    );
+
     await expect(repo.load(ctx, SITE)).resolves.toBeUndefined();
   });
 

--- a/packages/sharepoint/tests/unit/adapters/s3-manifest-repository.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/s3-manifest-repository.test.ts
@@ -136,6 +136,12 @@ describe('S3SharePointManifestRepository', () => {
       {
         'sharepoint/manifests/site-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
         'sharepoint/manifests/site-1/snap-corrupt.json': 'not-json',
+        // Listed so the injected get() failure below is actually reached: list() is derived
+        // from the stored keys, so a key present only in get_error is never read.
+        'sharepoint/manifests/site-1/snap-unreadable.json': make_manifest(
+          'snap-unreadable',
+          '2026-03-02T00:00:00Z',
+        ),
       },
       { 'sharepoint/manifests/site-1/snap-unreadable.json': new Error('decrypt failed') },
     );

--- a/packages/sharepoint/tests/unit/services/save/save.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/save/save.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
 import { Container } from 'inversify';
 import 'reflect-metadata';
 import { SharePointSaveService } from '@/services/save/save.service';
@@ -13,17 +14,6 @@ import type {
   TenantContext,
   TenantContextFactory,
 } from '@wisecom/atlas-types';
-
-/** Fixture overrides may blank an optional field; an explicit `undefined` drops the key. */
-type Overrides<T> = { [K in keyof T]?: T[K] | undefined };
-
-function apply_overrides<T extends object>(base: T, overrides: Overrides<T>): T {
-  const merged: Record<string, unknown> = { ...base, ...overrides };
-  for (const [key, value] of Object.entries(overrides)) {
-    if (value === undefined) delete merged[key];
-  }
-  return merged as T;
-}
 
 vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
   const mock_archive = {

--- a/packages/sharepoint/tests/unit/services/verification/verification.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/verification/verification.service.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type {
   SharePointManifestEntry,
@@ -11,17 +12,6 @@ import type {
 } from '@wisecom/atlas-types';
 import { stub_encrypted_object_store } from '@wisecom/atlas-types/testing/stub-encrypted-object-store';
 import { SharePointVerificationService } from '@/services/verification/verification.service';
-
-/** Fixture overrides may blank an optional field; an explicit `undefined` drops the key. */
-type Overrides<T> = { [K in keyof T]?: T[K] | undefined };
-
-function apply_overrides<T extends object>(base: T, overrides: Overrides<T>): T {
-  const merged: Record<string, unknown> = { ...base, ...overrides };
-  for (const [key, value] of Object.entries(overrides)) {
-    if (value === undefined) delete merged[key];
-  }
-  return merged as T;
-}
 
 const TENANT_ID = 'tenant-1';
 const SITE_ID = 'site-1';


### PR DESCRIPTION
## Summary

Three drive adapter tests injected a failure that the code under test never saw. They passed, but not for the reason their names claim, so a regression in the recovery branch would not have failed them. Tests only, no source changes.

Closes #304

## Changes

- `s3-manifest-repository.test.ts` (both packages): `snap-unreadable.json` was passed only in the `get_error` map. The storage stub derives `list()` from the stored keys, so the key was never listed and the injected error never thrown. It is now stored as well as failing, with a comment naming why, so the `get()` failure branch is exercised rather than just the sibling `not-json` parse failure.
- `s3-delta-cursor-repository.test.ts` (both packages): the test named "reads an undecryptable cursor as absent" injected the error into `storage.get()`, so the payload never reached `ctx.decrypt()`. It now returns a readable object and throws from `decrypt`, which is what a rotated or wrong key produces. The storage read failure it used to cover is kept as its own case, so both recovery paths have a test instead of one path having two.
- `save.service.test.ts` and `verification.service.test.ts` (both packages): four local copies of `Overrides` and `apply_overrides` replaced with the shared helper from `@wisecom/atlas-types/testing/apply-overrides`, which the version-restore tests already import. Port and fixture stubs belong in `packages/types/src/testing` per `.claude/CLAUDE.md`.

## Verification

Both corrected injections now fail when the recovery they claim to cover is removed, which is the property they were missing:

- Rethrowing from `download_manifest`'s catch fails `skips an unreadable object under the prefix`.
- Dropping the `ctx.decrypt` call in the cursor adapter fails `reads an undecryptable cursor as absent`, because the plaintext then parses and a cursor comes back.

## Checklist

- `pnpm run build`, `pnpm run lint`, `pnpm run typecheck` and the OneDrive and SharePoint suites pass.
- Counts go from 260 to 261 and 305 to 306: one new test per package, the storage-read case split out of the decrypt case.
- Tests only, so no documentation is due.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for encrypted cursor failures, ensuring unreadable cursors are treated as unavailable.
  * Improved coverage for unreadable manifest objects during storage listing.
  * Standardized test data overrides across OneDrive and SharePoint service tests using shared utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->