### PR TITLE
fix: stop re-fetching the whole file when a CDN ignores Range

### DIFF
--- a/packages/drive/src/backup/whole-file-stream.ts
+++ b/packages/drive/src/backup/whole-file-stream.ts
@@ -1,0 +1,33 @@
+/**
+ * Streams an item in one request and cuts it into fixed-size buffers.
+ *
+ * The fallback for a server that ignores `Range` and answers with the whole file (issue #301).
+ * Asking per chunk then costs the entire file every time, so a 1 GiB item moves 256 GiB to
+ * produce 1 GiB. Cutting the single response into the same buffers the caller's
+ * encrypt-and-upload pipeline expects keeps the memory ceiling at one chunk.
+ */
+export async function* stream_whole_file_in_chunks(
+  url: string,
+  item_id: string,
+  chunk_size_bytes: number,
+): AsyncGenerator<Buffer> {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`HTTP ${response.status} for the streamed download of ${item_id}`);
+  }
+
+  let pending: Buffer[] = [];
+  let pending_bytes = 0;
+  for await (const part of response.body as unknown as AsyncIterable<Uint8Array>) {
+    pending.push(Buffer.from(part));
+    pending_bytes += part.byteLength;
+    while (pending_bytes >= chunk_size_bytes) {
+      const joined = Buffer.concat(pending);
+      yield joined.subarray(0, chunk_size_bytes);
+      const rest = joined.subarray(chunk_size_bytes);
+      pending = rest.length > 0 ? [rest] : [];
+      pending_bytes = rest.length;
+    }
+  }
+  if (pending_bytes > 0) yield Buffer.concat(pending);
+}

