### PR TITLE
refactor: share the drive file processor, large-file pipeline and change classifier

### DIFF
--- a/packages/drive/src/backup/change-classifier.ts
+++ b/packages/drive/src/backup/change-classifier.ts
@@ -1,0 +1,72 @@
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import type { DriveChangeType, DriveDeltaItem } from '@/drive-ports';
+
+/**
+ * Determines the type of change for a delta item based on previous state.
+ * Returns undefined if no meaningful change is detected (skip the item).
+ */
+export function classify_drive_change(
+  workload_label: string,
+  item: DriveDeltaItem,
+  previous_path_by_file_id: Record<string, string>,
+  previous_name_by_file_id: Record<string, string>,
+  previous_etag_by_file_id: Record<string, string>,
+): DriveChangeType | undefined {
+  if (item.deleted) return 'deleted';
+
+  const previous_path = previous_path_by_file_id[item.item_id];
+  const previous_name = previous_name_by_file_id[item.item_id];
+  const previous_etag = previous_etag_by_file_id[item.item_id];
+  const previously_known = Boolean(previous_path || previous_name || previous_etag);
+
+  if (!previously_known) return 'created';
+
+  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
+  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
+  const etags_missing = !previous_etag && !item.etag;
+
+  // Relocation before content: an item that moved and changed in the same delta window carries
+  // both signals, and the ETag branch used to answer first, erasing the move from the change
+  // record (issue #297). The new content blob makes the update self-evident; the old location is
+  // only recorded here. Content is downloaded either way, so the label is all that moves.
+  const relocation = relocation_label(path_changed, name_changed);
+  if (relocation) {
+    // Still worth saying when both ETags are absent: the relocation is certain, but with no ETag
+    // on either side a content change alongside it cannot be detected at all.
+    if (etags_missing) warn_missing_etag(workload_label, item.item_id);
+    return relocation;
+  }
+
+  if (is_etag_transition(previous_etag, item.etag)) {
+    if (etags_missing) warn_missing_etag(workload_label, item.item_id);
+    return 'updated';
+  }
+  return undefined;
+}
+
+/** Which relocation happened, if any: the label an operator uses to find where a file went. */
+function relocation_label(
+  path_changed: boolean,
+  name_changed: boolean,
+): DriveChangeType | undefined {
+  if (path_changed && name_changed) return 'moved_and_renamed';
+  if (path_changed) return 'moved';
+  if (name_changed) return 'renamed';
+  return undefined;
+}
+
+/** Any ETag movement for an item already known, including one absent on both sides. */
+function is_etag_transition(
+  previous_etag: string | undefined,
+  current_etag: string | undefined,
+): boolean {
+  if (previous_etag && current_etag) return previous_etag !== current_etag;
+  return true;
+}
+
+function warn_missing_etag(workload_label: string, item_id: string): void {
+  logger.warn(
+    `${workload_label} delta item ${item_id}: missing etag on prior and current snapshot; ` +
+      'a content change cannot be detected',
+  );
+}

