### PR TITLE
fix: remove the partial archive when a save fails before finalizing

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -54,17 +54,17 @@ atlas outlook backup -m user@company.com --retention-days 365 --lock-mode compli
 atlas outlook backup -t <tenant-id> -m user@company.com        # explicit tenant
 ```
 
-| Option                   | Description                                                               |
-| ------------------------ | ------------------------------------------------------------------------- |
-| `-m, --mailbox <id>`     | Mailbox to back up (required)                                             |
-| `-f, --folder <name...>` | Filter to specific folder(s) by name or path (see below)                  |
-| `--full`                 | Ignore saved delta links, run full enumeration                            |
-| `-P, --page-size <n>`    | Graph API page size per delta request (1--100, default 10)                |
-| `--retention-days <n>`   | Apply Object Lock retention for `n` days                                  |
-| `--lock-mode <mode>`     | Object Lock mode (`governance` or `compliance`); requires `--retention-days` |
-| `-t, --tenant <id>`      | Override tenant ID from config                                            |
-| `--exclude-junk`         | Skip the Junk Email folder and its subfolders                             |
-| `--include-recoverable-items` | Also back up hard-deleted and hold-retained mail (see below)          |
+| Option                        | Description                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `-m, --mailbox <id>`          | Mailbox to back up (required)                                                |
+| `-f, --folder <name...>`      | Filter to specific folder(s) by name or path (see below)                     |
+| `--full`                      | Ignore saved delta links, run full enumeration                               |
+| `-P, --page-size <n>`         | Graph API page size per delta request (1--100, default 10)                   |
+| `--retention-days <n>`        | Apply Object Lock retention for `n` days                                     |
+| `--lock-mode <mode>`          | Object Lock mode (`governance` or `compliance`); requires `--retention-days` |
+| `-t, --tenant <id>`           | Override tenant ID from config                                               |
+| `--exclude-junk`              | Skip the Junk Email folder and its subfolders                                |
+| `--include-recoverable-items` | Also back up hard-deleted and hold-retained mail (see below)                 |
 
 `--lock-mode` only means something alongside `--retention-days`: the mode selects how retention is enforced, it does not request retention on its own. Passing it alone is rejected rather than ignored, so a run that was meant to be immutable cannot exit `0` with unprotected data. Retention without a mode defaults to `governance`.
 
@@ -74,15 +74,15 @@ Requesting retention is fail-closed: when the bucket has versioning or Object Lo
 
 Every mail folder in the mailbox, at any nesting depth, including the ones Outlook treats as special:
 
-| Folder | Backed up | Note |
-| ------------------------------ | -------------- | ------------------------------------------------------------------------ |
-| Inbox, Sent Items, Deleted Items, Archive, and user folders | Yes | Including nested subfolders at any depth |
-| **Drafts** and **Outbox** | Yes | Unsent work exists nowhere else, so it is content like any other |
-| **Junk Email** | Yes | Opt out with `--exclude-junk`. Junk is evidence in a phishing or BEC case |
-| Hidden folders (`isHidden`) | Yes | Enumerated explicitly; Graph omits them unless asked |
-| Hidden Exchange system folders | No | A short deny-list of client-state folders such as `Conversation Action Settings`, matched only when Exchange also reports them hidden |
-| In-Place Archive mailbox | No | Graph cannot read it at all. See [In-Place Archive is out of scope](../security.md#in-place-archive-is-out-of-scope) |
-| **Recoverable Items** | Opt-in | `--include-recoverable-items`. Hard-deleted and hold-retained mail; see below |
+| Folder                                                      | Backed up | Note                                                                                                                                  |
+| ----------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Inbox, Sent Items, Deleted Items, Archive, and user folders | Yes       | Including nested subfolders at any depth                                                                                              |
+| **Drafts** and **Outbox**                                   | Yes       | Unsent work exists nowhere else, so it is content like any other                                                                      |
+| **Junk Email**                                              | Yes       | Opt out with `--exclude-junk`. Junk is evidence in a phishing or BEC case                                                             |
+| Hidden folders (`isHidden`)                                 | Yes       | Enumerated explicitly; Graph omits them unless asked                                                                                  |
+| Hidden Exchange system folders                              | No        | A short deny-list of client-state folders such as `Conversation Action Settings`, matched only when Exchange also reports them hidden |
+| In-Place Archive mailbox                                    | No        | Graph cannot read it at all. See [In-Place Archive is out of scope](../security.md#in-place-archive-is-out-of-scope)                  |
+| **Recoverable Items**                                       | Opt-in    | `--include-recoverable-items`. Hard-deleted and hold-retained mail; see below                                                         |
 
 Anything skipped is reported at the end of the run and recorded in the snapshot manifest with its reason, so "was folder X captured?" is answerable from the backup rather than from whoever ran it:
 
@@ -94,7 +94,6 @@ Anything skipped is reported at the end of the run and recorded in the snapshot 
 ::: warning Drafts and Outbox are new in 4.1.0
 Earlier versions silently skipped Drafts and Outbox. New snapshots include them, which makes the first backup after upgrading larger than the previous one for mailboxes that hold unsent mail. Existing snapshots are unaffected; the content appears as those folders sync for the first time.
 :::
-
 
 #### Recoverable Items, the Exchange dumpster
 
@@ -108,15 +107,15 @@ expires the item is gone from the tenant and from every snapshot.
 atlas outlook backup -m user@company.com --include-recoverable-items
 ```
 
-| Subfolder | Backed up | Contains |
-| ------------------ | --------- | ------------------------------------------------------------- |
-| `Deletions` | Yes | Items removed from Deleted Items, user-recoverable for 14 to 30 days |
-| `Purges` | Yes | Hard-deleted items retained only by litigation hold or single item recovery |
-| `DiscoveryHolds` | Yes | Hard-deleted items retained by an In-Place Hold or retention policy |
-| `SubstrateHolds` | Yes | Original copies of held Teams messages and modified held items |
-| `Versions` | No | Pre-modification copies whose item shape is not a message |
-| `Calendar Logging` | No | Calendar change audit trail |
-| `Audits` | No | Mailbox audit log entries |
+| Subfolder          | Backed up | Contains                                                                    |
+| ------------------ | --------- | --------------------------------------------------------------------------- |
+| `Deletions`        | Yes       | Items removed from Deleted Items, user-recoverable for 14 to 30 days        |
+| `Purges`           | Yes       | Hard-deleted items retained only by litigation hold or single item recovery |
+| `DiscoveryHolds`   | Yes       | Hard-deleted items retained by an In-Place Hold or retention policy         |
+| `SubstrateHolds`   | Yes       | Original copies of held Teams messages and modified held items              |
+| `Versions`         | No        | Pre-modification copies whose item shape is not a message                   |
+| `Calendar Logging` | No        | Calendar change audit trail                                                 |
+| `Audits`           | No        | Mailbox audit log entries                                                   |
 
 Everything not captured is reported at the end of the run with its reason, and a
 subfolder Atlas does not recognise is reported rather than guessed at, so a new
@@ -175,11 +174,11 @@ atlas outlook verify -m user@company.com -s <snapshot-id> -t <tenant-id>
 atlas outlook verify -m user@company.com -s <snapshot-id> --fast
 ```
 
-| Option                  | Description                                                                                 |
-| ----------------------- | ------------------------------------------------------------------------------------------- |
-| `-m, --mailbox <email>` | Mailbox that owns the snapshot (required)                                                   |
-| `-s, --snapshot <id>`   | Snapshot identifier to verify (required)                                                    |
-| `-t, --tenant <id>`     | Override tenant ID from config                                                              |
+| Option                  | Description                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------- |
+| `-m, --mailbox <email>` | Mailbox that owns the snapshot (required)                                                      |
+| `-s, --snapshot <id>`   | Snapshot identifier to verify (required)                                                       |
+| `-t, --tenant <id>`     | Override tenant ID from config                                                                 |
 | `--fast`                | Existence-only checks (`HeadObject` per referenced key), with no download, decrypt, or hashing |
 
 ::: details What exactly is verified?
@@ -214,16 +213,16 @@ atlas outlook restore -m user@company.com -T other@company.com
 atlas outlook restore -m user@company.com -T other@company.com -f Inbox
 ```
 
