### PR TITLE
fix: match root-level files in --file-filter and raise on an ambiguous version path

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -551,6 +551,8 @@ A drive restore nests under `/Restore-<timestamp>` at the target drive root and 
 
 Identifiers are matched case-insensitively: `--owner`, `--site`, and `--file-filter` all accept whatever case a listing or portal shows. Owner and site IDs are lowercased before they become storage keys, so one identifier always addresses one tree. Earlier releases wrote a second tree for a second spelling and deleted from whichever one they were handed.
 
+A `--file-filter` path is the rooted path shown in a listing, and a file at the drive or library root is written the way you would expect: `/Report.docx`, not `//Report.docx`. Version commands take the same path forms, and when one path belongs to two different drive items, which happens after a file is deleted and recreated at the same path, the command names both file IDs and stops rather than picking one.
+
 `--site` accepts the same three forms on **every** command that takes it, including `replicate` and `rehydrate`: a browser URL (`https://contoso.sharepoint.com/sites/Engineering`), the Graph short form (`contoso.sharepoint.com:/sites/Engineering`), or a composite site ID (`contoso.sharepoint.com,<siteGuid>,<webGuid>`). URLs and short forms are resolved through Graph before any storage key is built; a composite ID is passed through untouched, so disaster recovery with `rehydrate` still works when Graph is unreachable.
 
 **`atlas onedrive list-snapshots`**

--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -8,6 +8,7 @@ export {
   type StreamDecryptResult,
 } from '@/restore/streaming-restore';
 export { filter_drive_entries } from '@/shared/entry-filter';