--- a/packages/drive/src/backup/whole-file-stream.ts
+++ b/packages/drive/src/backup/whole-file-stream.ts
@@ -1,3 +1,17 @@
+/** Options for {@link stream_whole_file_in_chunks}. */
+export interface WholeFileStreamOptions {
+  /** Size of each yielded buffer; must be a positive integer. */
+  readonly chunk_size_bytes: number;
+  /**
+   * Milliseconds allowed between two reads before the request is aborted.
+   *
+   * A server that sends headers and then stalls would otherwise hold the download forever, which
+   * is the failure the Range path bounds per chunk (issue #198). The clock is reset on every
+   * part, so a slow-but-moving transfer is never cut off.
+   */
+  readonly stall_timeout_ms: number;
+}
+
 /**
  * Streams an item in one request and cuts it into fixed-size buffers.
  *
@@ -9,25 +23,49 @@
 export async function* stream_whole_file_in_chunks(
   url: string,
   item_id: string,
-  chunk_size_bytes: number,
+  options: WholeFileStreamOptions,
 ): AsyncGenerator<Buffer> {
-  const response = await fetch(url);
-  if (!response.ok || !response.body) {
-    throw new Error(`HTTP ${response.status} for the streamed download of ${item_id}`);
+  const { chunk_size_bytes, stall_timeout_ms } = options;
+  if (!Number.isSafeInteger(chunk_size_bytes) || chunk_size_bytes <= 0) {
+    throw new Error(`Invalid chunk size for the streamed download of ${item_id}`);
   }
 
-  let pending: Buffer[] = [];
-  let pending_bytes = 0;
-  for await (const part of response.body as unknown as AsyncIterable<Uint8Array>) {
-    pending.push(Buffer.from(part));
-    pending_bytes += part.byteLength;
-    while (pending_bytes >= chunk_size_bytes) {
-      const joined = Buffer.concat(pending);
-      yield joined.subarray(0, chunk_size_bytes);
-      const rest = joined.subarray(chunk_size_bytes);
-      pending = rest.length > 0 ? [rest] : [];
-      pending_bytes = rest.length;
+  const controller = new AbortController();
+  let timer = arm_stall_timer(controller, stall_timeout_ms, item_id);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok || !response.body) {
+      throw new Error(`HTTP ${response.status} for the streamed download of ${item_id}`);
     }
+
+    let pending: Buffer[] = [];
+    let pending_bytes = 0;
+    for await (const part of response.body as unknown as AsyncIterable<Uint8Array>) {
+      clearTimeout(timer);
+      timer = arm_stall_timer(controller, stall_timeout_ms, item_id);
+      pending.push(Buffer.from(part));
+      pending_bytes += part.byteLength;
+      while (pending_bytes >= chunk_size_bytes) {
+        const joined = Buffer.concat(pending);
+        yield joined.subarray(0, chunk_size_bytes);
+        const rest = joined.subarray(chunk_size_bytes);
+        pending = rest.length > 0 ? [rest] : [];
+        pending_bytes = rest.length;
+      }
+    }
+    if (pending_bytes > 0) yield Buffer.concat(pending);
+  } finally {
+    clearTimeout(timer);
   }
-  if (pending_bytes > 0) yield Buffer.concat(pending);
+}
+
+function arm_stall_timer(
+  controller: AbortController,
+  stall_timeout_ms: number,
+  item_id: string,
+): NodeJS.Timeout {
+  return setTimeout(() => {
+    controller.abort(new Error(`Streamed download of ${item_id} stalled`));
+  }, stall_timeout_ms);
 }

--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -1,6 +1,7 @@
 export * from '@/drive-ports';
 export { download_with_retry, type DownloadRetryOptions } from '@/backup/download-retry';
 export { LARGE_FILE_THRESHOLD } from '@/backup/large-file-threshold';
+export { stream_whole_file_in_chunks } from '@/backup/whole-file-stream';
 export {
   should_stream_restore,
   verify_streaming_checksum,

--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -1,7 +1,10 @@
 export * from '@/drive-ports';
 export { download_with_retry, type DownloadRetryOptions } from '@/backup/download-retry';
 export { LARGE_FILE_THRESHOLD } from '@/backup/large-file-threshold';
-export { stream_whole_file_in_chunks } from '@/backup/whole-file-stream';
+export {
+  stream_whole_file_in_chunks,
+  type WholeFileStreamOptions,
+} from '@/backup/whole-file-stream';
 export {
   should_stream_restore,
   verify_streaming_checksum,

--- a/packages/drive/tests/unit/backup/whole-file-stream.test.ts
+++ b/packages/drive/tests/unit/backup/whole-file-stream.test.ts
@@ -1,0 +1,139 @@
+import { createHash } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { stream_whole_file_in_chunks } from '@/backup/whole-file-stream';
+
+const CHUNK_SIZE = 4 * 1024 * 1024;
+
+/** A response whose body yields the given parts. */
+function streamed_response(parts: Buffer[]): Response {
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+        for (const part of parts) yield new Uint8Array(part);
+      },
+    },
+  } as unknown as Response;
+}
+
+/**
+ * A response that yields one part and then never yields again until the request is aborted,
+ * which is what a server that sends headers and then stops looks like from here.
+ */
+function stalling_response(signal_holder: { signal: AbortSignal | undefined }): Response {
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+        yield new Uint8Array(Buffer.alloc(16, 1));
+        const { promise, reject } = Promise.withResolvers<never>();
+        signal_holder.signal?.addEventListener('abort', () =>
+          reject(new Error('The operation was aborted')),
+        );
+        await promise;
+      },
+    },
+  } as unknown as Response;
+}
+
+async function collect(response: Response, stall_timeout_ms = 30_000): Promise<Buffer[]> {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((_url: string, init?: { signal?: AbortSignal }) => {
+      init?.signal?.addEventListener('abort', () => undefined);
+      return Promise.resolve(response);
+    }),
+  );
+  const parts: Buffer[] = [];
+  for await (const chunk of stream_whole_file_in_chunks('https://cdn.test/file', 'item-1', {
+    chunk_size_bytes: CHUNK_SIZE,
+    stall_timeout_ms,
+  })) {
+    parts.push(chunk);
+  }
+  return parts;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('stream_whole_file_in_chunks', () => {
+  it('re-cuts a body that arrives in unrelated sizes into fixed chunks', async () => {
+    const whole = Buffer.alloc(CHUNK_SIZE + 1024, 3);
+    const thirds = [
+      whole.subarray(0, 1_000_000),
+      whole.subarray(1_000_000, 3_500_000),
+      whole.subarray(3_500_000),
+    ];
+
+    const parts = await collect(streamed_response(thirds.map((part) => Buffer.from(part))));
+
+    expect(parts.map((part) => part.length)).toEqual([CHUNK_SIZE, 1024]);
+    const rebuilt = Buffer.concat(parts);
+    expect(createHash('sha256').update(rebuilt).digest('hex')).toBe(
+      createHash('sha256').update(whole).digest('hex'),
+    );
+  });
+
+  it('yields a body smaller than one chunk as a single buffer', async () => {
+    const parts = await collect(streamed_response([Buffer.alloc(512, 1)]));
+
+    expect(parts.map((part) => part.length)).toEqual([512]);
+  });
+
+  it('yields nothing for an empty body', async () => {
+    expect(await collect(streamed_response([]))).toEqual([]);
+  });
+
+  it('rejects a chunk size that would loop forever', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+
+    // `pending_bytes >= 0` never stops being true, so this would yield until the heap gave out.
+    await expect(
+      (async () => {
+        for await (const _ of stream_whole_file_in_chunks('https://cdn.test/file', 'item-1', {
+          chunk_size_bytes: 0,
+          stall_timeout_ms: 30_000,
+        })) {
+          void _;
+        }
+      })(),
+    ).rejects.toThrow(/Invalid chunk size/);
+  });
+
+  it('aborts a body that stops arriving', async () => {
+    // The Range path bounds every chunk (issue #198); the fallback has to bound the gaps too,
+    // or a server that sends headers and then stalls holds the backup open forever.
+    vi.useFakeTimers();
+    const holder: { signal: AbortSignal | undefined } = { signal: undefined };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((_url: string, init?: { signal?: AbortSignal }) => {
+        holder.signal = init?.signal;
+        return Promise.resolve(stalling_response(holder));
+      }),
+    );
+
+    const consumed = (async () => {
+      for await (const _ of stream_whole_file_in_chunks('https://cdn.test/file', 'item-1', {
+        chunk_size_bytes: CHUNK_SIZE,
+        stall_timeout_ms: 30_000,
+      })) {
+        void _;
+      }
+    })();
+    const settled = expect(consumed).rejects.toThrow(/aborted/);
+    await vi.advanceTimersByTimeAsync(30_001);
+    await settled;
+  });
+
+  it('rejects a refused download', async () => {
+    await expect(
+      collect({ ok: false, status: 403, body: undefined } as unknown as Response),
+    ).rejects.toThrow(/HTTP 403/);
+  });
+});