-| Option                      | Description                                                     |
-| --------------------------- | --------------------------------------------------------------- |
-| `-s, --snapshot <id>`       | Restore from a specific snapshot                                |
-| `-m, --mailbox <email>`     | Restore from all snapshots for this mailbox                     |
-| `-T, --target <email>`      | Target mailbox for cross-mailbox restore (defaults to source)   |
-| `-f, --folder <name>`       | Restore only messages from this folder or its subfolders        |
-| `--message <ref>`           | Restore a single message by `#` index from `atlas outlook list` |
-| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date                 |
-| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date                |
-| `-t, --tenant <id>`         | Override tenant ID                                              |
+| Option                        | Description                                                           |
+| ----------------------------- | --------------------------------------------------------------------- |
+| `-s, --snapshot <id>`         | Restore from a specific snapshot                                      |
+| `-m, --mailbox <email>`       | Restore from all snapshots for this mailbox                           |
+| `-T, --target <email>`        | Target mailbox for cross-mailbox restore (defaults to source)         |
+| `-f, --folder <name>`         | Restore only messages from this folder or its subfolders              |
+| `--message <ref>`             | Restore a single message by `#` index from `atlas outlook list`       |
+| `--start-date <YYYY-MM-DD>`   | Include snapshots created on or after this date                       |
+| `--end-date <YYYY-MM-DD>`     | Include snapshots created on or before this date                      |
+| `-t, --tenant <id>`           | Override tenant ID                                                    |
 | `--include-recoverable-items` | Also include hard-deleted and hold-retained mail; excluded by default |
 
 Exactly one of `--snapshot` or `--mailbox` is required; passing both exits `1`, as described under [`atlas outlook`](#atlas-outlook). `-T, --target` works in either mode. In mailbox mode, entries are deduplicated across snapshots (newest version of each message wins). Cross-mailbox restores preserve the original folder names from the source mailbox. Nested source folders are recreated as nested subfolders under the `Restore-{timestamp}` root, so `Inbox/Projects/2026` restores to `Restore-.../Inbox/Projects/2026` instead of collapsing into one flat level.
@@ -268,12 +267,12 @@ atlas outlook read -s <snapshot-id> --message 34 --raw
 atlas outlook read -s <snapshot-id> --message 34 --raw > message.eml
 ```
 
-| Option                | Description                                                        |
-| --------------------- | ------------------------------------------------------------------ |
-| `-s, --snapshot <id>` | Snapshot containing the message                                    |
-| `--message <ref>`     | Message `#` from `atlas outlook list`, or full Graph message ID    |
+| Option                | Description                                                           |
+| --------------------- | --------------------------------------------------------------------- |
+| `-s, --snapshot <id>` | Snapshot containing the message                                       |
+| `--message <ref>`     | Message `#` from `atlas outlook list`, or full Graph message ID       |
 | `--raw`               | Output the stored object verbatim instead of formatted headers + body |
-| `-t, --tenant <id>`   | Override tenant ID                                                 |
+| `-t, --tenant <id>`   | Override tenant ID                                                    |
 
 What `--raw` prints depends on the format of the stored object. For a message archived as RFC 5322 MIME -- the default for snapshots taken by this version -- Atlas writes the decrypted MIME bytes to stdout verbatim: no banner, no colour, no added trailing newline. Redirecting that output produces a valid `.eml` file with its original `Received:` chain, `Authentication-Results`, and any S/MIME payload intact, which is what you want when handing a single message to an investigator or verifying a DKIM signature by hand.
 
@@ -316,17 +315,17 @@ atlas outlook save -m user@company.com --start-date 2026-01-01
 atlas outlook save -m user@company.com --start-date 2026-01-01 --end-date 2026-06-30
 ```
 
-| Option                      | Description                                                  |
-| --------------------------- | ------------------------------------------------------------ |
-| `-s, --snapshot <id>`       | Save from a specific snapshot                                |
-| `-m, --mailbox <email>`     | Save from all snapshots for this mailbox                     |
-| `-f, --folder <name>`       | Save only messages from this folder or its subfolders        |
-| `--message <ref>`           | Save a single message by `#` index from `atlas outlook list` |
-| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date              |
-| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date             |
-| `-o, --output <path>`       | Output file path (default: `Restore-<timestamp>.zip`)        |
-| `--skip-verify`             | Skip SHA-256 integrity checks (faster on low-power systems)  |
-| `-t, --tenant <id>`         | Override tenant ID                                           |
+| Option                        | Description                                                           |
+| ----------------------------- | --------------------------------------------------------------------- |
+| `-s, --snapshot <id>`         | Save from a specific snapshot                                         |
+| `-m, --mailbox <email>`       | Save from all snapshots for this mailbox                              |
+| `-f, --folder <name>`         | Save only messages from this folder or its subfolders                 |
+| `--message <ref>`             | Save a single message by `#` index from `atlas outlook list`          |
+| `--start-date <YYYY-MM-DD>`   | Include snapshots created on or after this date                       |
+| `--end-date <YYYY-MM-DD>`     | Include snapshots created on or before this date                      |
+| `-o, --output <path>`         | Output file path (default: `Restore-<timestamp>.zip`)                 |
+| `--skip-verify`               | Skip SHA-256 integrity checks (faster on low-power systems)           |
+| `-t, --tenant <id>`           | Override tenant ID                                                    |
 | `--include-recoverable-items` | Also include hard-deleted and hold-retained mail; excluded by default |
 
 With both `-s` and `-m`, the named snapshot is exported and `-m` is ignored with a warning; see [`atlas outlook`](#atlas-outlook). Earlier releases silently exported the whole mailbox instead.
@@ -497,27 +496,27 @@ atlas onedrive delete -o user@company.com -s od-snap-123
 atlas onedrive delete -o user@company.com -y
 ```
 
-| Option           | Description                                                              |
-| ---------------- | ------------------------------------------------------------------------ |
-| `backup`         | Incremental sync; use `--full` to ignore saved delta state               |
-| `restore`        | Restore files from a snapshot to the user's (or another user's) OneDrive |
-| `list-snapshots` | List snapshot IDs and timestamps for the owner                           |
-| `list-versions`  | List indexed versions for one file (`-f` file ID or path)                |
-| `restore-version`| Push stored file versions back into the drive, one file or a whole rollback |
-| `verify`         | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows    |
-| `status`         | Report pending Graph changes per drive without backing up                |
-| `delete`         | Delete the owner's OneDrive backups, or a single snapshot                |
+| Option            | Description                                                                 |
+| ----------------- | --------------------------------------------------------------------------- |
+| `backup`          | Incremental sync; use `--full` to ignore saved delta state                  |
+| `restore`         | Restore files from a snapshot to the user's (or another user's) OneDrive    |
+| `list-snapshots`  | List snapshot IDs and timestamps for the owner                              |
+| `list-versions`   | List indexed versions for one file (`-f` file ID or path)                   |
+| `restore-version` | Push stored file versions back into the drive, one file or a whole rollback |
+| `verify`          | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows       |
+| `status`          | Report pending Graph changes per drive without backing up                   |
+| `delete`          | Delete the owner's OneDrive backups, or a single snapshot                   |
 
 **`atlas onedrive backup`**
 
-| Option                 | Description                                                           |
-| ---------------------- | --------------------------------------------------------------------- |
-| `-o, --owner <id>`     | User email or Entra object ID (required)                              |
-| `--full`               | Force full crawl ignoring saved delta links                           |
-| `--folder <path>`      | Back up only this folder and its subfolders; see note below           |
-| `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (see note below) |
+| Option                 | Description                                                                                        |
+| ---------------------- | -------------------------------------------------------------------------------------------------- |
+| `-o, --owner <id>`     | User email or Entra object ID (required)                                                           |
+| `--full`               | Force full crawl ignoring saved delta links                                                        |
+| `--folder <path>`      | Back up only this folder and its subfolders; see note below                                        |
+| `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (see note below)                              |
 | `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`); requires `--retention-days` |
-| `-t, --tenant <id>`    | Override tenant ID from config                                        |
+| `-t, --tenant <id>`    | Override tenant ID from config                                                                     |
 
 While the backup runs, a live dashboard shows one row per drive: delta fetch (`fetching changes...`), then per-item progress with rate and ETA, finishing as `[ok]` with stored/dedup/version counts or `[==] up to date` when an incremental delta has no changes. Non-interactive runs (cron/CI) print one plain log line per finished drive instead. Service messages (version syncs, warnings) print above the live region.
 
@@ -535,17 +534,17 @@ A snapshot taken with `--folder` contains only that folder's files. Restoring it
 
 **`atlas onedrive restore`**
 
-| Option                     | Description                                                                       |
-| -------------------------- | --------------------------------------------------------------------------------- |
-| `-o, --owner <id>`         | User email or Entra object ID (required)                                           |
-| `-s, --snapshot <id>`      | Snapshot to restore from (required)                                                |
-| `--target-owner <id>`      | Restore to a different user's OneDrive (defaults to owner)                         |
-| `--destination <path>`     | Folder to restore under, created when missing (default: `/Restore-<timestamp>`)    |
-| `--in-place`               | Restore to the original paths instead of a restore root                            |
-| `--name <filename>`        | Rename the restored file; rejected unless exactly one file matches                 |
-| `--file-filter <paths...>` | Only restore specific files by ID or path                                          |
-| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`)          |
-| `-t, --tenant <id>`        | Override tenant ID from config                                                     |
+| Option                     | Description                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------- |
+| `-o, --owner <id>`         | User email or Entra object ID (required)                                        |
+| `-s, --snapshot <id>`      | Snapshot to restore from (required)                                             |
+| `--target-owner <id>`      | Restore to a different user's OneDrive (defaults to owner)                      |
+| `--destination <path>`     | Folder to restore under, created when missing (default: `/Restore-<timestamp>`) |
+| `--in-place`               | Restore to the original paths instead of a restore root                         |
+| `--name <filename>`        | Rename the restored file; rejected unless exactly one file matches              |
+| `--file-filter <paths...>` | Only restore specific files by ID or path                                       |
+| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`)        |
+| `-t, --tenant <id>`        | Override tenant ID from config                                                  |
 
 A drive restore nests under `/Restore-<timestamp>` at the target drive root and recreates the original folder structure beneath it, matching how Outlook restores have always worked. `--in-place` reproduces the pre-4.0.0 behaviour of writing back over the original paths; it is never the default, because `--conflict rename` turns a repeated in-place restore into suffixed duplicates scattered through live content rather than a failure. See [Where restored files land](/onedrive-backup#where-restored-files-land).
 
@@ -573,15 +572,15 @@ Identifiers are matched case-insensitively: `--owner`, `--site`, and `--file-fil
 Restores the version bytes Atlas holds. Use it to roll a file back past a bad
 edit, or a whole folder back past a mass encrypt-and-sync event.
 
-| Option              | Description                                                                  |
-| ------------------- | ---------------------------------------------------------------------------- |
-| `-o, --owner <id>`  | User email or Entra object ID (required)                                     |
-| `-f, --file <ref>`  | Graph file ID or drive path; required with `--version`                       |
-| `--version <id>`    | Exact stored version, as shown in the `Version` column of `list-versions`    |
-| `--before <iso>`    | Restore each file's newest version at or before this instant                  |
-| `--path <prefix>`   | Limit a `--before` rollback to this folder and below                         |
-| `--in-place`        | Upload over the original file instead of writing a copy beside it            |
-| `-t, --tenant <id>` | Override tenant ID from config                                               |
+| Option              | Description                                                               |
+| ------------------- | ------------------------------------------------------------------------- |
+| `-o, --owner <id>`  | User email or Entra object ID (required)                                  |
+| `-f, --file <ref>`  | Graph file ID or drive path; required with `--version`                    |
+| `--version <id>`    | Exact stored version, as shown in the `Version` column of `list-versions` |
+| `--before <iso>`    | Restore each file's newest version at or before this instant              |
+| `--path <prefix>`   | Limit a `--before` rollback to this folder and below                      |
+| `--in-place`        | Upload over the original file instead of writing a copy beside it         |
+| `-t, --tenant <id>` | Override tenant ID from config                                            |
 
 Either `--file` with `--version`, or `--before`. `--version` alone is rejected
 because a version id is only unique within one file, and `--path` cannot be
@@ -618,6 +617,8 @@ to restore.
 **`atlas onedrive save`**
 
 Save decrypted files from a OneDrive snapshot to a local zip archive. The archive preserves the original folder structure. Each file is SHA-256 verified after decryption by default.
+
+A save that fails before the archive is finalised leaves no file behind: the stream is destroyed and the partial zip is removed, because a truncated archive is indistinguishable from a finished one. An output path that already held a file is never deleted, so pointing `-O` at an existing file and having the run fail leaves that file untouched.
 
 ```bash
 atlas onedrive save -o user@company.com -s od-snap-1735689600000-a1b2c3
@@ -669,12 +670,12 @@ Reports pending Graph changes per drive by replaying the saved delta links from 
 
 Deletes the owner's OneDrive backups behind the same confirmation prompt as the Outlook delete. Without `-s` it sweeps the owner's `manifests`, `data`, `index`, `_meta` and `staging` prefixes, staging included so an interrupted large-file upload does not leave file content parked in the bucket. With `-s` only that snapshot's manifest is removed; the content-addressed blobs stay, because other snapshots may reference them.
 
-| Option                | Description                                          |
-| --------------------- | ---------------------------------------------------- |
-| `-o, --owner <id>`    | User email or Entra object ID (required)             |
-| `-s, --snapshot <id>` | Delete only this snapshot instead of every backup    |
-| `-y, --yes`           | Skip confirmation prompt                             |
-| `-t, --tenant <id>`   | Override tenant ID from config                       |
+| Option                | Description                                       |
+| --------------------- | ------------------------------------------------- |
+| `-o, --owner <id>`    | User email or Entra object ID (required)          |
+| `-s, --snapshot <id>` | Delete only this snapshot instead of every backup |
+| `-y, --yes`           | Skip confirmation prompt                          |
+| `-t, --tenant <id>`   | Override tenant ID from config                    |
 
 ::: tip Permissions
 Application permissions `Files.Read.All` and `User.Read.All` are required for backup and read operations; `Files.ReadWrite.All` is additionally required for restore. See Details and storage layout are documented on the [OneDrive Backup](/onedrive-backup) page.
@@ -702,28 +703,28 @@ atlas sharepoint delete --site https://contoso.sharepoint.com/sites/Engineering 
 atlas sharepoint delete --site https://contoso.sharepoint.com/sites/Engineering -y
 ```
 
-| Subcommand       | Description                                                           |
-| ---------------- | --------------------------------------------------------------------- |
-| `backup`         | Incremental sync; use `--full` to ignore saved delta state            |
-| `list-snapshots` | List all SharePoint snapshots for a site                              |
-| `list-versions`  | List all backed-up versions for a specific file                       |
-| `restore-version`| Push stored file versions back into the library, one file or a whole rollback |
-| `restore`        | Restore files from a snapshot back to the site's document libraries   |
-| `save`           | Decrypt and save files from a snapshot to a local zip archive         |
-| `verify`         | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows |
-| `status`         | Report pending Graph changes per document library without backing up  |
-| `delete`         | Delete the site's SharePoint backups, or a single snapshot            |
+| Subcommand        | Description                                                                   |
+| ----------------- | ----------------------------------------------------------------------------- |
+| `backup`          | Incremental sync; use `--full` to ignore saved delta state                    |
+| `list-snapshots`  | List all SharePoint snapshots for a site                                      |
+| `list-versions`   | List all backed-up versions for a specific file                               |
+| `restore-version` | Push stored file versions back into the library, one file or a whole rollback |
+| `restore`         | Restore files from a snapshot back to the site's document libraries           |
+| `save`            | Decrypt and save files from a snapshot to a local zip archive                 |
+| `verify`          | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows         |
+| `status`          | Report pending Graph changes per document library without backing up          |
+| `delete`          | Delete the site's SharePoint backups, or a single snapshot                    |
 
 **`atlas sharepoint backup`**
 
-| Option                 | Description                                                                       |
-| ---------------------- | --------------------------------------------------------------------------------- |
-| `--site <url-or-id>`   | SharePoint site URL or Graph site ID (required)                                   |
-| `--full`               | Force full crawl ignoring saved delta links                                       |
-| `--include-subsites`   | Also back up every subsite beneath the site, one snapshot per subsite             |
-| `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (same semantics as OneDrive) |
+| Option                 | Description                                                                                        |
+| ---------------------- | -------------------------------------------------------------------------------------------------- |
+| `--site <url-or-id>`   | SharePoint site URL or Graph site ID (required)                                                    |
+| `--full`               | Force full crawl ignoring saved delta links                                                        |
+| `--include-subsites`   | Also back up every subsite beneath the site, one snapshot per subsite                              |
+| `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (same semantics as OneDrive)                  |
 | `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`); requires `--retention-days` |
