### PR TITLE
fix: key the restore folder memo by drive so two drives cannot collide

### DIFF
--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -57,6 +57,7 @@ export {
   list_drive_file_versions,
   type DriveCatalogDeps,
 } from '@/catalog/catalog-queries';
+export { ensure_drive_folder_path, type DriveFolderCreator } from '@/restore/folder-path';
 export {
   restore_drive_version,
   type DriveUploadConnector,

--- a/packages/drive/src/restore/folder-path.ts
+++ b/packages/drive/src/restore/folder-path.ts
@@ -1,0 +1,92 @@
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+/** The one connector call folder creation needs. */
+export interface DriveFolderCreator {
+  create_folder(
+    tenant_id: string,
+    owner_id: string,
+    drive_id: string,
+    parent_id: string,
+    name: string,
+  ): Promise<string>;
+}
+
+/**
+ * Resolves a restore-side path to a drive item id, creating the folders that are missing.
+ *
+ * `folder_ids` is the per-restore memo, so a restore root shared by every entry is created once
+ * rather than once per file. Keys are `drive_id:path`, never the path alone: one snapshot spans
+ * several drives or libraries, and the same path means a different folder in each. Keying by path
+ * made a restore write the second drive's files into the first drive's folder, silently, because
+ * the memo answered before the create call was ever made (issue #316).
+ *
+ * Returns undefined when a segment could not be created; the caller reports that entry as
+ * skipped, which is what keeps one over-long path from aborting the whole run.
+ */
+export async function ensure_drive_folder_path(
+  connector: DriveFolderCreator,
+  tenant_id: string,
+  owner_id: string,
+  drive_id: string,
+  path: string,
+  folder_ids: Map<string, string>,
+): Promise<string | undefined> {
+  const normalized = path.length === 0 || path === '.' ? '/' : path;
+  const cache_key = `${drive_id}:${normalized}`;
+  const cached = folder_ids.get(cache_key);
+  if (cached !== undefined) return cached;
+
+  if (normalized === '/') {
+    folder_ids.set(cache_key, 'root');
+    return 'root';
+  }
+
+  const segments = normalized.split('/').filter(Boolean);
+  let current_path = '';
+  let parent_id = 'root';
+
+  for (const segment of segments) {
+    current_path = current_path ? `${current_path}/${segment}` : `/${segment}`;
+    const segment_key = `${drive_id}:${current_path}`;
+    const known = folder_ids.get(segment_key);
+    if (known !== undefined) {
+      parent_id = known;
+      continue;
+    }
+
+    try {
+      const folder_id = await connector.create_folder(
+        tenant_id,
+        owner_id,
+        drive_id,
+        parent_id,
+        segment,
+      );
+      folder_ids.set(segment_key, folder_id);
+      parent_id = folder_id;
+    } catch (err) {
+      logger.warn(
+        `Failed to create folder ${current_path} in drive ${drive_id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  return parent_id;
+}
+
+/**
+ * How many folders the restore actually created, from the memo.
+ *
+ * The memo also holds one root marker per drive, keyed `<drive_id>:/` with the value `root`,
+ * which the run did not create. Both providers previously corrected for that with a constant,
+ * which was right for exactly one drive.
+ */
+export function count_created_folders(folder_ids: ReadonlyMap<string, string>): number {
+  let created = 0;
+  for (const [key, id] of folder_ids) {
+    if (id === 'root' && key.endsWith(':/')) continue;
+    created++;
+  }
+  return created;
+}

--- a/packages/drive/src/restore/version-restore.ts
+++ b/packages/drive/src/restore/version-restore.ts
@@ -109,8 +109,9 @@ export async function restore_drive_version(
 
     // The version row records the drive it came from, so a version restore needs no drive lookup
     // and stays correct for an owning segment with several drives, where "the first drive" would
-    // be a guess.
-    const folder_ids_by_drive = new Map<string, Map<string, string>>();
+    // be a guess. One memo for all of them: `ensure_folder_path` keys it by `drive_id:path`, so
+    // two drives holding the same path cannot collide in it (issue #316).
+    const folder_ids = new Map<string, string>();
     const restored: DriveRestoredVersion[] = [];
     const errors: string[] = [...selection.skipped];
     let files_skipped = selection.skipped.length;
@@ -130,7 +131,7 @@ export async function restore_drive_version(
         tenant_id,
         owner_id,
         ctx,
-        folder_ids_by_drive,
+        folder_ids,
         candidate,
         placement,
       );
@@ -179,7 +180,7 @@ async function restore_one_version(
   tenant_id: string,
   owner_id: string,
   ctx: TenantContext,
-  folder_ids_by_drive: Map<string, Map<string, string>>,
+  folder_ids: Map<string, string>,
   candidate: SelectedVersion,
   placement: DriveVersionPlacement,
 ): Promise<{ restored?: DriveRestoredVersion; error?: string }> {
@@ -189,14 +190,6 @@ async function restore_one_version(
     const content = await deps.download_blob(ctx, version);
     if (!content) {
       return { error: `${original_path}: stored version could not be read or verified` };
-    }
-
-    // Folder ids are cached per drive: the same path exists in more than one drive of the same
-    // owning segment and means a different folder in each.
-    let folder_ids = folder_ids_by_drive.get(drive_id);
-    if (!folder_ids) {
-      folder_ids = new Map<string, string>([['/', 'root']]);
-      folder_ids_by_drive.set(drive_id, folder_ids);
     }
 
     const { parent_path } = split_parent_path(original_path);

--- a/packages/drive/tests/unit/restore/folder-path.test.ts
+++ b/packages/drive/tests/unit/restore/folder-path.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  count_created_folders,
+  ensure_drive_folder_path,
+  type DriveFolderCreator,
+} from '@/restore/folder-path';
+
+const TENANT = 'tenant-1';
+const OWNER = 'owner-1';
+
+/** Hands out an id per created folder so a caller can tell two folders apart. */
+function make_connector(): DriveFolderCreator & { create_folder: ReturnType<typeof vi.fn> } {
+  let next = 0;
+  return {
+    create_folder: vi.fn(
+      (_tenant: string, _owner: string, drive_id: string, parent_id: string, name: string) => {
+        next++;
+        return Promise.resolve(`${drive_id}:${parent_id}:${name}:${next}`);
+      },
+    ),
+  };
+}
+
+describe('ensure_drive_folder_path', () => {
+  it('creates each missing segment and returns the deepest folder id', async () => {
+    const connector = make_connector();
+    const memo = new Map<string, string>();
+
+    const id = await ensure_drive_folder_path(
+      connector,
+      TENANT,
+      OWNER,
+      'drive-1',
+      '/Documents/Reports',
+      memo,
+    );
+
+    expect(connector.create_folder).toHaveBeenCalledTimes(2);
+    expect(id).toBe('drive-1:drive-1:root:Documents:1:Reports:2');
+  });
+
+  it('creates a shared parent once across entries', async () => {
+    const connector = make_connector();
+    const memo = new Map<string, string>();
+
+    await ensure_drive_folder_path(connector, TENANT, OWNER, 'drive-1', '/Restore/a', memo);
+    await ensure_drive_folder_path(connector, TENANT, OWNER, 'drive-1', '/Restore/b', memo);
+
+    // `/Restore` once, then one leaf per entry. Re-creating the root per file is what the memo
+    // exists to avoid.
+    expect(connector.create_folder).toHaveBeenCalledTimes(3);
+  });
+
+  it('resolves the same path in two drives to two folders (issue #316)', async () => {
+    const connector = make_connector();
+    const memo = new Map<string, string>();
+
+    const first = await ensure_drive_folder_path(
+      connector,
+      TENANT,
+      OWNER,
+      'drive-1',
+      '/Documents/Reports',
+      memo,
+    );
+    const second = await ensure_drive_folder_path(
+      connector,
+      TENANT,
+      OWNER,
+      'drive-2',
+      '/Documents/Reports',
+      memo,
+    );
+
+    // Keyed by path alone, the second call answered from the memo and the second drive's files
+    // were written into the first drive's folder, with a successful upload against a real id.
+    expect(second).not.toBe(first);
+    expect(connector.create_folder).toHaveBeenCalledTimes(4);
+    const drives_created = connector.create_folder.mock.calls.map((call) => call[2]);
+    expect(drives_created).toEqual(['drive-1', 'drive-1', 'drive-2', 'drive-2']);
+  });
+
+  it('treats the drive root as root without creating anything', async () => {
+    const connector = make_connector();
+
+    for (const path of ['/', '', '.']) {
+      expect(
+        await ensure_drive_folder_path(
+          connector,
+          TENANT,
+          OWNER,
+          'drive-1',
+          path,
+          new Map<string, string>(),
+        ),
+      ).toBe('root');
+    }
+    expect(connector.create_folder).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when a segment cannot be created', async () => {
+    const connector = make_connector();
+    connector.create_folder.mockRejectedValueOnce(new Error('nameAlreadyExists'));
+
+    const id = await ensure_drive_folder_path(
+      connector,
+      TENANT,
+      OWNER,
+      'drive-1',
+      '/Documents/Reports',
+      new Map<string, string>(),
+    );
+
+    // The caller reports that one entry as skipped; one over-long path must not abort the run.
+    expect(id).toBeUndefined();
+  });
+
+  it('reuses a cached parent from the same drive without recreating it', async () => {
+    const connector = make_connector();
+    const memo = new Map<string, string>([['drive-1:/Documents', 'cached-id']]);
+
+    const id = await ensure_drive_folder_path(
+      connector,
+      TENANT,
+      OWNER,
+      'drive-1',
+      '/Documents',
+      memo,
+    );
+
+    expect(id).toBe('cached-id');
+    expect(connector.create_folder).not.toHaveBeenCalled();
+  });
+});
+
+describe('count_created_folders', () => {
+  it('counts the folders created and not the per-drive root markers', async () => {
+    const connector = make_connector();
+    const memo = new Map<string, string>();
+
+    await ensure_drive_folder_path(connector, TENANT, OWNER, 'drive-1', '/Documents', memo);
+    await ensure_drive_folder_path(connector, TENANT, OWNER, 'drive-1', '/', memo);
+    await ensure_drive_folder_path(connector, TENANT, OWNER, 'drive-2', '/', memo);
+
+    // Three memo entries, one real folder. Subtracting a constant for "the root" was right for
+    // one drive and wrong for every restore that spanned two (issue #316).
+    expect(memo.size).toBe(3);
+    expect(count_created_folders(memo)).toBe(1);
+  });
+
+  it('is zero for a restore that created nothing', () => {
+    expect(count_created_folders(new Map())).toBe(0);
+  });
+});

--- a/packages/onedrive/src/services/restore/restore-folder-path.ts
+++ b/packages/onedrive/src/services/restore/restore-folder-path.ts
@@ -1,17 +1,11 @@
-// Deliberately not shared with the SharePoint copy (#306): 28 differing lines of 106. The memo
-// keys differ, path here against `drive_id:path` there, which is a behavioural difference
-// rather than a naming one and is tracked separately.
 import type { OneDriveConnector } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
+import { ensure_drive_folder_path } from '@wisecom/atlas-drive/restore/folder-path';
 
 /**
  * Resolves a restore-side path to a drive item id, creating the folders that are missing.
  *
- * `folder_ids` is the per-restore memo, keyed by path, so a restore root shared by every entry is
- * created once rather than once per file. Returns undefined when a segment could not be created;
- * the caller reports that entry as skipped, which is what keeps one over-long path from aborting
- * the run. Mirrors `ensure_sharepoint_folder_path`, which keys by `drive_id:path` because a
- * SharePoint snapshot spans several libraries.
+ * `folder_ids` is the per-restore memo, keyed by `drive_id:path` so that two of the owner's
+ * drives holding the same path do not resolve to one folder (issue #316).
  */
 export async function ensure_onedrive_folder_path(
   connector: OneDriveConnector,
@@ -21,39 +15,5 @@ export async function ensure_onedrive_folder_path(
   path: string,
   folder_ids: Map<string, string>,
 ): Promise<string | undefined> {
-  const normalized = path.length === 0 || path === '.' ? '/' : path;
-  const cached = folder_ids.get(normalized);
-  if (cached !== undefined) return cached;
-
-  const segments = normalized.split('/').filter(Boolean);
-  let current_path = '';
-  let parent_id = 'root';
-
-  for (const segment of segments) {
-    current_path = current_path ? `${current_path}/${segment}` : `/${segment}`;
-    const known = folder_ids.get(current_path);
-    if (known !== undefined) {
-      parent_id = known;
-      continue;
-    }
-
-    try {
-      const folder_id = await connector.create_folder(
-        tenant_id,
-        owner_id,
-        drive_id,
-        parent_id,
-        segment,
-      );
-      folder_ids.set(current_path, folder_id);
-      parent_id = folder_id;
-    } catch (err) {
-      logger.warn(
-        `Failed to create folder ${current_path}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-
-  return parent_id;
+  return ensure_drive_folder_path(connector, tenant_id, owner_id, drive_id, path, folder_ids);
 }

--- a/packages/onedrive/src/services/restore/restore.service.ts
+++ b/packages/onedrive/src/services/restore/restore.service.ts
@@ -38,6 +38,7 @@ import {
   resolve_restore_root,
   restore_parent_path,
 } from '@wisecom/atlas-core/services/shared/restore-destination';
+import { count_created_folders } from '@wisecom/atlas-drive/restore/folder-path';
 import { ensure_onedrive_folder_path } from '@/services/restore/restore-folder-path';
 
 const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
@@ -87,7 +88,6 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       assert_renameable(options.rename_to, restorable.length);
       const restore_root = resolve_restore_root(options);
       const folder_ids = new Map<string, string>();
-      folder_ids.set('/', 'root');
 
       let files_restored = 0;
       let files_skipped = 0;
@@ -129,7 +129,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
         });
       }
 
-      const folders_created = Math.max(0, folder_ids.size - 1);
+      const folders_created = count_created_folders(folder_ids);
       const interrupted = finish_operation_progress(
         options,
         'restore',

--- a/packages/sharepoint/src/services/restore/restore-folder-path.ts
+++ b/packages/sharepoint/src/services/restore/restore-folder-path.ts
@@ -1,15 +1,11 @@
-// Deliberately not shared with the OneDrive copy (#306): 28 differing lines of 106. The memo
-// keys differ, `drive_id:path` here against path alone there, which is a behavioural
-// difference rather than a naming one and is tracked separately.
 import type { SharePointSiteConnector } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
+import { ensure_drive_folder_path } from '@wisecom/atlas-drive/restore/folder-path';
 
 /**
  * Resolves a manifest `parent_path` to a drive item id, creating the folders that are missing.
  *
- * `folder_ids` is the per-restore memo. Keys are `drive_id:path` because one snapshot spans several
- * document libraries and the same path means a different folder in each. Returns undefined when a
- * segment could not be created; the caller reports the entry as skipped.
+ * `folder_ids` is the per-restore memo, keyed by `drive_id:path` because one snapshot spans
+ * several document libraries and the same path means a different folder in each.
  */
 export async function ensure_sharepoint_folder_path(
   connector: SharePointSiteConnector,
@@ -19,46 +15,5 @@ export async function ensure_sharepoint_folder_path(
   path: string,
   folder_ids: Map<string, string>,
 ): Promise<string | undefined> {
-  const normalized = path.length === 0 || path === '.' ? '/' : path;
-  const cache_key = `${drive_id}:${normalized}`;
-  const cached = folder_ids.get(cache_key);
-  if (cached !== undefined) return cached;
-
-  if (normalized === '/') {
-    folder_ids.set(cache_key, 'root');
-    return 'root';
-  }
-
-  const segments = normalized.split('/').filter(Boolean);
-  let current_path = '';
-  let parent_id = 'root';
-
-  for (const segment of segments) {
-    current_path = current_path ? `${current_path}/${segment}` : `/${segment}`;
-    const segment_key = `${drive_id}:${current_path}`;
-    const known = folder_ids.get(segment_key);
-    if (known !== undefined) {
-      parent_id = known;
-      continue;
-    }
-
-    try {
-      const folder_id = await connector.create_folder(
-        tenant_id,
-        site_id,
-        drive_id,
-        parent_id,
-        segment,
-      );
-      folder_ids.set(segment_key, folder_id);
-      parent_id = folder_id;
-    } catch (err) {
-      logger.warn(
-        `Failed to create folder ${current_path} in drive ${drive_id}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-
-  return parent_id;
+  return ensure_drive_folder_path(connector, tenant_id, site_id, drive_id, path, folder_ids);
 }

--- a/packages/sharepoint/src/services/restore/restore.service.ts
+++ b/packages/sharepoint/src/services/restore/restore.service.ts
@@ -39,6 +39,7 @@ import {
   load_drive_chain_entries,
   restorable_entries,
 } from '@wisecom/atlas-drive/shared/manifest-chain';
+import { count_created_folders } from '@wisecom/atlas-drive/restore/folder-path';
 import { ensure_sharepoint_folder_path } from '@/services/restore/restore-folder-path';
 import {
   assert_renameable,
@@ -161,7 +162,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
         });
       }
 
-      const folders_created = folder_ids.size;
+      const folders_created = count_created_folders(folder_ids);
       const interrupted = finish_operation_progress(
         options,
         'restore',


### PR DESCRIPTION
## Summary

An OneDrive restore that spanned two of an owner's drives could write files into the wrong drive's folder, silently. The folder-id memo was keyed by path alone, so the second drive's `/Documents/Reports` was answered from the first drive's cache entry and the upload succeeded against a real, wrong folder id.

Closes #316

## The fix

`ensure_drive_folder_path` now lives once in `packages/drive/src/restore/folder-path.ts`, keyed by `drive_id:path`. That was already the SharePoint behaviour, and the SharePoint copy documented why ("one snapshot spans several document libraries and the same path means a different folder in each"); the drive version-restore path added in #305 keeps folder ids per drive for the same reason. OneDrive restore was the one place still assuming a path identifies a folder.

Both providers keep their named wrappers, so no caller changed. This is the pair #306 measured at 28 differing lines and deliberately left alone, because the difference was behavioural: with the behaviour settled, the module is shareable and the note comes off both copies.

## Two things that fell out of it

**The per-drive map in version restore is gone.** `restore_drive_version` carried a `Map<drive_id, Map<path, id>>` purely to work around path-only keys. With the resolver keying by drive, one flat memo does the same job, and the seeded `['/', 'root']` entry each inner map needed is no longer necessary.

**`folders_created` was wrong on both providers**, and the fix would have made it worse. OneDrive seeded the memo with a root marker and reported `size - 1`; SharePoint reported `size`, which counted its per-drive root markers as folders it created. Neither is right once there is one marker per drive. `count_created_folders` skips the `<drive_id>:/` markers and counts the rest, so the number is exact for any drive count. A restore that created nothing reports zero rather than a negative clamped to zero.

## Tests

`packages/drive/tests/unit/restore/folder-path.test.ts`, new, eight cases. The one that pins the bug:

- the same path in two drives resolves to two different folder ids, and `create_folder` is called for both drives rather than answered from the memo.

Plus segment-by-segment creation, a shared parent created once across entries, the three root spellings (`/`, empty, `.`) resolving to `root` without a create call, a failed segment returning undefined so the caller skips one entry instead of aborting the run, a cached parent from the same drive not being recreated, and the two `count_created_folders` cases.

## Checklist

- `pnpm run build`, `pnpm run lint`, `pnpm run format:check`, `pnpm run typecheck` and the full `pnpm run test` pass. Drive goes from 52 to 58 tests; OneDrive and SharePoint counts unchanged.
- No CLI, SDK or config surface change. `folders_created` in a restore result is now accurate where it was previously off by one per drive, which is a correction to a reported number rather than a new field, and `docs/sharepoint-backup.md` already describes it without stating a formula.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved folder-path restoration across OneDrive and SharePoint, including nested folders, shared parent reuse, and isolation between drives.
  - Added consistent handling for normalized paths, root folders, cached folders, and folder-creation failures.
  - Folder creation totals now accurately exclude root markers.

- **Bug Fixes**
  - Prevented folder-cache collisions between different drives.
  - Improved reporting of folders created during restore operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->