--- a/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
@@ -1,9 +1,23 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { stream_whole_file_in_chunks } from '@wisecom/atlas-drive/backup/whole-file-stream';
 import {
   is_retryable_error,
   is_transient_error,
   parse_retry_after_ms,
 } from '@wisecom/atlas-m365-graph';
+
+/**
+ * Raised when the server answers a Range request with the whole file.
+ *
+ * It is a property of the server, not of the chunk, so the caller stops asking for ranges
+ * entirely rather than re-discovering it once per chunk (issue #301).
+ */
+class RangeIgnoredError extends Error {
+  constructor() {
+    super('Range header ignored');
+    this.name = 'RangeIgnoredError';
+  }
+}
 
 /** Maximum bytes per HTTP Range chunk (4 MiB). */
 export const CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
@@ -37,16 +51,30 @@ export async function* fetch_file_chunks(
     const range_end = Math.min(range_start + CHUNK_SIZE_BYTES - 1, total_bytes - 1);
     const expected_length = range_end - range_start + 1;
 
-    yield await download_chunk_with_retry(
-      download_url,
-      range_start,
-      range_end,
-      expected_length,
-      item_id,
-      i + 1,
-      chunk_count,
-      total_bytes,
-    );
+    try {
+      yield await download_chunk_with_retry(
+        download_url,
+        range_start,
+        range_end,
+        expected_length,
+        item_id,
+        i + 1,
+        chunk_count,
+        total_bytes,
+        chunk_count > 1,
+      );
+    } catch (err) {
+      if (!(err instanceof RangeIgnoredError)) throw err;
+      // Every remaining chunk would fetch and discard the same whole file: a 1 GiB item costs
+      // 256 GiB transferred to produce 1 GiB. One streamed pass delivers the rest, and the
+      // chunks already yielded are re-read from the start, which is the price of finding out.
+      logger.warn(
+        `Range requests are ignored for ${item_id} (HTTP 200 with the full body); ` +
+          `falling back to one streamed download`,
+      );
+      yield* stream_whole_file_in_chunks(download_url, item_id, CHUNK_SIZE_BYTES);
+      return;
+    }
   }
 }
 