-| `-t, --tenant <id>`    | Override tenant ID from config                                                    |
+| `-t, --tenant <id>`    | Override tenant ID from config                                                                     |
 
 :::: tip Subsites are separate sites
 `GET /sites/{site-id}/sites` returns only a site's _direct_ subsites, so Atlas walks the tree explicitly. By default a backup covers the named site alone and emits one warning per uncovered subsite. Classic site collections with nested subsite trees would otherwise look fully protected while entire subsites sat outside the backup.
@@ -750,15 +751,15 @@ Graph returns only the subsites the application can read. A subsite that cannot 
 
 **`atlas sharepoint restore-version`**
 
-| Option               | Description                                                               |
-| -------------------- | ------------------------------------------------------------------------- |
-| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required)                           |
-| `-f, --file <ref>`   | File ID or path; required with `--version`                                |
-| `--version <id>`     | Exact stored version, as shown by `list-versions`                         |
-| `--before <iso>`     | Restore each file's newest version at or before this instant               |
-| `--path <prefix>`    | Limit a `--before` rollback to this folder and below                      |
-| `--in-place`         | Upload over the original file instead of writing a copy beside it         |
-| `-t, --tenant <id>`  | Override tenant ID from config                                            |
+| Option               | Description                                                       |
+| -------------------- | ----------------------------------------------------------------- |
+| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required)                   |
+| `-f, --file <ref>`   | File ID or path; required with `--version`                        |
+| `--version <id>`     | Exact stored version, as shown by `list-versions`                 |
+| `--before <iso>`     | Restore each file's newest version at or before this instant      |
+| `--path <prefix>`    | Limit a `--before` rollback to this folder and below              |
+| `--in-place`         | Upload over the original file instead of writing a copy beside it |
+| `-t, --tenant <id>`  | Override tenant ID from config                                    |
 
 Identical semantics to [`atlas onedrive restore-version`](#atlas-onedrive),
 including the copy-by-default placement and the reason Atlas uploads its own
@@ -767,16 +768,16 @@ into the document library they were captured from.
 
 **`atlas sharepoint restore`**
 
-| Option                      | Description                                                                    |
-| --------------------------- | ------------------------------------------------------------------------------ |
-| `--site <url-or-id>`        | SharePoint site URL or Graph site ID (required)                                |
-| `-s, --snapshot <id>`       | SharePoint snapshot ID (required)                                              |
-| `--target-site <url-or-id>` | Restore to a different site (defaults to original)                             |
+| Option                      | Description                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------- |
+| `--site <url-or-id>`        | SharePoint site URL or Graph site ID (required)                                 |
+| `-s, --snapshot <id>`       | SharePoint snapshot ID (required)                                               |
+| `--target-site <url-or-id>` | Restore to a different site (defaults to original)                              |
 | `--destination <path>`      | Folder to restore under, created when missing (default: `/Restore-<timestamp>`) |
 | `--in-place`                | Restore to the original paths instead of a restore root                         |
-| `--name <filename>`         | Rename the restored file; rejected unless exactly one file matches             |
-| `--file-filter <paths...>`  | Only restore specific files (by ID or path)                                    |
-| `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`)       |
+| `--name <filename>`         | Rename the restored file; rejected unless exactly one file matches              |
+| `--file-filter <paths...>`  | Only restore specific files (by ID or path)                                     |
+| `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`)        |
 | `-t, --tenant <id>`         | Override tenant ID from config                                                  |
 
 Restored files nest under `Restore-<timestamp>` in each destination library, with the original