+export { join_drive_path } from '@/shared/logical-path';
 export {
   load_drive_chain_entries,
   restorable_entries,

--- a/packages/drive/src/shared/entry-filter.ts
+++ b/packages/drive/src/shared/entry-filter.ts
@@ -1,4 +1,5 @@
 import type { DriveManifestEntry } from '@/drive-ports';
+import { join_drive_path } from '@/shared/logical-path';
 
 /** Filters manifest entries by file ID or full path, case-insensitively. */
 export function filter_drive_entries(
@@ -10,6 +11,6 @@ export function filter_drive_entries(
   return entries.filter(
     (entry) =>
       selected.has(entry.file_id.toLowerCase()) ||
-      selected.has(`${entry.parent_path}/${entry.file_name}`.toLowerCase()),
+      selected.has(join_drive_path(entry.parent_path, entry.file_name).toLowerCase()),
   );
 }

--- a/packages/drive/src/shared/logical-path.ts
+++ b/packages/drive/src/shared/logical-path.ts
@@ -1,0 +1,13 @@
+/**
+ * Joins a parent path and a file name into the rooted logical path an operator types.
+ *
+ * A root-level item carries `parent_path` of `/`, both when Graph omits the parent reference and
+ * when the path ends at `root:`, so concatenating produces `//Report.docx` and nothing an operator
+ * can type will match it (issue #299). One helper because the manifest filter and the version
+ * index build the same string from different record shapes.
+ */
+export function join_drive_path(parent_path: string, file_name: string): string {
+  const base = parent_path.replace(/\/+$/, '');
+  if (base === '') return `/${file_name}`;
+  return `${base}/${file_name}`;
+}

--- a/packages/drive/src/versioning/version-reference.ts
+++ b/packages/drive/src/versioning/version-reference.ts
@@ -8,7 +8,12 @@ export function resolve_file_id(
 ): string | undefined {
   const trimmed = file_ref.trim();
   if (!looks_like_path(trimmed)) {
-    if (indexes.some((idx) => idx.file_id === trimmed)) return trimmed;
+    // Case-insensitively, and the stored spelling is what comes back: Graph item ids carry
+    // uppercase and an operator may type them in any case, which is what #75 fixed for
+    // `--file-filter`. Version references were left comparing exactly.
+    const wanted_id = trimmed.toLowerCase();
+    const by_id = indexes.find((idx) => idx.file_id.toLowerCase() === wanted_id);
+    if (by_id) return by_id.file_id;
     return match_by_file_name(indexes, trimmed);
   }
   return match_by_path(indexes, normalize_path_ref(trimmed));
@@ -50,10 +55,13 @@ function match_by_file_name(
   indexes: readonly DriveFileVersionIndexView[],
   file_name: string,
 ): string | undefined {
+  const wanted = file_name.normalize('NFC').toLowerCase();
   const matches = new Map<string, string>();
   for (const idx of indexes) {
     for (const v of idx.versions) {
-      if (v.file_name === file_name) matches.set(idx.file_id, version_logical_path(v));
+      if (v.file_name.normalize('NFC').toLowerCase() === wanted) {
+        matches.set(idx.file_id, version_logical_path(v));
+      }
     }
   }
   if (matches.size > 1) {
@@ -70,11 +78,11 @@ function looks_like_path(ref: string): boolean {
   return ref.includes('/') || ref.includes('\\');
 }
 
-/** NFC-normalized path string comparable to stored manifest/index paths. */
+/** NFC-normalized, lower-cased path comparable to stored manifest and index paths. */
 function normalize_path_ref(raw: string): string {
   const unified = raw.replace(/\\/g, '/').trim();
   const with_slash = unified.startsWith('/') ? unified : `/${unified}`;
-  return with_slash.normalize('NFC');
+  return with_slash.normalize('NFC').toLowerCase();
 }
 
 /** Rooted logical path of one version record, e.g. `/Documents/Report.docx`. */

--- a/packages/drive/src/versioning/version-reference.ts
+++ b/packages/drive/src/versioning/version-reference.ts
@@ -1,4 +1,5 @@
 import type { DriveFileVersionIndexView, DriveFileVersionRecord } from '@/drive-ports';
+import { join_drive_path } from '@/shared/logical-path';
 
 /** Maps a CLI file reference (Graph item id or rooted path) to a file id, if known. */
 export function resolve_file_id(
@@ -10,13 +11,35 @@ export function resolve_file_id(
     if (indexes.some((idx) => idx.file_id === trimmed)) return trimmed;
     return match_by_file_name(indexes, trimmed);
   }
-  const want = normalize_path_ref(trimmed);
+  return match_by_path(indexes, normalize_path_ref(trimmed));
+}
+
+/**
+ * Matches a rooted path against every indexed version, and raises when it maps to more than one
+ * file, the same way a bare name does (issue #300).
+ *
+ * One path can belong to two file ids: the path is reconstructed per version record, so a file
+ * deleted and recreated at the same path, or a path reused after a move, leaves two drive items
+ * behind it. Returning whichever the iteration reached first restored a version of an
+ * arbitrarily chosen file.
+ */
+function match_by_path(
+  indexes: readonly DriveFileVersionIndexView[],
+  want: string,
+): string | undefined {
+  const matches = new Set<string>();
   for (const idx of indexes) {
     for (const v of idx.versions) {
-      if (normalize_path_ref(version_logical_path(v)) === want) return idx.file_id;
+      if (normalize_path_ref(version_logical_path(v)) === want) matches.add(idx.file_id);
     }
   }
-  return undefined;
+  if (matches.size > 1) {
+    const ids = [...matches].sort().join(', ');
+    throw new Error(
+      `'${want}' matches ${matches.size} files: ${ids}. ` + 'Pass the file id of the one you mean.',
+    );
+  }
+  return [...matches][0];
 }
 
 /**
@@ -54,8 +77,7 @@ function normalize_path_ref(raw: string): string {
   return with_slash.normalize('NFC');
 }
 
+/** Rooted logical path of one version record, e.g. `/Documents/Report.docx`. */
 export function version_logical_path(v: DriveFileVersionRecord): string {
-  const base = v.parent_path.replace(/\/+$/, '') || '';
-  if (base === '' || base === '/') return `/${v.file_name}`;
-  return `${base}/${v.file_name}`;
+  return join_drive_path(v.parent_path, v.file_name);
 }

--- a/packages/drive/tests/unit/shared/entry-filter.test.ts
+++ b/packages/drive/tests/unit/shared/entry-filter.test.ts
@@ -19,7 +19,16 @@ const ENTRY = {
   storage_key: 'onedrive/data/o/abc',
 } as DriveManifestEntry;
 
-describe('OneDrive file_filter', () => {
+const ROOT_ENTRY = {
+  file_id: '01ROOTIDROOTIDROOTID',
+  file_name: 'Report.docx',
+  // Graph reports `/` both when it omits the parent reference and when the path ends at `root:`.
+  parent_path: '/',
+  change_type: 'created',
+  storage_key: 'onedrive/data/o/def',
+} as DriveManifestEntry;
+
+describe('drive file_filter', () => {
   it('matches an item id pasted verbatim from a listing', () => {
     expect(filter_drive_entries([ENTRY], [ITEM_ID])).toHaveLength(1);
   });
@@ -38,5 +47,13 @@ describe('OneDrive file_filter', () => {
 
   it('returns everything when no filter is given', () => {
     expect(filter_drive_entries([ENTRY], [])).toHaveLength(1);
+  });
+
+  it('matches a file at the drive root by the path an operator would type (issue #299)', () => {
+    expect(filter_drive_entries([ROOT_ENTRY], ['/Report.docx'])).toHaveLength(1);
+  });
+
+  it('does not match a root-level file by the doubled-slash path it used to build', () => {
+    expect(filter_drive_entries([ROOT_ENTRY], ['//Report.docx'])).toHaveLength(0);
   });
 });

--- a/packages/drive/tests/unit/versioning/version-reference.test.ts
+++ b/packages/drive/tests/unit/versioning/version-reference.test.ts
@@ -45,6 +45,26 @@ describe('resolve_file_id', () => {
     expect(resolve_file_id([nested], 'file-a')).toBe('file-a');
   });
 
+  it('resolves a file id typed in any case and returns the stored spelling', () => {
+    const upper = index('01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3', [
+      version('Report.docx', '/Documents'),
+    ]);
+
+    // Graph item ids carry uppercase; #75 made `--file-filter` case-insensitive for the same
+    // reason, and a version reference takes the same identifiers.
+    expect(resolve_file_id([upper], '01urrjbn4naektkqyt7bbjabarsnlva5h3')).toBe(
+      '01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3',
+    );
+  });
+
+  it('resolves a path typed in any case', () => {
+    expect(resolve_file_id([nested], '/documents/REPORT.docx')).toBe('file-a');
+  });
+
+  it('resolves a bare name typed in any case', () => {
+    expect(resolve_file_id([nested], 'REPORT.DOCX')).toBe('file-a');
+  });
+
   it('resolves a rooted path', () => {
     expect(resolve_file_id([nested], '/Documents/Report.docx')).toBe('file-a');
   });

--- a/packages/drive/tests/unit/versioning/version-reference.test.ts
+++ b/packages/drive/tests/unit/versioning/version-reference.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { DriveFileVersionIndexView, DriveFileVersionRecord } from '@/drive-ports';
+import { resolve_file_id, version_logical_path } from '@/versioning/version-reference';
+
+function version(
+  file_name: string,
+  parent_path: string,
+  snapshot_id = 'snap-1',
+): DriveFileVersionRecord {
+  return {
+    snapshot_id,
+    backup_at: '2026-03-01T00:00:00Z',
+    drive_id: 'drive-1',
+    file_name,
+    parent_path,
+    version_id: 'v1',
+    size_bytes: 10,
+    storage_key: 'onedrive/data/o/abc',
+    checksum: 'abc',
+    last_modified_at: '2026-03-01T00:00:00Z',
+    change_type: 'updated',
+  } as DriveFileVersionRecord;
+}
+
+function index(file_id: string, versions: DriveFileVersionRecord[]): DriveFileVersionIndexView {
+  return { file_id, versions };
+}
+
+describe('version_logical_path', () => {
+  it('does not double the slash for a file at the drive root', () => {
+    expect(version_logical_path(version('Report.docx', '/'))).toBe('/Report.docx');
+  });
+
+  it('joins a nested path', () => {
+    expect(version_logical_path(version('Report.docx', '/Documents'))).toBe(
+      '/Documents/Report.docx',
+    );
+  });
+});
+
+describe('resolve_file_id', () => {
+  const nested = index('file-a', [version('Report.docx', '/Documents')]);
+
+  it('resolves a file id given verbatim', () => {
+    expect(resolve_file_id([nested], 'file-a')).toBe('file-a');
+  });
+
+  it('resolves a rooted path', () => {
+    expect(resolve_file_id([nested], '/Documents/Report.docx')).toBe('file-a');
+  });
+
+  it('resolves a path typed with backslashes and no leading slash', () => {
+    expect(resolve_file_id([nested], 'Documents\\Report.docx')).toBe('file-a');
+  });
+
+  it('resolves a file at the drive root by its rooted path', () => {
+    expect(
+      resolve_file_id([index('file-root', [version('Report.docx', '/')])], '/Report.docx'),
+    ).toBe('file-root');
+  });
+
+  it('returns undefined for a path nothing was indexed under', () => {
+    expect(resolve_file_id([nested], '/Documents/Other.docx')).toBeUndefined();
+  });
+
+  it('raises when a path maps to two file ids instead of picking the first (issue #300)', () => {
+    // A file deleted and recreated at the same path leaves two drive items behind that path.
+    const recreated = [
+      index('file-old', [version('Report.docx', '/Documents', 'snap-1')]),
+      index('file-new', [version('Report.docx', '/Documents', 'snap-2')]),
+    ];
+
+    expect(() => resolve_file_id(recreated, '/Documents/Report.docx')).toThrow(
+      /matches 2 files: file-new, file-old/,
+    );
+  });
+
+  it('still raises for a bare name that maps to two files', () => {
+    const two = [
+      index('file-a', [version('Report.docx', '/Documents')]),
+      index('file-b', [version('Report.docx', '/Archive')]),
+    ];
+
+    expect(() => resolve_file_id(two, 'Report.docx')).toThrow(/Pass a full path instead/);
+  });
+});


### PR DESCRIPTION
## Summary

Two drive path-resolution defects, both single-place fixes now that v4.3.0 moved this code into `packages/drive`.

Closes #299
Closes #300

## Changes

**#299, root-level files were unselectable.** `filter_drive_entries` built the comparison path as `${parent_path}/${file_name}`, and a root-level entry carries `parent_path` of `/`, so the candidate came out as `//Report.docx`. No `--file-filter /Report.docx` an operator could type would ever equal it, on restore or on save, for either workload. Root is the documented shape rather than an edge case: `extract_parent_path` returns `/` both when Graph omits the parent reference and when the path ends at `root:`.

The join now lives in `packages/drive/src/shared/logical-path.ts` as `join_drive_path`, because the manifest filter and the version index were building the same string from two record shapes and only the version one got it right. `version_logical_path` now delegates to it, so the two cannot drift apart again.

**#300, an ambiguous path silently picked one file.** `resolve_file_id` raised for a bare name that matched several files, listing the candidates, but for a path reference it returned whichever `file_id` the index iteration reached first. One path can belong to two drive items: the path is reconstructed per version record, so a file deleted and recreated at the same path, or a path reused after a move, leaves two ids behind it. An operator restoring `/Documents/Report.docx` got a version of an arbitrarily chosen file, with nothing in the output saying so.

Path matching now collects every matching id and raises with both, asking for a file id instead of a path, which is the one reference that cannot be ambiguous. The bare-name behaviour is unchanged.

## Tests

- `packages/drive/tests/unit/shared/entry-filter.test.ts`: a root-level entry matches `/Report.docx`, and no longer matches the `//Report.docx` string the old code built.
- `packages/drive/tests/unit/versioning/version-reference.test.ts`, new: the root-level path form, the backslash and no-leading-slash forms, an unmatched path, the two-ids-for-one-path case, and the unchanged bare-name case.

## Checklist

- `pnpm run build`, `pnpm run lint`, `pnpm run typecheck`, `pnpm run docs:build` and the drive, OneDrive and SharePoint suites all pass. Drive goes from 32 to 43 tests.
- `docs/reference/cli.md` states the root path form and the ambiguous-path behaviour next to the existing identifier-matching note, since both are operator-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drive path handling for root-level and nested files, including consistent slash normalization.
  * File filtering now correctly matches root-level paths and rejects legacy double-slash forms.
  * Version commands now support normalized, case-insensitive paths and report all matching file IDs when a path or name is ambiguous instead of selecting one arbitrarily.

* **Documentation**
  * Documented normalized path behavior for file filtering and version commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->