@@ -76,6 +104,7 @@ async function download_chunk_with_retry(
   chunk_index: number,
   total_chunks: number,
   total_bytes: number,
+  report_ignored_range: boolean,
 ): Promise<Buffer> {
   for (let attempt = 0; attempt <= MAX_CHUNK_RETRIES; attempt++) {
     try {
@@ -86,8 +115,11 @@ async function download_chunk_with_retry(
         expected_length,
         item_id,
         total_bytes,
+        report_ignored_range,
       );
     } catch (err) {
+      // Not retryable and not a failure: the caller switches strategy on it.
+      if (err instanceof RangeIgnoredError) throw err;
       if (!is_cdn_retryable(err) || attempt === MAX_CHUNK_RETRIES) {
         throw new Error(
           `Failed chunk ${chunk_index}/${total_chunks} of ${item_id} ` +
@@ -126,6 +158,7 @@ async function download_single_chunk(
   expected_length: number,
   item_id: string,
   total_bytes: number,
+  report_ignored_range: boolean,
 ): Promise<Buffer> {
   // Scaled to this chunk, not to the file. Passing total_bytes here gave every
   // non-final chunk a ceil(total_bytes / 256) ms budget, so one stalled CDN
@@ -159,6 +192,12 @@ async function download_single_chunk(
     // the body about to be drained is total_bytes rather than one chunk. Only
     // that case needs the whole-file budget, and by now it is known rather than
     // assumed, so re-arm before reading instead of pre-paying on every chunk.
+    if (response.status === 200 && report_ignored_range) {
+      // Drop the body unread: buffering a whole file per chunk is the cost this avoids.
+      await response.body?.cancel();
+      throw new RangeIgnoredError();
+    }
+
     if (response.status === 200) {
       clearTimeout(timer);
       timer = setTimeout(() => controller.abort(), compute_chunk_timeout_ms(total_bytes));
@@ -167,10 +206,7 @@ async function download_single_chunk(
     const buf = Buffer.from(await response.arrayBuffer());
 
     if (response.status === 200) {
-      logger.warn(
-        `CDN returned HTTP 200 instead of 206 for Range request on ${item_id} — ` +
-          `server ignored Range header, slicing ${buf.length} bytes to expected range`,
-      );
+      // A single-chunk item legitimately comes back whole, so the slice is a no-op there.
       if (buf.length < range_end + 1) {
         throw new CdnHttpError(
           `CDN returned 200 with ${buf.length} bytes but range_end is ${range_end} for ${item_id}`,

--- a/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
@@ -72,7 +72,12 @@ export async function* fetch_file_chunks(
         `Range requests are ignored for ${item_id} (HTTP 200 with the full body); ` +
           `falling back to one streamed download`,
       );
-      yield* stream_whole_file_in_chunks(download_url, item_id, CHUNK_SIZE_BYTES);
+      yield* stream_whole_file_in_chunks(download_url, item_id, {
+        chunk_size_bytes: CHUNK_SIZE_BYTES,
+        // Same per-chunk budget the Range path uses, applied between reads rather than to the
+        // whole transfer, so a stalled body is cut off but a slow one is not (issue #198).
+        stall_timeout_ms: compute_chunk_timeout_ms(CHUNK_SIZE_BYTES),
+      });
       return;
     }
   }

--- a/packages/onedrive/tests/unit/adapters/graph-chunked-download.test.ts
+++ b/packages/onedrive/tests/unit/adapters/graph-chunked-download.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { download_file_chunked } from '@/adapters/graph-onedrive-chunked-download';
 
@@ -13,9 +14,17 @@ function to_array_buffer(body: Buffer): ArrayBuffer {
 function range_response(status: number, body = Buffer.alloc(0)): Response {
   return {
     status,
+    ok: status >= 200 && status < 300,
     headers: { get: (): string | null => null },
     arrayBuffer: (): Promise<ArrayBuffer> => Promise.resolve(to_array_buffer(body)),
     text: (): Promise<string> => Promise.resolve(''),
+    // The Range-ignored path cancels the body unread, and the streamed fallback iterates it.
+    body: {
+      cancel: (): Promise<void> => Promise.resolve(),
+      async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+        yield new Uint8Array(body);
+      },
+    },
   } as unknown as Response;
 }
 
@@ -53,5 +62,24 @@ describe('download_file_chunked', () => {
       download_file_chunked('https://cdn.test/file', payload.length, 'item-1'),
     ).rejects.toThrow('HTTP 404');
     expect(fetch_mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops asking for ranges once the CDN answers one with the whole file (issue #301)', async () => {
+    vi.useRealTimers();
+    const chunk_size = 4 * 1024 * 1024;
+    const whole = Buffer.alloc(chunk_size + 1024, 1);
+    const fetch_mock = vi.fn().mockResolvedValue(range_response(200, whole));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    const body = await download_file_chunked('https://cdn.test/file', whole.length, 'item-1');
+
+    // Two requests, not one per chunk: the Range probe, then one streamed download. Asking per
+    // chunk fetched the whole file every time, so a 1 GiB item moved 256 GiB.
+    expect(fetch_mock).toHaveBeenCalledTimes(2);
+    expect((fetch_mock.mock.calls[1] as unknown[])[1]).toBeUndefined();
+    expect(body.length).toBe(whole.length);
+    expect(createHash('sha256').update(body).digest('hex')).toBe(
+      createHash('sha256').update(whole).digest('hex'),
+    );
   });
 });

--- a/packages/onedrive/tests/unit/adapters/graph-chunked-download.test.ts
+++ b/packages/onedrive/tests/unit/adapters/graph-chunked-download.test.ts
@@ -76,7 +76,13 @@ describe('download_file_chunked', () => {
     // Two requests, not one per chunk: the Range probe, then one streamed download. Asking per
     // chunk fetched the whole file every time, so a 1 GiB item moved 256 GiB.
     expect(fetch_mock).toHaveBeenCalledTimes(2);
-    expect((fetch_mock.mock.calls[1] as unknown[])[1]).toBeUndefined();
+    // The streamed request carries no Range header, only the stall-abort signal.
+    const streamed_init = (fetch_mock.mock.calls[1] as unknown[])[1] as {
+      headers?: Record<string, string>;
+      signal?: AbortSignal;
+    };
+    expect(streamed_init.headers).toBeUndefined();
+    expect(streamed_init.signal).toBeInstanceOf(AbortSignal);
     expect(body.length).toBe(whole.length);
     expect(createHash('sha256').update(body).digest('hex')).toBe(
       createHash('sha256').update(whole).digest('hex'),

--- a/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
+++ b/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
@@ -1,10 +1,24 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { stream_whole_file_in_chunks } from '@wisecom/atlas-drive/backup/whole-file-stream';
 
 const CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
 const MAX_CHUNK_RETRIES = 5;
 const CHUNK_BASE_DELAY_MS = 1_000;
 const CHUNK_MAX_DELAY_MS = 30_000;
 const MIN_THROUGHPUT_BYTES_PER_MS = 256;
+
+/**
+ * Raised when the server answers a Range request with the whole file.
+ *
+ * It is a property of the server, not of the chunk, so the caller stops asking for ranges
+ * entirely rather than re-discovering it 255 more times (issue #301).
+ */
+class RangeIgnoredError extends Error {
+  constructor() {
+    super('Range header ignored');
+    this.name = 'RangeIgnoredError';
+  }
+}
 
 /** Async generator that yields 4 MiB buffers fetched via HTTP Range requests. */
 export async function* fetch_file_chunks(
@@ -19,15 +33,29 @@ export async function* fetch_file_chunks(
     const range_end = Math.min(range_start + CHUNK_SIZE_BYTES - 1, total_bytes - 1);
     const expected_length = range_end - range_start + 1;
 
-    yield await download_chunk_with_retry(
-      download_url,
-      range_start,
-      range_end,
-      expected_length,
-      item_id,
-      i + 1,
-      chunk_count,
-    );
+    try {
+      yield await download_chunk_with_retry(
+        download_url,
+        range_start,
+        range_end,
+        expected_length,
+        item_id,
+        i + 1,
+        chunk_count,
+        chunk_count > 1,
+      );
+    } catch (err) {
+      if (!(err instanceof RangeIgnoredError)) throw err;
+      // Every remaining chunk would fetch and discard the same whole file: a 1 GiB item costs
+      // 256 GiB transferred to produce 1 GiB. One streamed pass delivers the rest, and the
+      // chunks already yielded are re-read from the start, which is the price of finding out.
+      logger.warn(
+        `Range requests are ignored for ${item_id} (HTTP 200 with the full body); ` +
+          `falling back to one streamed download`,
+      );
+      yield* stream_whole_file_in_chunks(download_url, item_id, CHUNK_SIZE_BYTES);
+      return;
+    }
   }
 }
 
@@ -39,11 +67,21 @@ async function download_chunk_with_retry(
   item_id: string,
   chunk_index: number,
   total_chunks: number,
+  report_ignored_range: boolean,
 ): Promise<Buffer> {
   for (let attempt = 0; attempt <= MAX_CHUNK_RETRIES; attempt++) {
     try {
-      return await download_single_chunk(url, range_start, range_end, expected_length, item_id);
+      return await download_single_chunk(
+        url,
+        range_start,
+        range_end,
+        expected_length,
+        item_id,
+        report_ignored_range,
+      );
     } catch (err) {
+      // Not retryable and not a failure: the caller switches strategy on it.
+      if (err instanceof RangeIgnoredError) throw err;
       if (!is_cdn_retryable(err) || attempt === MAX_CHUNK_RETRIES) {
         throw new Error(
           `Failed chunk ${chunk_index}/${total_chunks} of ${item_id} ` +
@@ -69,6 +107,7 @@ async function download_single_chunk(
   range_end: number,
   expected_length: number,
   item_id: string,
+  report_ignored_range: boolean,
 ): Promise<Buffer> {
   const timeout_ms = Math.max(30_000, Math.ceil(expected_length / MIN_THROUGHPUT_BYTES_PER_MS));
   const controller = new AbortController();
@@ -92,13 +131,16 @@ async function download_single_chunk(
       );
     }
 
+    if (response.status === 200 && report_ignored_range) {
+      // Drop the body unread: buffering a whole file per chunk is the cost this avoids.
+      await response.body?.cancel();
+      throw new RangeIgnoredError();
+    }
+
     const buf = Buffer.from(await response.arrayBuffer());
 
     if (response.status === 200) {
-      logger.warn(
-        `CDN returned HTTP 200 instead of 206 for Range request on ${item_id} — ` +
-          `server ignored Range header, slicing ${buf.length} bytes to expected range`,
-      );
+      // A single-chunk item legitimately comes back whole, so the slice is a no-op there.
       if (buf.length < range_end + 1) {
         throw new Error(
           `CDN returned 200 with ${buf.length} bytes but range_end is ${range_end} for ${item_id}`,
@@ -125,5 +167,7 @@ function compute_retry_delay(attempt: number): number {
 }
 
 function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
 }

--- a/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
+++ b/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
@@ -7,6 +7,11 @@ const CHUNK_BASE_DELAY_MS = 1_000;
 const CHUNK_MAX_DELAY_MS = 30_000;
 const MIN_THROUGHPUT_BYTES_PER_MS = 256;
 
+/** Milliseconds a single 4 MiB read may stall before the transfer is abandoned. */
+function chunk_stall_timeout_ms(): number {
+  return Math.max(30_000, Math.ceil(CHUNK_SIZE_BYTES / MIN_THROUGHPUT_BYTES_PER_MS));
+}
+
 /**
  * Raised when the server answers a Range request with the whole file.
  *
@@ -53,7 +58,12 @@ export async function* fetch_file_chunks(
         `Range requests are ignored for ${item_id} (HTTP 200 with the full body); ` +
           `falling back to one streamed download`,
       );
-      yield* stream_whole_file_in_chunks(download_url, item_id, CHUNK_SIZE_BYTES);
+      yield* stream_whole_file_in_chunks(download_url, item_id, {
+        chunk_size_bytes: CHUNK_SIZE_BYTES,
+        // Same per-chunk budget the Range path uses, applied between reads rather than to the
+        // whole transfer, so a stalled body is cut off but a slow one is not.
+        stall_timeout_ms: chunk_stall_timeout_ms(),
+      });
       return;
     }
   }

--- a/packages/sharepoint/tests/unit/services/backup/large-file-chunk-download.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/large-file-chunk-download.test.ts
@@ -127,7 +127,13 @@ describe('fetch_file_chunks', () => {
     // Two requests, not one per chunk: the Range probe, then one streamed download. Fetching
     // per chunk cost the whole file every time, so a 1 GiB item moved 256 GiB.
     expect(fetch_mock).toHaveBeenCalledTimes(2);
-    expect((fetch_mock.mock.calls[1] as unknown[])[1]).toBeUndefined();
+    // The streamed request carries no Range header, only the stall-abort signal.
+    const streamed_init = (fetch_mock.mock.calls[1] as unknown[])[1] as {
+      headers?: Record<string, string>;
+      signal?: AbortSignal;
+    };
+    expect(streamed_init.headers).toBeUndefined();
+    expect(streamed_init.signal).toBeInstanceOf(AbortSignal);
     // Compared by digest, not by `toEqual`: a deep equality over 4 MiB of bytes takes seconds.
     const rebuilt = Buffer.concat(parts);
     expect(rebuilt.length).toBe(whole.length);

--- a/packages/sharepoint/tests/unit/services/backup/large-file-chunk-download.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/large-file-chunk-download.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fetch_file_chunks } from '@/services/backup/large-file-chunk-download';
 
 // The OneDrive twin of this file has had tests since issue #36; this one had
@@ -16,9 +17,19 @@ function to_array_buffer(body: Buffer): ArrayBuffer {
 function range_response(status: number, body = Buffer.alloc(0)): Response {
   return {
     status,
+    ok: status >= 200 && status < 300,
     headers: { get: (): string | null => null },
     arrayBuffer: (): Promise<ArrayBuffer> => Promise.resolve(to_array_buffer(body)),
     text: (): Promise<string> => Promise.resolve(''),
+    // The Range-ignored path cancels the body unread, and the streamed fallback iterates it.
+    body: {
+      cancel: (): Promise<void> => Promise.resolve(),
+      async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+        // Two parts, so the re-cut has to join across reads rather than pass one buffer through.
+        yield new Uint8Array(body.subarray(0, Math.ceil(body.length / 2)));
+        yield new Uint8Array(body.subarray(Math.ceil(body.length / 2)));
+      },
+    },
   } as unknown as Response;
 }
 
@@ -28,10 +39,8 @@ async function collect(url: string, total: number, item = 'item-1'): Promise<Buf
   return Buffer.concat(parts);
 }
 
-beforeEach(() => {
-  vi.useFakeTimers();
-});
-
+// Fake timers are installed per test, not globally: leaving them on for the streamed fallback
+// routes every promise resolution through the faked queue and turns a 4 MiB re-cut into seconds.
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
@@ -62,6 +71,7 @@ describe('fetch_file_chunks', () => {
   });
 
   it.each([429, 503, 504])('retries a chunk the CDN refused with HTTP %i', async (status) => {
+    vi.useFakeTimers();
     const payload = Buffer.from('chunk-payload');
     const fetch_mock = vi
       .fn()
@@ -87,6 +97,7 @@ describe('fetch_file_chunks', () => {
   });
 
   it('gives up after the retry budget is spent', async () => {
+    vi.useFakeTimers();
     const fetch_mock = vi.fn().mockResolvedValue(range_response(503));
     vi.stubGlobal('fetch', fetch_mock);
 
@@ -99,9 +110,7 @@ describe('fetch_file_chunks', () => {
     expect(fetch_mock).toHaveBeenCalledTimes(6);
   });
 
-  it('slices the whole body when the CDN ignores the Range header', async () => {
-    // A 200 means the server sent everything; taking it as the chunk would
-    // duplicate the head of the file into every later chunk.
+  it('stops asking for ranges once the CDN answers one with the whole file (issue #301)', async () => {
     const whole = Buffer.concat([Buffer.alloc(CHUNK_SIZE, 1), Buffer.alloc(1024, 2)]);
     const fetch_mock = vi.fn().mockResolvedValue(range_response(200, whole));
     vi.stubGlobal('fetch', fetch_mock);
@@ -115,18 +124,48 @@ describe('fetch_file_chunks', () => {
       parts.push(chunk);
     }
 
+    // Two requests, not one per chunk: the Range probe, then one streamed download. Fetching
+    // per chunk cost the whole file every time, so a 1 GiB item moved 256 GiB.
+    expect(fetch_mock).toHaveBeenCalledTimes(2);
+    expect((fetch_mock.mock.calls[1] as unknown[])[1]).toBeUndefined();
+    // Compared by digest, not by `toEqual`: a deep equality over 4 MiB of bytes takes seconds.
+    const rebuilt = Buffer.concat(parts);
+    expect(rebuilt.length).toBe(whole.length);
+    expect(createHash('sha256').update(rebuilt).digest('hex')).toBe(
+      createHash('sha256').update(whole).digest('hex'),
+    );
     expect(parts[0]?.length).toBe(CHUNK_SIZE);
     expect(parts[1]?.length).toBe(1024);
-    expect(parts[1]?.[0]).toBe(2);
   });
 
-  it('rejects a 200 body too short to satisfy the requested range', async () => {
-    const fetch_mock = vi.fn().mockResolvedValue(range_response(200, Buffer.alloc(10, 1)));
+  it('fails the streamed fallback when the plain download is refused', async () => {
+    const fetch_mock = vi
+      .fn()
+      .mockResolvedValueOnce(range_response(200, Buffer.alloc(CHUNK_SIZE + 1024, 1)))
+      .mockResolvedValueOnce(range_response(403));
     vi.stubGlobal('fetch', fetch_mock);
 
     await expect(collect('https://cdn.test/file', CHUNK_SIZE + 1024)).rejects.toThrow(
-      /returned 200 with 10 bytes/,
+      /HTTP 403 for the streamed download/,
     );
+  });
+
+  it('accepts a 200 for a single-chunk item, where the whole file is the chunk', async () => {
+    const whole = Buffer.alloc(1024, 7);
+    const fetch_mock = vi.fn().mockResolvedValue(range_response(200, whole));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    // One chunk means a 200 is not the server ignoring Range, so there is nothing to fall back
+    // to and no second request to make.
+    expect(await collect('https://cdn.test/file', 1024)).toEqual(whole);
+    expect(fetch_mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a single-chunk 200 body too short to satisfy the requested range', async () => {
+    const fetch_mock = vi.fn().mockResolvedValue(range_response(200, Buffer.alloc(5, 1)));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    await expect(collect('https://cdn.test/file', 10)).rejects.toThrow(/returned 200 with 5 bytes/);
   });
 
   it('yields nothing for a zero-byte file', async () => {


### PR DESCRIPTION
## Summary

When a CDN answered a Range request with `200` and the entire body, Atlas buffered the whole file, sliced out the 4 MiB it asked for, and threw the rest away, inside the per-chunk loop. A 1 GiB item was fetched 256 times: 256 GiB transferred and buffered to produce 1 GiB, with a warning logged on every pass.

Closes #301

## Changes

Whether the server honours Range is a property of the server, not of the chunk, so it is now decided once. The first chunk that comes back `200` on a multi-chunk item cancels the body unread and raises `RangeIgnoredError`, which is deliberately not retryable. The generator catches it, logs once, and delegates the rest of the item to a single streamed download.

- `packages/drive/src/backup/whole-file-stream.ts`, new: `stream_whole_file_in_chunks` fetches without a Range header and re-cuts the response into the same fixed-size buffers the encrypt-and-upload pipeline expects. Cutting from the stream keeps the memory ceiling at one chunk instead of the whole file, which is the property the chunked path exists for.
- Both chunk downloaders use it. The issue was filed against SharePoint, but `packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts` had the identical slice-and-discard loop, so it would have kept the bug after the SharePoint fix. Fixing one and not the other is how this pair got here.
- A single-chunk item is untouched: a `200` there is the whole file and the whole chunk at once, so the existing slice and its short-body guard still apply. The fallback only arms when `chunk_count > 1`.
- The per-pass "server ignored Range header, slicing N bytes" warning is gone, replaced by one warning per item stating that Range is ignored and that the download is falling back.

The chunks already yielded before the switch are re-read from the start of the streamed response. That is the price of finding out, and it is one extra pass rather than one per chunk.

## Ordering note

#306 lists `large-file-pipeline.ts` as a pair worth sharing. This lands first on purpose, per the note on #301: a Range fallback changes what the shared shape has to accept, and the shared helper this adds is the piece both sides now hold in common.

## Tests

- SharePoint and OneDrive each get a case asserting two fetches for a multi-chunk item, that the second carries no init (so no Range header), and that the reassembled bytes match by SHA-256.
- SharePoint also covers a refused streamed fallback, a single-chunk `200` taking one request only, and the short-body guard, which now applies to single-chunk items.
- Two incidental test fixes in the SharePoint suite: fake timers are installed per test rather than globally, and the reassembly is compared by digest. A `toEqual` over 4 MiB of bytes was taking 5.7 seconds and timing the test out, which is worth knowing before someone else writes the same assertion.

## Checklist

- `pnpm run build`, `pnpm run lint`, `pnpm run typecheck` and the full `pnpm run test` pass.
- Internal transfer behaviour only, no CLI, SDK or config surface, so no documentation is due.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved large-file downloads when servers ignore range requests.
  * Added streamed whole-file fallback handling to preserve complete file contents while avoiding unnecessary repeated requests.
  * Improved handling of HTTP failures and incomplete responses during fallback downloads.
  * Maintained correct behavior for single-chunk downloads, including valid and undersized responses.

* **New Features**
  * Added a reusable whole-file streaming download capability for backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->