### PR TITLE
fix: report a drive whose delta peek failed as not up to date

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -6,13 +6,13 @@ Backup is user-targeted: one run processes every drive belonging to a single use
 
 ## What Gets Backed Up
 
-| Item                         | Coverage                                                                                                    |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Files in the user's drives   | Current content, SHA-256 content-addressed and deduplicated per owner                                       |
-| File version history         | Every new historical version Graph returns for an item                                                      |
-| Folder paths                 | Recorded on the manifest entry and normalized to Unicode NFC                                                |
-| OneNote notebooks            | Section files and table of contents, stored as ordinary files (see [OneNote Notebooks](#onenote-notebooks)) |
-| Moves, renames, and deletions | Recorded as manifest changes on the next delta sync                                                        |
+| Item                          | Coverage                                                                                                    |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Files in the user's drives    | Current content, SHA-256 content-addressed and deduplicated per owner                                       |
+| File version history          | Every new historical version Graph returns for an item                                                      |
+| Folder paths                  | Recorded on the manifest entry and normalized to Unicode NFC                                                |
+| OneNote notebooks             | Section files and table of contents, stored as ordinary files (see [OneNote Notebooks](#onenote-notebooks)) |
+| Moves, renames, and deletions | Recorded as manifest changes on the next delta sync                                                         |
 
 ## Prerequisites
 
@@ -77,11 +77,11 @@ Ciphertext is stored at the key name shown above. There is no separate `.enc` fi
 
 Implementation thresholds from `@wisecom/atlas-onedrive`:
 
-| Size                          | Strategy                                                                                                                                                                 |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **≤ 4 MiB**                   | Single read of the file into memory (pre-authenticated URL or Graph content fallback when needed), encrypt, `put`                                                        |
-| **> 4 MiB** and **< 64 MiB**  | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                |
-| **≥ 64 MiB**                  | `process_large_file`: stream encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `onedrive/data/{owner_id}/{sha256}` |
+| Size                         | Strategy                                                                                                                                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **≤ 4 MiB**                  | Single read of the file into memory (pre-authenticated URL or Graph content fallback when needed), encrypt, `put`                                                        |
+| **> 4 MiB** and **< 64 MiB** | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                |
+| **≥ 64 MiB**                 | `process_large_file`: stream encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `onedrive/data/{owner_id}/{sha256}` |
 
 Chunked downloads retry each **4 MiB** range independently (5 attempts with backoff in the adapter), so a transient failure replays a single chunk instead of the whole file. Each range request is also aborted if the chunk has not transferred at roughly 256 KB/s, with a floor of 30 seconds. That budget is sized from the chunk being fetched, not the file, so a dead connection costs about 30 seconds and then a retry regardless of whether the file is 5 MB or 5 GB.
 
@@ -216,11 +216,11 @@ Versions the service reports as gone (`404` or `410`, content purged by the site
 
 A OneNote notebook is not a file. Graph returns the notebook root as a driveItem carrying a **`package` facet** (`package.type == "oneNote"`) alongside a `folder` facet, and its actual content as ordinary child files:
 
-| Item                        | Facets                               | Backed up                                                                                                                     |
+| Item                        | Facets                               | Backed up                                                                                                                       |
 | --------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | Notebook root (e.g. `Test`) | `folder` + `package`                 | Treated as a folder. `GET /items/{id}/content` returns **404**, because the root has no content of its own and nothing to store |
-| `<Section>.one`             | `file`, MIME `application/msonenote` | Yes, byte-for-byte, like any other file                                                                                       |
-| `Open Notebook.onetoc2`     | `file`                               | Yes, byte-for-byte                                                                                                            |
+| `<Section>.one`             | `file`, MIME `application/msonenote` | Yes, byte-for-byte, like any other file                                                                                         |
+| `Open Notebook.onetoc2`     | `file`                               | Yes, byte-for-byte                                                                                                              |
 
 Notebook **content is covered by backups today**: each section file is content-addressed, encrypted, and stored under the notebook's folder path. What the run additionally reports is the notebook itself, because file counters alone cannot answer "did the notebook come through whole?":
 
@@ -267,17 +267,17 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 
 ### `atlas onedrive restore`
 
-| Flag                       | Description                                          | Default                    |
-| -------------------------- | ---------------------------------------------------- | -------------------------- |
-| `-o, --owner <id>`         | User email or Entra object ID                        | Required                   |
-| `-s, --snapshot <id>`      | Snapshot to restore from                             | Required                   |
-| `--target-owner <id>`      | Restore to a different user's OneDrive               | Same as `--owner`          |
-| `--destination <path>`     | Folder to restore under, created when missing        | `/Restore-<timestamp>`     |
-| `--in-place`               | Restore to the original paths                        | `false`                    |
-| `--name <filename>`        | Rename the restored file; single-file restores only  | Original name              |
-| `--file-filter <paths...>` | Only restore specific files (by ID or path)          | All files                  |
-| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` | `rename`                   |
-| `-t, --tenant <id>`        | Tenant identifier                                    | Config default             |
+| Flag                       | Description                                          | Default                |
+| -------------------------- | ---------------------------------------------------- | ---------------------- |
+| `-o, --owner <id>`         | User email or Entra object ID                        | Required               |
+| `-s, --snapshot <id>`      | Snapshot to restore from                             | Required               |
+| `--target-owner <id>`      | Restore to a different user's OneDrive               | Same as `--owner`      |
+| `--destination <path>`     | Folder to restore under, created when missing        | `/Restore-<timestamp>` |
+| `--in-place`               | Restore to the original paths                        | `false`                |
+| `--name <filename>`        | Rename the restored file; single-file restores only  | Original name          |
+| `--file-filter <paths...>` | Only restore specific files (by ID or path)          | All files              |
+| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` | `rename`               |
+| `-t, --tenant <id>`        | Tenant identifier                                    | Config default         |
 
 ### `atlas onedrive save`
 
@@ -309,15 +309,15 @@ On Windows the archive is stamped with Mark-of-the-Web (`Zone.Identifier`, `Zone
 
 ### `atlas onedrive restore-version`
 
-| Flag                | Description                                        | Default        |
-| ------------------- | -------------------------------------------------- | -------------- |
-| `-o, --owner <id>`  | User email or Entra object ID                      | Required       |
-| `-f, --file <ref>`  | File ID or path; required with `--version`         | Optional       |
-| `--version <id>`    | Exact stored version to restore                    | Optional       |
-| `--before <iso>`    | Newest version at or before this instant, per file | Optional       |
-| `--path <prefix>`   | Limit a `--before` rollback to one folder          | Whole drive    |
+| Flag                | Description                                        | Default            |
+| ------------------- | -------------------------------------------------- | ------------------ |
+| `-o, --owner <id>`  | User email or Entra object ID                      | Required           |
+| `-f, --file <ref>`  | File ID or path; required with `--version`         | Optional           |
+| `--version <id>`    | Exact stored version to restore                    | Optional           |
+| `--before <iso>`    | Newest version at or before this instant, per file | Optional           |
+| `--path <prefix>`   | Limit a `--before` rollback to one folder          | Whole drive        |
 | `--in-place`        | Upload over the original file                      | Off, writes a copy |
-| `-t, --tenant <id>` | Tenant identifier                                  | Config default |
+| `-t, --tenant <id>` | Tenant identifier                                  | Config default     |
 
 ### `atlas onedrive verify`
 
@@ -413,11 +413,11 @@ Files larger than 4 MiB use a streaming decrypt pipeline: the encrypted blob is 
 
 **Conflict behavior** controls what happens when a file already exists at the target path:
 
-| Mode                | Behavior                                                                              |
-| ------------------- | --------------------------------------------------------------------------------------- |
-| `rename` (default)  | Appends a numeric suffix, so user edits made after a previous restore are not overwritten |
-| `replace`           | Overwrites the existing file                                                            |
-| `fail`              | Skips the file and logs an error                                                        |
+| Mode               | Behavior                                                                                  |
+| ------------------ | ----------------------------------------------------------------------------------------- |
+| `rename` (default) | Appends a numeric suffix, so user edits made after a previous restore are not overwritten |
+| `replace`          | Overwrites the existing file                                                              |
+| `fail`             | Skips the file and logs an error                                                          |
 
 ### Saving to a local archive
 
@@ -459,15 +459,15 @@ for (const drive of status.drives) {
 
 `checkStatus` returns an `OneDriveStatusResult`:
 
-| Field                   | Type                    | Description                                                        |
-| ----------------------- | ----------------------- | ------------------------------------------------------------------ |
-| `owner_id`              | `string`                | The user's Entra object ID                                         |
-| `last_backup_at`        | `Date \| undefined`     | Timestamp of the most recent snapshot                              |
-| `last_snapshot_id`      | `string \| undefined`   | ID of the most recent snapshot                                     |
-| `total_drives`          | `number`                | Number of drives discovered                                        |
-| `drives`                | `OneDriveDriveStatus[]` | Per-drive backup status                                            |
-| `is_up_to_date`         | `boolean`               | `true` if all drives have been backed up with zero pending changes |
-| `total_pending_changes` | `number`                | Sum of pending changes across all drives                           |
+| Field                   | Type                    | Description                                                                                                                                                                                                                                    |
+| ----------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `owner_id`              | `string`                | The user's Entra object ID                                                                                                                                                                                                                     |
+| `last_backup_at`        | `Date \| undefined`     | Timestamp of the most recent snapshot                                                                                                                                                                                                          |
+| `last_snapshot_id`      | `string \| undefined`   | ID of the most recent snapshot                                                                                                                                                                                                                 |
+| `total_drives`          | `number`                | Number of drives discovered                                                                                                                                                                                                                    |
+| `drives`                | `OneDriveDriveStatus[]` | Per-drive backup status                                                                                                                                                                                                                        |
+| `is_up_to_date`         | `boolean`               | `true` only when every drive reports itself up to date. A drive that has never been backed up, or whose delta peek failed, makes this `false` even though it contributes zero pending changes: a peek that could not run is unknown, not clean |
+| `total_pending_changes` | `number`                | Sum of pending changes across all drives                                                                                                                                                                                                       |
 
 ## Deletion
 

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -6,14 +6,14 @@ Backup is site-targeted: one run processes every document library in a single Sh
 
 ## What Gets Backed Up
 
-| Item                          | Coverage                                                                                                    |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Files in every document library | Current content, SHA-256 content-addressed and deduplicated per site                                      |
-| File version history          | Every new historical version Graph returns for an item                                                      |
-| Library and folder paths      | Recorded on the manifest entry, one delta cursor per library                                                |
-| OneNote notebooks             | Section files and table of contents, stored as ordinary files (see [OneNote Notebooks](#onenote-notebooks)) |
-| Subsites                      | Only with `--include-subsites`, which produces one snapshot per subsite                                     |
-| Moves, renames, and deletions | Recorded as manifest changes on the next delta sync                                                         |
+| Item                            | Coverage                                                                                                    |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Files in every document library | Current content, SHA-256 content-addressed and deduplicated per site                                        |
+| File version history            | Every new historical version Graph returns for an item                                                      |
+| Library and folder paths        | Recorded on the manifest entry, one delta cursor per library                                                |
+| OneNote notebooks               | Section files and table of contents, stored as ordinary files (see [OneNote Notebooks](#onenote-notebooks)) |
+| Subsites                        | Only with `--include-subsites`, which produces one snapshot per subsite                                     |
+| Moves, renames, and deletions   | Recorded as manifest changes on the next delta sync                                                         |
 
 ## Prerequisites
 
@@ -76,11 +76,11 @@ Ciphertext is stored at the key name shown above. There is no separate `.enc` fi
 
 Implementation thresholds from `@wisecom/atlas-sharepoint`:
 
-| Size                          | Strategy                                                                                                                                                                                       |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **≤ 4 MiB**                   | Single read via pre-authenticated URL (with transient-status retry and Retry-After backoff) or Graph content fallback, encrypt, `put`                                                          |
-| **> 4 MiB** and **< 64 MiB**  | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                                      |
-| **≥ 64 MiB**                  | Streaming pipeline: chunk download into streaming encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `sharepoint/data/{site_id}/{sha256}` |
+| Size                         | Strategy                                                                                                                                                                                       |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **≤ 4 MiB**                  | Single read via pre-authenticated URL (with transient-status retry and Retry-After backoff) or Graph content fallback, encrypt, `put`                                                          |
+| **> 4 MiB** and **< 64 MiB** | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                                      |
+| **≥ 64 MiB**                 | Streaming pipeline: chunk download into streaming encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `sharepoint/data/{site_id}/{sha256}` |
 
 Chunked downloads retry each **4 MiB** range independently (5 attempts with exponential backoff), so a transient failure replays a single chunk instead of the whole file. A chunk is retried on the same statuses as any other Graph call (429, 500, 502, 503, and 504), because the CDN in front of Graph raises `500` and `502` under load. A `4xx` response fails the chunk immediately.
 
@@ -187,11 +187,11 @@ Versions the service reports as gone (`404` or `410`, content purged by the site
 
 A OneNote notebook is not a file. Graph returns the notebook root as a driveItem carrying a **`package` facet** (`package.type == "oneNote"`) alongside a `folder` facet, and its actual content as ordinary child files:
 
-| Item                        | Facets                               | Backed up                                                                                                                     |
+| Item                        | Facets                               | Backed up                                                                                                                       |
 | --------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | Notebook root (e.g. `Test`) | `folder` + `package`                 | Treated as a folder. `GET /items/{id}/content` returns **404**, because the root has no content of its own and nothing to store |
-| `<Section>.one`             | `file`, MIME `application/msonenote` | Yes, byte-for-byte, like any other file                                                                                       |
-| `Open Notebook.onetoc2`     | `file`                               | Yes, byte-for-byte                                                                                                            |
+| `<Section>.one`             | `file`, MIME `application/msonenote` | Yes, byte-for-byte, like any other file                                                                                         |
+| `Open Notebook.onetoc2`     | `file`                               | Yes, byte-for-byte                                                                                                              |
 
 Notebook **content is covered by backups today**: each section file is content-addressed, encrypted, and stored under the notebook's folder path. What the run additionally reports is the notebook itself, because file counters alone cannot answer "did the notebook come through whole?":
 
@@ -246,7 +246,7 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 | `--target-site <url-or-id>` | Restore to a different site                          | Original site          |
 | `--destination <path>`      | Folder to restore under, created when missing        | `/Restore-<timestamp>` |
 | `--in-place`                | Restore to the original paths                        | `false`                |
-| `--name <filename>`         | Rename the restored file; single-file restores only   | Original name          |
+| `--name <filename>`         | Rename the restored file; single-file restores only  | Original name          |
 | `--file-filter <paths...>`  | Only restore specific files (by ID or path)          | All files              |
 | `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` | `rename`               |
 | `-t, --tenant <id>`         | Tenant identifier                                    | Config default         |
@@ -255,14 +255,14 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 
 On Windows the archive is stamped with Mark-of-the-Web (`Zone.Identifier`, `ZoneId=3`), so files extracted from it open in Protected View and their macros are blocked. Explorer propagates the mark to every extracted file; clear it with `Get-ChildItem -Recurse <dir> | Unblock-File` once you trust the content. Nothing is written on macOS or Linux, and an export to a filesystem without alternate data streams still succeeds with a warning. See [Exported archives and Mark-of-the-Web](./reference/cli.md#atlas-outlook-save).
 
-| Flag                       | Description                                  | Default        |
-| -------------------------- | -------------------------------------------- | -------------- |
-| `--site <url-or-id>`       | SharePoint site URL or Graph site ID         | Required       |
-| `-s, --snapshot <id>`      | Snapshot ID to save from                     | Required       |
-| `--file-filter <paths...>` | Only save specific files (by ID or path)     | All files      |
-| `-O, --output <path>`      | Output zip file path                         | Auto-generated |
-| `--skip-verify`            | Skip SHA-256 integrity checks                | `false`        |
-| `-t, --tenant <id>`        | Tenant identifier                            | Config default |
+| Flag                       | Description                              | Default        |
+| -------------------------- | ---------------------------------------- | -------------- |
+| `--site <url-or-id>`       | SharePoint site URL or Graph site ID     | Required       |
+| `-s, --snapshot <id>`      | Snapshot ID to save from                 | Required       |
+| `--file-filter <paths...>` | Only save specific files (by ID or path) | All files      |
+| `-O, --output <path>`      | Output zip file path                     | Auto-generated |
+| `--skip-verify`            | Skip SHA-256 integrity checks            | `false`        |
+| `-t, --tenant <id>`        | Tenant identifier                        | Config default |
 
 ### `atlas sharepoint list-snapshots`
 
@@ -362,7 +362,7 @@ Restore decrypts stored file blobs, verifies SHA-256 checksums, and uploads them
 Files with `change_type: 'deleted'` or a missing `storage_key` are skipped. Checksum verification runs before upload, and corrupted blobs are skipped with a warning.
 
 | Size        | Strategy                                                                                                               |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------ |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------- |
 | **≤ 4 MiB** | Single PUT via `PUT /sites/{site_id}/drives/{drive_id}/items/{parent}:/{name}:/content`                                |
 | **> 4 MiB** | Resumable upload session via `createUploadSession` with 10 MiB chunks (3 retries per chunk on 429, 500, 502, 503, 504) |
 
@@ -434,15 +434,15 @@ for (const lib of status.libraries) {
 
 `checkStatus` returns a `SharePointStatusResult`:
 
-| Field                   | Type                        | Description                                                           |
-| ----------------------- | --------------------------- | --------------------------------------------------------------------- |
-| `site_id`               | `string`                    | The Graph site ID                                                     |
-| `last_backup_at`        | `Date \| undefined`         | Timestamp of the most recent snapshot                                 |
-| `last_snapshot_id`      | `string \| undefined`       | ID of the most recent snapshot                                        |
-| `total_libraries`       | `number`                    | Number of document libraries discovered                               |
-| `libraries`             | `SharePointLibraryStatus[]` | Per-library backup status                                             |
-| `is_up_to_date`         | `boolean`                   | `true` if all libraries have been backed up with zero pending changes |
-| `total_pending_changes` | `number`                    | Sum of pending changes across all libraries                           |
+| Field                   | Type                        | Description                                                                                                                                                                                                                                        |
+| ----------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `site_id`               | `string`                    | The Graph site ID                                                                                                                                                                                                                                  |
+| `last_backup_at`        | `Date \| undefined`         | Timestamp of the most recent snapshot                                                                                                                                                                                                              |
+| `last_snapshot_id`      | `string \| undefined`       | ID of the most recent snapshot                                                                                                                                                                                                                     |
+| `total_libraries`       | `number`                    | Number of document libraries discovered                                                                                                                                                                                                            |
+| `libraries`             | `SharePointLibraryStatus[]` | Per-library backup status                                                                                                                                                                                                                          |
+| `is_up_to_date`         | `boolean`                   | `true` only when every library reports itself up to date. A library that has never been backed up, or whose delta peek failed, makes this `false` even though it contributes zero pending changes: a peek that could not run is unknown, not clean |
+| `total_pending_changes` | `number`                    | Sum of pending changes across all libraries                                                                                                                                                                                                        |
 
 ## Deletion
 

--- a/packages/onedrive/src/services/status/status.service.ts
+++ b/packages/onedrive/src/services/status/status.service.ts
@@ -56,7 +56,10 @@ export class OneDriveStatusService implements OneDriveStatusUseCase {
         last_snapshot_id: previous?.snapshot_id,
         total_drives: all_drives.length,
         drives: drive_statuses,
-        is_up_to_date: total_pending === 0 && drive_statuses.every((d) => d.has_backup),
+        // Every drive's own flag, not the pending total: a drive with no saved delta link and a
+        // drive whose peek threw both report `pending_changes: 0`, and the second also reports
+        // `has_backup: true`, so a Graph error used to read as a clean "up to date" (issue #298).
+        is_up_to_date: drive_statuses.every((d) => d.is_up_to_date),
         total_pending_changes: total_pending,
       };
     } finally {

--- a/packages/onedrive/tests/unit/services/status/status.service.test.ts
+++ b/packages/onedrive/tests/unit/services/status/status.service.test.ts
@@ -171,18 +171,33 @@ describe('OneDriveStatusService', () => {
     });
   });
 
-  it('currently rolls a failed peek up as up to date, which is wrong', async () => {
+  it('does not report the owner as up to date when a peek failed (issue #298)', async () => {
     vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('drive-1') as never);
     vi.mocked(mocks.connector.fetch_delta).mockRejectedValue(new Error('throttled'));
 
     const result = await check();
 
-    // Pins today's behaviour, it is not an endorsement. The roll-up is
-    // `total_pending === 0 && every(has_backup)`, which ignores each drive's
-    // own `is_up_to_date`, so a throttled peek counts as clean. Expected to
-    // flip to false when that is fixed; see the follow-up issue.
+    // The roll-up reads each drive's own flag. A throttled peek reports zero pending and
+    // `has_backup: true`, so the old `total_pending === 0 && every(has_backup)` called it clean.
     expect(result.drives[0]?.is_up_to_date).toBe(false);
-    expect(result.is_up_to_date).toBe(true);
+    expect(result.is_up_to_date).toBe(false);
+  });
+
+  it('does not report the owner as up to date when one drive of several failed', async () => {
+    vi.mocked(mocks.connector.list_drives).mockResolvedValue([
+      { drive_id: 'drive-1', drive_name: 'OneDrive' },
+      { drive_id: 'drive-2', drive_name: 'Second' },
+    ]);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('drive-1', 'drive-2') as never);
+    vi.mocked(mocks.connector.fetch_delta)
+      .mockRejectedValueOnce(new Error('throttled'))
+      .mockResolvedValueOnce({ items: [], delta_link: 'b' } as never);
+
+    const result = await check();
+
+    // The clean second drive must not mask the first: total pending is still zero here.
+    expect(result.total_pending_changes).toBe(0);
+    expect(result.is_up_to_date).toBe(false);
   });
 
   it('does not fail the whole check when one drive of several fails to peek', async () => {

--- a/packages/sharepoint/src/services/status/status.service.ts
+++ b/packages/sharepoint/src/services/status/status.service.ts
@@ -59,7 +59,10 @@ export class SharePointStatusService implements SharePointStatusUseCase {
         last_snapshot_id: previous_manifest?.snapshot_id,
         total_libraries: all_libraries.length,
         libraries: library_statuses,
-        is_up_to_date: total_pending === 0 && library_statuses.every((lib) => lib.has_backup),
+        // Every library's own flag, not the pending total: a library with no saved delta link and
+        // a library whose peek threw both report `pending_changes: 0`, and the second also reports
+        // `has_backup: true`, so a Graph error used to read as a clean "up to date" (issue #298).
+        is_up_to_date: library_statuses.every((lib) => lib.is_up_to_date),
         total_pending_changes: total_pending,
       };
     } finally {

--- a/packages/sharepoint/tests/unit/services/status/status.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/status/status.service.test.ts
@@ -176,18 +176,33 @@ describe('SharePointStatusService', () => {
     });
   });
 
-  it('currently rolls a failed peek up as up to date, which is wrong', async () => {
+  it('does not report the site as up to date when a peek failed (issue #298)', async () => {
     vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('library-1') as never);
     vi.mocked(mocks.connector.fetch_delta).mockRejectedValue(new Error('throttled'));
 
     const result = await check();
 
-    // Pins today's behaviour, it is not an endorsement. The roll-up is
-    // `total_pending === 0 && every(has_backup)`, which ignores each library's
-    // own `is_up_to_date`, so a throttled peek counts as clean. Expected to
-    // flip to false when that is fixed; see the follow-up issue.
+    // The roll-up reads each library's own flag. A throttled peek reports zero pending and
+    // `has_backup: true`, so the old `total_pending === 0 && every(has_backup)` called it clean.
     expect(result.libraries[0]?.is_up_to_date).toBe(false);
-    expect(result.is_up_to_date).toBe(true);
+    expect(result.is_up_to_date).toBe(false);
+  });
+
+  it('does not report the site as up to date when one library of several failed', async () => {
+    vi.mocked(mocks.connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'library-1', drive_name: 'Documents' },
+      { drive_id: 'library-2', drive_name: 'Shared Documents' },
+    ]);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('library-1', 'library-2') as never);
+    vi.mocked(mocks.connector.fetch_delta)
+      .mockRejectedValueOnce(new Error('throttled'))
+      .mockResolvedValueOnce({ items: [], delta_link: 'b' } as never);
+
+    const result = await check();
+
+    // The clean second library must not mask the first: total pending is still zero here.
+    expect(result.total_pending_changes).toBe(0);
+    expect(result.is_up_to_date).toBe(false);
   });
 
   it('does not fail the whole check when one library of several fails to peek', async () => {


### PR DESCRIPTION
## Summary

`status` reported an owner or site as up to date while one of its drives or libraries could not be checked. The roll-up was `total_pending === 0 && every(has_backup)`, which never consulted the per-drive `is_up_to_date` flag it had just built.

Closes #298

## Why it mattered

Two branches set the per-drive flag to `false` while leaving `pending_changes` at `0`: a drive with no saved delta link, and a drive whose peek threw. The second is the damaging one, because that branch also reports `has_backup: true`. A throttled or forbidden delta call therefore turned into a clean bill of health for the whole owner, which is the opposite of what an operator checking status wants: an unchecked drive is unknown, not current.

## Changes

- Both status services now roll up `every((d) => d.is_up_to_date)`. An owner with no drives at all still reports `true`, because `every` on an empty list is `true` and there is nothing to be behind on, which is the previous behaviour for that case.
- Two tests per package that pinned the old behaviour, and said so in their own comments ("Pins today's behaviour, it is not an endorsement... Expected to flip to false when that is fixed"), now assert the fixed behaviour. Each package also gains a case where one of two drives failed and the other is clean, so a healthy sibling cannot mask the failure.
- `docs/onedrive-backup.md` and `docs/sharepoint-backup.md` state what `is_up_to_date` actually means, since both tables claimed it was "all drives backed up with zero pending changes", which is exactly the wrong rule.

## Checklist

- `pnpm run lint`, `pnpm run typecheck`, `pnpm run docs:build` and both suites pass. Counts go 260 to 261 and 305 to 306, one added test per package.
- SDK-visible field semantics changed, so the SDK docs tables are updated in the same PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OneDrive and SharePoint backup status now correctly reports “not up to date” when a drive or library has never been backed up or when its status check fails—even when no pending changes are detected.
  - Overall status now accurately reflects the status of each individual drive or library.

- **Documentation**
  - Clarified backup status behavior and updated table and CLI reference formatting in the OneDrive and SharePoint documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->