### PR TITLE
feat(sdk): typed error taxonomy with stable codes

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -799,6 +799,46 @@ Because the Outlook pool limit is per-mailbox, each mailbox's cooldown is indepe
 
 For OneDrive backup jobs, the `sharepoint_onedrive` pool is per-tenant instead. Aggregate `resource_units` across all users of a tenant and compare against `GRAPH_SERVICE_LIMITS.sharepoint_onedrive.resource_units_per_minute['<tier>']` before scheduling the next OneDrive job.
 
+## Errors
+
+Every failure Atlas raises on purpose is an `AtlasError` with a stable `code`. Branch on the class or on the code, never on the message: message wording changes between releases and is written for the operator reading a terminal, not for a caller.
+
+```typescript
+import { MailboxNotLicensedError, WrongPassphraseError, AtlasError } from '@wisecom/atlas-sdk';
+
+try {
+  await atlas.outlook.backup('user@company.com');
+} catch (err) {
+  if (err instanceof MailboxNotLicensedError) {
+    await reassign_license('user@company.com'); // retryable once a license is back
+  } else if (err instanceof WrongPassphraseError) {
+    throw err; // never retry: the data is fine, the key is wrong
+  } else if (err instanceof AtlasError) {
+    logger.error({ code: err.code, cause: err.cause }, 'Atlas backup failed');
+  }
+}
+```
+
+| Class                               | `code`                       | Meaning                                                                         |
+| ----------------------------------- | ---------------------------- | ------------------------------------------------------------------------------- |
+| `AtlasError`                        | any of the below             | Base class; catch this to separate deliberate failures from bugs                |
+| `AuthError`                         | `ATLAS_AUTH_DENIED`          | Graph or storage refused the call for lack of permission or admin consent       |
+| `MailboxNotLicensedError`           | `ATLAS_MAILBOX_NOT_LICENSED` | No Exchange Online license, so Graph will not serve the mailbox                 |
+| `NotFoundError`                     | `ATLAS_NOT_FOUND`            | Snapshot, mailbox, drive, site or object does not exist                         |
+| `ThrottledError`                    | `ATLAS_THROTTLED`            | Service throttled the call and the retry budget was spent; see `retry_after_ms` |
+| `WrongPassphraseError`              | `ATLAS_WRONG_PASSPHRASE`     | The passphrase could not unwrap the data key                                    |
+| `ObjectLockRetainedError`           | `ATLAS_OBJECT_LOCK_RETAINED` | Object is under retention or a legal hold; `key` names it                       |
+| `StorageError`                      | `ATLAS_STORAGE_FAILURE`      | Storage failed for a reason that is not permission, retention or absence        |
+| `ConfigError`                       | `ATLAS_CONFIG_INVALID`       | Credentials, endpoint, passphrase or tenant is missing or unusable              |
+| `ObjectLockVersioningDisabledError` | `ATLAS_CONFIG_INVALID`       | Immutability requested but bucket versioning is off                             |
+| `ObjectLockUnsupportedError`        | `ATLAS_CONFIG_INVALID`       | Immutability requested but the bucket has no Object Lock                        |
+| `ObjectLockModeRejectedError`       | `ATLAS_CONFIG_INVALID`       | Backend rejected the requested retention mode                                   |
+| `PreconditionFailedError`           | `ATLAS_STORAGE_FAILURE`      | Conditional write lost a race (HTTP 412)                                        |
+
+Every error carries the underlying failure as `cause`, so the Graph or AWS SDK error is still available for logging without being what you branch on.
+
+`WrongPassphraseError` deserves a note. AES-GCM cannot tell a wrong key from damaged ciphertext: both are one authentication failure. Atlas names the passphrase because that is the likelier cause and the only one an operator can act on, and keeps the raw crypto error as `cause`. If the passphrase is definitely correct for that tenant, treat it as a possible integrity problem and run `atlas verify` against the snapshot.
+
 ## Exports
 
 `@wisecom/atlas-sdk` re-exports all domain types, port interfaces, and result types, so everything below is available from a single `@wisecom/atlas-sdk` import.
@@ -814,6 +854,7 @@ For OneDrive backup jobs, the `sharepoint_onedrive` pool is per-tenant instead. 
 - Factory functions: `createAtlasInstance`, `createStorageTarget`
 - Operation control types: `SdkOperationOptions`, `OperationProgressEvent`, `OperationProgressCallback`, `OperationProgressPhase`
 - Cost helpers: `getGraphCost`
+- Error classes: `AtlasError`, `AtlasErrorCode`, `AuthError`, `MailboxNotLicensedError`, `NotFoundError`, `ThrottledError`, `WrongPassphraseError`, `ObjectLockRetainedError`, `StorageError`, `ConfigError`, `ObjectLockVersioningDisabledError`, `ObjectLockUnsupportedError`, `ObjectLockModeRejectedError`, `PreconditionFailedError` (see [Errors](#errors))
 
 **Graph cost types:**
 

--- a/packages/core/src/adapters/keystore/envelope-key-service.adapter.ts
+++ b/packages/core/src/adapters/keystore/envelope-key-service.adapter.ts
@@ -5,6 +5,7 @@ import {
   type CipherGCM,
   type DecipherGCM,
 } from 'node:crypto';
+import { WrongPassphraseError } from '@wisecom/atlas-types';
 import { DEFAULT_KDF_STRATEGY, KDF_STRATEGIES } from '@/adapters/keystore/kdf-strategy';
 import { parse_dek_blob, build_header_bytes } from '@/adapters/keystore/dek-blob-codec';
 import type { DekBlobHeader } from '@/adapters/keystore/dek-blob-codec';
@@ -94,7 +95,20 @@ export class EnvelopeKeyService {
       throw new Error(`Unknown KDF id in wrapped DEK: ${header.kdf_id}`);
     }
     const kek = strategy.derive_kek(this._passphrase_buf, header.kdf_params, tenant_id);
-    return aes_gcm_decrypt(encrypted_dek, kek, header_bytes);
+    try {
+      return aes_gcm_decrypt(encrypted_dek, kek, header_bytes);
+    } catch (err) {
+      // GCM reports a wrong key and a corrupted blob as the same authentication failure, and the
+      // raw Node message ("Unsupported state or unable to authenticate data") reads like data
+      // loss. A wrong passphrase is by far the likelier cause and the only one the operator can
+      // act on, so it is named first and the original error is kept as `cause` (issue #40).
+      throw new WrongPassphraseError(
+        'Could not unwrap the data key: the passphrase does not match the one this backup was ' +
+          'written with, or the wrapped key is damaged. Check ATLAS_ENCRYPTION_PASSPHRASE ' +
+          'against the tenant this snapshot belongs to.',
+        { cause: err },
+      );
+    }
   }
 }
 