@@ -993,7 +994,7 @@ atlas rehydrate -o user@company.com -s od-snap-1735689600000-a1b2c3 --source-con
 | `--all`                     | Recover every workload: Outlook, OneDrive, and SharePoint    |
 | `--source-endpoint <url>`   | Source replica S3 endpoint URL                               |
 | `--source-access-key <key>` | Source replica S3 access key                                 |
-| `--source-secret-key <key>` | Source replica S3 secret key; `-` reads it from stdin         |
+| `--source-secret-key <key>` | Source replica S3 secret key; `-` reads it from stdin        |
 | `--source-region <region>`  | Source replica S3 region (default: `us-east-1`)              |
 | `--source-config <path>`    | Path to JSON file with source S3 credentials                 |
 | `-t, --tenant <id>`         | Override tenant ID                                           |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -618,7 +618,7 @@ to restore.
 
 Save decrypted files from a OneDrive snapshot to a local zip archive. The archive preserves the original folder structure. Each file is SHA-256 verified after decryption by default.
 
-A save that fails before the archive is finalised leaves no file behind: the stream is destroyed and the partial zip is removed, because a truncated archive is indistinguishable from a finished one. An output path that already held a file is never deleted, so pointing `-O` at an existing file and having the run fail leaves that file untouched.
+The archive is written to a temporary file next to the output path and moved onto it only once it is complete, so a save that fails leaves nothing behind: a truncated archive is indistinguishable from a finished one. It also means a file already sitting at the output path is not touched until a successful run replaces it, so pointing `-O` at an existing file and having the run fail leaves that file exactly as it was.
 
 ```bash
 atlas onedrive save -o user@company.com -s od-snap-1735689600000-a1b2c3

--- a/packages/core/src/services/shared/file-save-zip-writer.ts
+++ b/packages/core/src/services/shared/file-save-zip-writer.ts
@@ -1,5 +1,6 @@
-import { createWriteStream, existsSync, type WriteStream } from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import { createWriteStream, type WriteStream } from 'node:fs';
+import { rename, rm } from 'node:fs/promises';
 import { ZipArchive, type Archiver } from 'archiver';
 import { logger } from '@/utils/logger';
 
@@ -10,43 +11,53 @@ export interface FileArchive {
   readonly archive: FileArchiveWriter;
   readonly promise: Promise<number>;
   /**
-   * Destroys the stream and removes the partial file, for a run that failed before finalizing.
-   *
-   * A truncated zip left at the output path is indistinguishable from a complete one, which is
-   * worse than no file at all when the reason an operator ran a save is that they need the bytes
-   * (issue #307). A path that already held a file is never removed: the caller may have been
-   * handed the path of something unrelated.
+   * Moves the finished archive onto the output path. Call it after the archive is finalized and
+   * the byte count has resolved; until then the output path is untouched.
    */
+  publish(): Promise<void>;
+  /** Destroys the stream and removes the temporary file, for a run that failed before publishing. */
   abort(): Promise<void>;
 }
 
-/** Creates a zip archive writing to the given file path. Returns the archiver and a promise that resolves with total bytes written. */
+/**
+ * Creates a zip archive for the given output path. Returns the archiver and a promise that
+ * resolves with total bytes written.
+ *
+ * Entries are written to a sibling temporary file and moved onto the output path by
+ * {@link FileArchive.publish}, so nothing appears there until the archive is complete. A
+ * truncated zip is indistinguishable from a finished one, which is worse than no file at all when
+ * the reason an operator ran a save is that they need the bytes (issue #307), and a save that
+ * fails must not destroy a file that was already sitting at the path it was pointed at.
+ */
 export function create_file_archive(output_path: string): FileArchive {
-  const pre_existing = existsSync(output_path);
-  const output = createWriteStream(output_path);
+  const staging_path = `${output_path}.part-${randomBytes(6).toString('hex')}`;
+  const output = createWriteStream(staging_path);
   const archive = new ZipArchive({ zlib: { level: 6 } });
 
   const promise = new Promise<number>((resolve, reject) => {
     output.on('close', () => resolve(archive.pointer()));
     archive.on('error', reject);
+    // Errors on the destination are not forwarded through pipe(), so without this a failed write
+    // resolves on `close` and the caller reports a successful save.
+    output.on('error', reject);
   });
-  // Attach a handler now, so an archive error raised while entries are still being written is
-  // not an unhandled rejection. Awaiting `promise` later still sees the rejection.
+  // Attach a handler now, so an error raised while entries are still being written is not an
+  // unhandled rejection. Awaiting `promise` later still sees the rejection.
   promise.catch(() => undefined);
 
   archive.pipe(output);
   return {
     archive,
     promise,
-    abort: () => abort_archive(archive, output, output_path, pre_existing),
+    publish: () => rename(staging_path, output_path),
+    abort: () => abort_archive(archive, output, staging_path),
   };
 }
 
 async function abort_archive(
   archive: FileArchiveWriter,
   output: WriteStream,
-  output_path: string,
-  pre_existing: boolean,
+  staging_path: string,
 ): Promise<void> {
   try {
     archive.abort();
@@ -54,12 +65,11 @@ async function abort_archive(
     // Already destroyed or never started; the stream teardown below is what matters.
   }
   output.destroy();
-  if (pre_existing) return;
   try {
-    await rm(output_path, { force: true });
+    await rm(staging_path, { force: true });
   } catch (err) {
     logger.warn(
-      `Could not remove the partial archive at ${output_path}: ${err instanceof Error ? err.message : String(err)}`,
+      `Could not remove the partial archive at ${staging_path}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }

