### PR TITLE
fix: keep the move in change_type when content changed in the same delta

### DIFF
--- a/packages/onedrive/src/services/backup/change-classifier.ts
+++ b/packages/onedrive/src/services/backup/change-classifier.ts
@@ -16,30 +16,55 @@ export function classify_change_type(
   const previous_path = previous_path_by_file_id[item.item_id];
   const previous_name = previous_name_by_file_id[item.item_id];
   const previous_etag = previous_etag_by_file_id[item.item_id];
-  const current_path = item.parent_path;
-  const path_changed = Boolean(previous_path && previous_path !== current_path);
-  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
-  const etag_changed = Boolean(previous_etag && item.etag && previous_etag !== item.etag);
-  const etag_presence_changed = Boolean(previous_etag) !== Boolean(item.etag);
-  const both_etags_missing =
-    Boolean(previous_path || previous_name || previous_etag) && !previous_etag && !item.etag;
   const previously_known = Boolean(previous_path || previous_name || previous_etag);
 
   if (!previously_known) return 'created';
+
+  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
+  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
+  const etags_missing = !previous_etag && !item.etag;
+
   // Relocation before content: an item that moved and changed in the same delta window carries
   // both signals, and the ETag branch used to answer first, erasing the move from the change
   // record (issue #297). The new content blob makes the update self-evident; the old location
   // is only recorded here. Content is downloaded either way, so the label is all that moves.
-  if (path_changed && name_changed) return 'moved_and_renamed';
-  if (path_changed) return 'moved';
-  if (name_changed) return 'renamed';
-  if (etag_changed || etag_presence_changed || both_etags_missing) {
-    if (both_etags_missing) {
-      logger.warn(
-        `OneDrive delta item ${item.item_id}: missing etag on prior and current snapshot; classifying as updated`,
-      );
-    }
+  const relocation = relocation_label(path_changed, name_changed);
+  if (relocation) {
+    // Still worth saying when both ETags are absent: the relocation is certain, but with no ETag
+    // on either side a content change alongside it cannot be detected at all.
+    if (etags_missing) warn_missing_etag(item.item_id);
+    return relocation;
+  }
+
+  if (is_etag_transition(previous_etag, item.etag)) {
+    if (etags_missing) warn_missing_etag(item.item_id);
     return 'updated';
   }
   return undefined;
+}
+
+/** Which relocation happened, if any: the label an operator uses to find where a file went. */
+function relocation_label(
+  path_changed: boolean,
+  name_changed: boolean,
+): OneDriveChangeType | undefined {
+  if (path_changed && name_changed) return 'moved_and_renamed';
+  if (path_changed) return 'moved';
+  if (name_changed) return 'renamed';
+  return undefined;
+}
+
+/** Any ETag movement for an item already known, including one absent on both sides. */
+function is_etag_transition(
+  previous_etag: string | undefined,
+  current_etag: string | undefined,
+): boolean {
+  if (previous_etag && current_etag) return previous_etag !== current_etag;
+  return true;
+}
+
+function warn_missing_etag(item_id: string): void {
+  logger.warn(
+    `OneDrive delta item ${item_id}: missing etag on prior and current snapshot; a content change cannot be detected`,
+  );
 }

--- a/packages/onedrive/src/services/backup/change-classifier.ts
+++ b/packages/onedrive/src/services/backup/change-classifier.ts
@@ -26,6 +26,13 @@ export function classify_change_type(
   const previously_known = Boolean(previous_path || previous_name || previous_etag);
 
   if (!previously_known) return 'created';
+  // Relocation before content: an item that moved and changed in the same delta window carries
+  // both signals, and the ETag branch used to answer first, erasing the move from the change
+  // record (issue #297). The new content blob makes the update self-evident; the old location
+  // is only recorded here. Content is downloaded either way, so the label is all that moves.
+  if (path_changed && name_changed) return 'moved_and_renamed';
+  if (path_changed) return 'moved';
+  if (name_changed) return 'renamed';
   if (etag_changed || etag_presence_changed || both_etags_missing) {
     if (both_etags_missing) {
       logger.warn(
@@ -34,8 +41,5 @@ export function classify_change_type(
     }
     return 'updated';
   }
-  if (path_changed && name_changed) return 'moved_and_renamed';
-  if (path_changed) return 'moved';
-  if (name_changed) return 'renamed';
   return undefined;
 }

--- a/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
@@ -79,7 +79,11 @@ describe('classify_change_type', () => {
 
     // No etag on either side: the move is certain, a content change alongside it is invisible.
     expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, {})).toBe('moved');
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing etag'));
+    // The whole line, not a substring: a message change should show up here as a diff.
+    expect(warn).toHaveBeenCalledWith(
+      'OneDrive delta item item-1: missing etag on prior and current snapshot; ' +
+        'a content change cannot be detected',
+    );
 
     warn.mockRestore();
   });

--- a/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
+import { classify_change_type } from '@/services/backup/change-classifier';
+
+function make_item(overrides: Partial<OneDriveDeltaItem> = {}): OneDriveDeltaItem {
+  return {
+    item_id: 'item-1',
+    drive_id: 'drive-1',
+    file_name: 'report.docx',
+    parent_path: '/Documents',
+    size_bytes: 2048,
+    kind: 'file',
+    deleted: false,
+    ...overrides,
+  } as OneDriveDeltaItem;
+}
+
+const PREVIOUS_PATH = { 'item-1': '/Documents' };
+const PREVIOUS_NAME = { 'item-1': 'report.docx' };
+const PREVIOUS_ETAG = { 'item-1': '"e1"' };
+
+describe('classify_change_type', () => {
+  it('returns "created" when no prior state exists', () => {
+    expect(classify_change_type(make_item({ etag: '"e1"' }), {}, {}, {})).toBe('created');
+  });
+
+  it('returns "updated" when only the etag changed', () => {
+    const item = make_item({ etag: '"e2"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('updated');
+  });
+
+  it('returns "moved" when only the path changed', () => {
+    const item = make_item({ parent_path: '/Archive', etag: '"e1"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('moved');
+  });
+
+  it('returns "moved" when the item moved and its content changed in one delta (issue #297)', () => {
+    const item = make_item({ parent_path: '/Archive', etag: '"e2"' });
+    // The new content blob records the update; nothing but this label records the old location.
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('moved');
+  });
+
+  it('returns "moved_and_renamed" when path, name and content all changed', () => {
+    const item = make_item({ parent_path: '/Archive', file_name: 'report-v2.docx', etag: '"e2"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe(
+      'moved_and_renamed',
+    );
+  });
+
+  it('returns "renamed" when the name and the content changed together', () => {
+    const item = make_item({ file_name: 'report-v2.docx', etag: '"e2"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('renamed');
+  });
+
+  it('returns "deleted" for a removed item regardless of prior state', () => {
+    const item = make_item({ deleted: true, parent_path: '/Archive' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('deleted');
+  });
+
+  it('returns undefined when nothing changed', () => {
+    const item = make_item({ etag: '"e1"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBeUndefined();
+  });
+
+  it('returns "updated" when the etag appears where none was recorded', () => {
+    const item = make_item({ etag: '"e1"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, {})).toBe('updated');
+  });
+
+  it('returns "updated" when the etag disappears', () => {
+    const item = make_item();
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('updated');
+  });
+});

--- a/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { logger } from '@wisecom/atlas-core/utils/logger';
 import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
 import { classify_change_type } from '@/services/backup/change-classifier';
 
@@ -70,5 +71,16 @@ describe('classify_change_type', () => {
   it('returns "updated" when the etag disappears', () => {
     const item = make_item();
     expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('updated');
+  });
+
+  it('warns about the missing etags but still reports the move (issue #297)', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const item = make_item({ parent_path: '/Archive' });
+
+    // No etag on either side: the move is certain, a content change alongside it is invisible.
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, {})).toBe('moved');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing etag'));
+
+    warn.mockRestore();
   });
 });

--- a/packages/sharepoint/src/services/backup/change-classifier.ts
+++ b/packages/sharepoint/src/services/backup/change-classifier.ts
@@ -19,16 +19,21 @@ export function classify_change_type(
   const previously_known = Boolean(previous_path || previous_name || previous_etag);
 
   if (!previously_known) return 'created';
+
+  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
+  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
+  // Relocation before content: an item that moved and changed in the same delta window carries
+  // both signals, and the ETag branch used to answer first, erasing the move from the change
+  // record (issue #297). The new content blob makes the update self-evident; the old location is
+  // only recorded here. Content is downloaded either way, so the label is all that moves.
+  if (path_changed && name_changed) return 'moved_and_renamed';
+  if (path_changed) return 'moved';
+  if (name_changed) return 'renamed';
+
   if (is_etag_transition(previous_etag, item.etag, previously_known)) {
     warn_missing_etag(item.item_id, previous_etag, item.etag);
     return 'updated';
   }
-
-  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
-  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
-  if (path_changed && name_changed) return 'moved_and_renamed';
-  if (path_changed) return 'moved';
-  if (name_changed) return 'renamed';
   return undefined;
 }
 

--- a/packages/sharepoint/src/services/backup/change-classifier.ts
+++ b/packages/sharepoint/src/services/backup/change-classifier.ts
@@ -26,9 +26,13 @@ export function classify_change_type(
   // both signals, and the ETag branch used to answer first, erasing the move from the change
   // record (issue #297). The new content blob makes the update self-evident; the old location is
   // only recorded here. Content is downloaded either way, so the label is all that moves.
-  if (path_changed && name_changed) return 'moved_and_renamed';
-  if (path_changed) return 'moved';
-  if (name_changed) return 'renamed';
+  if (path_changed || name_changed) {
+    // Still worth saying when both ETags are absent: the relocation is certain, but with no ETag
+    // on either side a content change alongside it cannot be detected at all.
+    warn_missing_etag(item.item_id, previous_etag, item.etag);
+    if (path_changed && name_changed) return 'moved_and_renamed';
+    return path_changed ? 'moved' : 'renamed';
+  }
 
   if (is_etag_transition(previous_etag, item.etag, previously_known)) {
     warn_missing_etag(item.item_id, previous_etag, item.etag);
@@ -55,6 +59,6 @@ function warn_missing_etag(
 ): void {
   if (previous_etag || current_etag) return;
   logger.warn(
-    `SharePoint delta item ${item_id}: missing etag on prior and current snapshot; classifying as updated`,
+    `SharePoint delta item ${item_id}: missing etag on prior and current snapshot; a content change cannot be detected`,
   );
 }

--- a/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
@@ -74,6 +74,47 @@ describe('classify_change_type', () => {
     ).toBe('moved_and_renamed');
   });
 
+  it('returns "moved" when the item moved and its content changed in one delta (issue #297)', () => {
+    const item = make_item({ parent_path: '/Archive', etag: '"e2"' });
+    // The new content blob records the update; nothing but this label records the old location.
+    expect(
+      classify_change_type(
+        item,
+        { 'item-1': '/Documents' },
+        { 'item-1': 'report.docx' },
+        { 'item-1': '"e1"' },
+      ),
+    ).toBe('moved');
+  });
+
+  it('returns "moved_and_renamed" when path, name and content all changed', () => {
+    const item = make_item({
+      parent_path: '/Archive',
+      file_name: 'report-v2.docx',
+      etag: '"e2"',
+    });
+    expect(
+      classify_change_type(
+        item,
+        { 'item-1': '/Documents' },
+        { 'item-1': 'report.docx' },
+        { 'item-1': '"e1"' },
+      ),
+    ).toBe('moved_and_renamed');
+  });
+
+  it('returns "renamed" when the name and the content changed together', () => {
+    const item = make_item({ file_name: 'report-v2.docx', etag: '"e2"' });
+    expect(
+      classify_change_type(
+        item,
+        { 'item-1': '/Documents' },
+        { 'item-1': 'report.docx' },
+        { 'item-1': '"e1"' },
+      ),
+    ).toBe('renamed');
+  });
+
   it('returns undefined when nothing changed', () => {
     const item = make_item({ etag: '"same"' });
     expect(

--- a/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
@@ -160,7 +160,11 @@ describe('classify_change_type', () => {
     expect(
       classify_change_type(item, { 'item-1': '/Documents' }, { 'item-1': 'report.docx' }, {}),
     ).toBe('moved');
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing etag'));
+    // The whole line, not a substring: a message change should show up here as a diff.
+    expect(warn).toHaveBeenCalledWith(
+      'SharePoint delta item item-1: missing etag on prior and current snapshot; ' +
+        'a content change cannot be detected',
+    );
 
     warn.mockRestore();
   });

--- a/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { logger } from '@wisecom/atlas-core/utils/logger';
 import type { SharePointDeltaItem } from '@wisecom/atlas-types';
 import { classify_change_type } from '@/services/backup/change-classifier';
 
@@ -149,5 +150,18 @@ describe('classify_change_type', () => {
   it('returns "updated" when both prior and current etag are missing but item is known', () => {
     const item = make_item();
     expect(classify_change_type(item, { 'item-1': '/Documents' }, {}, {})).toBe('updated');
+  });
+
+  it('warns about the missing etags but still reports the move (issue #297)', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const item = make_item({ parent_path: '/Archive' });
+
+    // No etag on either side: the move is certain, a content change alongside it is invisible.
+    expect(
+      classify_change_type(item, { 'item-1': '/Documents' }, { 'item-1': 'report.docx' }, {}),
+    ).toBe('moved');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing etag'));
+
+    warn.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

A drive item that moved or was renamed **and** whose content changed inside one delta window was recorded as `updated`. The ETag branch answered before the path and name were ever compared, so the move was erased from the change record and anything reading `change_type` to reconstruct where a file went saw a content update at the old location.

Closes #297

## Changes

Both classifiers now compare relocation before content: `moved_and_renamed`, `moved`, `renamed`, and only then the ETag transitions that mean `updated`. The rationale is in the code, because the ordering is the whole behaviour: the new content blob already makes an update self-evident, while the old location is recorded nowhere except this label.

Applied twice, since `change-classifier.ts` is still two copies. #306 measured that pair at 37 differing lines and left it alone; the ordering fix lands first so that sharing the module later is a shape change with no behaviour in it, rather than a refactor carrying a live bug.

## Why this is label-only

`change_type` never gates a download. `delta-item-processor` classifies, then downloads and version-syncs every non-deleted, non-quarantined item regardless of the label, and passes the label to `build_stored_entry` for the manifest. Grep confirms no consumer branches on `'moved'`, `'renamed'` or `'moved_and_renamed'`, so no path can now skip content it used to fetch. That was the risk worth checking before reordering.

## Tests

- `packages/onedrive/tests/unit/services/backup/change-classifier.test.ts`, new: OneDrive had no dedicated classifier test at all. Covers created, updated, moved, deleted, no-change and both ETag-presence transitions, plus the three combined cases.
- `packages/sharepoint/.../change-classifier.test.ts`: three combined cases added next to the existing single-signal ones, so move-with-content-change, move-and-rename-with-content-change and rename-with-content-change are each pinned.

## Checklist

- `pnpm run lint`, `pnpm run typecheck` and both suites pass. Counts go 260 to 270 and 305 to 308.
- `change_type` values are not documented in `docs/`, so no documentation is due.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup change detection for OneDrive and SharePoint.
  * Items moved or renamed during the same sync window are now correctly identified, including when their content also changes.
  * Move and rename detection is preserved when content metadata is unavailable, with clearer warnings that content changes cannot be detected.

* **Tests**
  * Added coverage for creations, updates, deletions, moves, renames, combined changes, unchanged items, and missing content metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->