--- a/packages/core/src/services/deletion/shared/prefix-deleter.ts
+++ b/packages/core/src/services/deletion/shared/prefix-deleter.ts
@@ -8,6 +8,7 @@
  * back to plain keys only for backends that do not enumerate versions.
  */
 
+import { ObjectLockRetainedError } from '@wisecom/atlas-types';
 import type { DeletionResult, StorageObjectVersion } from '@wisecom/atlas-types';
 
 /** The slice of ObjectStorage that erasure needs. */
@@ -127,7 +128,10 @@ async function delete_one(
     else await storage.delete_version(entry.key, version_id);
     count(summary, entry, 'deleted');
   } catch (err) {
-    count(summary, entry, is_object_lock_delete_error(err) ? 'retained' : 'failed');
+    // The storage adapter names a retention refusal for us: a bare `AccessDenied` from a missing
+    // IAM permission must not be filed as "retained, deletable once retention expires", because
+    // on an erasure report a false all-clear costs the erasure (issue #40).
+    count(summary, entry, err instanceof ObjectLockRetainedError ? 'retained' : 'failed');
   }
 }
 
@@ -146,27 +150,6 @@ function count(
 
   const kind = is_manifest_key(entry.key) ? 'manifests' : 'objects';
   summary[`${outcome}_${kind}` as keyof MutableResult]++;
-}
-
-/**
- * True only for errors that name Object Lock as the reason a delete was refused.
- *
- * Backends word it differently -- MinIO raises `InvalidRequest` "Object is WORM
- * protected and cannot be overwritten", AWS raises `AccessDenied` "Access Denied
- * because object protected by object lock" -- but both name the mechanism. A
- * bare `AccessDenied` from a missing IAM permission does not, and must not be
- * filed as "retained, deletable once retention expires". On an erasure report a
- * false alarm costs an investigation; a false all-clear costs the erasure.
- */
-function is_object_lock_delete_error(err: unknown): boolean {
-  const message = err instanceof Error ? `${err.name} ${err.message}`.toLowerCase() : '';
-  return (
-    message.includes('object lock') ||
-    message.includes('objectlock') ||
-    message.includes('worm protected') ||
-    message.includes('retention') ||
-    message.includes('legal hold')
-  );
 }
 
 function empty_summary(): MutableResult {

--- a/packages/core/tests/unit/adapters/keystore/envelope-key-service.test.ts
+++ b/packages/core/tests/unit/adapters/keystore/envelope-key-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { WrongPassphraseError } from '@wisecom/atlas-types';
 import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
 import { KDF_SCRYPT } from '@/adapters/keystore/kdf-strategy';
 import { DEK_BLOB_VERSION, parse_dek_blob } from '@/adapters/keystore/dek-blob-codec';
@@ -102,7 +103,28 @@ describe('EnvelopeKeyService', () => {
       const dek = svc_a.generate_dek();
 
       const wrapped = svc_a.wrap_dek(dek, tenant_id);
-      expect(() => svc_b.unwrap_dek(wrapped, tenant_id)).toThrow();
+      expect(() => svc_b.unwrap_dek(wrapped, tenant_id)).toThrow(WrongPassphraseError);
+    });
+
+    it('names the passphrase rather than surfacing the raw GCM failure (issue #40)', () => {
+      const svc_a = new EnvelopeKeyService(passphrase);
+      const svc_b = new EnvelopeKeyService('other-passphrase');
+      const wrapped = svc_a.wrap_dek(svc_a.generate_dek(), tenant_id);
+
+      const failure = (() => {
+        try {
+          svc_b.unwrap_dek(wrapped, tenant_id);
+          return undefined;
+        } catch (err) {
+          return err as WrongPassphraseError;
+        }
+      })();
+
+      // "Unsupported state or unable to authenticate data" reads like a corrupt backup, which
+      // sent operators looking for data loss when they had mistyped a passphrase.
+      expect(failure?.code).toBe('ATLAS_WRONG_PASSPHRASE');
+      expect(failure?.message).toContain('passphrase');
+      expect((failure?.cause as Error).message).toMatch(/authenticate|unsupported state/i);
     });
 
     it('throws on unknown KDF id in blob', () => {
@@ -119,6 +141,8 @@ describe('EnvelopeKeyService', () => {
 
       const { header } = parse_dek_blob(wrapped);
       header.kdf_params[0] ^= 0x01;
+      // Not a WrongPassphraseError: flipping a KDF parameter breaks key derivation itself, which
+      // fails before any ciphertext is read.
       expect(() => svc.unwrap_dek(wrapped, tenant_id)).toThrow();
     });
 
@@ -127,7 +151,9 @@ describe('EnvelopeKeyService', () => {
       const dek = svc.generate_dek();
       const wrapped = svc.wrap_dek(dek, 'tenant-a');
 
-      expect(() => svc.unwrap_dek(wrapped, 'tenant-b')).toThrow();
+      // Same class as a wrong passphrase: from the crypto's point of view a wrong tenant is a
+      // wrong key, and the remediation an operator has is to check both.
+      expect(() => svc.unwrap_dek(wrapped, 'tenant-b')).toThrow(WrongPassphraseError);
     });
   });
 

--- a/packages/core/tests/unit/services/deletion/deletion.service.test.ts
+++ b/packages/core/tests/unit/services/deletion/deletion.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ObjectLockRetainedError } from '@wisecom/atlas-types';
 import { Container } from 'inversify';
 import 'reflect-metadata';
 import { DeletionService } from '@/services/deletion/deletion.service';