--- a/packages/core/src/services/shared/file-save-zip-writer.ts
+++ b/packages/core/src/services/shared/file-save-zip-writer.ts
@@ -1,5 +1,7 @@
-import { createWriteStream } from 'node:fs';
+import { createWriteStream, existsSync, type WriteStream } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { ZipArchive, type Archiver } from 'archiver';
+import { logger } from '@/utils/logger';
 
 /** The archiver instance file entries are appended to. */
 export type FileArchiveWriter = Archiver;
@@ -7,10 +9,20 @@ export type FileArchiveWriter = Archiver;
 export interface FileArchive {
   readonly archive: FileArchiveWriter;
   readonly promise: Promise<number>;
+  /**
+   * Destroys the stream and removes the partial file, for a run that failed before finalizing.
+   *
+   * A truncated zip left at the output path is indistinguishable from a complete one, which is
+   * worse than no file at all when the reason an operator ran a save is that they need the bytes
+   * (issue #307). A path that already held a file is never removed: the caller may have been
+   * handed the path of something unrelated.
+   */
+  abort(): Promise<void>;
 }
 
 /** Creates a zip archive writing to the given file path. Returns the archiver and a promise that resolves with total bytes written. */
 export function create_file_archive(output_path: string): FileArchive {
+  const pre_existing = existsSync(output_path);
   const output = createWriteStream(output_path);
   const archive = new ZipArchive({ zlib: { level: 6 } });
 
@@ -18,9 +30,38 @@ export function create_file_archive(output_path: string): FileArchive {
     output.on('close', () => resolve(archive.pointer()));
     archive.on('error', reject);
   });
+  // Attach a handler now, so an archive error raised while entries are still being written is
+  // not an unhandled rejection. Awaiting `promise` later still sees the rejection.
+  promise.catch(() => undefined);
 
   archive.pipe(output);