--- a/packages/drive/src/backup/download-retry.ts
+++ b/packages/drive/src/backup/download-retry.ts
@@ -1,6 +1,7 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import { is_retryable_error, is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
 import type { DriveContentConnector, DriveDeltaItem } from '@/drive-ports';
+import { format_bytes } from '@/shared/format-bytes';
 
 const DEFAULT_MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 2_000;
@@ -60,13 +61,6 @@ function compute_file_retry_delay(attempt: number): number {
   const base = BASE_DELAY_MS * 2 ** (attempt - 1);
   const jitter = Math.random() * BASE_DELAY_MS;
   return Math.min(base + jitter, MAX_DELAY_MS);
-}
-
-function format_bytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/drive/src/backup/file-processor.ts
+++ b/packages/drive/src/backup/file-processor.ts
@@ -1,0 +1,67 @@
+import { createHash } from 'node:crypto';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import { is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
+import type { TenantContext } from '@wisecom/atlas-types';
+import { download_with_retry } from '@/backup/download-retry';
+import { LARGE_FILE_THRESHOLD } from '@/backup/large-file-threshold';
+import {
+  process_large_drive_file,
+  type DriveDownloadUrlResolver,
+  type DriveLargeFileDeps,
+} from '@/backup/large-file-pipeline';
+import type { DriveContentConnector, DriveDeltaItem } from '@/drive-ports';
+
+const HASH_CHUNK_SIZE = 64 * 1024 * 1024;
+
+export interface FileProcessResult {
+  storage_key: string;
+  checksum: string;
+  stored: boolean;
+  deduplicated: boolean;
+}
+
+/** Downloads or deduplicates a single delta file item. */
+export async function process_drive_backup_file(
+  deps: DriveLargeFileDeps,
+  connector: DriveContentConnector & DriveDownloadUrlResolver,
+  item: DriveDeltaItem,
+  owner_id: string,
+  ctx: TenantContext,
+): Promise<FileProcessResult | undefined> {
+  if (item.size_bytes >= LARGE_FILE_THRESHOLD) {
+    try {
+      return await process_large_drive_file(deps, connector, item, owner_id, ctx);
+    } catch (err) {
+      // A missing grant or a service refusal is not a skip: it must reach the caller
+      // so the run can name the cause instead of reporting a lost file (issue #246).
+      if (is_unretryable_download_failure(err)) throw err;
+      logger.warn(
+        `Skipping large file ${item.item_id} (${item.file_name}): ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  const raw_body = await download_with_retry(connector, item);
+  if (!raw_body) return undefined;
+
+  const checksum = compute_sha256_chunked(raw_body);
+  const storage_key = deps.keys.data_key(owner_id, checksum);
+  const exists = await ctx.storage.exists(storage_key);
+
+  if (!exists) {
+    await ctx.storage.put(storage_key, ctx.encrypt(raw_body));
+    return { storage_key, checksum, stored: true, deduplicated: false };
+  }
+
+  return { storage_key, checksum, stored: false, deduplicated: true };
+}
+
+/** Computes SHA-256 in chunks to avoid ERR_OUT_OF_RANGE on buffers > 2 GB. */
+function compute_sha256_chunked(data: Buffer): string {
+  const hash = createHash('sha256');
+  for (let offset = 0; offset < data.length; offset += HASH_CHUNK_SIZE) {
+    hash.update(data.subarray(offset, Math.min(offset + HASH_CHUNK_SIZE, data.length)));
+  }
+  return hash.digest('hex');
+}

--- a/packages/drive/src/backup/large-file-pipeline.ts
+++ b/packages/drive/src/backup/large-file-pipeline.ts
@@ -1,0 +1,96 @@
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import { stream_to_content_addressed_storage } from '@wisecom/atlas-core/services/shared/stream-encrypt-upload';
+import type { StorageObjectLockPolicy, TenantContext } from '@wisecom/atlas-types';
+import type { DriveDeltaItem } from '@/drive-ports';
+import { format_bytes } from '@/shared/format-bytes';
+import type { DriveStorageKeys } from '@/shared/storage-keys';
+
+export interface LargeFileResult {
+  readonly checksum: string;
+  readonly storage_key: string;
+  readonly stored: boolean;
+  readonly deduplicated: boolean;
+}
+
+/** Resolves the short-lived download URL for an item whose delta page did not carry one. */
+export interface DriveDownloadUrlResolver {
+  resolve_download_url(item: DriveDeltaItem): Promise<string | undefined>;
+}
+
+/**
+ * What a provider supplies to the shared large-file pipeline: its key layout and its chunk
+ * fetcher. The two providers reach for different chunked-download adapters, which is the only
+ * behavioural difference between the copies this replaces.
+ */
+export interface DriveLargeFileDeps {
+  readonly keys: DriveStorageKeys;
+  readonly fetch_chunks: (
+    download_url: string,
+    total_bytes: number,
+    item_id: string,
+  ) => AsyncIterable<Buffer>;
+}
+
+/**
+ * Single-download, zero-disk pipeline for files at or above the large-file threshold. Streams
+ * encrypted parts to an S3 staging key, then either aborts (dedup) or copies to the canonical
+ * content-addressed key.
+ */
+export async function process_large_drive_file(
+  deps: DriveLargeFileDeps,
+  connector: DriveDownloadUrlResolver,
+  item: DriveDeltaItem,
+  owner_id: string,
+  ctx: TenantContext,
+  object_lock_policy?: StorageObjectLockPolicy,
+): Promise<LargeFileResult> {
+  const download_url = item.download_url ?? (await connector.resolve_download_url(item));
+  if (!download_url) {
+    throw new Error(`Could not resolve download URL for large file ${item.item_id}`);
+  }
+
+  const staging_key = deps.keys.staging_key(owner_id, item.item_id);
+
+  logger.info(
+    `Streaming large file ${item.file_name} (${format_bytes(item.size_bytes)}) via staging key...`,
+  );
+
+  const result = await stream_to_content_addressed_storage(
+    ctx,
+    deps.fetch_chunks(download_url, item.size_bytes, item.item_id),
+    {
+      staging_key,
+      staging_prefix: deps.keys.staging_prefix_for(owner_id),
+      build_data_key: (checksum) => deps.keys.data_key(owner_id, checksum),
+      ...(object_lock_policy && { object_lock_policy }),
+    },
+  );
+
+  if (result.deduplicated) {
+    logger.info(`Deduplicated ${item.file_name} (already stored)`);
+  } else {
+    logger.info(`Stored ${item.file_name} (${format_bytes(item.size_bytes)})`);
+  }
+
+  return result;
+}
+
+/** Removes leftover staging objects and incomplete multipart uploads. */
+export async function cleanup_stale_drive_staging(
+  keys: DriveStorageKeys,
+  ctx: TenantContext,
+  owner_id: string,
+): Promise<void> {
+  const prefix = keys.staging_prefix_for(owner_id);
+
+  const stale_keys = await ctx.storage.list(prefix);
+  for (const key of stale_keys) {
+    logger.info(`Cleaning up stale staging object: ${key}`);
+    await ctx.storage.delete(key).catch(() => {});
+  }
+
+  const aborted = await ctx.storage.abort_incomplete_uploads(prefix);
+  if (aborted > 0) {
+    logger.info(`Aborted ${aborted} incomplete staging upload(s)`);
+  }
+}

--- a/packages/drive/src/drive-ports.ts
+++ b/packages/drive/src/drive-ports.ts
@@ -1,4 +1,5 @@
 import type {
+  OneDriveChangeType,
   OneDriveDeltaItem,
   OneDriveFileVersion,
   OneDriveFileVersionIndex,
@@ -15,6 +16,7 @@ import type {
  * day a provider's shape diverges the callers in that package stop compiling instead of drifting
  * quietly. Aliasing beats re-declaring here: a hand-copied interface would drift in silence.
  */
+export type DriveChangeType = OneDriveChangeType;
 export type DriveDeltaItem = OneDriveDeltaItem;
 export type DriveFileVersion = OneDriveFileVersion;
 export type DriveFileVersionRecord = OneDriveFileVersionRecord;

--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -1,5 +1,27 @@
+/**
+ * The drive behaviour OneDrive and SharePoint share, taking each provider's values as arguments.
+ *
+ * The modules that still exist twice in the provider packages fall into two groups (#306). The
+ * ones with real differences carry a comment saying so and what the difference is:
+ * `backup.service.ts`, `restore.service.ts`, `status.service.ts`, `backup-builders.ts` and
+ * `restore-folder-path.ts`. Everything else that still pairs up by name is a binder: a class that
+ * satisfies a per-provider port, a descriptor that names the manifest lookup, or a module that
+ * supplies the key layout and a chunk fetcher to the shared code below. Those exist precisely to
+ * hold the provider's values, so deduplicating them would mean giving up the separate ports, and
+ * a near-zero diff there is the intended result rather than duplication left behind.
+ */
 export * from '@/drive-ports';
 export { download_with_retry, type DownloadRetryOptions } from '@/backup/download-retry';
+export { classify_drive_change } from '@/backup/change-classifier';
+export { process_drive_backup_file, type FileProcessResult } from '@/backup/file-processor';
+export {
+  process_large_drive_file,
+  cleanup_stale_drive_staging,
+  type DriveDownloadUrlResolver,
+  type DriveLargeFileDeps,
+  type LargeFileResult,
+} from '@/backup/large-file-pipeline';
+export { format_bytes } from '@/shared/format-bytes';
 export { LARGE_FILE_THRESHOLD } from '@/backup/large-file-threshold';
 export {
   stream_whole_file_in_chunks,

--- a/packages/drive/src/shared/format-bytes.ts
+++ b/packages/drive/src/shared/format-bytes.ts
@@ -1,0 +1,7 @@
+/** Human-readable byte size for operator-facing log lines. */
+export function format_bytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}

--- a/packages/onedrive/src/services/backup/backup-builders.ts
+++ b/packages/onedrive/src/services/backup/backup-builders.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the SharePoint copy (#306): 68 differing lines of 432. The
+// manifests they build differ in their identity fields and in what each provider records per
+// entry, so the shared version would be generic over almost every line.
 import type {
   OneDriveBackupResult,
   OneDriveChangeType,

--- a/packages/onedrive/src/services/backup/backup-file-processor.ts
+++ b/packages/onedrive/src/services/backup/backup-file-processor.ts
@@ -1,19 +1,11 @@
-import { createHash } from 'node:crypto';
 import type { OneDriveConnector, OneDriveDeltaItem, TenantContext } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
-import { is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
-import { download_with_retry } from '@wisecom/atlas-drive/backup/download-retry';
-import { LARGE_FILE_THRESHOLD, process_large_file } from '@/services/backup/large-file-pipeline';
-import { onedrive_data_key } from '@/services/shared/storage-keys';
+import {
+  process_drive_backup_file,
+  type FileProcessResult,
+} from '@wisecom/atlas-drive/backup/file-processor';
+import { ONEDRIVE_LARGE_FILE_DEPS } from '@/services/backup/large-file-pipeline';
 
-const HASH_CHUNK_SIZE = 64 * 1024 * 1024;
-
-export interface FileProcessResult {
-  storage_key: string;
-  checksum: string;
-  stored: boolean;
-  deduplicated: boolean;
-}
+export type { FileProcessResult } from '@wisecom/atlas-drive/backup/file-processor';
 
 /** Downloads or deduplicates a single delta file item. */
 export async function process_backup_file(
@@ -22,33 +14,7 @@ export async function process_backup_file(
   owner_id: string,
   ctx: TenantContext,
 ): Promise<FileProcessResult | undefined> {
-  if (item.size_bytes >= LARGE_FILE_THRESHOLD) {
-    try {
-      return await process_large_file(connector, item, owner_id, ctx);
-    } catch (err) {
-      // A missing grant or a service refusal is not a skip: it must reach the caller
-      // so the run can name the cause instead of reporting a lost file (issue #246).
-      if (is_unretryable_download_failure(err)) throw err;
-      logger.warn(
-        `Skipping large file ${item.item_id} (${item.file_name}): ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-
-  const raw_body = await download_with_retry(connector, item);
-  if (!raw_body) return undefined;
-
-  const checksum = compute_sha256_chunked(raw_body);
-  const storage_key = onedrive_data_key(owner_id, checksum);
-  const exists = await ctx.storage.exists(storage_key);
-
-  if (!exists) {
-    await ctx.storage.put(storage_key, ctx.encrypt(raw_body));
-    return { storage_key, checksum, stored: true, deduplicated: false };
-  }
-
-  return { storage_key, checksum, stored: false, deduplicated: true };
+  return process_drive_backup_file(ONEDRIVE_LARGE_FILE_DEPS, connector, item, owner_id, ctx);
 }
 
 /** @throws Error when no drives are returned (likely missing Graph permissions). */
@@ -57,13 +23,4 @@ export function ensure_drives_discovered(drive_count: number): void {
   throw new Error(
     'Missing Microsoft Graph application permissions for OneDrive: Files.Read.All, Sites.Read.All.',
   );
-}
-
-/** Computes SHA-256 in chunks to avoid ERR_OUT_OF_RANGE on buffers > 2 GB. */
-function compute_sha256_chunked(data: Buffer): string {
-  const hash = createHash('sha256');
-  for (let offset = 0; offset < data.length; offset += HASH_CHUNK_SIZE) {
-    hash.update(data.subarray(offset, Math.min(offset + HASH_CHUNK_SIZE, data.length)));
-  }
-  return hash.digest('hex');
 }

--- a/packages/onedrive/src/services/backup/backup.service.ts
+++ b/packages/onedrive/src/services/backup/backup.service.ts
@@ -1,3 +1,7 @@
+// Deliberately not shared with the SharePoint copy (#306): 306 differing lines of 604. OneDrive
+// enumerates an owner's drives and carries a folder scope and a per-drive delta cursor;
+// SharePoint walks a site tree, then libraries within it, and has no folder scope. Unifying
+// them means a parameter per branch, which is the shape that made the copies hard to change.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { randomBytes } from 'node:crypto';
 import {

--- a/packages/onedrive/src/services/backup/change-classifier.ts
+++ b/packages/onedrive/src/services/backup/change-classifier.ts
@@ -1,5 +1,5 @@
 import type { OneDriveChangeType, OneDriveDeltaItem } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
+import { classify_drive_change } from '@wisecom/atlas-drive/backup/change-classifier';
 
 /**
  * Determines the type of change for a delta item based on previous state.
@@ -11,60 +11,11 @@ export function classify_change_type(
   previous_name_by_file_id: Record<string, string>,
   previous_etag_by_file_id: Record<string, string>,
 ): OneDriveChangeType | undefined {
-  if (item.deleted) return 'deleted';
-
-  const previous_path = previous_path_by_file_id[item.item_id];
-  const previous_name = previous_name_by_file_id[item.item_id];
-  const previous_etag = previous_etag_by_file_id[item.item_id];
-  const previously_known = Boolean(previous_path || previous_name || previous_etag);
-
-  if (!previously_known) return 'created';
-
-  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
-  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
-  const etags_missing = !previous_etag && !item.etag;
-
-  // Relocation before content: an item that moved and changed in the same delta window carries
-  // both signals, and the ETag branch used to answer first, erasing the move from the change
-  // record (issue #297). The new content blob makes the update self-evident; the old location
-  // is only recorded here. Content is downloaded either way, so the label is all that moves.
-  const relocation = relocation_label(path_changed, name_changed);
-  if (relocation) {
-    // Still worth saying when both ETags are absent: the relocation is certain, but with no ETag
-    // on either side a content change alongside it cannot be detected at all.
-    if (etags_missing) warn_missing_etag(item.item_id);
-    return relocation;
-  }
-
-  if (is_etag_transition(previous_etag, item.etag)) {
-    if (etags_missing) warn_missing_etag(item.item_id);
-    return 'updated';
-  }
-  return undefined;
-}
-
-/** Which relocation happened, if any: the label an operator uses to find where a file went. */
-function relocation_label(
-  path_changed: boolean,
-  name_changed: boolean,
-): OneDriveChangeType | undefined {
-  if (path_changed && name_changed) return 'moved_and_renamed';
-  if (path_changed) return 'moved';
-  if (name_changed) return 'renamed';
-  return undefined;
-}
-
-/** Any ETag movement for an item already known, including one absent on both sides. */
-function is_etag_transition(
-  previous_etag: string | undefined,
-  current_etag: string | undefined,
-): boolean {
-  if (previous_etag && current_etag) return previous_etag !== current_etag;
-  return true;
-}
-
-function warn_missing_etag(item_id: string): void {
-  logger.warn(
-    `OneDrive delta item ${item_id}: missing etag on prior and current snapshot; a content change cannot be detected`,
+  return classify_drive_change(
+    'OneDrive',
+    item,
+    previous_path_by_file_id,
+    previous_name_by_file_id,
+    previous_etag_by_file_id,
   );
 }

--- a/packages/onedrive/src/services/backup/large-file-pipeline.ts
+++ b/packages/onedrive/src/services/backup/large-file-pipeline.ts
@@ -1,32 +1,24 @@
-import { fetch_file_chunks } from '@/adapters/graph-onedrive-chunked-download';
+import type { StorageObjectLockPolicy, TenantContext } from '@wisecom/atlas-types';
+import type { OneDriveConnector, OneDriveDeltaItem } from '@wisecom/atlas-types';
 import {
-  onedrive_data_key,
-  onedrive_staging_key,
-  onedrive_staging_prefix,
-} from '@/services/shared/storage-keys';
-import { logger } from '@wisecom/atlas-core/utils/logger';
-import { stream_to_content_addressed_storage } from '@wisecom/atlas-core/services/shared/stream-encrypt-upload';
-import type {
-  OneDriveConnector,
-  OneDriveDeltaItem,
-  StorageObjectLockPolicy,
-  TenantContext,
-} from '@wisecom/atlas-types';
+  cleanup_stale_drive_staging,
+  process_large_drive_file,
+  type DriveLargeFileDeps,
+  type LargeFileResult,
+} from '@wisecom/atlas-drive/backup/large-file-pipeline';
+import { fetch_file_chunks } from '@/adapters/graph-onedrive-chunked-download';
+import { ONEDRIVE_KEYS } from '@/services/shared/storage-keys';
 
 export { LARGE_FILE_THRESHOLD } from '@wisecom/atlas-drive/backup/large-file-threshold';
+export type { LargeFileResult } from '@wisecom/atlas-drive/backup/large-file-pipeline';
 
-export interface LargeFileResult {
-  readonly checksum: string;
-  readonly storage_key: string;
-  readonly stored: boolean;
-  readonly deduplicated: boolean;
-}
+/** OneDrive's half of the shared large-file pipeline: its key layout and its chunk fetcher. */
+export const ONEDRIVE_LARGE_FILE_DEPS: DriveLargeFileDeps = {
+  keys: ONEDRIVE_KEYS,
+  fetch_chunks: fetch_file_chunks,
+};
 
-/**
- * Single-download, zero-disk pipeline for files at or above
- * {@link LARGE_FILE_THRESHOLD}. Streams encrypted parts to an S3 staging key,
- * then either aborts (dedup) or copies to the canonical content-addressed key.
- */
+/** Streams a large file to storage through a staging key, deduplicating by content hash. */
 export async function process_large_file(
   connector: OneDriveConnector,
   item: OneDriveDeltaItem,
@@ -34,56 +26,17 @@ export async function process_large_file(
   ctx: TenantContext,
   object_lock_policy?: StorageObjectLockPolicy,
 ): Promise<LargeFileResult> {
-  const download_url = item.download_url ?? (await connector.resolve_download_url(item));
-  if (!download_url) {
-    throw new Error(`Could not resolve download URL for large file ${item.item_id}`);
-  }
-
-  const staging_key = onedrive_staging_key(owner_id, item.item_id);
-
-  logger.info(
-    `Streaming large file ${item.file_name} (${format_bytes(item.size_bytes)}) via staging key...`,
-  );
-
-  const result = await stream_to_content_addressed_storage(
+  return process_large_drive_file(
+    ONEDRIVE_LARGE_FILE_DEPS,
+    connector,
+    item,
+    owner_id,
     ctx,
-    fetch_file_chunks(download_url, item.size_bytes, item.item_id),
-    {
-      staging_key,
-      staging_prefix: onedrive_staging_prefix(owner_id),
-      build_data_key: (checksum) => onedrive_data_key(owner_id, checksum),
-      ...(object_lock_policy && { object_lock_policy }),
-    },
+    object_lock_policy,
   );
-
-  if (result.deduplicated) {
-    logger.info(`Deduplicated ${item.file_name} (already stored)`);
-  } else {
-    logger.info(`Stored ${item.file_name} (${format_bytes(item.size_bytes)})`);
-  }
-
-  return result;
 }
 
 /** Removes leftover staging objects and incomplete multipart uploads. */
 export async function cleanup_stale_staging(ctx: TenantContext, owner_id: string): Promise<void> {
-  const prefix = onedrive_staging_prefix(owner_id);
-
-  const stale_keys = await ctx.storage.list(prefix);
-  for (const key of stale_keys) {
-    logger.info(`Cleaning up stale staging object: ${key}`);
-    await ctx.storage.delete(key).catch(() => {});
-  }
-
-  const aborted = await ctx.storage.abort_incomplete_uploads(prefix);
-  if (aborted > 0) {
-    logger.info(`Aborted ${aborted} incomplete staging upload(s)`);
-  }
-}
-
-function format_bytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+  return cleanup_stale_drive_staging(ONEDRIVE_KEYS, ctx, owner_id);
 }

--- a/packages/onedrive/src/services/restore/restore-folder-path.ts
+++ b/packages/onedrive/src/services/restore/restore-folder-path.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the SharePoint copy (#306): 28 differing lines of 106. The memo
+// keys differ, path here against `drive_id:path` there, which is a behavioural difference
+// rather than a naming one and is tracked separately.
 import type { OneDriveConnector } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 

--- a/packages/onedrive/src/services/restore/restore.service.ts
+++ b/packages/onedrive/src/services/restore/restore.service.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the SharePoint copy (#306): 194 differing lines of 496. The
+// restore target differs in kind, an owner's drive against a resolved site and library, and
+// so does the conflict handling around the restore root.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import {
   begin_operation_progress,

--- a/packages/onedrive/src/services/status/status.service.ts
+++ b/packages/onedrive/src/services/status/status.service.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the SharePoint copy (#306): 71 differing lines of 247. Both
+// peek at delta state, but over drives against libraries, with different discovery calls and
+// different result shapes exposed through the ports.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {

--- a/packages/sharepoint/src/services/backup/backup-builders.ts
+++ b/packages/sharepoint/src/services/backup/backup-builders.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the OneDrive copy (#306): 68 differing lines of 432. The
+// manifests they build differ in their identity fields and in what each provider records per
+// entry, so the shared version would be generic over almost every line.
 import type {
   SharePointBackupResult,
   SharePointChangeType,

--- a/packages/sharepoint/src/services/backup/backup-file-processor.ts
+++ b/packages/sharepoint/src/services/backup/backup-file-processor.ts
@@ -1,23 +1,15 @@
-import { createHash } from 'node:crypto';
 import type {
-  SharePointSiteConnector,
   SharePointDeltaItem,
+  SharePointSiteConnector,
   TenantContext,
 } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
-import { is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
-import { download_with_retry } from '@wisecom/atlas-drive/backup/download-retry';
-import { LARGE_FILE_THRESHOLD, process_large_file } from '@/services/backup/large-file-pipeline';
-import { sharepoint_data_key } from '@/services/shared/storage-keys';
+import {
+  process_drive_backup_file,
+  type FileProcessResult,
+} from '@wisecom/atlas-drive/backup/file-processor';
+import { SHAREPOINT_LARGE_FILE_DEPS } from '@/services/backup/large-file-pipeline';
 
-const HASH_CHUNK_SIZE = 64 * 1024 * 1024;
-
-export interface FileProcessResult {
-  storage_key: string;
-  checksum: string;
-  stored: boolean;
-  deduplicated: boolean;
-}
+export type { FileProcessResult } from '@wisecom/atlas-drive/backup/file-processor';
 
 /** Downloads or deduplicates a single delta file item. */
 export async function process_backup_file(
@@ -26,33 +18,7 @@ export async function process_backup_file(
   site_id: string,
   ctx: TenantContext,
 ): Promise<FileProcessResult | undefined> {
-  if (item.size_bytes >= LARGE_FILE_THRESHOLD) {
-    try {
-      return await process_large_file(connector, item, site_id, ctx);
-    } catch (err) {
-      // A missing grant or a service refusal is not a skip: it must reach the caller
-      // so the run can name the cause instead of reporting a lost file (issue #246).
-      if (is_unretryable_download_failure(err)) throw err;
-      logger.warn(
-        `Skipping large file ${item.item_id} (${item.file_name}): ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-
-  const raw_body = await download_with_retry(connector, item);
-  if (!raw_body) return undefined;
-
-  const checksum = compute_sha256_chunked(raw_body);
-  const storage_key = sharepoint_data_key(site_id, checksum);
-  const exists = await ctx.storage.exists(storage_key);
-
-  if (!exists) {
-    await ctx.storage.put(storage_key, ctx.encrypt(raw_body));
-    return { storage_key, checksum, stored: true, deduplicated: false };
-  }
-
-  return { storage_key, checksum, stored: false, deduplicated: true };
+  return process_drive_backup_file(SHAREPOINT_LARGE_FILE_DEPS, connector, item, site_id, ctx);
 }
 
 /** @throws Error when no document libraries are returned (likely missing Graph permissions). */
@@ -61,13 +27,4 @@ export function ensure_libraries_discovered(library_count: number): void {
   throw new Error(
     'Missing Microsoft Graph application permissions for SharePoint: Sites.Read.All.',
   );
-}
-
-/** Computes SHA-256 in chunks to avoid ERR_OUT_OF_RANGE on buffers > 2 GB. */
-function compute_sha256_chunked(data: Buffer): string {
-  const hash = createHash('sha256');
-  for (let offset = 0; offset < data.length; offset += HASH_CHUNK_SIZE) {
-    hash.update(data.subarray(offset, Math.min(offset + HASH_CHUNK_SIZE, data.length)));
-  }
-  return hash.digest('hex');
 }

--- a/packages/sharepoint/src/services/backup/backup.service.ts
+++ b/packages/sharepoint/src/services/backup/backup.service.ts
@@ -1,3 +1,7 @@
+// Deliberately not shared with the OneDrive copy (#306): 306 differing lines of 604. SharePoint
+// walks a site tree, then libraries within it; OneDrive enumerates an owner's drives and
+// carries a folder scope and a per-drive delta cursor. Unifying them means a parameter per
+// branch, which is the shape that made the copies hard to change.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { randomBytes } from 'node:crypto';
 import {

--- a/packages/sharepoint/src/services/backup/change-classifier.ts
+++ b/packages/sharepoint/src/services/backup/change-classifier.ts
@@ -1,5 +1,5 @@
 import type { SharePointChangeType, SharePointDeltaItem } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
+import { classify_drive_change } from '@wisecom/atlas-drive/backup/change-classifier';
 
 /**
  * Determines the type of change for a delta item based on previous state.
@@ -11,54 +11,11 @@ export function classify_change_type(
   previous_name_by_file_id: Record<string, string>,
   previous_etag_by_file_id: Record<string, string>,
 ): SharePointChangeType | undefined {
-  if (item.deleted) return 'deleted';
-
-  const previous_path = previous_path_by_file_id[item.item_id];
-  const previous_name = previous_name_by_file_id[item.item_id];
-  const previous_etag = previous_etag_by_file_id[item.item_id];
-  const previously_known = Boolean(previous_path || previous_name || previous_etag);
-
-  if (!previously_known) return 'created';
-
-  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
-  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
-  // Relocation before content: an item that moved and changed in the same delta window carries
-  // both signals, and the ETag branch used to answer first, erasing the move from the change
-  // record (issue #297). The new content blob makes the update self-evident; the old location is
-  // only recorded here. Content is downloaded either way, so the label is all that moves.
-  if (path_changed || name_changed) {
-    // Still worth saying when both ETags are absent: the relocation is certain, but with no ETag
-    // on either side a content change alongside it cannot be detected at all.
-    warn_missing_etag(item.item_id, previous_etag, item.etag);
-    if (path_changed && name_changed) return 'moved_and_renamed';
-    return path_changed ? 'moved' : 'renamed';
-  }
-
-  if (is_etag_transition(previous_etag, item.etag, previously_known)) {
-    warn_missing_etag(item.item_id, previous_etag, item.etag);
-    return 'updated';
-  }
-  return undefined;
-}
-
-function is_etag_transition(
-  previous_etag: string | undefined,
-  current_etag: string | undefined,
-  previously_known: boolean,
-): boolean {
-  if (previous_etag && !current_etag) return true;
-  if (!previous_etag && current_etag) return true;
-  if (previous_etag && current_etag && previous_etag !== current_etag) return true;
-  return previously_known && !previous_etag && !current_etag;
-}
-
-function warn_missing_etag(
-  item_id: string,
-  previous_etag: string | undefined,
-  current_etag: string | undefined,
-): void {
-  if (previous_etag || current_etag) return;
-  logger.warn(
-    `SharePoint delta item ${item_id}: missing etag on prior and current snapshot; a content change cannot be detected`,
+  return classify_drive_change(
+    'SharePoint',
+    item,
+    previous_path_by_file_id,
+    previous_name_by_file_id,
+    previous_etag_by_file_id,
   );
 }

--- a/packages/sharepoint/src/services/backup/large-file-pipeline.ts
+++ b/packages/sharepoint/src/services/backup/large-file-pipeline.ts
@@ -1,32 +1,24 @@
-import { logger } from '@wisecom/atlas-core/utils/logger';
-import { stream_to_content_addressed_storage } from '@wisecom/atlas-core/services/shared/stream-encrypt-upload';
-import type {
-  SharePointSiteConnector,
-  SharePointDeltaItem,
-  StorageObjectLockPolicy,
-  TenantContext,
-} from '@wisecom/atlas-types';
-import { fetch_file_chunks } from '@/services/backup/large-file-chunk-download';
+import type { StorageObjectLockPolicy, TenantContext } from '@wisecom/atlas-types';
+import type { SharePointDeltaItem, SharePointSiteConnector } from '@wisecom/atlas-types';
 import {
-  sharepoint_data_key,
-  sharepoint_staging_key,
-  sharepoint_staging_prefix,
-} from '@/services/shared/storage-keys';
+  cleanup_stale_drive_staging,
+  process_large_drive_file,
+  type DriveLargeFileDeps,
+  type LargeFileResult,
+} from '@wisecom/atlas-drive/backup/large-file-pipeline';
+import { fetch_file_chunks } from '@/services/backup/large-file-chunk-download';
+import { SHAREPOINT_KEYS } from '@/services/shared/storage-keys';
 
 export { LARGE_FILE_THRESHOLD } from '@wisecom/atlas-drive/backup/large-file-threshold';
+export type { LargeFileResult } from '@wisecom/atlas-drive/backup/large-file-pipeline';
 
-export interface LargeFileResult {
-  readonly checksum: string;
-  readonly storage_key: string;
-  readonly stored: boolean;
-  readonly deduplicated: boolean;
-}
+/** SharePoint's half of the shared large-file pipeline: its key layout and its chunk fetcher. */
+export const SHAREPOINT_LARGE_FILE_DEPS: DriveLargeFileDeps = {
+  keys: SHAREPOINT_KEYS,
+  fetch_chunks: fetch_file_chunks,
+};
 
-/**
- * Single-download, zero-disk pipeline for files at or above
- * {@link LARGE_FILE_THRESHOLD}. Streams encrypted parts to an S3 staging key,
- * then either aborts (dedup) or copies to the canonical content-addressed key.
- */
+/** Streams a large file to storage through a staging key, deduplicating by content hash. */
 export async function process_large_file(
   connector: SharePointSiteConnector,
   item: SharePointDeltaItem,
@@ -34,56 +26,17 @@ export async function process_large_file(
   ctx: TenantContext,
   object_lock_policy?: StorageObjectLockPolicy,
 ): Promise<LargeFileResult> {
-  const download_url = item.download_url ?? (await connector.resolve_download_url(item));
-  if (!download_url) {
-    throw new Error(`Could not resolve download URL for large file ${item.item_id}`);
-  }
-
-  const staging_key = sharepoint_staging_key(site_id, item.item_id);
-
-  logger.info(
-    `Streaming large file ${item.file_name} (${format_bytes(item.size_bytes)}) via staging key...`,
-  );
-
-  const result = await stream_to_content_addressed_storage(
+  return process_large_drive_file(
+    SHAREPOINT_LARGE_FILE_DEPS,
+    connector,
+    item,
+    site_id,
     ctx,
-    fetch_file_chunks(download_url, item.size_bytes, item.item_id),
-    {
-      staging_key,
-      staging_prefix: sharepoint_staging_prefix(site_id),
-      build_data_key: (checksum) => sharepoint_data_key(site_id, checksum),
-      ...(object_lock_policy && { object_lock_policy }),
-    },
+    object_lock_policy,
   );
-
-  if (result.deduplicated) {
-    logger.info(`Deduplicated ${item.file_name} (already stored)`);
-  } else {
-    logger.info(`Stored ${item.file_name} (${format_bytes(item.size_bytes)})`);
-  }
-
-  return result;
 }
 
 /** Removes leftover staging objects and incomplete multipart uploads. */
 export async function cleanup_stale_staging(ctx: TenantContext, site_id: string): Promise<void> {
-  const prefix = sharepoint_staging_prefix(site_id);
-
-  const stale_keys = await ctx.storage.list(prefix);
-  for (const key of stale_keys) {
-    logger.info(`Cleaning up stale staging object: ${key}`);
-    await ctx.storage.delete(key).catch(() => {});
-  }
-
-  const aborted = await ctx.storage.abort_incomplete_uploads(prefix);
-  if (aborted > 0) {
-    logger.info(`Aborted ${aborted} incomplete staging upload(s)`);
-  }
-}
-
-function format_bytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+  return cleanup_stale_drive_staging(SHAREPOINT_KEYS, ctx, site_id);
 }

--- a/packages/sharepoint/src/services/restore/restore-folder-path.ts
+++ b/packages/sharepoint/src/services/restore/restore-folder-path.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the OneDrive copy (#306): 28 differing lines of 106. The memo
+// keys differ, `drive_id:path` here against path alone there, which is a behavioural
+// difference rather than a naming one and is tracked separately.
 import type { SharePointSiteConnector } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 

--- a/packages/sharepoint/src/services/restore/restore.service.ts
+++ b/packages/sharepoint/src/services/restore/restore.service.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the OneDrive copy (#306): 194 differing lines of 496. The
+// restore target differs in kind, a resolved site and library against an owner's drive, and
+// so does the conflict handling around the restore root.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import {
   begin_operation_progress,

--- a/packages/sharepoint/src/services/status/status.service.ts
+++ b/packages/sharepoint/src/services/status/status.service.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the OneDrive copy (#306): 71 differing lines of 247. Both peek
+// at delta state, but over libraries against drives, with different discovery calls and
+// different result shapes exposed through the ports.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {


### PR DESCRIPTION
## Summary

The last v4.4.0 issue, and the second half of #151. Shares the drive pairs that were close enough to share, and records a reason next to every pair that is deliberately staying as two copies, so the remaining duplication is a decision on record rather than an open question.

Closes #306

## What is now shared

Three modules moved into `packages/drive`, each taking the provider's values as arguments:

- `backup/large-file-pipeline.ts`: the staged, zero-disk upload path. The only behavioural difference between the copies was which chunked-download adapter each reached for, so `DriveLargeFileDeps` carries the key layout and a `fetch_chunks` function. This is why #301 landed first: the Range fallback changed what that chunk fetcher has to be, and sharing the shape before deciding it would have been the wrong order.
- `backup/file-processor.ts`: download, hash, deduplicate, store. Chunked SHA-256 for buffers above 2 GB comes with it.
- `backup/change-classifier.ts`: the classification #297 just fixed in two places. Sharing it now means the next fix there is applied once. The provider name in the missing-ETag warning is the one value it takes.
- `shared/format-bytes.ts`: three copies of the same byte formatter, one of them already inside `packages/drive`.

Measured with the pair diff from #151, after normalising the provider token:

|pair|before|after|
|---|---|---|
|`large-file-pipeline.ts`|154 lines, 20 differing|76 lines, 6 differing|
|`backup-file-processor.ts`|124 lines, 16 differing|50 lines, 14 differing|
|`change-classifier.ts`|118 lines, 42 differing|40 lines, 0 differing|

The provider modules keep their paths, their exported names and their JSDoc, so no caller and no test import changed.

## What stays as two copies, and why

Each of these now carries the reason as a comment at the top of both files:

|pair|differing / total|reason|
|---|---|---|
|`backup.service.ts`|312 / 612|OneDrive enumerates an owner's drives with a folder scope and a per-drive cursor; SharePoint walks a site tree then libraries. Unifying means a parameter per branch|
|`restore.service.ts`|196 / 502|The restore target differs in kind, and so does the conflict handling around the restore root|
|`status.service.ts`|75 / 253|Same delta peek over drives against libraries, different discovery calls and result shapes|
|`backup-builders.ts`|68 / 438|The manifests differ in identity fields and in what each provider records per entry|
|`restore-folder-path.ts`|32 / 112|The memo keys differ in behaviour, not naming. Filed as #316|

Everything else that still pairs up by name is a binder: a class satisfying a per-provider port, the manifest-lookup descriptor, or a module supplying the key layout and chunk fetcher. Those exist to hold the provider's values, so a near-zero diff there is the intended result, not duplication left behind. That rule is written once at the top of `packages/drive/src/index.ts` rather than repeated in twelve files.

## One bug found while triaging

`ensure_onedrive_folder_path` memoises folder ids by path alone; the SharePoint copy keys the same memo by `drive_id:path`, and documents why. An owner can have several drives, and the same path is a different folder in each, so a restore spanning two drives can write into the wrong one, silently. Filed as #316 rather than fixed here: it is a behaviour change with a real failure mode, and folding it into a deduplication PR would hide it. The two copies stay until it is fixed, which is also why the pair keeps its note.

## Checklist

- `pnpm run build`, `pnpm run lint`, `pnpm run typecheck` and the full `pnpm run test` pass. Counts unchanged: OneDrive 275, SharePoint 313, drive 52.
- Acceptance criteria from #306: every pair below 25 differing lines is now either shared or a binder, and every pair that keeps two copies has its reason recorded next to it.
- No port change, no behaviour change, no CLI or SDK surface change, so no documentation is due.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent backup change classification for created, deleted, moved, renamed, updated, and insignificant items across supported drive providers.
  * Added shared processing for regular and large files, including retries, encryption, deduplication, streaming, and cleanup of stale temporary data.
  * Added human-readable byte formatting for file sizes.

* **Improvements**
  * Standardized OneDrive and SharePoint backup handling while preserving provider-specific behavior.
  * Improved detection of relocations and content changes during backup processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->