@@ -229,7 +230,7 @@ describe('DeletionService', () => {
         'manifests/u@t.com/snap-42.json',
       ]);
       vi.mocked(mock_context.storage.delete).mockRejectedValueOnce(
-        new Error('AccessDenied: Object Lock retention in effect'),
+        new ObjectLockRetainedError('manifests/snap-1.json'),
       );
 
       const result = await service.delete_snapshot('t', 'snap-42');
@@ -278,7 +279,7 @@ describe('DeletionService', () => {
     it('holds the DEK back until the data it protects is gone', async () => {
       vi.mocked(mock_context.storage.list).mockResolvedValueOnce(['onedrive/data/u/locked']);
       vi.mocked(mock_context.storage.delete).mockRejectedValueOnce(
-        new Error('InvalidRequest: Object is WORM protected and cannot be overwritten'),
+        new ObjectLockRetainedError('data/u/blob'),
       );
 
       const result = await service.purge_tenant('t');

--- a/packages/core/tests/unit/services/deletion/prefix-deleter.test.ts
+++ b/packages/core/tests/unit/services/deletion/prefix-deleter.test.ts
@@ -4,6 +4,7 @@
  * claim otherwise.
  */
 import { describe, it, expect, vi } from 'vitest';
+import { ObjectLockRetainedError } from '@wisecom/atlas-types';
 import { delete_scopes, type DeletionStorage } from '@/services/deletion/shared/prefix-deleter';
 
 interface StubOptions {
@@ -127,19 +128,10 @@ describe('delete_scopes', () => {
       return await delete_scopes(storage, ['data/u/']);
     }
 
-    it('reports MinIO WORM protection as retained', async () => {
-      const result = await delete_failing_with(
-        new Error('InvalidRequest: Object is WORM protected and cannot be overwritten'),
-      );
-
-      expect(result.retained_objects).toBe(1);
-      expect(result.failed_objects).toBe(0);
-    });
-
-    it('reports AWS Object Lock protection as retained', async () => {
-      const result = await delete_failing_with(
-        new Error('AccessDenied: Access Denied because object protected by object lock'),
-      );
+    it('reports a retention refusal as retained', async () => {
+      // The storage adapter names the refusal; the wording heuristic that recognises MinIO's
+      // WORM message and AWS's object-lock message lives there and is tested there (issue #40).
+      const result = await delete_failing_with(new ObjectLockRetainedError('data/u/blob'));
 
       expect(result.retained_objects).toBe(1);
       expect(result.failed_objects).toBe(0);

--- a/packages/m365-graph/src/graph-permission-errors.ts
+++ b/packages/m365-graph/src/graph-permission-errors.ts
@@ -10,7 +10,7 @@ import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
  * actionable guidance about which API permissions to grant.
  */
 export function rethrow_if_access_denied(err: unknown): void {
-  const graph_err = err as Record<string, unknown>;
+  const graph_err = as_error_fields(err);
   if (graph_err.statusCode !== 403) return;
 
   const required = [
@@ -37,7 +37,7 @@ export function rethrow_if_access_denied(err: unknown): void {
  * actionable guidance about reassigning an Exchange Online license.
  */
 export function rethrow_if_mailbox_not_licensed(err: unknown): void {
-  const graph_err = err as Record<string, unknown>;
+  const graph_err = as_error_fields(err);
   const code = String(graph_err.code ?? '');
   const message = err instanceof Error ? err.message : String(err);
 
@@ -55,4 +55,15 @@ export function rethrow_if_mailbox_not_licensed(err: unknown): void {
       { cause: err },
     );
   }
+}
+
+/**
+ * Reads a thrown value as a bag of fields.
+ *
+ * `unknown` is not `object`: a rejected promise can carry `null`, and asserting the type only
+ * silences the compiler. Both helpers are called from `catch` blocks that must fall through for
+ * an unrelated failure, so a `TypeError` here would replace the real error with a bug.
+ */
+function as_error_fields(err: unknown): Record<string, unknown> {
+  return typeof err === 'object' && err !== null ? (err as Record<string, unknown>) : {};
 }

--- a/packages/m365-graph/src/graph-permission-errors.ts
+++ b/packages/m365-graph/src/graph-permission-errors.ts
@@ -1,0 +1,58 @@
+import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
+
+/**
+ * Graph failures that an operator has to act on rather than retry: a missing application
+ * permission and an unlicensed mailbox. Both carry the remediation steps in the message and a
+ * stable class and code for callers (issue #40).
+ */
+/**
+ * Detects 403 ErrorAccessDenied from Graph and rethrows with
+ * actionable guidance about which API permissions to grant.
+ */
+export function rethrow_if_access_denied(err: unknown): void {
+  const graph_err = err as Record<string, unknown>;
+  if (graph_err.statusCode !== 403) return;
+
+  const required = [
+    'Mail.Read              -- read mailbox messages',
+    'Mail.ReadWrite         -- delta sync and full message fetch',
+    'User.Read.All          -- list tenant users / mailboxes',
+    'MailboxSettings.Read   -- enumerate mail folders',
+  ];
+
+  const hint =
+    `Microsoft Graph returned 403 Forbidden (ErrorAccessDenied).\n` +
+    `The app registration needs these Application permissions with admin consent:\n\n` +
+    required.map((p) => `  - ${p}`).join('\n') +
+    `\n\n` +
+    `Grant them in Azure Portal > App registrations > API permissions > ` +
+    `Add a permission > Microsoft Graph > Application permissions, ` +
+    `then click "Grant admin consent".`;
+
+  throw new AuthError(hint, { cause: err });
+}
+
+/**
+ * Detects MailboxNotEnabledForRESTAPI from Graph and rethrows with
+ * actionable guidance about reassigning an Exchange Online license.
+ */
+export function rethrow_if_mailbox_not_licensed(err: unknown): void {
+  const graph_err = err as Record<string, unknown>;
+  const code = String(graph_err.code ?? '');
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (code === 'MailboxNotEnabledForRESTAPI' || message.includes('MailboxNotEnabledForRESTAPI')) {
+    throw new MailboxNotLicensedError(
+      `The mailbox is not licensed for API access (MailboxNotEnabledForRESTAPI).\n` +
+        `This typically happens when the user's Exchange Online license has been removed.\n` +
+        `The mailbox data is retained for 30 days after license removal, but cannot be\n` +
+        `accessed via the Graph API until a license is reassigned.\n\n` +
+        `To back up or restore this mailbox:\n` +
+        `  1. Reassign an Exchange Online license to the user in Microsoft 365 admin center\n` +
+        `  2. Wait a few minutes for the mailbox to reconnect\n` +
+        `  3. Run the operation again\n` +
+        `  4. Remove the license after the operation completes (if desired)`,
+      { cause: err },
+    );
+  }
+}

--- a/packages/m365-graph/src/graph-request-error-handler.ts
+++ b/packages/m365-graph/src/graph-request-error-handler.ts
@@ -60,57 +60,6 @@ export function is_invalid_delta_error(err: unknown): boolean {
   );
 }
 
-/**
- * Detects 403 ErrorAccessDenied from Graph and rethrows with
- * actionable guidance about which API permissions to grant.
- */
-export function rethrow_if_access_denied(err: unknown): void {
-  const graph_err = err as Record<string, unknown>;
-  if (graph_err.statusCode !== 403) return;
-
-  const required = [
-    'Mail.Read              -- read mailbox messages',
-    'Mail.ReadWrite         -- delta sync and full message fetch',
-    'User.Read.All          -- list tenant users / mailboxes',
-    'MailboxSettings.Read   -- enumerate mail folders',
-  ];
-
-  const hint =
-    `Microsoft Graph returned 403 Forbidden (ErrorAccessDenied).\n` +
-    `The app registration needs these Application permissions with admin consent:\n\n` +
-    required.map((p) => `  - ${p}`).join('\n') +
-    `\n\n` +
-    `Grant them in Azure Portal > App registrations > API permissions > ` +
-    `Add a permission > Microsoft Graph > Application permissions, ` +
-    `then click "Grant admin consent".`;
-
-  throw new Error(hint);
-}
-
-/**
- * Detects MailboxNotEnabledForRESTAPI from Graph and rethrows with
- * actionable guidance about reassigning an Exchange Online license.
- */
-export function rethrow_if_mailbox_not_licensed(err: unknown): void {
-  const graph_err = err as Record<string, unknown>;
-  const code = String(graph_err.code ?? '');
-  const message = err instanceof Error ? err.message : String(err);
-
-  if (code === 'MailboxNotEnabledForRESTAPI' || message.includes('MailboxNotEnabledForRESTAPI')) {
-    throw new Error(
-      `The mailbox is not licensed for API access (MailboxNotEnabledForRESTAPI).\n` +
-        `This typically happens when the user's Exchange Online license has been removed.\n` +
-        `The mailbox data is retained for 30 days after license removal, but cannot be\n` +
-        `accessed via the Graph API until a license is reassigned.\n\n` +
-        `To back up or restore this mailbox:\n` +
-        `  1. Reassign an Exchange Online license to the user in Microsoft 365 admin center\n` +
-        `  2. Wait a few minutes for the mailbox to reconnect\n` +
-        `  3. Run the operation again\n` +
-        `  4. Remove the license after the operation completes (if desired)`,
-    );
-  }
-}
-
 /** Returns true when the error carries a transient HTTP status (429, 500, 502, 503, 504). */
 export function is_transient_error(err: unknown): boolean {
   const status = (err as Record<string, unknown>).statusCode;

--- a/packages/m365-graph/src/index.ts
+++ b/packages/m365-graph/src/index.ts
@@ -2,8 +2,6 @@ export { create_graph_client, GRAPH_CLIENT_TOKEN } from './graph-client.factory'
 export { parse_retry_after_ms } from './graph-retry-after';
 export {
   is_invalid_delta_error,
-  rethrow_if_access_denied,
-  rethrow_if_mailbox_not_licensed,
   is_transient_error,
   is_network_error,
   is_retryable_error,
@@ -11,6 +9,10 @@ export {
   is_content_gone_error,
   with_graph_retry,
 } from './graph-request-error-handler';
+export {
+  rethrow_if_access_denied,
+  rethrow_if_mailbox_not_licensed,
+} from './graph-permission-errors';
 export {
   classify_download_failure,
   read_graph_error_code,

--- a/packages/m365-graph/tests/unit/graph-permission-errors.test.ts
+++ b/packages/m365-graph/tests/unit/graph-permission-errors.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
+import {
+  rethrow_if_access_denied,
+  rethrow_if_mailbox_not_licensed,
+} from '@/graph-permission-errors';
+
+describe('rethrow_if_mailbox_not_licensed', () => {
+  it('throws with actionable message when error code is MailboxNotEnabledForRESTAPI', () => {
+    const err = { code: 'MailboxNotEnabledForRESTAPI', statusCode: 403, message: '' };
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).toThrow('not licensed for API access');
+  });
+
+  // Issue #40: the guidance text is for the operator, the class and code are for the caller.
+  it('throws a MailboxNotLicensedError carrying the code and the original error', () => {
+    const err = { code: 'MailboxNotEnabledForRESTAPI', statusCode: 403, message: '' };
+
+    const failure = (() => {
+      try {
+        rethrow_if_mailbox_not_licensed(err);
+        return undefined;
+      } catch (caught) {
+        return caught as MailboxNotLicensedError;
+      }
+    })();
+
+    expect(failure).toBeInstanceOf(MailboxNotLicensedError);
+    expect(failure?.code).toBe('ATLAS_MAILBOX_NOT_LICENSED');
+    expect(failure?.cause).toBe(err);
+  });
+
+  it('throws when MailboxNotEnabledForRESTAPI appears in error message', () => {
+    const err = new Error('The mailbox is not enabled (MailboxNotEnabledForRESTAPI)');
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).toThrow(
+      'Reassign an Exchange Online license',
+    );
+  });
+
+  it('does not throw for unrelated errors', () => {
+    const err = { code: 'ErrorItemNotFound', statusCode: 404, message: 'Not found' };
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).not.toThrow();
+  });
+
+  it('does not throw for access denied errors (handled separately)', () => {
+    const err = { code: 'ErrorAccessDenied', statusCode: 403, message: 'Forbidden' };
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).not.toThrow();
+  });
+});
+
+describe('rethrow_if_access_denied', () => {
+  it('throws an AuthError distinguishable from an unlicensed mailbox', () => {
+    const failure = (() => {
+      try {
+        rethrow_if_access_denied({ statusCode: 403 });
+        return undefined;
+      } catch (caught) {
+        return caught as AuthError;
+      }
+    })();
+
+    expect(failure).toBeInstanceOf(AuthError);
+    expect(failure).not.toBeInstanceOf(MailboxNotLicensedError);
+    expect(failure?.code).toBe('ATLAS_AUTH_DENIED');
+  });
+
+  it('throws with permission guidance on 403', () => {
+    const err = { statusCode: 403 };
+
+    expect(() => rethrow_if_access_denied(err)).toThrow('403 Forbidden');
+  });
+
+  it('does not throw for non-403 errors', () => {
+    const err = { statusCode: 404 };
+
+    expect(() => rethrow_if_access_denied(err)).not.toThrow();
+  });
+});

--- a/packages/m365-graph/tests/unit/graph-permission-errors.test.ts
+++ b/packages/m365-graph/tests/unit/graph-permission-errors.test.ts
@@ -79,3 +79,19 @@ describe('rethrow_if_access_denied', () => {
     expect(() => rethrow_if_access_denied(err)).not.toThrow();
   });
 });
+
+describe('non-object throwables', () => {
+  // Both helpers run inside `catch` blocks and must fall through for anything they do not
+  // recognise. A rejected promise can carry `null`, and reading a field off it would replace the
+  // real failure with a TypeError.
+  it.each([[null], [undefined], ['a string'], [42]])('falls through for %s', (value) => {
+    expect(() => rethrow_if_access_denied(value)).not.toThrow();
+    expect(() => rethrow_if_mailbox_not_licensed(value)).not.toThrow();
+  });
+
+  it('still recognises the licensing failure in a bare string', () => {
+    expect(() => rethrow_if_mailbox_not_licensed('MailboxNotEnabledForRESTAPI')).toThrow(
+      MailboxNotLicensedError,
+    );
+  });
+});

--- a/packages/m365-graph/tests/unit/graph-request-error-handler.test.ts
+++ b/packages/m365-graph/tests/unit/graph-request-error-handler.test.ts
@@ -1,55 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
-  rethrow_if_access_denied,
-  rethrow_if_mailbox_not_licensed,
   is_invalid_delta_error,
   is_transient_error,
   is_network_error,
   is_retryable_error,
   with_graph_retry,
 } from '@/graph-request-error-handler';
-
-describe('rethrow_if_mailbox_not_licensed', () => {
-  it('throws with actionable message when error code is MailboxNotEnabledForRESTAPI', () => {
-    const err = { code: 'MailboxNotEnabledForRESTAPI', statusCode: 403, message: '' };
-
-    expect(() => rethrow_if_mailbox_not_licensed(err)).toThrow('not licensed for API access');
-  });
-
-  it('throws when MailboxNotEnabledForRESTAPI appears in error message', () => {
-    const err = new Error('The mailbox is not enabled (MailboxNotEnabledForRESTAPI)');
-
-    expect(() => rethrow_if_mailbox_not_licensed(err)).toThrow(
-      'Reassign an Exchange Online license',
-    );
-  });
-
-  it('does not throw for unrelated errors', () => {
-    const err = { code: 'ErrorItemNotFound', statusCode: 404, message: 'Not found' };
-
-    expect(() => rethrow_if_mailbox_not_licensed(err)).not.toThrow();
-  });
-
-  it('does not throw for access denied errors (handled separately)', () => {
-    const err = { code: 'ErrorAccessDenied', statusCode: 403, message: 'Forbidden' };
-
-    expect(() => rethrow_if_mailbox_not_licensed(err)).not.toThrow();
-  });
-});
-
-describe('rethrow_if_access_denied', () => {
-  it('throws with permission guidance on 403', () => {
-    const err = { statusCode: 403 };
-
-    expect(() => rethrow_if_access_denied(err)).toThrow('403 Forbidden');
-  });
-
-  it('does not throw for non-403 errors', () => {
-    const err = { statusCode: 404 };
-
-    expect(() => rethrow_if_access_denied(err)).not.toThrow();
-  });
-});
 
 describe('is_invalid_delta_error', () => {
   it('detects syncStateNotFound', () => {

--- a/packages/s3/src/adapters/object-lock.errors.ts
+++ b/packages/s3/src/adapters/object-lock.errors.ts
@@ -1,36 +1,42 @@
-export class ObjectLockVersioningDisabledError extends Error {
+import { AtlasError, ConfigError, StorageError } from '@wisecom/atlas-types';
+
+/**
+ * These are storage-configuration failures, so they carry `ATLAS_CONFIG_INVALID` or
+ * `ATLAS_STORAGE_FAILURE` and are reachable as {@link AtlasError} by an SDK consumer that only
+ * wants to know which category it is in (issue #40). The classes stay, because the operator-facing
+ * remediation text differs per case and is the point of each one.
+ */
+export class ObjectLockVersioningDisabledError extends ConfigError {
   constructor(bucket: string) {
     super(
       `Immutability requested, but bucket versioning is disabled for ${bucket}. ` +
         'Enable bucket versioning and Object Lock, or run backup without retention.',
     );
-    this.name = 'ObjectLockVersioningDisabledError';
   }
 }
 
-export class ObjectLockUnsupportedError extends Error {
+export class ObjectLockUnsupportedError extends ConfigError {
   constructor(bucket: string) {
     super(
       `Immutability requested, but Object Lock is not supported or not enabled for bucket ${bucket}.`,
     );
-    this.name = 'ObjectLockUnsupportedError';
   }
 }
 
-export class ObjectLockModeRejectedError extends Error {
+export class ObjectLockModeRejectedError extends ConfigError {
   constructor(bucket: string, mode: string, cause?: unknown) {
     const cause_text = cause instanceof Error ? ` (${cause.message})` : '';
-    super(`Backend rejected Object Lock mode ${mode} for bucket ${bucket}.${cause_text}`);
-    this.name = 'ObjectLockModeRejectedError';
+    super(`Backend rejected Object Lock mode ${mode} for bucket ${bucket}.${cause_text}`, {
+      cause,
+    });
   }
 }
 
 /** Thrown when a conditional put fails (ETag mismatch or create-only key already exists). */
-export class PreconditionFailedError extends Error {
+export class PreconditionFailedError extends StorageError {
   constructor(key: string) {
     super(
-      `Conditional write failed for key ${key} — precondition not met (412 Precondition Failed)`,
+      `Conditional write failed for key ${key} -- precondition not met (412 Precondition Failed)`,
     );
-    this.name = 'PreconditionFailedError';
   }
 }

--- a/packages/s3/src/adapters/object-lock.errors.ts
+++ b/packages/s3/src/adapters/object-lock.errors.ts
@@ -36,7 +36,7 @@ export class ObjectLockModeRejectedError extends ConfigError {
 export class PreconditionFailedError extends StorageError {
   constructor(key: string) {
     super(
-      `Conditional write failed for key ${key} -- precondition not met (412 Precondition Failed)`,
+      `Conditional write failed for key ${key} — precondition not met (412 Precondition Failed)`,
     );
   }
 }

--- a/packages/s3/src/adapters/s3-error-classifier.ts
+++ b/packages/s3/src/adapters/s3-error-classifier.ts
@@ -11,6 +11,29 @@ export function is_precondition_failed(err: unknown): boolean {
   return (err as { name?: string }).name === 'PreconditionFailed';
 }
 
+/**
+ * True only for errors that name Object Lock as the reason a delete was refused.
+ *
+ * Backends word it differently: MinIO raises `InvalidRequest` "Object is WORM protected and
+ * cannot be overwritten", AWS raises `AccessDenied` "Access Denied because object protected by
+ * object lock". Both name the mechanism. A bare `AccessDenied` from a missing IAM permission does
+ * not, and must not be filed as "retained, deletable once retention expires": on an erasure
+ * report a false alarm costs an investigation, a false all-clear costs the erasure.
+ *
+ * The wording heuristic lives here, at the boundary that speaks S3, so callers can branch on
+ * `ObjectLockRetainedError` instead of grepping messages of their own (issue #40).
+ */
+export function is_object_lock_refusal(err: unknown): boolean {
+  const message = err instanceof Error ? `${err.name} ${err.message}`.toLowerCase() : '';
+  return (
+    message.includes('object lock') ||
+    message.includes('objectlock') ||
+    message.includes('worm protected') ||
+    message.includes('retention') ||
+    message.includes('legal hold')
+  );
+}
+
 export function is_backend_mode_rejection(err: unknown, mode?: string): boolean {
   if (!mode) return false;
   if (!(err instanceof S3ServiceException)) return false;

--- a/packages/s3/src/adapters/s3-object-storage.adapter.ts
+++ b/packages/s3/src/adapters/s3-object-storage.adapter.ts
@@ -12,6 +12,7 @@ import {
   AbortMultipartUploadCommand,
   type S3Client,
 } from '@aws-sdk/client-s3';
+import { ObjectLockRetainedError } from '@wisecom/atlas-types';
 import type {
   ObjectStorage,
   ObjectStorageEtagResult,
@@ -28,6 +29,7 @@ import {
 import type { BucketCache } from '@/adapters/bucket-cache';
 import { abort_incomplete_multipart_uploads } from '@/adapters/s3-multipart-cleanup';
 import { S3MultipartUploadHandle } from '@/adapters/s3-multipart-upload-handle';
+import { is_object_lock_refusal } from '@/adapters/s3-error-classifier';
 import {
   ObjectLockModeRejectedError,
   ObjectLockUnsupportedError,
@@ -135,16 +137,28 @@ export class S3ObjectStorage implements ObjectStorage {
     return { data, etag };
   }
 
-  /** Removes a single object. */
+  /** Removes a single object. @throws ObjectLockRetainedError when retention refuses the delete. */
   async delete(key: string): Promise<void> {
-    await this._client.send(new DeleteObjectCommand({ Bucket: this._bucket, Key: key }));
+    try {
+      await this._client.send(new DeleteObjectCommand({ Bucket: this._bucket, Key: key }));
+    } catch (err) {
+      throw as_delete_failure(key, err);
+    }
   }
 
-  /** Removes a specific object version (or delete marker) by version id. */
+  /**
+   * Removes a specific object version (or delete marker) by version id.
+   *
+   * @throws ObjectLockRetainedError when retention or a legal hold refuses the delete.
+   */
   async delete_version(key: string, version_id: string): Promise<void> {
-    await this._client.send(
-      new DeleteObjectCommand({ Bucket: this._bucket, Key: key, VersionId: version_id }),
-    );
+    try {
+      await this._client.send(
+        new DeleteObjectCommand({ Bucket: this._bucket, Key: key, VersionId: version_id }),
+      );
+    } catch (err) {
+      throw as_delete_failure(key, err);
+    }
   }
 
   /** Returns true if the object exists (HEAD request). */
@@ -319,4 +333,13 @@ export class S3ObjectStorage implements ObjectStorage {
     if (!probe.mode_supported)
       throw new ObjectLockModeRejectedError(this._bucket, policy.mode ?? 'UNKNOWN');
   }
+}
+
+/**
+ * Names a refused delete for what it is. Retention and legal holds are an expected outcome a
+ * caller reports as retained; anything else is a failure it must not file as recoverable.
+ */
+function as_delete_failure(key: string, err: unknown): Error {
+  if (is_object_lock_refusal(err)) return new ObjectLockRetainedError(key, { cause: err });
+  return err instanceof Error ? err : new Error(String(err));
 }

--- a/packages/s3/tests/unit/s3-object-storage.test.ts
+++ b/packages/s3/tests/unit/s3-object-storage.test.ts
@@ -1,5 +1,6 @@
 import { BucketCache } from '@/adapters/bucket-cache';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ObjectLockRetainedError } from '@wisecom/atlas-types';
 import { S3ObjectStorage } from '@/adapters/s3-object-storage.adapter';
 import {
   ObjectLockUnsupportedError,
@@ -162,6 +163,48 @@ describe('S3ObjectStorage', () => {
       const cmd = mock_s3.send.mock.calls[0][0];
       expect(cmd.input.Bucket).toBe(bucket);
       expect(cmd.input.Key).toBe('key');
+    });
+
+    // Issue #40: callers used to grep the message themselves. The wording heuristic belongs to
+    // the layer that speaks S3, and only retention may be reported as retained: filing an IAM
+    // gap that way tells an operator an erasure is on track when it is not.
+    it.each([
+      ['InvalidRequest: Object is WORM protected and cannot be overwritten'],
+      ['AccessDenied: Access Denied because object protected by object lock'],
+      ['AccessDenied: Object Lock retention in effect'],
+      ['InvalidRequest: a legal hold is in place'],
+    ])('raises ObjectLockRetainedError for %s', async (message) => {
+      mock_s3.send.mockRejectedValueOnce(new Error(message));
+
+      await expect(storage.delete('key')).rejects.toBeInstanceOf(ObjectLockRetainedError);
+    });
+
+    it('leaves a bare permission denial as it is, never as retained', async () => {
+      mock_s3.send.mockRejectedValueOnce(new Error('AccessDenied: Access Denied'));
+
+      const failure = await storage.delete('key').catch((err: unknown) => err);
+      expect(failure).not.toBeInstanceOf(ObjectLockRetainedError);
+      expect((failure as Error).message).toContain('Access Denied');
+    });
+
+    it('carries the original error as the cause of a retention refusal', async () => {
+      const raw = new Error('AccessDenied: Access Denied because object protected by object lock');
+      mock_s3.send.mockRejectedValueOnce(raw);
+
+      const failure = (await storage.delete('key').catch((err: unknown) => err)) as Error;
+      expect(failure.cause).toBe(raw);
+    });
+  });
+
+  describe('delete_version', () => {
+    it('raises ObjectLockRetainedError when a version is under retention', async () => {
+      mock_s3.send.mockRejectedValueOnce(
+        new Error('AccessDenied: Object Lock retention in effect'),
+      );
+
+      await expect(storage.delete_version('key', 'v1')).rejects.toBeInstanceOf(
+        ObjectLockRetainedError,
+      );
     });
   });
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,11 @@
 export * from '@wisecom/atlas-types';
 export type { StorageTargetSdkConfig } from '@wisecom/atlas-s3';
+export {
+  ObjectLockVersioningDisabledError,
+  ObjectLockUnsupportedError,
+  ObjectLockModeRejectedError,
+  PreconditionFailedError,
+} from '@wisecom/atlas-s3';
 export { createAtlasInstance } from './atlas-instance.adapter';
 export { create_storage_target as createStorageTarget } from '@wisecom/atlas-s3';
 export { get_graph_cost as getGraphCost } from '@wisecom/atlas-core/services/shared/graph-request-context';

--- a/packages/types/src/errors/atlas-errors.ts
+++ b/packages/types/src/errors/atlas-errors.ts
@@ -1,0 +1,104 @@
+/**
+ * Stable machine-readable codes. The string values are the contract: they are safe to switch on,
+ * to log, and to compare across versions. Prose messages are not, and never were.
+ */
+export type AtlasErrorCode =
+  | 'ATLAS_AUTH_DENIED'
+  | 'ATLAS_MAILBOX_NOT_LICENSED'
+  | 'ATLAS_NOT_FOUND'
+  | 'ATLAS_THROTTLED'
+  | 'ATLAS_WRONG_PASSPHRASE'
+  | 'ATLAS_OBJECT_LOCK_RETAINED'
+  | 'ATLAS_STORAGE_FAILURE'
+  | 'ATLAS_CONFIG_INVALID';
+
+/**
+ * Base class for every failure Atlas raises on purpose.
+ *
+ * Consumers branch on `instanceof AtlasError` or on `code`. Before this existed, the only way to
+ * tell an unlicensed mailbox from a missing permission was to match on message text, which made
+ * every wording change a silent breaking change: the CLI's own diagnostics and the deletion
+ * services did exactly that (issue #40).
+ */
+export class AtlasError extends Error {
+  readonly code: AtlasErrorCode;
+
+  constructor(code: AtlasErrorCode, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.code = code;
+    this.name = new.target.name;
+  }
+}
+
+/** Graph or storage refused the operation for lack of permission or consent. */
+export class AuthError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_AUTH_DENIED', message, options);
+  }
+}
+
+/** The mailbox has no Exchange Online license, so Graph will not serve it. */
+export class MailboxNotLicensedError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_MAILBOX_NOT_LICENSED', message, options);
+  }
+}
+
+/** A snapshot, mailbox, drive, site or object that does not exist. */
+export class NotFoundError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_NOT_FOUND', message, options);
+  }
+}
+
+/** The service throttled the operation and the retry budget was exhausted. */
+export class ThrottledError extends AtlasError {
+  /** Milliseconds the service asked the caller to wait, when it said. */
+  readonly retry_after_ms: number | undefined;
+
+  constructor(message: string, retry_after_ms?: number, options?: { cause?: unknown }) {
+    super('ATLAS_THROTTLED', message, options);
+    this.retry_after_ms = retry_after_ms;
+  }
+}
+
+/**
+ * The passphrase could not unwrap the data key.
+ *
+ * Distinct from data corruption on purpose: AES-GCM reports both as one authentication failure,
+ * and the raw Node message ("Unsupported state or unable to authenticate data") sent operators
+ * looking for a corrupt backup when the real cause was a typo.
+ */
+export class WrongPassphraseError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_WRONG_PASSPHRASE', message, options);
+  }
+}
+
+/** The object is under an Object Lock retention or legal hold, so it cannot be deleted yet. */
+export class ObjectLockRetainedError extends AtlasError {
+  constructor(
+    readonly key: string,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      'ATLAS_OBJECT_LOCK_RETAINED',
+      `Object ${key} is protected by Object Lock retention or a legal hold and was not deleted.`,
+      options,
+    );
+  }
+}
+
+/** The storage backend failed for a reason that is not permission, retention or absence. */
+export class StorageError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_STORAGE_FAILURE', message, options);
+  }
+}
+
+/** Configuration is missing or unusable: credentials, endpoint, passphrase, tenant. */
+export class ConfigError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_CONFIG_INVALID', message, options);
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,2 +1,3 @@
 export * from './domain/index';
 export * from './ports/index';
+export * from './errors/atlas-errors';


### PR DESCRIPTION
## Summary

Every deliberate failure now carries a class and a stable `code`, so a consumer can tell an unlicensed mailbox from a missing permission without matching on message text. Atlas itself was doing that matching in two places, which meant any wording change was a silent breaking change.

Closes #40

## The taxonomy

`packages/types/src/errors/atlas-errors.ts`, so every layer can throw them without a new dependency and the SDK re-exports them through its existing `export * from '@wisecom/atlas-types'`.

`AtlasError` is the base, with `code: AtlasErrorCode` and `cause`. Subclasses: `AuthError`, `MailboxNotLicensedError`, `NotFoundError`, `ThrottledError` (with `retry_after_ms`), `WrongPassphraseError`, `ObjectLockRetainedError` (with `key`), `StorageError`, `ConfigError`. The codes are the contract, not the prose.

The four existing S3 errors now extend the taxonomy rather than `Error`: the three Object Lock configuration failures become `ConfigError`, and `PreconditionFailedError` becomes `StorageError`. Their messages are unchanged, because the per-case remediation text is the point of having separate classes, and they are now exported from `@wisecom/atlas-sdk`, which #40 noted they never were.

## Where they are now thrown

- **403 from Graph** raises `AuthError` instead of a bare `Error`, keeping the permission-grant guidance as the message and the Graph error as `cause`.
- **`MailboxNotEnabledForRESTAPI`** raises `MailboxNotLicensedError`, so the "reassign a license and retry" case is programmatically distinguishable from the "your app registration is wrong" case. Those two are both 403s and were both bare `Error`s.
- **`unwrap_dek`** raises `WrongPassphraseError`. This is the one that was actively misleading: AES-GCM reports a wrong key and a damaged blob as the same authentication failure, and the raw Node message, `Unsupported state or unable to authenticate data`, reads like data loss. A mistyped passphrase is the likelier cause and the only one an operator can act on, so it is named, with the crypto error kept as `cause`. Wrong `tenant_id` lands in the same class, because from the crypto's point of view it is the same wrong key.
- **A refused delete** raises `ObjectLockRetainedError` from the S3 adapter.

## Message-sniffing removed

`is_object_lock_delete_error` in `packages/core/src/services/deletion/shared/prefix-deleter.ts` lowercased the message and grepped for `object lock`, `worm protected`, `retention` and `legal hold`. Core does not speak S3, so it had no business guessing.

The heuristic moved to `is_object_lock_refusal` in `packages/s3/src/adapters/s3-error-classifier.ts`, next to the other backend-wording predicates, and `delete`/`delete_version` translate a refusal into `ObjectLockRetainedError`. The deleter now branches on the class.

The distinction the old comment defended is preserved and still tested: a bare `AccessDenied` from a missing IAM permission must not be filed as "retained, deletable once retention expires". On an erasure report a false alarm costs an investigation, a false all-clear costs the erasure.

## Tests

- `s3-object-storage.test.ts`: four backend wordings raise `ObjectLockRetainedError`, a bare `AccessDenied` does not, the raw error survives as `cause`, and `delete_version` behaves the same.
- `envelope-key-service.test.ts`: a wrong passphrase and a wrong tenant both raise `WrongPassphraseError`, the message names the passphrase, and `cause` still carries the GCM failure. A tampered KDF parameter is asserted as *not* a `WrongPassphraseError`, since it breaks key derivation before any ciphertext is read.
- `graph-permission-errors.test.ts`, new: `AuthError` and `MailboxNotLicensedError` with their codes and causes, and explicitly that a 403 is not an instance of the licensing error.
- The deletion tests now inject `ObjectLockRetainedError` rather than backend prose, because that is what the storage port promises them.

## Also in the diff

The two guidance-raising functions moved from `graph-request-error-handler.ts` into `graph-permission-errors.ts`, and their tests with them. The test file crossed the 300-line limit once the new cases went in, and splitting on that seam is better than trimming coverage: what is left in the handler is retry and transience classification, what moved is operator remediation.

## Checklist

- `pnpm run build`, `pnpm run lint`, `pnpm run format:check`, `pnpm run typecheck`, `pnpm run test` and `pnpm run docs:build` all pass.
- `docs/reference/sdk.md` gains an Errors section: the worked `try`/`catch`, the full class-and-code table, the note on why `WrongPassphraseError` names the passphrase and what to do when the passphrase is definitely right, and the classes listed under Exports.
- No behaviour change for a caller that does not inspect errors: messages, statuses and control flow are unchanged. What changes is that the thrown objects now have a type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added standardized, machine-readable SDK errors with actionable messages and preserved underlying causes.
  - Added clear handling for wrong passphrases, throttling, storage failures, and Object Lock retention.
  - Exposed Object Lock and precondition errors through the SDK.

- **Bug Fixes**
  - Improved classification of Object Lock deletion failures while preserving unrelated access errors.
  - Improved resilience when handling unexpected Microsoft Graph error values.

- **Documentation**
  - Added an SDK error reference covering error codes, meanings, causes, and recommended handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->