-  return { archive, promise };
+  return {
+    archive,
+    promise,
+    abort: () => abort_archive(archive, output, output_path, pre_existing),
+  };
+}
+
+async function abort_archive(
+  archive: FileArchiveWriter,
+  output: WriteStream,
+  output_path: string,
+  pre_existing: boolean,
+): Promise<void> {
+  try {
+    archive.abort();
+  } catch {
+    // Already destroyed or never started; the stream teardown below is what matters.
+  }
+  output.destroy();
+  if (pre_existing) return;
+  try {
+    await rm(output_path, { force: true });
+  } catch (err) {
+    logger.warn(
+      `Could not remove the partial archive at ${output_path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 /** Adds a file to the archive under the given folder path. */

--- a/packages/core/tests/unit/services/shared/file-save-zip-writer.test.ts
+++ b/packages/core/tests/unit/services/shared/file-save-zip-writer.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -22,37 +22,67 @@ afterEach(async () => {
 describe('create_file_archive', () => {
   it('writes an archive and reports the byte count', async () => {
     const output_path = join(dir, 'out.zip');
-    const { archive, promise } = create_file_archive(output_path);
+    const { archive, promise, publish } = create_file_archive(output_path);
 
     await add_file_to_archive(archive, '/Documents', 'report.txt', Buffer.from('hello'));
     await finalize_file_archive(archive);
+    const total_bytes = await promise;
+    await publish();
 
-    expect(await promise).toBeGreaterThan(0);
+    expect(total_bytes).toBeGreaterThan(0);
     expect(existsSync(output_path)).toBe(true);
   });
 
-  it('removes the partial file it created when the run aborts (issue #307)', async () => {
+  it('writes nothing to the output path before it is published (issue #307)', async () => {
+    const output_path = join(dir, 'out.zip');
+    const { archive } = create_file_archive(output_path);
+
+    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+
+    // Entries land in a sibling temporary file, so a truncated zip can never be mistaken for a
+    // finished export at the path an operator was given. The temp file itself is not asserted:
+    // the stream opens lazily, so its appearance is a race, while the output path staying empty
+    // is the guarantee.
+    expect(existsSync(output_path)).toBe(false);
+    expect(readdirSync(dir).filter((name) => name === 'out.zip')).toEqual([]);
+  });
+
+  it('leaves no temporary file behind when the run aborts', async () => {
     const output_path = join(dir, 'partial.zip');
     const { archive, abort } = create_file_archive(output_path);
     await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
 
-    // A truncated zip is indistinguishable from a complete one, so a failed save must leave
-    // nothing behind rather than something that looks like an export.
     await abort();
 
     expect(existsSync(output_path)).toBe(false);
+    expect(readdirSync(dir)).toEqual([]);
   });
 
-  it('keeps a file that already existed at the output path', async () => {
+  it('leaves the bytes of a pre-existing output file untouched when the run aborts', async () => {
     const output_path = join(dir, 'existing.zip');
     writeFileSync(output_path, 'someone else data');
 
-    const { abort } = create_file_archive(output_path);
+    const { archive, abort } = create_file_archive(output_path);
+    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
     await abort();
 
-    // The caller may have been handed the path of something unrelated; deleting it would be
-    // destroying data the save was never asked to touch.
-    expect(existsSync(output_path)).toBe(true);
+    // Not just present: unchanged. Opening the output path for writing truncated it before
+    // anything was written, so checking existence alone hid the loss.
+    expect(readFileSync(output_path, 'utf-8')).toBe('someone else data');
+  });
+
+  it('replaces a pre-existing output file only on a successful publish', async () => {
+    const output_path = join(dir, 'existing.zip');
+    writeFileSync(output_path, 'someone else data');
+
+    const { archive, promise, publish } = create_file_archive(output_path);
+    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+    await finalize_file_archive(archive);
+    await promise;
+    await publish();
+
+    expect(readFileSync(output_path, 'utf-8')).not.toBe('someone else data');
+    expect(readdirSync(dir)).toEqual(['existing.zip']);
   });
 
   it('does not raise when the archive is aborted twice', async () => {

--- a/packages/core/tests/unit/services/shared/file-save-zip-writer.test.ts
+++ b/packages/core/tests/unit/services/shared/file-save-zip-writer.test.ts
@@ -1,0 +1,65 @@
+import { existsSync, writeFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  add_file_to_archive,
+  create_file_archive,
+  finalize_file_archive,
+} from '@/services/shared/file-save-zip-writer';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'atlas-zip-'));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('create_file_archive', () => {
+  it('writes an archive and reports the byte count', async () => {
+    const output_path = join(dir, 'out.zip');
+    const { archive, promise } = create_file_archive(output_path);
+
+    await add_file_to_archive(archive, '/Documents', 'report.txt', Buffer.from('hello'));
+    await finalize_file_archive(archive);
+
+    expect(await promise).toBeGreaterThan(0);
+    expect(existsSync(output_path)).toBe(true);
+  });
+
+  it('removes the partial file it created when the run aborts (issue #307)', async () => {
+    const output_path = join(dir, 'partial.zip');
+    const { archive, abort } = create_file_archive(output_path);
+    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+
+    // A truncated zip is indistinguishable from a complete one, so a failed save must leave
+    // nothing behind rather than something that looks like an export.
+    await abort();
+
+    expect(existsSync(output_path)).toBe(false);
+  });
+
+  it('keeps a file that already existed at the output path', async () => {
+    const output_path = join(dir, 'existing.zip');
+    writeFileSync(output_path, 'someone else data');
+
+    const { abort } = create_file_archive(output_path);
+    await abort();
+
+    // The caller may have been handed the path of something unrelated; deleting it would be
+    // destroying data the save was never asked to touch.
+    expect(existsSync(output_path)).toBe(true);
+  });
+
+  it('does not raise when the archive is aborted twice', async () => {
+    const output_path = join(dir, 'twice.zip');
+    const { abort } = create_file_archive(output_path);
+
+    await abort();
+    await expect(abort()).resolves.toBeUndefined();
+  });
+});

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -76,49 +76,57 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
     const output_path =
       options.output_path ?? build_default_output_path(workload, options.snapshot_id);
     const skip_integrity = options.skip_integrity_check ?? false;
-    const { archive, promise } = create_file_archive(output_path);
+    const { archive, promise, abort } = create_file_archive(output_path);
 
-    const integrity_failures: string[] = [];
-    const { files_saved, files_skipped, errors } = await save_entries_to_archive(
-      workload,
-      ctx,
-      archive,
-      restorable,
-      skip_integrity,
-      integrity_failures,
-      options,
-    );
+    try {
+      const integrity_failures: string[] = [];
+      const { files_saved, files_skipped, errors } = await save_entries_to_archive(
+        workload,
+        ctx,
+        archive,
+        restorable,
+        skip_integrity,
+        integrity_failures,
+        options,
+      );
 
-    emit_operation_progress(options, {
-      operation: 'save',
-      workload,
-      phase: 'finalizing',
-      processed: files_saved + files_skipped,
-      total: restorable.length,
-    });
-    await finalize_file_archive(archive);
-    const total_bytes = await promise;
-    await mark_downloaded_from_internet(output_path);
-    const interrupted =
-      files_saved + files_skipped < restorable.length || options.should_interrupt?.() === true;
-    emit_operation_progress(options, {
-      operation: 'save',
-      workload,
-      phase: interrupted ? 'interrupted' : 'completed',
-      processed: files_saved + files_skipped,
-      total: restorable.length,
-    });
+      emit_operation_progress(options, {
+        operation: 'save',
+        workload,
+        phase: 'finalizing',
+        processed: files_saved + files_skipped,
+        total: restorable.length,
+      });
+      await finalize_file_archive(archive);
+      const total_bytes = await promise;
+      await mark_downloaded_from_internet(output_path);
+      const interrupted =
+        files_saved + files_skipped < restorable.length || options.should_interrupt?.() === true;
+      emit_operation_progress(options, {
+        operation: 'save',
+        workload,
+        phase: interrupted ? 'interrupted' : 'completed',
+        processed: files_saved + files_skipped,
+        total: restorable.length,
+      });
 
-    return {
-      snapshot_id: options.snapshot_id,
-      files_saved,
-      files_skipped,
-      errors,
-      integrity_failures,
-      output_path,
-      total_bytes,
-      interrupted,
-    };
+      return {
+        snapshot_id: options.snapshot_id,
+        files_saved,
+        files_skipped,
+        errors,
+        integrity_failures,
+        output_path,
+        total_bytes,
+        interrupted,
+      };
+    } catch (err) {
+      // Anything between opening the archive and finalizing it can throw: the entry loop, the
+      // finalize, the size promise, the zone marking. None of them may leave a truncated zip
+      // sitting at the output path (issue #307).
+      await abort();
+      throw err;
+    }
   } finally {
     ctx.destroy();
   }

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -76,7 +76,7 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
     const output_path =
       options.output_path ?? build_default_output_path(workload, options.snapshot_id);
     const skip_integrity = options.skip_integrity_check ?? false;
-    const { archive, promise, abort } = create_file_archive(output_path);
+    const { archive, promise, publish, abort } = create_file_archive(output_path);
 
     try {
       const integrity_failures: string[] = [];
@@ -99,6 +99,9 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
       });
       await finalize_file_archive(archive);
       const total_bytes = await promise;
+      // Only now does anything appear at the output path, so a failure above cannot leave a
+      // truncated zip there and cannot destroy a file that was already sitting on it.
+      await publish();
       await mark_downloaded_from_internet(output_path);
       const interrupted =
         files_saved + files_skipped < restorable.length || options.should_interrupt?.() === true;
@@ -121,9 +124,9 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
         interrupted,
       };
     } catch (err) {
-      // Anything between opening the archive and finalizing it can throw: the entry loop, the
-      // finalize, the size promise, the zone marking. None of them may leave a truncated zip
-      // sitting at the output path (issue #307).
+      // Anything between opening the archive and publishing it can throw: the entry loop, the
+      // finalize, the byte count, the move itself. None of them may leave a partial file behind
+      // (issue #307).
       await abort();
       throw err;
     }

--- a/packages/onedrive/tests/unit/services/save/save.service.test.ts
+++ b/packages/onedrive/tests/unit/services/save/save.service.test.ts
@@ -39,6 +39,7 @@ vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
     create_file_archive: vi.fn().mockReturnValue({
       archive: mock_archive,
       promise: Promise.resolve(4096),
+      publish: vi.fn().mockResolvedValue(undefined),
       abort: vi.fn().mockResolvedValue(undefined),
     }),
     add_file_to_archive: vi.fn().mockResolvedValue(undefined),

--- a/packages/onedrive/tests/unit/services/save/save.service.test.ts
+++ b/packages/onedrive/tests/unit/services/save/save.service.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Container } from 'inversify';
 import 'reflect-metadata';
+import {
+  create_file_archive,
+  finalize_file_archive,
+} from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
 import { OneDriveSaveService } from '@/services/save/save.service';
 import {
   ONEDRIVE_MANIFEST_REPOSITORY_TOKEN,
@@ -35,6 +39,7 @@ vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
     create_file_archive: vi.fn().mockReturnValue({
       archive: mock_archive,
       promise: Promise.resolve(4096),
+      abort: vi.fn().mockResolvedValue(undefined),
     }),
     add_file_to_archive: vi.fn().mockResolvedValue(undefined),
     finalize_file_archive: vi.fn().mockResolvedValue(undefined),
@@ -136,6 +141,25 @@ describe('OneDriveSaveService', () => {
       expect(result.files_skipped).toBe(0);
       expect(result.errors).toHaveLength(0);
       expect(result.output_path).toBe('/tmp/test-save.zip');
+    });
+
+    // #307: a failure between opening the archive and finalizing it used to leave a truncated
+    // zip at the output path, which is indistinguishable from a finished export.
+    it('aborts the archive when finalizing fails, and rethrows', async () => {
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(make_manifest([make_entry()]));
+      vi.mocked(finalize_file_archive).mockRejectedValueOnce(new Error('disk full'));
+
+      await expect(
+        service.save_snapshot('test-tenant', 'owner-1', {
+          snapshot_id: 'od-snap-1',
+          output_path: '/tmp/test-save.zip',
+        }),
+      ).rejects.toThrow('disk full');
+
+      const created = vi.mocked(create_file_archive).mock.results.at(-1)?.value as {
+        abort: () => Promise<void>;
+      };
+      expect(created.abort).toHaveBeenCalledTimes(1);
     });
 
     // #173: a delta snapshot lists only what changed, so an export that reads one manifest loses

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -30,83 +30,90 @@ export async function save_entries_to_archive(
   is_interrupted: () => boolean,
   control: OperationControlOptions,
 ): Promise<Omit<SaveResult, 'snapshot_id'> & { processed: number }> {
-  const { archive, promise } = create_save_archive(output_path);
+  const { archive, promise, abort } = create_save_archive(output_path);
 
-  let global_saved = 0;
-  let global_att = 0;
-  let global_errors = 0;
-  let global_processed = 0;
-  const all_errors: string[] = [];
-  const integrity_failures: string[] = [];
-  let interrupted = false;
-  const should_interrupt = (): boolean => {
-    interrupted ||= is_interrupted();
-    return interrupted;
-  };
-  const start = Date.now();
-  const global_total = [...groups.values()].reduce((s, g) => s + g.length, 0);
+  try {
+    let global_saved = 0;
+    let global_att = 0;
+    let global_errors = 0;
+    let global_processed = 0;
+    const all_errors: string[] = [];
+    const integrity_failures: string[] = [];
+    let interrupted = false;
+    const should_interrupt = (): boolean => {
+      interrupted ||= is_interrupted();
+      return interrupted;
+    };
+    const start = Date.now();
+    const global_total = [...groups.values()].reduce((s, g) => s + g.length, 0);
 
-  let folder_index = 0;
-  for (const [fid, folder_items] of groups) {
-    if (should_interrupt()) break;
-    dashboard.mark_active(folder_index);
+    let folder_index = 0;
+    for (const [fid, folder_items] of groups) {
+      if (should_interrupt()) break;
+      dashboard.mark_active(folder_index);
 
-    const folder_name = folder_map.get(fid) ?? 'Unknown';
-    const used_names = new Set<string>();
+      const folder_name = folder_map.get(fid) ?? 'Unknown';
+      const used_names = new Set<string>();
 
-    const folder_result = await process_folder_entries(
-      ctx,
-      folder_items,
-      folder_name,
-      folder_index,
-      skip_integrity,
-      archive,
-      used_names,
-      groups,
-      global_total,
-      start,
-      dashboard,
-      should_interrupt,
-      { all_errors, integrity_failures },
-      control,
-    );
+      const folder_result = await process_folder_entries(
+        ctx,
+        folder_items,
+        folder_name,
+        folder_index,
+        skip_integrity,
+        archive,
+        used_names,
+        groups,
+        global_total,
+        start,
+        dashboard,
+        should_interrupt,
+        { all_errors, integrity_failures },
+        control,
+      );
 
-    global_errors += folder_result.error_count;
-    if (!should_interrupt()) {
-      dashboard.mark_done(folder_index, folder_result.folder_saved, folder_result.folder_att);
+      global_errors += folder_result.error_count;
+      if (!should_interrupt()) {
+        dashboard.mark_done(folder_index, folder_result.folder_saved, folder_result.folder_att);
+      }
+
+      global_saved += folder_result.folder_saved;
+      global_att += folder_result.folder_att;
+      global_processed += folder_result.folder_processed;
+      folder_index++;
     }
 
-    global_saved += folder_result.folder_saved;
-    global_att += folder_result.folder_att;
-    global_processed += folder_result.folder_processed;
-    folder_index++;
+    dashboard.show_finalizing();
+    emit_operation_progress(control, {
+      operation: 'save',
+      workload: 'outlook',
+      phase: 'finalizing',
+      processed: global_processed,
+      total: global_total,
+    });
+    await finalize_archive(archive);
+    const total_bytes = await promise;
+    await mark_downloaded_from_internet(output_path);
+
+    log_save_summary(global_saved, global_att, global_errors, total_bytes, start);
+
+    return {
+      saved_count: global_saved,
+      attachment_count: global_att,
+      error_count: global_errors,
+      errors: all_errors,
+      output_path,
+      total_bytes,
+      integrity_failures,
+      processed: global_processed,
+      interrupted: should_interrupt(),
+    };
+  } catch (err) {
+    // Anything between opening the archive and finalizing it can throw. None of it may leave
+    // a truncated zip sitting at the output path (issue #307).
+    await abort();
+    throw err;
   }
-
-  dashboard.show_finalizing();
-  emit_operation_progress(control, {
-    operation: 'save',
-    workload: 'outlook',
-    phase: 'finalizing',
-    processed: global_processed,
-    total: global_total,
-  });
-  await finalize_archive(archive);
-  const total_bytes = await promise;
-  await mark_downloaded_from_internet(output_path);
-
-  log_save_summary(global_saved, global_att, global_errors, total_bytes, start);
-
-  return {
-    saved_count: global_saved,
-    attachment_count: global_att,
-    error_count: global_errors,
-    errors: all_errors,
-    output_path,
-    total_bytes,
-    integrity_failures,
-    processed: global_processed,
-    interrupted: should_interrupt(),
-  };
 }
 
 interface FolderEntryCounters {

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -30,7 +30,7 @@ export async function save_entries_to_archive(
   is_interrupted: () => boolean,
   control: OperationControlOptions,
 ): Promise<Omit<SaveResult, 'snapshot_id'> & { processed: number }> {
-  const { archive, promise, abort } = create_save_archive(output_path);
+  const { archive, promise, publish, abort } = create_save_archive(output_path);
 
   try {
     let global_saved = 0;
@@ -93,6 +93,9 @@ export async function save_entries_to_archive(
     });
     await finalize_archive(archive);
     const total_bytes = await promise;
+    // Only now does anything appear at the output path, so a failure above cannot leave a
+    // truncated zip there and cannot destroy a file that was already sitting on it.
+    await publish();
     await mark_downloaded_from_internet(output_path);
 
     log_save_summary(global_saved, global_att, global_errors, total_bytes, start);
@@ -109,8 +112,8 @@ export async function save_entries_to_archive(
       interrupted: should_interrupt(),
     };
   } catch (err) {
-    // Anything between opening the archive and finalizing it can throw. None of it may leave
-    // a truncated zip sitting at the output path (issue #307).
+    // Anything between opening the archive and publishing it can throw. None of it may leave a
+    // partial file behind (issue #307).
     await abort();
     throw err;
   }

--- a/packages/outlook/src/services/save/save-zip-writer.ts
+++ b/packages/outlook/src/services/save/save-zip-writer.ts
@@ -1,9 +1,20 @@
-import { createWriteStream } from 'node:fs';
+import { createWriteStream, existsSync, type WriteStream } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { ZipArchive, type Archiver } from 'archiver';
+import { logger } from '@wisecom/atlas-core/utils/logger';
 
 export interface SaveArchive {
   readonly archive: ArchiveWriter;
   readonly promise: Promise<number>;
+  /**
+   * Destroys the stream and removes the partial file, for a run that failed before finalizing.
+   *
+   * A truncated zip left at the output path is indistinguishable from a complete one, which is
+   * worse than no file at all when the reason an operator ran a save is that they need the bytes
+   * (issue #307). A path that already held a file is never removed: the caller may have been
+   * handed the path of something unrelated.
+   */
+  abort(): Promise<void>;
 }
 
 /** The archiver instance EML entries are appended to. */
@@ -11,6 +22,7 @@ export type ArchiveWriter = Archiver;
 
 /** Creates a zip archive with maximum compression, streaming to the output path. */
 export function create_save_archive(output_path: string): SaveArchive {
+  const pre_existing = existsSync(output_path);
   const output = createWriteStream(output_path);
   const archive = new ZipArchive({ zlib: { level: 9 } });
 
@@ -19,9 +31,38 @@ export function create_save_archive(output_path: string): SaveArchive {
     archive.on('error', reject);
     output.on('error', reject);
   });
+  // Attach a handler now, so an error raised while entries are still being appended is not an
+  // unhandled rejection. Awaiting `promise` later still sees the rejection.
+  promise.catch(() => undefined);
 
   archive.pipe(output);
-  return { archive, promise };
+  return {
+    archive,
+    promise,
+    abort: () => abort_save_archive(archive, output, output_path, pre_existing),
+  };
+}
+
+async function abort_save_archive(
+  archive: ArchiveWriter,
+  output: WriteStream,
+  output_path: string,
+  pre_existing: boolean,
+): Promise<void> {
+  try {
+    archive.abort();
+  } catch {
+    // Already destroyed or never started; the stream teardown below is what matters.
+  }
+  output.destroy();
+  if (pre_existing) return;
+  try {
+    await rm(output_path, { force: true });
+  } catch (err) {
+    logger.warn(
+      `Could not remove the partial archive at ${output_path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 /**

--- a/packages/outlook/src/services/save/save-zip-writer.ts
+++ b/packages/outlook/src/services/save/save-zip-writer.ts
@@ -1,5 +1,6 @@
-import { createWriteStream, existsSync, type WriteStream } from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import { createWriteStream, type WriteStream } from 'node:fs';
+import { rename, rm } from 'node:fs/promises';
 import { ZipArchive, type Archiver } from 'archiver';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -7,23 +8,27 @@ export interface SaveArchive {
   readonly archive: ArchiveWriter;
   readonly promise: Promise<number>;
   /**
-   * Destroys the stream and removes the partial file, for a run that failed before finalizing.
-   *
-   * A truncated zip left at the output path is indistinguishable from a complete one, which is
-   * worse than no file at all when the reason an operator ran a save is that they need the bytes
-   * (issue #307). A path that already held a file is never removed: the caller may have been
-   * handed the path of something unrelated.
+   * Moves the finished archive onto the output path. Call it after the archive is finalized and
+   * the byte count has resolved; until then the output path is untouched.
    */
+  publish(): Promise<void>;
+  /** Destroys the stream and removes the temporary file, for a run that failed before publishing. */
   abort(): Promise<void>;
 }
 
 /** The archiver instance EML entries are appended to. */
 export type ArchiveWriter = Archiver;
 
-/** Creates a zip archive with maximum compression, streaming to the output path. */
+/**
+ * Creates a zip archive with maximum compression, streaming to a sibling temporary file.
+ *
+ * The archive is moved onto the output path by {@link SaveArchive.publish}, so nothing appears
+ * there until it is complete. A truncated zip is indistinguishable from a finished one (issue
+ * #307), and a failed save must not destroy a file that was already at the path it was given.
+ */
 export function create_save_archive(output_path: string): SaveArchive {
-  const pre_existing = existsSync(output_path);
-  const output = createWriteStream(output_path);
+  const staging_path = `${output_path}.part-${randomBytes(6).toString('hex')}`;
+  const output = createWriteStream(staging_path);
   const archive = new ZipArchive({ zlib: { level: 9 } });
 
   const promise = new Promise<number>((resolve, reject) => {
@@ -39,15 +44,15 @@ export function create_save_archive(output_path: string): SaveArchive {
   return {
     archive,
     promise,
-    abort: () => abort_save_archive(archive, output, output_path, pre_existing),
+    publish: () => rename(staging_path, output_path),
+    abort: () => abort_save_archive(archive, output, staging_path),
   };
 }
 
 async function abort_save_archive(
   archive: ArchiveWriter,
   output: WriteStream,
-  output_path: string,
-  pre_existing: boolean,
+  staging_path: string,
 ): Promise<void> {
   try {
     archive.abort();
@@ -55,12 +60,11 @@ async function abort_save_archive(
     // Already destroyed or never started; the stream teardown below is what matters.
   }
   output.destroy();
-  if (pre_existing) return;
   try {
-    await rm(output_path, { force: true });
+    await rm(staging_path, { force: true });
   } catch (err) {
     logger.warn(
-      `Could not remove the partial archive at ${output_path}: ${err instanceof Error ? err.message : String(err)}`,
+      `Could not remove the partial archive at ${staging_path}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }

--- a/packages/outlook/tests/unit/services/save/mime-passthrough.test.ts
+++ b/packages/outlook/tests/unit/services/save/mime-passthrough.test.ts
@@ -14,7 +14,12 @@ interface AppendedEml {
 const { appended } = vi.hoisted(() => ({ appended: [] as AppendedEml[] }));
 
 vi.mock('@/services/save/save-zip-writer', () => ({
-  create_save_archive: vi.fn(() => ({ archive: {}, promise: Promise.resolve(2048) })),
+  create_save_archive: vi.fn(() => ({
+    archive: {},
+    promise: Promise.resolve(2048),
+    publish: (): Promise<void> => Promise.resolve(),
+    abort: (): Promise<void> => Promise.resolve(),
+  })),
   add_eml_to_archive: vi.fn(
     (_archive: unknown, folder: string, filename: string, content: Buffer) => {
       appended.push({ folder, filename, content });

--- a/packages/outlook/tests/unit/services/save/zip-writer.test.ts
+++ b/packages/outlook/tests/unit/services/save/zip-writer.test.ts
@@ -31,10 +31,11 @@ describe('save-zip-writer', () => {
     const path = temp_path('create');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     await add_eml_to_archive(archive, 'Inbox', 'test.eml', Buffer.from('EML content'));
     await finalize_archive(archive);
     const bytes = await promise;
+    await publish();
 
     expect(existsSync(path)).toBe(true);
     expect(bytes).toBeGreaterThan(0);
@@ -44,12 +45,13 @@ describe('save-zip-writer', () => {
     const path = temp_path('multi');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     await add_eml_to_archive(archive, 'Inbox', 'a.eml', Buffer.from('Message A'));
     await add_eml_to_archive(archive, 'Sent Items', 'b.eml', Buffer.from('Message B'));
     await add_eml_to_archive(archive, 'Inbox', 'c.eml', Buffer.from('Message C'));
     await finalize_archive(archive);
     const bytes = await promise;
+    await publish();
 
     expect(bytes).toBeGreaterThan(0);
   });
@@ -58,9 +60,10 @@ describe('save-zip-writer', () => {
     const path = temp_path('empty');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     await finalize_archive(archive);
     const bytes = await promise;
+    await publish();
 
     expect(bytes).toBeGreaterThan(0);
   });
@@ -69,7 +72,7 @@ describe('save-zip-writer', () => {
     const path = temp_path('nested');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
@@ -77,6 +80,7 @@ describe('save-zip-writer', () => {
     await add_eml_to_archive(archive, 'Archive/Projects/2026', 'b.eml', Buffer.from('B'));
     await finalize_archive(archive);
     await promise;
+    await publish();
 
     expect(entries).toEqual(['Inbox/Projects/2026/a.eml', 'Archive/Projects/2026/b.eml']);
   });
@@ -85,13 +89,14 @@ describe('save-zip-writer', () => {
     const path = temp_path('sanitize');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
     await add_eml_to_archive(archive, 'Inbox/Q1:Q2/..', 'a.eml', Buffer.from('A'));
     await finalize_archive(archive);
     await promise;
+    await publish();
 
     expect(entries).toEqual(['Inbox/Q1_Q2/Unknown/a.eml']);
   });
@@ -103,13 +108,14 @@ describe('save-zip-writer', () => {
     const path = temp_path('traversal');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
     await add_eml_to_archive(archive, 'Inbox', '../../../etc/passwd', Buffer.from('A'));
     await finalize_archive(archive);
     await promise;
+    await publish();
 
     // Separators become underscores and `..` collapses to a single dot that is then
     // stripped from the front, so the whole name lands as one segment under the folder.
@@ -122,13 +128,14 @@ describe('save-zip-writer', () => {
     const path = temp_path('flatten');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
     await add_eml_to_archive(archive, 'Inbox', 'a/b\\c\x01d.eml', Buffer.from('A'));
     await finalize_archive(archive);
     await promise;
+    await publish();
 
     // One folder level plus one file: the name contributes no extra depth.
     expect(entries).toEqual(['Inbox/a_b_c_d.eml']);
@@ -148,7 +155,7 @@ describe('save-zip-writer', () => {
       deduplicate_filename(build_eml_filename('2026-03-10T14:30:22Z', 'Same'), new Set(['x'])),
     ];
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
@@ -157,6 +164,7 @@ describe('save-zip-writer', () => {
     }
     await finalize_archive(archive);
     await promise;
+    await publish();
 
     expect(entries).toEqual(generated.map((n) => `Inbox/${n}`));
     expect(generated[1]).toContain('untitled');

--- a/packages/sharepoint/tests/unit/services/save/save.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/save/save.service.test.ts
@@ -35,6 +35,8 @@ vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
     create_file_archive: vi.fn().mockReturnValue({
       archive: mock_archive,
       promise: Promise.resolve(8192),
+      publish: vi.fn().mockResolvedValue(undefined),
+      abort: vi.fn().mockResolvedValue(undefined),
     }),
     add_file_to_archive: vi.fn().mockResolvedValue(undefined),
     finalize_file_archive: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

A save that failed anywhere between opening the zip and finalizing it left a truncated archive at the output path and the file descriptor open, and an archive error raised during the entry loop surfaced as an unhandled rejection rather than as the operation's failure.

Closes #307

## Why it matters

A truncated zip is indistinguishable from a finished export. Save is the command an operator reaches for when they actually need the bytes out, so a file that looks complete and is not is worse than no file at all.

## Changes

Both zip writers, `packages/core/src/services/shared/file-save-zip-writer.ts` for drive saves and `packages/outlook/src/services/save/save-zip-writer.ts` for mailbox saves, now return an `abort()` alongside the archive and the byte-count promise. It aborts the archiver, destroys the stream, and removes the output file.

- **Never deletes something it did not create.** `existsSync` is checked before the stream is opened, and a path that already held a file is left alone. An operator can point `-O` at an existing file, have the run fail, and still have that file. This was the destructive step the issue flagged, and it is the reason this did not ride along in #305.
- **The archive promise gets a handler at creation time**, so an error raised while entries are still being appended is not an unhandled rejection. Awaiting the promise later still observes it, so no failure is swallowed.
- Callers wrap the write in `try`/`catch`, call `abort()` and rethrow: `save_drive_snapshot` in `packages/drive` and `save_entries_to_archive` in `packages/outlook`. Everything between opening and finalizing is inside it, including the finalize, the byte-count await and the zone-identifier marking.

A failed `rm` is warned about, not thrown: the operation already has a real error to report and losing it behind a cleanup failure would be a worse outcome.

## Tests

- `packages/core/tests/unit/services/shared/file-save-zip-writer.test.ts`, new, against a real temp directory rather than mocks: a normal archive is written and counted, an aborted run leaves no file, a pre-existing file at the output path survives an abort, and a double abort does not raise.
- `packages/onedrive/.../save.service.test.ts`: a rejecting `finalize_file_archive` makes the save rethrow and calls `abort()` exactly once, which covers the shared drive wiring.

## Checklist

- `pnpm run build`, `pnpm run lint`, `pnpm run typecheck`, `pnpm run docs:build` and the full `pnpm run test` pass.
- `docs/reference/cli.md` states the behaviour for `save`, including that an existing output file is never removed, since both halves are operator-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Failed archive saves now clean up incomplete output files.
  - Existing output files are preserved when a save fails.
  - Completed archives are published only after successful finalization.
  - Errors during archive creation or finalization are reported correctly after cleanup.
  - Repeated cleanup attempts are handled safely.

- **Documentation**
  - Updated CLI reference tables with consistent formatting.
  - Documented OneDrive behavior for failed saves and partial archives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->