### PR TITLE
chore(release): 4.4.0

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -23,7 +23,7 @@ operational procedure.
 
 1. **Never bump a version outside a release or hotfix PR.** The bump _is_ the
    release trigger. A bump merged in an ordinary PR publishes to npm on arrival.
-2. **Never hand-edit the nine `packages/*/package.json` versions.** Use
+2. **Never hand-edit the ten `packages/*/package.json` versions.** Use
    `pnpm run release:version <version>`. They move in lockstep; a partial bump
    fails the publish workflow's tag/version check.
 3. **Never delete a tag whose npm publish already succeeded.** npm versions are
@@ -74,7 +74,7 @@ gh workflow run release-start.yml -f version=2.2.0 -f from=dev
 gh run watch
 ```
 
-It creates `release/v<version>`, bumps all nine packages, commits
+It creates `release/v<version>`, bumps all ten packages, commits
 `chore(release): <version>`, and prints a prefilled compare link in the run
 summary. The organisation forbids GitHub Actions from creating pull requests, so
 open the release PR from that link:
@@ -94,7 +94,21 @@ Before merging:
   everything in the release: CLI flags, SDK methods, config variables, and
   security changes all have documentation in place.
 
-Merging the PR is the release. Then watch the pipeline:
+Merging the PR is the release, and expect to need `--admin` for it:
+
+```bash
+gh pr merge <n> --merge --admin
+```
+
+The `main` ruleset sets `require_extra_approval_for_unattributed_changes`, and
+the release commit is authored by the workflow rather than by a person, so the
+rule demands an approving review. The person who opened the release PR cannot
+supply it: GitHub refuses to let an author approve their own pull request. Every
+release therefore either takes a second person's approval or an admin merge, and
+admin is what the releases so far have used. Do not work around it by committing
+the bump by hand, which produces an unsigned commit and an unmergeable PR.
+
+Then watch the pipeline:
 
 ```bash
 gh run watch                                    # publish.yml: plan, publish, sync-dev
@@ -138,24 +152,26 @@ correct it with `npm dist-tag add`, never by republishing.
 
 ## When a release did not happen
 
-| Symptom                                | Cause                                                     | Fix                                                |
-| -------------------------------------- | --------------------------------------------------------- | -------------------------------------------------- |
-| Merged to `main`, no tag               | Version was already tagged -- no bump in the merge        | Cut a real release with a higher version           |
-| `release-guard` fails on branch name   | Branch version disagrees with `packages/sdk/package.json` | `pnpm run release:version <branch version>`        |
-| `release-guard` fails on existing tag  | Version already released                                  | Pick a higher version                              |
-| Tag exists, `publish.yml` never ran    | Tag pushed by hand with `GITHUB_TOKEN`                    | `gh workflow run publish.yml -f version=<version>` |
-| No `publish.yml` run after the merge    | Event delivery is late, not dropped (issue #212)          | Wait a few minutes and re-check; only then `gh workflow run publish.yml -f version=<version> --ref main`, which tags the ref when the tag is missing |
-| Publish failed on build, lint, or test | Broken release commit                                     | Delete the tag, fix via a PR into `dev`, cut again |
-| SDK published, CLI failed              | Partial publish; npm is immutable                         | Hotfix forward at the next patch version           |
+| Symptom                                | Cause                                                     | Fix                                                                                                                                                  |
+| -------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Merged to `main`, no tag               | Version was already tagged -- no bump in the merge        | Cut a real release with a higher version                                                                                                             |
+| `release-guard` fails on branch name   | Branch version disagrees with `packages/sdk/package.json` | `pnpm run release:version <branch version>`                                                                                                          |
+| `release-guard` fails on existing tag  | Version already released                                  | Pick a higher version                                                                                                                                |
+| Tag exists, `publish.yml` never ran    | Tag pushed by hand with `GITHUB_TOKEN`                    | `gh workflow run publish.yml -f version=<version>`                                                                                                   |
+| No `publish.yml` run after the merge   | Event delivery is late, not dropped (issue #212)          | Wait a few minutes and re-check; only then `gh workflow run publish.yml -f version=<version> --ref main`, which tags the ref when the tag is missing |
+| Publish failed on build, lint, or test | Broken release commit                                     | Delete the tag, fix via a PR into `dev`, cut again                                                                                                   |
+| SDK published, CLI failed              | Partial publish; npm is immutable                         | Hotfix forward at the next patch version                                                                                                             |
 
 ## Repairing a botched bump
 
 ```bash
-pnpm run release:version 2.2.0        # explicit version, all nine packages
+pnpm run release:version 2.2.0        # explicit version, all ten packages
 pnpm run release:version patch        # or a keyword
-git diff --stat                       # expect exactly 9 package.json files
+git diff --stat                       # expect exactly 10 package.json files
 ```
 
-Nine files and nothing else. Internal dependencies are `workspace:*` and are
-rewritten by pnpm at publish time, so they never need editing. If the diff shows
-a different count, stop -- a package was added or the filter is wrong.
+Ten files and nothing else, one per workspace package. Internal dependencies are
+`workspace:*` and are rewritten by pnpm at publish time, so they never need
+editing. If the diff shows a different count, stop and check whether a package
+was added or the filter is wrong: the count is `ls -d packages/*/ | wc -l`, and
+it went from nine to ten when `packages/drive` arrived in v4.3.0.

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -199,10 +199,15 @@ gh run list --workflow e2e.yml --limit 3
 
 ## Branch protection
 
-`main` is governed by a repository **ruleset** (not classic branch protection --
-`/branches/main/protection` returns 404, the rules live under
-`/repos/:owner/:repo/rulesets`). The settings interact with the automation in ways
-that are not obvious:
+`main` is governed by two mechanisms at once, which is the part that misleads.
+Most rules live in a repository **ruleset** under
+`/repos/:owner/:repo/rulesets`, and `/branches/main/protection` returns nothing
+useful for them. Signed commits are the exception: that requirement sits in
+classic branch protection and is only visible at
+`/branches/main/protection/required_signatures`, which reports `enabled: true`
+for `main` and `false` for `dev`. Reading only the ruleset makes signing look
+optional. The settings interact with the automation in ways that are not
+obvious:
 
 | Rule                                    | State | Reason                                                                                                                                                                                                                                                                                                                                                   |
 | --------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -212,7 +217,7 @@ that are not obvious:
 | Restrict deletions                      | On    | Deleting `main` would orphan every published tag                                                                                                                                                                                                                                                                                                         |
 | Block force pushes                      | On    | A force push can strand a published tag on an orphaned commit                                                                                                                                                                                                                                                                                            |
 | **Require linear history**              | Off   | Release tags sit on PR merge commits; requiring linear history would break the release path                                                                                                                                                                                                                                                              |
-| Require signed commits                  | Off   | Optional -- the release commit is API-created and signed, so enabling it would not break the flow                                                                                                                                                                                                                                                        |
+| Require signed commits                  | On    | Enforced by classic branch protection, not by the ruleset, so it does not appear in `/rulesets`. This is why `release-start.yml` creates the bump through the GraphQL commit API: a runner-side `git commit` is unsigned and lands an unmergeable release PR                                                                                             |
 | Extra approval for unattributed changes | On    | The one rule that does bite. The release commit is created through the GraphQL commit API so it is signed, which also means it is attributed to the workflow rather than to a person, so this rule demands an approving review that the PR author cannot give. Every release PR needs either a second person's approval or `gh pr merge --merge --admin` |
 
 Tag rulesets are deliberately **not** configured: a `v*` rule can block

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -55,7 +55,7 @@ real input:
 The workflow then:
 
 1. Branches `release/v<version>` from `dev` (or `hotfix/v<version>` from `main`).
-2. Runs `pnpm run release:version <version>`, bumping all nine workspace
+2. Runs `pnpm run release:version <version>`, bumping all ten workspace
    packages in lockstep. Internal dependencies are `workspace:*`, so pnpm
    rewrites them to the exact version at publish time -- there is nothing else to
    edit.
@@ -204,15 +204,16 @@ gh run list --workflow e2e.yml --limit 3
 `/repos/:owner/:repo/rulesets`). The settings interact with the automation in ways
 that are not obvious:
 
-| Rule                       | State | Reason                                                                                               |
-| -------------------------- | ----- | ---------------------------------------------------------------------------------------------------- |
-| Require a pull request     | On    | Blocks a direct push of a version bump, which would publish to npm with no review                    |
-| Required approvals         | 0     | GitHub forbids self-approval; any higher number makes release PRs unmergeable for a solo maintainer  |
-| Require code owner review  | Off   | No `CODEOWNERS` file exists, and one naming the sole maintainer recreates the self-approval deadlock |
-| Restrict deletions         | On    | Deleting `main` would orphan every published tag                                                     |
-| Block force pushes         | On    | A force push can strand a published tag on an orphaned commit                                        |
-| **Require linear history** | Off   | Release tags sit on PR merge commits; requiring linear history would break the release path          |
-| Require signed commits     | Off   | Optional -- the release commit is API-created and signed, so enabling it would not break the flow    |
+| Rule                                    | State | Reason                                                                                                                                                                                                                                                                                                                                                   |
+| --------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Require a pull request                  | On    | Blocks a direct push of a version bump, which would publish to npm with no review                                                                                                                                                                                                                                                                        |
+| Required approvals                      | 0     | GitHub forbids self-approval; any higher number makes release PRs unmergeable for a solo maintainer                                                                                                                                                                                                                                                      |
+| Require code owner review               | Off   | No `CODEOWNERS` file exists, and one naming the sole maintainer recreates the self-approval deadlock                                                                                                                                                                                                                                                     |
+| Restrict deletions                      | On    | Deleting `main` would orphan every published tag                                                                                                                                                                                                                                                                                                         |
+| Block force pushes                      | On    | A force push can strand a published tag on an orphaned commit                                                                                                                                                                                                                                                                                            |
+| **Require linear history**              | Off   | Release tags sit on PR merge commits; requiring linear history would break the release path                                                                                                                                                                                                                                                              |
+| Require signed commits                  | Off   | Optional -- the release commit is API-created and signed, so enabling it would not break the flow                                                                                                                                                                                                                                                        |
+| Extra approval for unattributed changes | On    | The one rule that does bite. The release commit is created through the GraphQL commit API so it is signed, which also means it is attributed to the workflow rather than to a person, so this rule demands an approving review that the PR author cannot give. Every release PR needs either a second person's approval or `gh pr merge --merge --admin` |
 
 Tag rulesets are deliberately **not** configured: a `v*` rule can block
 `github-actions[bot]` from pushing the release tag, which stops every publish
@@ -229,7 +230,7 @@ pnpm run release:version 2.2.0   # explicit version
 pnpm run release:version patch   # 2.2.0 -> 2.2.1
 ```
 
-This edits all nine `packages/*/package.json` files and nothing else -- no git
+This edits all ten `packages/*/package.json` files and nothing else -- no git
 tag, no commit. Prefer the **Start release** workflow; use this only when working
 offline or repairing a botched bump.
 

--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -6,13 +6,13 @@ Backup is user-targeted: one run processes every drive belonging to a single use
 
 ## What Gets Backed Up
 
-| Item                         | Coverage                                                                                                    |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Files in the user's drives   | Current content, SHA-256 content-addressed and deduplicated per owner                                       |
-| File version history         | Every new historical version Graph returns for an item                                                      |
-| Folder paths                 | Recorded on the manifest entry and normalized to Unicode NFC                                                |
-| OneNote notebooks            | Section files and table of contents, stored as ordinary files (see [OneNote Notebooks](#onenote-notebooks)) |
-| Moves, renames, and deletions | Recorded as manifest changes on the next delta sync                                                        |
+| Item                          | Coverage                                                                                                    |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Files in the user's drives    | Current content, SHA-256 content-addressed and deduplicated per owner                                       |
+| File version history          | Every new historical version Graph returns for an item                                                      |
+| Folder paths                  | Recorded on the manifest entry and normalized to Unicode NFC                                                |
+| OneNote notebooks             | Section files and table of contents, stored as ordinary files (see [OneNote Notebooks](#onenote-notebooks)) |
+| Moves, renames, and deletions | Recorded as manifest changes on the next delta sync                                                         |
 
 ## Prerequisites
 
@@ -77,11 +77,11 @@ Ciphertext is stored at the key name shown above. There is no separate `.enc` fi
 
 Implementation thresholds from `@wisecom/atlas-onedrive`:
 
-| Size                          | Strategy                                                                                                                                                                 |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **≤ 4 MiB**                   | Single read of the file into memory (pre-authenticated URL or Graph content fallback when needed), encrypt, `put`                                                        |
-| **> 4 MiB** and **< 64 MiB**  | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                |
-| **≥ 64 MiB**                  | `process_large_file`: stream encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `onedrive/data/{owner_id}/{sha256}` |
+| Size                         | Strategy                                                                                                                                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **≤ 4 MiB**                  | Single read of the file into memory (pre-authenticated URL or Graph content fallback when needed), encrypt, `put`                                                        |
+| **> 4 MiB** and **< 64 MiB** | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                |
+| **≥ 64 MiB**                 | `process_large_file`: stream encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `onedrive/data/{owner_id}/{sha256}` |
 
 Chunked downloads retry each **4 MiB** range independently (5 attempts with backoff in the adapter), so a transient failure replays a single chunk instead of the whole file. Each range request is also aborted if the chunk has not transferred at roughly 256 KB/s, with a floor of 30 seconds. That budget is sized from the chunk being fetched, not the file, so a dead connection costs about 30 seconds and then a retry regardless of whether the file is 5 MB or 5 GB.
 
@@ -216,11 +216,11 @@ Versions the service reports as gone (`404` or `410`, content purged by the site
 
 A OneNote notebook is not a file. Graph returns the notebook root as a driveItem carrying a **`package` facet** (`package.type == "oneNote"`) alongside a `folder` facet, and its actual content as ordinary child files:
 
-| Item                        | Facets                               | Backed up                                                                                                                     |
+| Item                        | Facets                               | Backed up                                                                                                                       |
 | --------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | Notebook root (e.g. `Test`) | `folder` + `package`                 | Treated as a folder. `GET /items/{id}/content` returns **404**, because the root has no content of its own and nothing to store |
-| `<Section>.one`             | `file`, MIME `application/msonenote` | Yes, byte-for-byte, like any other file                                                                                       |
-| `Open Notebook.onetoc2`     | `file`                               | Yes, byte-for-byte                                                                                                            |
+| `<Section>.one`             | `file`, MIME `application/msonenote` | Yes, byte-for-byte, like any other file                                                                                         |
+| `Open Notebook.onetoc2`     | `file`                               | Yes, byte-for-byte                                                                                                              |
 
 Notebook **content is covered by backups today**: each section file is content-addressed, encrypted, and stored under the notebook's folder path. What the run additionally reports is the notebook itself, because file counters alone cannot answer "did the notebook come through whole?":
 
@@ -267,17 +267,17 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 
 ### `atlas onedrive restore`
 
-| Flag                       | Description                                          | Default                    |
-| -------------------------- | ---------------------------------------------------- | -------------------------- |
-| `-o, --owner <id>`         | User email or Entra object ID                        | Required                   |
-| `-s, --snapshot <id>`      | Snapshot to restore from                             | Required                   |
-| `--target-owner <id>`      | Restore to a different user's OneDrive               | Same as `--owner`          |
-| `--destination <path>`     | Folder to restore under, created when missing        | `/Restore-<timestamp>`     |
-| `--in-place`               | Restore to the original paths                        | `false`                    |
-| `--name <filename>`        | Rename the restored file; single-file restores only  | Original name              |
-| `--file-filter <paths...>` | Only restore specific files (by ID or path)          | All files                  |
-| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` | `rename`                   |
-| `-t, --tenant <id>`        | Tenant identifier                                    | Config default             |
+| Flag                       | Description                                          | Default                |
+| -------------------------- | ---------------------------------------------------- | ---------------------- |
+| `-o, --owner <id>`         | User email or Entra object ID                        | Required               |
+| `-s, --snapshot <id>`      | Snapshot to restore from                             | Required               |
+| `--target-owner <id>`      | Restore to a different user's OneDrive               | Same as `--owner`      |
+| `--destination <path>`     | Folder to restore under, created when missing        | `/Restore-<timestamp>` |
+| `--in-place`               | Restore to the original paths                        | `false`                |
+| `--name <filename>`        | Rename the restored file; single-file restores only  | Original name          |
+| `--file-filter <paths...>` | Only restore specific files (by ID or path)          | All files              |
+| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` | `rename`               |
+| `-t, --tenant <id>`        | Tenant identifier                                    | Config default         |
 
 ### `atlas onedrive save`
 
@@ -309,15 +309,15 @@ On Windows the archive is stamped with Mark-of-the-Web (`Zone.Identifier`, `Zone
 
 ### `atlas onedrive restore-version`
 
-| Flag                | Description                                        | Default        |
-| ------------------- | -------------------------------------------------- | -------------- |
-| `-o, --owner <id>`  | User email or Entra object ID                      | Required       |
-| `-f, --file <ref>`  | File ID or path; required with `--version`         | Optional       |
-| `--version <id>`    | Exact stored version to restore                    | Optional       |
-| `--before <iso>`    | Newest version at or before this instant, per file | Optional       |
-| `--path <prefix>`   | Limit a `--before` rollback to one folder          | Whole drive    |
+| Flag                | Description                                        | Default            |
+| ------------------- | -------------------------------------------------- | ------------------ |
+| `-o, --owner <id>`  | User email or Entra object ID                      | Required           |
+| `-f, --file <ref>`  | File ID or path; required with `--version`         | Optional           |
+| `--version <id>`    | Exact stored version to restore                    | Optional           |
+| `--before <iso>`    | Newest version at or before this instant, per file | Optional           |
+| `--path <prefix>`   | Limit a `--before` rollback to one folder          | Whole drive        |
 | `--in-place`        | Upload over the original file                      | Off, writes a copy |
-| `-t, --tenant <id>` | Tenant identifier                                  | Config default |
+| `-t, --tenant <id>` | Tenant identifier                                  | Config default     |
 
 ### `atlas onedrive verify`
 
@@ -413,11 +413,11 @@ Files larger than 4 MiB use a streaming decrypt pipeline: the encrypted blob is 
 
 **Conflict behavior** controls what happens when a file already exists at the target path:
 
-| Mode                | Behavior                                                                              |
-| ------------------- | --------------------------------------------------------------------------------------- |
-| `rename` (default)  | Appends a numeric suffix, so user edits made after a previous restore are not overwritten |
-| `replace`           | Overwrites the existing file                                                            |
-| `fail`              | Skips the file and logs an error                                                        |
+| Mode               | Behavior                                                                                  |
+| ------------------ | ----------------------------------------------------------------------------------------- |
+| `rename` (default) | Appends a numeric suffix, so user edits made after a previous restore are not overwritten |
+| `replace`          | Overwrites the existing file                                                              |
+| `fail`             | Skips the file and logs an error                                                          |
 
 ### Saving to a local archive
 
@@ -459,15 +459,15 @@ for (const drive of status.drives) {
 
 `checkStatus` returns an `OneDriveStatusResult`:
 
-| Field                   | Type                    | Description                                                        |
-| ----------------------- | ----------------------- | ------------------------------------------------------------------ |
-| `owner_id`              | `string`                | The user's Entra object ID                                         |
-| `last_backup_at`        | `Date \| undefined`     | Timestamp of the most recent snapshot                              |
-| `last_snapshot_id`      | `string \| undefined`   | ID of the most recent snapshot                                     |
-| `total_drives`          | `number`                | Number of drives discovered                                        |
-| `drives`                | `OneDriveDriveStatus[]` | Per-drive backup status                                            |
-| `is_up_to_date`         | `boolean`               | `true` if all drives have been backed up with zero pending changes |
-| `total_pending_changes` | `number`                | Sum of pending changes across all drives                           |
+| Field                   | Type                    | Description                                                                                                                                                                                                                                    |
+| ----------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `owner_id`              | `string`                | The user's Entra object ID                                                                                                                                                                                                                     |
+| `last_backup_at`        | `Date \| undefined`     | Timestamp of the most recent snapshot                                                                                                                                                                                                          |
+| `last_snapshot_id`      | `string \| undefined`   | ID of the most recent snapshot                                                                                                                                                                                                                 |
+| `total_drives`          | `number`                | Number of drives discovered                                                                                                                                                                                                                    |
+| `drives`                | `OneDriveDriveStatus[]` | Per-drive backup status                                                                                                                                                                                                                        |
+| `is_up_to_date`         | `boolean`               | `true` only when every drive reports itself up to date. A drive that has never been backed up, or whose delta peek failed, makes this `false` even though it contributes zero pending changes: a peek that could not run is unknown, not clean |
+| `total_pending_changes` | `number`                | Sum of pending changes across all drives                                                                                                                                                                                                       |
 
 ## Deletion
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -54,17 +54,17 @@ atlas outlook backup -m user@company.com --retention-days 365 --lock-mode compli
 atlas outlook backup -t <tenant-id> -m user@company.com        # explicit tenant
 ```
 
-| Option                   | Description                                                               |
-| ------------------------ | ------------------------------------------------------------------------- |
-| `-m, --mailbox <id>`     | Mailbox to back up (required)                                             |
-| `-f, --folder <name...>` | Filter to specific folder(s) by name or path (see below)                  |
-| `--full`                 | Ignore saved delta links, run full enumeration                            |
-| `-P, --page-size <n>`    | Graph API page size per delta request (1--100, default 10)                |
-| `--retention-days <n>`   | Apply Object Lock retention for `n` days                                  |
-| `--lock-mode <mode>`     | Object Lock mode (`governance` or `compliance`); requires `--retention-days` |
-| `-t, --tenant <id>`      | Override tenant ID from config                                            |
-| `--exclude-junk`         | Skip the Junk Email folder and its subfolders                             |
-| `--include-recoverable-items` | Also back up hard-deleted and hold-retained mail (see below)          |
+| Option                        | Description                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `-m, --mailbox <id>`          | Mailbox to back up (required)                                                |
+| `-f, --folder <name...>`      | Filter to specific folder(s) by name or path (see below)                     |
+| `--full`                      | Ignore saved delta links, run full enumeration                               |
+| `-P, --page-size <n>`         | Graph API page size per delta request (1--100, default 10)                   |
+| `--retention-days <n>`        | Apply Object Lock retention for `n` days                                     |
+| `--lock-mode <mode>`          | Object Lock mode (`governance` or `compliance`); requires `--retention-days` |
+| `-t, --tenant <id>`           | Override tenant ID from config                                               |
+| `--exclude-junk`              | Skip the Junk Email folder and its subfolders                                |
+| `--include-recoverable-items` | Also back up hard-deleted and hold-retained mail (see below)                 |
 
 `--lock-mode` only means something alongside `--retention-days`: the mode selects how retention is enforced, it does not request retention on its own. Passing it alone is rejected rather than ignored, so a run that was meant to be immutable cannot exit `0` with unprotected data. Retention without a mode defaults to `governance`.
 
@@ -74,15 +74,15 @@ Requesting retention is fail-closed: when the bucket has versioning or Object Lo
 
 Every mail folder in the mailbox, at any nesting depth, including the ones Outlook treats as special:
 
-| Folder | Backed up | Note |
-| ------------------------------ | -------------- | ------------------------------------------------------------------------ |
-| Inbox, Sent Items, Deleted Items, Archive, and user folders | Yes | Including nested subfolders at any depth |
-| **Drafts** and **Outbox** | Yes | Unsent work exists nowhere else, so it is content like any other |
-| **Junk Email** | Yes | Opt out with `--exclude-junk`. Junk is evidence in a phishing or BEC case |
-| Hidden folders (`isHidden`) | Yes | Enumerated explicitly; Graph omits them unless asked |
-| Hidden Exchange system folders | No | A short deny-list of client-state folders such as `Conversation Action Settings`, matched only when Exchange also reports them hidden |
-| In-Place Archive mailbox | No | Graph cannot read it at all. See [In-Place Archive is out of scope](../security.md#in-place-archive-is-out-of-scope) |
-| **Recoverable Items** | Opt-in | `--include-recoverable-items`. Hard-deleted and hold-retained mail; see below |
+| Folder                                                      | Backed up | Note                                                                                                                                  |
+| ----------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Inbox, Sent Items, Deleted Items, Archive, and user folders | Yes       | Including nested subfolders at any depth                                                                                              |
+| **Drafts** and **Outbox**                                   | Yes       | Unsent work exists nowhere else, so it is content like any other                                                                      |
+| **Junk Email**                                              | Yes       | Opt out with `--exclude-junk`. Junk is evidence in a phishing or BEC case                                                             |
+| Hidden folders (`isHidden`)                                 | Yes       | Enumerated explicitly; Graph omits them unless asked                                                                                  |
+| Hidden Exchange system folders                              | No        | A short deny-list of client-state folders such as `Conversation Action Settings`, matched only when Exchange also reports them hidden |
+| In-Place Archive mailbox                                    | No        | Graph cannot read it at all. See [In-Place Archive is out of scope](../security.md#in-place-archive-is-out-of-scope)                  |
+| **Recoverable Items**                                       | Opt-in    | `--include-recoverable-items`. Hard-deleted and hold-retained mail; see below                                                         |
 
 Anything skipped is reported at the end of the run and recorded in the snapshot manifest with its reason, so "was folder X captured?" is answerable from the backup rather than from whoever ran it:
 
@@ -94,7 +94,6 @@ Anything skipped is reported at the end of the run and recorded in the snapshot 
 ::: warning Drafts and Outbox are new in 4.1.0
 Earlier versions silently skipped Drafts and Outbox. New snapshots include them, which makes the first backup after upgrading larger than the previous one for mailboxes that hold unsent mail. Existing snapshots are unaffected; the content appears as those folders sync for the first time.
 :::
-
 
 #### Recoverable Items, the Exchange dumpster
 
@@ -108,15 +107,15 @@ expires the item is gone from the tenant and from every snapshot.
 atlas outlook backup -m user@company.com --include-recoverable-items
 ```
 
-| Subfolder | Backed up | Contains |
-| ------------------ | --------- | ------------------------------------------------------------- |
-| `Deletions` | Yes | Items removed from Deleted Items, user-recoverable for 14 to 30 days |
-| `Purges` | Yes | Hard-deleted items retained only by litigation hold or single item recovery |
-| `DiscoveryHolds` | Yes | Hard-deleted items retained by an In-Place Hold or retention policy |
-| `SubstrateHolds` | Yes | Original copies of held Teams messages and modified held items |
-| `Versions` | No | Pre-modification copies whose item shape is not a message |
-| `Calendar Logging` | No | Calendar change audit trail |
-| `Audits` | No | Mailbox audit log entries |
+| Subfolder          | Backed up | Contains                                                                    |
+| ------------------ | --------- | --------------------------------------------------------------------------- |
+| `Deletions`        | Yes       | Items removed from Deleted Items, user-recoverable for 14 to 30 days        |
+| `Purges`           | Yes       | Hard-deleted items retained only by litigation hold or single item recovery |
+| `DiscoveryHolds`   | Yes       | Hard-deleted items retained by an In-Place Hold or retention policy         |
+| `SubstrateHolds`   | Yes       | Original copies of held Teams messages and modified held items              |
+| `Versions`         | No        | Pre-modification copies whose item shape is not a message                   |
+| `Calendar Logging` | No        | Calendar change audit trail                                                 |
+| `Audits`           | No        | Mailbox audit log entries                                                   |
 
 Everything not captured is reported at the end of the run with its reason, and a
 subfolder Atlas does not recognise is reported rather than guessed at, so a new
@@ -175,11 +174,11 @@ atlas outlook verify -m user@company.com -s <snapshot-id> -t <tenant-id>
 atlas outlook verify -m user@company.com -s <snapshot-id> --fast
 ```
 
-| Option                  | Description                                                                                 |
-| ----------------------- | ------------------------------------------------------------------------------------------- |
-| `-m, --mailbox <email>` | Mailbox that owns the snapshot (required)                                                   |
-| `-s, --snapshot <id>`   | Snapshot identifier to verify (required)                                                    |
-| `-t, --tenant <id>`     | Override tenant ID from config                                                              |
+| Option                  | Description                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------- |
+| `-m, --mailbox <email>` | Mailbox that owns the snapshot (required)                                                      |
+| `-s, --snapshot <id>`   | Snapshot identifier to verify (required)                                                       |
+| `-t, --tenant <id>`     | Override tenant ID from config                                                                 |
 | `--fast`                | Existence-only checks (`HeadObject` per referenced key), with no download, decrypt, or hashing |
 
 ::: details What exactly is verified?
@@ -214,16 +213,16 @@ atlas outlook restore -m user@company.com -T other@company.com
 atlas outlook restore -m user@company.com -T other@company.com -f Inbox
 ```
 
-| Option                      | Description                                                     |
-| --------------------------- | --------------------------------------------------------------- |
-| `-s, --snapshot <id>`       | Restore from a specific snapshot                                |
-| `-m, --mailbox <email>`     | Restore from all snapshots for this mailbox                     |
-| `-T, --target <email>`      | Target mailbox for cross-mailbox restore (defaults to source)   |
-| `-f, --folder <name>`       | Restore only messages from this folder or its subfolders        |
-| `--message <ref>`           | Restore a single message by `#` index from `atlas outlook list` |
-| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date                 |
-| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date                |
-| `-t, --tenant <id>`         | Override tenant ID                                              |
+| Option                        | Description                                                           |
+| ----------------------------- | --------------------------------------------------------------------- |
+| `-s, --snapshot <id>`         | Restore from a specific snapshot                                      |
+| `-m, --mailbox <email>`       | Restore from all snapshots for this mailbox                           |
+| `-T, --target <email>`        | Target mailbox for cross-mailbox restore (defaults to source)         |
+| `-f, --folder <name>`         | Restore only messages from this folder or its subfolders              |
+| `--message <ref>`             | Restore a single message by `#` index from `atlas outlook list`       |
+| `--start-date <YYYY-MM-DD>`   | Include snapshots created on or after this date                       |
+| `--end-date <YYYY-MM-DD>`     | Include snapshots created on or before this date                      |
+| `-t, --tenant <id>`           | Override tenant ID                                                    |
 | `--include-recoverable-items` | Also include hard-deleted and hold-retained mail; excluded by default |
 
 Exactly one of `--snapshot` or `--mailbox` is required; passing both exits `1`, as described under [`atlas outlook`](#atlas-outlook). `-T, --target` works in either mode. In mailbox mode, entries are deduplicated across snapshots (newest version of each message wins). Cross-mailbox restores preserve the original folder names from the source mailbox. Nested source folders are recreated as nested subfolders under the `Restore-{timestamp}` root, so `Inbox/Projects/2026` restores to `Restore-.../Inbox/Projects/2026` instead of collapsing into one flat level.
@@ -268,12 +267,12 @@ atlas outlook read -s <snapshot-id> --message 34 --raw
 atlas outlook read -s <snapshot-id> --message 34 --raw > message.eml
 ```
 
-| Option                | Description                                                        |
-| --------------------- | ------------------------------------------------------------------ |
-| `-s, --snapshot <id>` | Snapshot containing the message                                    |
-| `--message <ref>`     | Message `#` from `atlas outlook list`, or full Graph message ID    |
+| Option                | Description                                                           |
+| --------------------- | --------------------------------------------------------------------- |
+| `-s, --snapshot <id>` | Snapshot containing the message                                       |
+| `--message <ref>`     | Message `#` from `atlas outlook list`, or full Graph message ID       |
 | `--raw`               | Output the stored object verbatim instead of formatted headers + body |
-| `-t, --tenant <id>`   | Override tenant ID                                                 |
+| `-t, --tenant <id>`   | Override tenant ID                                                    |
 
 What `--raw` prints depends on the format of the stored object. For a message archived as RFC 5322 MIME -- the default for snapshots taken by this version -- Atlas writes the decrypted MIME bytes to stdout verbatim: no banner, no colour, no added trailing newline. Redirecting that output produces a valid `.eml` file with its original `Received:` chain, `Authentication-Results`, and any S/MIME payload intact, which is what you want when handing a single message to an investigator or verifying a DKIM signature by hand.
 
@@ -316,17 +315,17 @@ atlas outlook save -m user@company.com --start-date 2026-01-01
 atlas outlook save -m user@company.com --start-date 2026-01-01 --end-date 2026-06-30
 ```
 
-| Option                      | Description                                                  |
-| --------------------------- | ------------------------------------------------------------ |
-| `-s, --snapshot <id>`       | Save from a specific snapshot                                |
-| `-m, --mailbox <email>`     | Save from all snapshots for this mailbox                     |
-| `-f, --folder <name>`       | Save only messages from this folder or its subfolders        |
-| `--message <ref>`           | Save a single message by `#` index from `atlas outlook list` |
-| `--start-date <YYYY-MM-DD>` | Include snapshots created on or after this date              |
-| `--end-date <YYYY-MM-DD>`   | Include snapshots created on or before this date             |
-| `-o, --output <path>`       | Output file path (default: `Restore-<timestamp>.zip`)        |
-| `--skip-verify`             | Skip SHA-256 integrity checks (faster on low-power systems)  |
-| `-t, --tenant <id>`         | Override tenant ID                                           |
+| Option                        | Description                                                           |
+| ----------------------------- | --------------------------------------------------------------------- |
+| `-s, --snapshot <id>`         | Save from a specific snapshot                                         |
+| `-m, --mailbox <email>`       | Save from all snapshots for this mailbox                              |
+| `-f, --folder <name>`         | Save only messages from this folder or its subfolders                 |
+| `--message <ref>`             | Save a single message by `#` index from `atlas outlook list`          |
+| `--start-date <YYYY-MM-DD>`   | Include snapshots created on or after this date                       |
+| `--end-date <YYYY-MM-DD>`     | Include snapshots created on or before this date                      |
+| `-o, --output <path>`         | Output file path (default: `Restore-<timestamp>.zip`)                 |
+| `--skip-verify`               | Skip SHA-256 integrity checks (faster on low-power systems)           |
+| `-t, --tenant <id>`           | Override tenant ID                                                    |
 | `--include-recoverable-items` | Also include hard-deleted and hold-retained mail; excluded by default |
 
 With both `-s` and `-m`, the named snapshot is exported and `-m` is ignored with a warning; see [`atlas outlook`](#atlas-outlook). Earlier releases silently exported the whole mailbox instead.
@@ -497,27 +496,27 @@ atlas onedrive delete -o user@company.com -s od-snap-123
 atlas onedrive delete -o user@company.com -y
 ```
 
-| Option           | Description                                                              |
-| ---------------- | ------------------------------------------------------------------------ |
-| `backup`         | Incremental sync; use `--full` to ignore saved delta state               |
-| `restore`        | Restore files from a snapshot to the user's (or another user's) OneDrive |
-| `list-snapshots` | List snapshot IDs and timestamps for the owner                           |
-| `list-versions`  | List indexed versions for one file (`-f` file ID or path)                |
-| `restore-version`| Push stored file versions back into the drive, one file or a whole rollback |
-| `verify`         | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows    |
-| `status`         | Report pending Graph changes per drive without backing up                |
-| `delete`         | Delete the owner's OneDrive backups, or a single snapshot                |
+| Option            | Description                                                                 |
+| ----------------- | --------------------------------------------------------------------------- |
+| `backup`          | Incremental sync; use `--full` to ignore saved delta state                  |
+| `restore`         | Restore files from a snapshot to the user's (or another user's) OneDrive    |
+| `list-snapshots`  | List snapshot IDs and timestamps for the owner                              |
+| `list-versions`   | List indexed versions for one file (`-f` file ID or path)                   |
+| `restore-version` | Push stored file versions back into the drive, one file or a whole rollback |
+| `verify`          | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows       |
+| `status`          | Report pending Graph changes per drive without backing up                   |
+| `delete`          | Delete the owner's OneDrive backups, or a single snapshot                   |
 
 **`atlas onedrive backup`**
 
-| Option                 | Description                                                           |
-| ---------------------- | --------------------------------------------------------------------- |
-| `-o, --owner <id>`     | User email or Entra object ID (required)                              |
-| `--full`               | Force full crawl ignoring saved delta links                           |
-| `--folder <path>`      | Back up only this folder and its subfolders; see note below           |
-| `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (see note below) |
+| Option                 | Description                                                                                        |
+| ---------------------- | -------------------------------------------------------------------------------------------------- |
+| `-o, --owner <id>`     | User email or Entra object ID (required)                                                           |
+| `--full`               | Force full crawl ignoring saved delta links                                                        |
+| `--folder <path>`      | Back up only this folder and its subfolders; see note below                                        |
+| `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (see note below)                              |
 | `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`); requires `--retention-days` |
-| `-t, --tenant <id>`    | Override tenant ID from config                                        |
+| `-t, --tenant <id>`    | Override tenant ID from config                                                                     |
 
 While the backup runs, a live dashboard shows one row per drive: delta fetch (`fetching changes...`), then per-item progress with rate and ETA, finishing as `[ok]` with stored/dedup/version counts or `[==] up to date` when an incremental delta has no changes. Non-interactive runs (cron/CI) print one plain log line per finished drive instead. Service messages (version syncs, warnings) print above the live region.
 
@@ -535,17 +534,17 @@ A snapshot taken with `--folder` contains only that folder's files. Restoring it
 
 **`atlas onedrive restore`**
 
-| Option                     | Description                                                                       |
-| -------------------------- | --------------------------------------------------------------------------------- |
-| `-o, --owner <id>`         | User email or Entra object ID (required)                                           |
-| `-s, --snapshot <id>`      | Snapshot to restore from (required)                                                |
-| `--target-owner <id>`      | Restore to a different user's OneDrive (defaults to owner)                         |
-| `--destination <path>`     | Folder to restore under, created when missing (default: `/Restore-<timestamp>`)    |
-| `--in-place`               | Restore to the original paths instead of a restore root                            |
-| `--name <filename>`        | Rename the restored file; rejected unless exactly one file matches                 |
-| `--file-filter <paths...>` | Only restore specific files by ID or path                                          |
-| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`)          |
-| `-t, --tenant <id>`        | Override tenant ID from config                                                     |
+| Option                     | Description                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------- |
+| `-o, --owner <id>`         | User email or Entra object ID (required)                                        |
+| `-s, --snapshot <id>`      | Snapshot to restore from (required)                                             |
+| `--target-owner <id>`      | Restore to a different user's OneDrive (defaults to owner)                      |
+| `--destination <path>`     | Folder to restore under, created when missing (default: `/Restore-<timestamp>`) |
+| `--in-place`               | Restore to the original paths instead of a restore root                         |
+| `--name <filename>`        | Rename the restored file; rejected unless exactly one file matches              |
+| `--file-filter <paths...>` | Only restore specific files by ID or path                                       |
+| `-c, --conflict <mode>`    | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`)        |
+| `-t, --tenant <id>`        | Override tenant ID from config                                                  |
 
 A drive restore nests under `/Restore-<timestamp>` at the target drive root and recreates the original folder structure beneath it, matching how Outlook restores have always worked. `--in-place` reproduces the pre-4.0.0 behaviour of writing back over the original paths; it is never the default, because `--conflict rename` turns a repeated in-place restore into suffixed duplicates scattered through live content rather than a failure. See [Where restored files land](/onedrive-backup#where-restored-files-land).
 
@@ -573,15 +572,15 @@ Identifiers are matched case-insensitively: `--owner`, `--site`, and `--file-fil
 Restores the version bytes Atlas holds. Use it to roll a file back past a bad
 edit, or a whole folder back past a mass encrypt-and-sync event.
 
-| Option              | Description                                                                  |
-| ------------------- | ---------------------------------------------------------------------------- |
-| `-o, --owner <id>`  | User email or Entra object ID (required)                                     |
-| `-f, --file <ref>`  | Graph file ID or drive path; required with `--version`                       |
-| `--version <id>`    | Exact stored version, as shown in the `Version` column of `list-versions`    |
-| `--before <iso>`    | Restore each file's newest version at or before this instant                  |
-| `--path <prefix>`   | Limit a `--before` rollback to this folder and below                         |
-| `--in-place`        | Upload over the original file instead of writing a copy beside it            |
-| `-t, --tenant <id>` | Override tenant ID from config                                               |
+| Option              | Description                                                               |
+| ------------------- | ------------------------------------------------------------------------- |
+| `-o, --owner <id>`  | User email or Entra object ID (required)                                  |
+| `-f, --file <ref>`  | Graph file ID or drive path; required with `--version`                    |
+| `--version <id>`    | Exact stored version, as shown in the `Version` column of `list-versions` |
+| `--before <iso>`    | Restore each file's newest version at or before this instant              |
+| `--path <prefix>`   | Limit a `--before` rollback to this folder and below                      |
+| `--in-place`        | Upload over the original file instead of writing a copy beside it         |
+| `-t, --tenant <id>` | Override tenant ID from config                                            |
 
 Either `--file` with `--version`, or `--before`. `--version` alone is rejected
 because a version id is only unique within one file, and `--path` cannot be
@@ -618,6 +617,8 @@ to restore.
 **`atlas onedrive save`**
 
 Save decrypted files from a OneDrive snapshot to a local zip archive. The archive preserves the original folder structure. Each file is SHA-256 verified after decryption by default.
+
+A save that fails before the archive is finalised leaves no file behind: the stream is destroyed and the partial zip is removed, because a truncated archive is indistinguishable from a finished one. An output path that already held a file is never deleted, so pointing `-O` at an existing file and having the run fail leaves that file untouched.
 
 ```bash
 atlas onedrive save -o user@company.com -s od-snap-1735689600000-a1b2c3
@@ -669,12 +670,12 @@ Reports pending Graph changes per drive by replaying the saved delta links from 
 
 Deletes the owner's OneDrive backups behind the same confirmation prompt as the Outlook delete. Without `-s` it sweeps the owner's `manifests`, `data`, `index`, `_meta` and `staging` prefixes, staging included so an interrupted large-file upload does not leave file content parked in the bucket. With `-s` only that snapshot's manifest is removed; the content-addressed blobs stay, because other snapshots may reference them.
 
-| Option                | Description                                          |
-| --------------------- | ---------------------------------------------------- |
-| `-o, --owner <id>`    | User email or Entra object ID (required)             |
-| `-s, --snapshot <id>` | Delete only this snapshot instead of every backup    |
-| `-y, --yes`           | Skip confirmation prompt                             |
-| `-t, --tenant <id>`   | Override tenant ID from config                       |
+| Option                | Description                                       |
+| --------------------- | ------------------------------------------------- |
+| `-o, --owner <id>`    | User email or Entra object ID (required)          |
+| `-s, --snapshot <id>` | Delete only this snapshot instead of every backup |
+| `-y, --yes`           | Skip confirmation prompt                          |
+| `-t, --tenant <id>`   | Override tenant ID from config                    |
 
 ::: tip Permissions
 Application permissions `Files.Read.All` and `User.Read.All` are required for backup and read operations; `Files.ReadWrite.All` is additionally required for restore. See Details and storage layout are documented on the [OneDrive Backup](/onedrive-backup) page.
@@ -702,28 +703,28 @@ atlas sharepoint delete --site https://contoso.sharepoint.com/sites/Engineering 
 atlas sharepoint delete --site https://contoso.sharepoint.com/sites/Engineering -y
 ```
 
-| Subcommand       | Description                                                           |
-| ---------------- | --------------------------------------------------------------------- |
-| `backup`         | Incremental sync; use `--full` to ignore saved delta state            |
-| `list-snapshots` | List all SharePoint snapshots for a site                              |
-| `list-versions`  | List all backed-up versions for a specific file                       |
-| `restore-version`| Push stored file versions back into the library, one file or a whole rollback |
-| `restore`        | Restore files from a snapshot back to the site's document libraries   |
-| `save`           | Decrypt and save files from a snapshot to a local zip archive         |
-| `verify`         | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows |
-| `status`         | Report pending Graph changes per document library without backing up  |
-| `delete`         | Delete the site's SharePoint backups, or a single snapshot            |
+| Subcommand        | Description                                                                   |
+| ----------------- | ----------------------------------------------------------------------------- |
+| `backup`          | Incremental sync; use `--full` to ignore saved delta state                    |
+| `list-snapshots`  | List all SharePoint snapshots for a site                                      |
+| `list-versions`   | List all backed-up versions for a specific file                               |
+| `restore-version` | Push stored file versions back into the library, one file or a whole rollback |
+| `restore`         | Restore files from a snapshot back to the site's document libraries           |
+| `save`            | Decrypt and save files from a snapshot to a local zip archive                 |
+| `verify`          | Decrypt manifests/blobs for a snapshot and check SHA-256 + index rows         |
+| `status`          | Report pending Graph changes per document library without backing up          |
+| `delete`          | Delete the site's SharePoint backups, or a single snapshot                    |
 
 **`atlas sharepoint backup`**
 
-| Option                 | Description                                                                       |
-| ---------------------- | --------------------------------------------------------------------------------- |
-| `--site <url-or-id>`   | SharePoint site URL or Graph site ID (required)                                   |
-| `--full`               | Force full crawl ignoring saved delta links                                       |
-| `--include-subsites`   | Also back up every subsite beneath the site, one snapshot per subsite             |
-| `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (same semantics as OneDrive) |
+| Option                 | Description                                                                                        |
+| ---------------------- | -------------------------------------------------------------------------------------------------- |
+| `--site <url-or-id>`   | SharePoint site URL or Graph site ID (required)                                                    |
+| `--full`               | Force full crawl ignoring saved delta links                                                        |
+| `--include-subsites`   | Also back up every subsite beneath the site, one snapshot per subsite                              |
+| `--retention-days <n>` | Apply Object Lock **default retention** for `n` days (same semantics as OneDrive)                  |
 | `--lock-mode <mode>`   | Object Lock mode (`governance` or `compliance`, default `governance`); requires `--retention-days` |
-| `-t, --tenant <id>`    | Override tenant ID from config                                                    |
+| `-t, --tenant <id>`    | Override tenant ID from config                                                                     |
 
 :::: tip Subsites are separate sites
 `GET /sites/{site-id}/sites` returns only a site's _direct_ subsites, so Atlas walks the tree explicitly. By default a backup covers the named site alone and emits one warning per uncovered subsite. Classic site collections with nested subsite trees would otherwise look fully protected while entire subsites sat outside the backup.
@@ -750,15 +751,15 @@ Graph returns only the subsites the application can read. A subsite that cannot 
 
 **`atlas sharepoint restore-version`**
 
-| Option               | Description                                                               |
-| -------------------- | ------------------------------------------------------------------------- |
-| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required)                           |
-| `-f, --file <ref>`   | File ID or path; required with `--version`                                |
-| `--version <id>`     | Exact stored version, as shown by `list-versions`                         |
-| `--before <iso>`     | Restore each file's newest version at or before this instant               |
-| `--path <prefix>`    | Limit a `--before` rollback to this folder and below                      |
-| `--in-place`         | Upload over the original file instead of writing a copy beside it         |
-| `-t, --tenant <id>`  | Override tenant ID from config                                            |
+| Option               | Description                                                       |
+| -------------------- | ----------------------------------------------------------------- |
+| `--site <url-or-id>` | SharePoint site URL or Graph site ID (required)                   |
+| `-f, --file <ref>`   | File ID or path; required with `--version`                        |
+| `--version <id>`     | Exact stored version, as shown by `list-versions`                 |
+| `--before <iso>`     | Restore each file's newest version at or before this instant      |
+| `--path <prefix>`    | Limit a `--before` rollback to this folder and below              |
+| `--in-place`         | Upload over the original file instead of writing a copy beside it |
+| `-t, --tenant <id>`  | Override tenant ID from config                                    |
 
 Identical semantics to [`atlas onedrive restore-version`](#atlas-onedrive),
 including the copy-by-default placement and the reason Atlas uploads its own
@@ -767,16 +768,16 @@ into the document library they were captured from.
 
 **`atlas sharepoint restore`**
 
-| Option                      | Description                                                                    |
-| --------------------------- | ------------------------------------------------------------------------------ |
-| `--site <url-or-id>`        | SharePoint site URL or Graph site ID (required)                                |
-| `-s, --snapshot <id>`       | SharePoint snapshot ID (required)                                              |
-| `--target-site <url-or-id>` | Restore to a different site (defaults to original)                             |
+| Option                      | Description                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------- |
+| `--site <url-or-id>`        | SharePoint site URL or Graph site ID (required)                                 |
+| `-s, --snapshot <id>`       | SharePoint snapshot ID (required)                                               |
+| `--target-site <url-or-id>` | Restore to a different site (defaults to original)                              |
 | `--destination <path>`      | Folder to restore under, created when missing (default: `/Restore-<timestamp>`) |
 | `--in-place`                | Restore to the original paths instead of a restore root                         |
-| `--name <filename>`         | Rename the restored file; rejected unless exactly one file matches             |
-| `--file-filter <paths...>`  | Only restore specific files (by ID or path)                                    |
-| `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`)       |
+| `--name <filename>`         | Rename the restored file; rejected unless exactly one file matches              |
+| `--file-filter <paths...>`  | Only restore specific files (by ID or path)                                     |
+| `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` (default: `rename`)        |
 | `-t, --tenant <id>`         | Override tenant ID from config                                                  |
 
 Restored files nest under `Restore-<timestamp>` in each destination library, with the original
@@ -993,7 +994,7 @@ atlas rehydrate -o user@company.com -s od-snap-1735689600000-a1b2c3 --source-con
 | `--all`                     | Recover every workload: Outlook, OneDrive, and SharePoint    |
 | `--source-endpoint <url>`   | Source replica S3 endpoint URL                               |
 | `--source-access-key <key>` | Source replica S3 access key                                 |
-| `--source-secret-key <key>` | Source replica S3 secret key; `-` reads it from stdin         |
+| `--source-secret-key <key>` | Source replica S3 secret key; `-` reads it from stdin        |
 | `--source-region <region>`  | Source replica S3 region (default: `us-east-1`)              |
 | `--source-config <path>`    | Path to JSON file with source S3 credentials                 |
 | `-t, --tenant <id>`         | Override tenant ID                                           |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -551,6 +551,8 @@ A drive restore nests under `/Restore-<timestamp>` at the target drive root and 
 
 Identifiers are matched case-insensitively: `--owner`, `--site`, and `--file-filter` all accept whatever case a listing or portal shows. Owner and site IDs are lowercased before they become storage keys, so one identifier always addresses one tree. Earlier releases wrote a second tree for a second spelling and deleted from whichever one they were handed.
 
+A `--file-filter` path is the rooted path shown in a listing, and a file at the drive or library root is written the way you would expect: `/Report.docx`, not `//Report.docx`. Version commands take the same path forms, and when one path belongs to two different drive items, which happens after a file is deleted and recreated at the same path, the command names both file IDs and stops rather than picking one.
+
 `--site` accepts the same three forms on **every** command that takes it, including `replicate` and `rehydrate`: a browser URL (`https://contoso.sharepoint.com/sites/Engineering`), the Graph short form (`contoso.sharepoint.com:/sites/Engineering`), or a composite site ID (`contoso.sharepoint.com,<siteGuid>,<webGuid>`). URLs and short forms are resolved through Graph before any storage key is built; a composite ID is passed through untouched, so disaster recovery with `rehydrate` still works when Graph is unreachable.
 
 **`atlas onedrive list-snapshots`**

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -618,7 +618,7 @@ to restore.
 
 Save decrypted files from a OneDrive snapshot to a local zip archive. The archive preserves the original folder structure. Each file is SHA-256 verified after decryption by default.
 
-A save that fails before the archive is finalised leaves no file behind: the stream is destroyed and the partial zip is removed, because a truncated archive is indistinguishable from a finished one. An output path that already held a file is never deleted, so pointing `-O` at an existing file and having the run fail leaves that file untouched.
+The archive is written to a temporary file next to the output path and moved onto it only once it is complete, so a save that fails leaves nothing behind: a truncated archive is indistinguishable from a finished one. It also means a file already sitting at the output path is not touched until a successful run replaces it, so pointing `-O` at an existing file and having the run fail leaves that file exactly as it was.
 
 ```bash
 atlas onedrive save -o user@company.com -s od-snap-1735689600000-a1b2c3

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -799,6 +799,46 @@ Because the Outlook pool limit is per-mailbox, each mailbox's cooldown is indepe
 
 For OneDrive backup jobs, the `sharepoint_onedrive` pool is per-tenant instead. Aggregate `resource_units` across all users of a tenant and compare against `GRAPH_SERVICE_LIMITS.sharepoint_onedrive.resource_units_per_minute['<tier>']` before scheduling the next OneDrive job.
 
+## Errors
+
+Every failure Atlas raises on purpose is an `AtlasError` with a stable `code`. Branch on the class or on the code, never on the message: message wording changes between releases and is written for the operator reading a terminal, not for a caller.
+
+```typescript
+import { MailboxNotLicensedError, WrongPassphraseError, AtlasError } from '@wisecom/atlas-sdk';
+
+try {
+  await atlas.outlook.backup('user@company.com');
+} catch (err) {
+  if (err instanceof MailboxNotLicensedError) {
+    await reassign_license('user@company.com'); // retryable once a license is back
+  } else if (err instanceof WrongPassphraseError) {
+    throw err; // never retry: the data is fine, the key is wrong
+  } else if (err instanceof AtlasError) {
+    logger.error({ code: err.code, cause: err.cause }, 'Atlas backup failed');
+  }
+}
+```
+
+| Class                               | `code`                       | Meaning                                                                         |
+| ----------------------------------- | ---------------------------- | ------------------------------------------------------------------------------- |
+| `AtlasError`                        | any of the below             | Base class; catch this to separate deliberate failures from bugs                |
+| `AuthError`                         | `ATLAS_AUTH_DENIED`          | Graph or storage refused the call for lack of permission or admin consent       |
+| `MailboxNotLicensedError`           | `ATLAS_MAILBOX_NOT_LICENSED` | No Exchange Online license, so Graph will not serve the mailbox                 |
+| `NotFoundError`                     | `ATLAS_NOT_FOUND`            | Snapshot, mailbox, drive, site or object does not exist                         |
+| `ThrottledError`                    | `ATLAS_THROTTLED`            | Service throttled the call and the retry budget was spent; see `retry_after_ms` |
+| `WrongPassphraseError`              | `ATLAS_WRONG_PASSPHRASE`     | The passphrase could not unwrap the data key                                    |
+| `ObjectLockRetainedError`           | `ATLAS_OBJECT_LOCK_RETAINED` | Object is under retention or a legal hold; `key` names it                       |
+| `StorageError`                      | `ATLAS_STORAGE_FAILURE`      | Storage failed for a reason that is not permission, retention or absence        |
+| `ConfigError`                       | `ATLAS_CONFIG_INVALID`       | Credentials, endpoint, passphrase or tenant is missing or unusable              |
+| `ObjectLockVersioningDisabledError` | `ATLAS_CONFIG_INVALID`       | Immutability requested but bucket versioning is off                             |
+| `ObjectLockUnsupportedError`        | `ATLAS_CONFIG_INVALID`       | Immutability requested but the bucket has no Object Lock                        |
+| `ObjectLockModeRejectedError`       | `ATLAS_CONFIG_INVALID`       | Backend rejected the requested retention mode                                   |
+| `PreconditionFailedError`           | `ATLAS_STORAGE_FAILURE`      | Conditional write lost a race (HTTP 412)                                        |
+
+Every error carries the underlying failure as `cause`, so the Graph or AWS SDK error is still available for logging without being what you branch on.
+
+`WrongPassphraseError` deserves a note. AES-GCM cannot tell a wrong key from damaged ciphertext: both are one authentication failure. Atlas names the passphrase because that is the likelier cause and the only one an operator can act on, and keeps the raw crypto error as `cause`. If the passphrase is definitely correct for that tenant, treat it as a possible integrity problem and run `atlas verify` against the snapshot.
+
 ## Exports
 
 `@wisecom/atlas-sdk` re-exports all domain types, port interfaces, and result types, so everything below is available from a single `@wisecom/atlas-sdk` import.
@@ -814,6 +854,7 @@ For OneDrive backup jobs, the `sharepoint_onedrive` pool is per-tenant instead. 
 - Factory functions: `createAtlasInstance`, `createStorageTarget`
 - Operation control types: `SdkOperationOptions`, `OperationProgressEvent`, `OperationProgressCallback`, `OperationProgressPhase`
 - Cost helpers: `getGraphCost`
+- Error classes: `AtlasError`, `AtlasErrorCode`, `AuthError`, `MailboxNotLicensedError`, `NotFoundError`, `ThrottledError`, `WrongPassphraseError`, `ObjectLockRetainedError`, `StorageError`, `ConfigError`, `ObjectLockVersioningDisabledError`, `ObjectLockUnsupportedError`, `ObjectLockModeRejectedError`, `PreconditionFailedError` (see [Errors](#errors))
 
 **Graph cost types:**
 

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -6,14 +6,14 @@ Backup is site-targeted: one run processes every document library in a single Sh
 
 ## What Gets Backed Up
 
-| Item                          | Coverage                                                                                                    |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Files in every document library | Current content, SHA-256 content-addressed and deduplicated per site                                      |
-| File version history          | Every new historical version Graph returns for an item                                                      |
-| Library and folder paths      | Recorded on the manifest entry, one delta cursor per library                                                |
-| OneNote notebooks             | Section files and table of contents, stored as ordinary files (see [OneNote Notebooks](#onenote-notebooks)) |
-| Subsites                      | Only with `--include-subsites`, which produces one snapshot per subsite                                     |
-| Moves, renames, and deletions | Recorded as manifest changes on the next delta sync                                                         |
+| Item                            | Coverage                                                                                                    |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Files in every document library | Current content, SHA-256 content-addressed and deduplicated per site                                        |
+| File version history            | Every new historical version Graph returns for an item                                                      |
+| Library and folder paths        | Recorded on the manifest entry, one delta cursor per library                                                |
+| OneNote notebooks               | Section files and table of contents, stored as ordinary files (see [OneNote Notebooks](#onenote-notebooks)) |
+| Subsites                        | Only with `--include-subsites`, which produces one snapshot per subsite                                     |
+| Moves, renames, and deletions   | Recorded as manifest changes on the next delta sync                                                         |
 
 ## Prerequisites
 
@@ -76,11 +76,11 @@ Ciphertext is stored at the key name shown above. There is no separate `.enc` fi
 
 Implementation thresholds from `@wisecom/atlas-sharepoint`:
 
-| Size                          | Strategy                                                                                                                                                                                       |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **≤ 4 MiB**                   | Single read via pre-authenticated URL (with transient-status retry and Retry-After backoff) or Graph content fallback, encrypt, `put`                                                          |
-| **> 4 MiB** and **< 64 MiB**  | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                                      |
-| **≥ 64 MiB**                  | Streaming pipeline: chunk download into streaming encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `sharepoint/data/{site_id}/{sha256}` |
+| Size                         | Strategy                                                                                                                                                                                       |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **≤ 4 MiB**                  | Single read via pre-authenticated URL (with transient-status retry and Retry-After backoff) or Graph content fallback, encrypt, `put`                                                          |
+| **> 4 MiB** and **< 64 MiB** | Range-based chunked download (`CHUNK_SIZE_BYTES` = 4 MiB), encrypt, `put`                                                                                                                      |
+| **≥ 64 MiB**                 | Streaming pipeline: chunk download into streaming encrypt into multipart upload on staging, complete or abort after dedup check, then server-side copy to `sharepoint/data/{site_id}/{sha256}` |
 
 Chunked downloads retry each **4 MiB** range independently (5 attempts with exponential backoff), so a transient failure replays a single chunk instead of the whole file. A chunk is retried on the same statuses as any other Graph call (429, 500, 502, 503, and 504), because the CDN in front of Graph raises `500` and `502` under load. A `4xx` response fails the chunk immediately.
 
@@ -187,11 +187,11 @@ Versions the service reports as gone (`404` or `410`, content purged by the site
 
 A OneNote notebook is not a file. Graph returns the notebook root as a driveItem carrying a **`package` facet** (`package.type == "oneNote"`) alongside a `folder` facet, and its actual content as ordinary child files:
 
-| Item                        | Facets                               | Backed up                                                                                                                     |
+| Item                        | Facets                               | Backed up                                                                                                                       |
 | --------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | Notebook root (e.g. `Test`) | `folder` + `package`                 | Treated as a folder. `GET /items/{id}/content` returns **404**, because the root has no content of its own and nothing to store |
-| `<Section>.one`             | `file`, MIME `application/msonenote` | Yes, byte-for-byte, like any other file                                                                                       |
-| `Open Notebook.onetoc2`     | `file`                               | Yes, byte-for-byte                                                                                                            |
+| `<Section>.one`             | `file`, MIME `application/msonenote` | Yes, byte-for-byte, like any other file                                                                                         |
+| `Open Notebook.onetoc2`     | `file`                               | Yes, byte-for-byte                                                                                                              |
 
 Notebook **content is covered by backups today**: each section file is content-addressed, encrypted, and stored under the notebook's folder path. What the run additionally reports is the notebook itself, because file counters alone cannot answer "did the notebook come through whole?":
 
@@ -246,7 +246,7 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 | `--target-site <url-or-id>` | Restore to a different site                          | Original site          |
 | `--destination <path>`      | Folder to restore under, created when missing        | `/Restore-<timestamp>` |
 | `--in-place`                | Restore to the original paths                        | `false`                |
-| `--name <filename>`         | Rename the restored file; single-file restores only   | Original name          |
+| `--name <filename>`         | Rename the restored file; single-file restores only  | Original name          |
 | `--file-filter <paths...>`  | Only restore specific files (by ID or path)          | All files              |
 | `-c, --conflict <mode>`     | File conflict policy: `replace`, `rename`, or `fail` | `rename`               |
 | `-t, --tenant <id>`         | Tenant identifier                                    | Config default         |
@@ -255,14 +255,14 @@ That warning exists because partial capture is the dangerous case: a `.onetoc2` 
 
 On Windows the archive is stamped with Mark-of-the-Web (`Zone.Identifier`, `ZoneId=3`), so files extracted from it open in Protected View and their macros are blocked. Explorer propagates the mark to every extracted file; clear it with `Get-ChildItem -Recurse <dir> | Unblock-File` once you trust the content. Nothing is written on macOS or Linux, and an export to a filesystem without alternate data streams still succeeds with a warning. See [Exported archives and Mark-of-the-Web](./reference/cli.md#atlas-outlook-save).
 
-| Flag                       | Description                                  | Default        |
-| -------------------------- | -------------------------------------------- | -------------- |
-| `--site <url-or-id>`       | SharePoint site URL or Graph site ID         | Required       |
-| `-s, --snapshot <id>`      | Snapshot ID to save from                     | Required       |
-| `--file-filter <paths...>` | Only save specific files (by ID or path)     | All files      |
-| `-O, --output <path>`      | Output zip file path                         | Auto-generated |
-| `--skip-verify`            | Skip SHA-256 integrity checks                | `false`        |
-| `-t, --tenant <id>`        | Tenant identifier                            | Config default |
+| Flag                       | Description                              | Default        |
+| -------------------------- | ---------------------------------------- | -------------- |
+| `--site <url-or-id>`       | SharePoint site URL or Graph site ID     | Required       |
+| `-s, --snapshot <id>`      | Snapshot ID to save from                 | Required       |
+| `--file-filter <paths...>` | Only save specific files (by ID or path) | All files      |
+| `-O, --output <path>`      | Output zip file path                     | Auto-generated |
+| `--skip-verify`            | Skip SHA-256 integrity checks            | `false`        |
+| `-t, --tenant <id>`        | Tenant identifier                        | Config default |
 
 ### `atlas sharepoint list-snapshots`
 
@@ -362,7 +362,7 @@ Restore decrypts stored file blobs, verifies SHA-256 checksums, and uploads them
 Files with `change_type: 'deleted'` or a missing `storage_key` are skipped. Checksum verification runs before upload, and corrupted blobs are skipped with a warning.
 
 | Size        | Strategy                                                                                                               |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------ |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------- |
 | **≤ 4 MiB** | Single PUT via `PUT /sites/{site_id}/drives/{drive_id}/items/{parent}:/{name}:/content`                                |
 | **> 4 MiB** | Resumable upload session via `createUploadSession` with 10 MiB chunks (3 retries per chunk on 429, 500, 502, 503, 504) |
 
@@ -434,15 +434,15 @@ for (const lib of status.libraries) {
 
 `checkStatus` returns a `SharePointStatusResult`:
 
-| Field                   | Type                        | Description                                                           |
-| ----------------------- | --------------------------- | --------------------------------------------------------------------- |
-| `site_id`               | `string`                    | The Graph site ID                                                     |
-| `last_backup_at`        | `Date \| undefined`         | Timestamp of the most recent snapshot                                 |
-| `last_snapshot_id`      | `string \| undefined`       | ID of the most recent snapshot                                        |
-| `total_libraries`       | `number`                    | Number of document libraries discovered                               |
-| `libraries`             | `SharePointLibraryStatus[]` | Per-library backup status                                             |
-| `is_up_to_date`         | `boolean`                   | `true` if all libraries have been backed up with zero pending changes |
-| `total_pending_changes` | `number`                    | Sum of pending changes across all libraries                           |
+| Field                   | Type                        | Description                                                                                                                                                                                                                                        |
+| ----------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `site_id`               | `string`                    | The Graph site ID                                                                                                                                                                                                                                  |
+| `last_backup_at`        | `Date \| undefined`         | Timestamp of the most recent snapshot                                                                                                                                                                                                              |
+| `last_snapshot_id`      | `string \| undefined`       | ID of the most recent snapshot                                                                                                                                                                                                                     |
+| `total_libraries`       | `number`                    | Number of document libraries discovered                                                                                                                                                                                                            |
+| `libraries`             | `SharePointLibraryStatus[]` | Per-library backup status                                                                                                                                                                                                                          |
+| `is_up_to_date`         | `boolean`                   | `true` only when every library reports itself up to date. A library that has never been backed up, or whose delta peek failed, makes this `false` even though it contributes zero pending changes: a peek that could not run is unknown, not clean |
+| `total_pending_changes` | `number`                    | Sum of pending changes across all libraries                                                                                                                                                                                                        |
 
 ## Deletion
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-cli",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "CLI for Atlas — secure Microsoft 365 backup and restore to S3-compatible storage.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-core",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/adapters/keystore/envelope-key-service.adapter.ts
+++ b/packages/core/src/adapters/keystore/envelope-key-service.adapter.ts
@@ -5,6 +5,7 @@ import {
   type CipherGCM,
   type DecipherGCM,
 } from 'node:crypto';
+import { WrongPassphraseError } from '@wisecom/atlas-types';
 import { DEFAULT_KDF_STRATEGY, KDF_STRATEGIES } from '@/adapters/keystore/kdf-strategy';
 import { parse_dek_blob, build_header_bytes } from '@/adapters/keystore/dek-blob-codec';
 import type { DekBlobHeader } from '@/adapters/keystore/dek-blob-codec';
@@ -94,7 +95,20 @@ export class EnvelopeKeyService {
       throw new Error(`Unknown KDF id in wrapped DEK: ${header.kdf_id}`);
     }
     const kek = strategy.derive_kek(this._passphrase_buf, header.kdf_params, tenant_id);
-    return aes_gcm_decrypt(encrypted_dek, kek, header_bytes);
+    try {
+      return aes_gcm_decrypt(encrypted_dek, kek, header_bytes);
+    } catch (err) {
+      // GCM reports a wrong key and a corrupted blob as the same authentication failure, and the
+      // raw Node message ("Unsupported state or unable to authenticate data") reads like data
+      // loss. A wrong passphrase is by far the likelier cause and the only one the operator can
+      // act on, so it is named first and the original error is kept as `cause` (issue #40).
+      throw new WrongPassphraseError(
+        'Could not unwrap the data key: the passphrase does not match the one this backup was ' +
+          'written with, or the wrapped key is damaged. Check ATLAS_ENCRYPTION_PASSPHRASE ' +
+          'against the tenant this snapshot belongs to.',
+        { cause: err },
+      );
+    }
   }
 }
 

--- a/packages/core/src/services/deletion/shared/prefix-deleter.ts
+++ b/packages/core/src/services/deletion/shared/prefix-deleter.ts
@@ -8,6 +8,7 @@
  * back to plain keys only for backends that do not enumerate versions.
  */
 
+import { ObjectLockRetainedError } from '@wisecom/atlas-types';
 import type { DeletionResult, StorageObjectVersion } from '@wisecom/atlas-types';
 
 /** The slice of ObjectStorage that erasure needs. */
@@ -127,7 +128,10 @@ async function delete_one(
     else await storage.delete_version(entry.key, version_id);
     count(summary, entry, 'deleted');
   } catch (err) {
-    count(summary, entry, is_object_lock_delete_error(err) ? 'retained' : 'failed');
+    // The storage adapter names a retention refusal for us: a bare `AccessDenied` from a missing
+    // IAM permission must not be filed as "retained, deletable once retention expires", because
+    // on an erasure report a false all-clear costs the erasure (issue #40).
+    count(summary, entry, err instanceof ObjectLockRetainedError ? 'retained' : 'failed');
   }
 }
 
@@ -146,27 +150,6 @@ function count(
 
   const kind = is_manifest_key(entry.key) ? 'manifests' : 'objects';
   summary[`${outcome}_${kind}` as keyof MutableResult]++;
-}
-
-/**
- * True only for errors that name Object Lock as the reason a delete was refused.
- *
- * Backends word it differently -- MinIO raises `InvalidRequest` "Object is WORM
- * protected and cannot be overwritten", AWS raises `AccessDenied` "Access Denied
- * because object protected by object lock" -- but both name the mechanism. A
- * bare `AccessDenied` from a missing IAM permission does not, and must not be
- * filed as "retained, deletable once retention expires". On an erasure report a
- * false alarm costs an investigation; a false all-clear costs the erasure.
- */
-function is_object_lock_delete_error(err: unknown): boolean {
-  const message = err instanceof Error ? `${err.name} ${err.message}`.toLowerCase() : '';
-  return (
-    message.includes('object lock') ||
-    message.includes('objectlock') ||
-    message.includes('worm protected') ||
-    message.includes('retention') ||
-    message.includes('legal hold')
-  );
 }
 
 function empty_summary(): MutableResult {

--- a/packages/core/src/services/shared/file-save-zip-writer.ts
+++ b/packages/core/src/services/shared/file-save-zip-writer.ts
@@ -1,5 +1,6 @@
-import { createWriteStream, existsSync, type WriteStream } from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import { createWriteStream, type WriteStream } from 'node:fs';
+import { rename, rm } from 'node:fs/promises';
 import { ZipArchive, type Archiver } from 'archiver';
 import { logger } from '@/utils/logger';
 
@@ -10,43 +11,53 @@ export interface FileArchive {
   readonly archive: FileArchiveWriter;
   readonly promise: Promise<number>;
   /**
-   * Destroys the stream and removes the partial file, for a run that failed before finalizing.
-   *
-   * A truncated zip left at the output path is indistinguishable from a complete one, which is
-   * worse than no file at all when the reason an operator ran a save is that they need the bytes
-   * (issue #307). A path that already held a file is never removed: the caller may have been
-   * handed the path of something unrelated.
+   * Moves the finished archive onto the output path. Call it after the archive is finalized and
+   * the byte count has resolved; until then the output path is untouched.
    */
+  publish(): Promise<void>;
+  /** Destroys the stream and removes the temporary file, for a run that failed before publishing. */
   abort(): Promise<void>;
 }
 
-/** Creates a zip archive writing to the given file path. Returns the archiver and a promise that resolves with total bytes written. */
+/**
+ * Creates a zip archive for the given output path. Returns the archiver and a promise that
+ * resolves with total bytes written.
+ *
+ * Entries are written to a sibling temporary file and moved onto the output path by
+ * {@link FileArchive.publish}, so nothing appears there until the archive is complete. A
+ * truncated zip is indistinguishable from a finished one, which is worse than no file at all when
+ * the reason an operator ran a save is that they need the bytes (issue #307), and a save that
+ * fails must not destroy a file that was already sitting at the path it was pointed at.
+ */
 export function create_file_archive(output_path: string): FileArchive {
-  const pre_existing = existsSync(output_path);
-  const output = createWriteStream(output_path);
+  const staging_path = `${output_path}.part-${randomBytes(6).toString('hex')}`;
+  const output = createWriteStream(staging_path);
   const archive = new ZipArchive({ zlib: { level: 6 } });
 
   const promise = new Promise<number>((resolve, reject) => {
     output.on('close', () => resolve(archive.pointer()));
     archive.on('error', reject);
+    // Errors on the destination are not forwarded through pipe(), so without this a failed write
+    // resolves on `close` and the caller reports a successful save.
+    output.on('error', reject);
   });
-  // Attach a handler now, so an archive error raised while entries are still being written is
-  // not an unhandled rejection. Awaiting `promise` later still sees the rejection.
+  // Attach a handler now, so an error raised while entries are still being written is not an
+  // unhandled rejection. Awaiting `promise` later still sees the rejection.
   promise.catch(() => undefined);
 
   archive.pipe(output);
   return {
     archive,
     promise,
-    abort: () => abort_archive(archive, output, output_path, pre_existing),
+    publish: () => rename(staging_path, output_path),
+    abort: () => abort_archive(archive, output, staging_path),
   };
 }
 
 async function abort_archive(
   archive: FileArchiveWriter,
   output: WriteStream,
-  output_path: string,
-  pre_existing: boolean,
+  staging_path: string,
 ): Promise<void> {
   try {
     archive.abort();
@@ -54,12 +65,11 @@ async function abort_archive(
     // Already destroyed or never started; the stream teardown below is what matters.
   }
   output.destroy();
-  if (pre_existing) return;
   try {
-    await rm(output_path, { force: true });
+    await rm(staging_path, { force: true });
   } catch (err) {
     logger.warn(
-      `Could not remove the partial archive at ${output_path}: ${err instanceof Error ? err.message : String(err)}`,
+      `Could not remove the partial archive at ${staging_path}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }

--- a/packages/core/src/services/shared/file-save-zip-writer.ts
+++ b/packages/core/src/services/shared/file-save-zip-writer.ts
@@ -1,5 +1,7 @@
-import { createWriteStream } from 'node:fs';
+import { createWriteStream, existsSync, type WriteStream } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { ZipArchive, type Archiver } from 'archiver';
+import { logger } from '@/utils/logger';
 
 /** The archiver instance file entries are appended to. */
 export type FileArchiveWriter = Archiver;
@@ -7,10 +9,20 @@ export type FileArchiveWriter = Archiver;
 export interface FileArchive {
   readonly archive: FileArchiveWriter;
   readonly promise: Promise<number>;
+  /**
+   * Destroys the stream and removes the partial file, for a run that failed before finalizing.
+   *
+   * A truncated zip left at the output path is indistinguishable from a complete one, which is
+   * worse than no file at all when the reason an operator ran a save is that they need the bytes
+   * (issue #307). A path that already held a file is never removed: the caller may have been
+   * handed the path of something unrelated.
+   */
+  abort(): Promise<void>;
 }
 
 /** Creates a zip archive writing to the given file path. Returns the archiver and a promise that resolves with total bytes written. */
 export function create_file_archive(output_path: string): FileArchive {
+  const pre_existing = existsSync(output_path);
   const output = createWriteStream(output_path);
   const archive = new ZipArchive({ zlib: { level: 6 } });
 
@@ -18,9 +30,38 @@ export function create_file_archive(output_path: string): FileArchive {
     output.on('close', () => resolve(archive.pointer()));
     archive.on('error', reject);
   });
+  // Attach a handler now, so an archive error raised while entries are still being written is
+  // not an unhandled rejection. Awaiting `promise` later still sees the rejection.
+  promise.catch(() => undefined);
 
   archive.pipe(output);
-  return { archive, promise };
+  return {
+    archive,
+    promise,
+    abort: () => abort_archive(archive, output, output_path, pre_existing),
+  };
+}
+
+async function abort_archive(
+  archive: FileArchiveWriter,
+  output: WriteStream,
+  output_path: string,
+  pre_existing: boolean,
+): Promise<void> {
+  try {
+    archive.abort();
+  } catch {
+    // Already destroyed or never started; the stream teardown below is what matters.
+  }
+  output.destroy();
+  if (pre_existing) return;
+  try {
+    await rm(output_path, { force: true });
+  } catch (err) {
+    logger.warn(
+      `Could not remove the partial archive at ${output_path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 /** Adds a file to the archive under the given folder path. */

--- a/packages/core/tests/unit/adapters/keystore/envelope-key-service.test.ts
+++ b/packages/core/tests/unit/adapters/keystore/envelope-key-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { WrongPassphraseError } from '@wisecom/atlas-types';
 import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
 import { KDF_SCRYPT } from '@/adapters/keystore/kdf-strategy';
 import { DEK_BLOB_VERSION, parse_dek_blob } from '@/adapters/keystore/dek-blob-codec';
@@ -102,7 +103,28 @@ describe('EnvelopeKeyService', () => {
       const dek = svc_a.generate_dek();
 
       const wrapped = svc_a.wrap_dek(dek, tenant_id);
-      expect(() => svc_b.unwrap_dek(wrapped, tenant_id)).toThrow();
+      expect(() => svc_b.unwrap_dek(wrapped, tenant_id)).toThrow(WrongPassphraseError);
+    });
+
+    it('names the passphrase rather than surfacing the raw GCM failure (issue #40)', () => {
+      const svc_a = new EnvelopeKeyService(passphrase);
+      const svc_b = new EnvelopeKeyService('other-passphrase');
+      const wrapped = svc_a.wrap_dek(svc_a.generate_dek(), tenant_id);
+
+      const failure = (() => {
+        try {
+          svc_b.unwrap_dek(wrapped, tenant_id);
+          return undefined;
+        } catch (err) {
+          return err as WrongPassphraseError;
+        }
+      })();
+
+      // "Unsupported state or unable to authenticate data" reads like a corrupt backup, which
+      // sent operators looking for data loss when they had mistyped a passphrase.
+      expect(failure?.code).toBe('ATLAS_WRONG_PASSPHRASE');
+      expect(failure?.message).toContain('passphrase');
+      expect((failure?.cause as Error).message).toMatch(/authenticate|unsupported state/i);
     });
 
     it('throws on unknown KDF id in blob', () => {
@@ -119,6 +141,8 @@ describe('EnvelopeKeyService', () => {
 
       const { header } = parse_dek_blob(wrapped);
       header.kdf_params[0] ^= 0x01;
+      // Not a WrongPassphraseError: flipping a KDF parameter breaks key derivation itself, which
+      // fails before any ciphertext is read.
       expect(() => svc.unwrap_dek(wrapped, tenant_id)).toThrow();
     });
 
@@ -127,7 +151,9 @@ describe('EnvelopeKeyService', () => {
       const dek = svc.generate_dek();
       const wrapped = svc.wrap_dek(dek, 'tenant-a');
 
-      expect(() => svc.unwrap_dek(wrapped, 'tenant-b')).toThrow();
+      // Same class as a wrong passphrase: from the crypto's point of view a wrong tenant is a
+      // wrong key, and the remediation an operator has is to check both.
+      expect(() => svc.unwrap_dek(wrapped, 'tenant-b')).toThrow(WrongPassphraseError);
     });
   });
 

--- a/packages/core/tests/unit/services/deletion/deletion.service.test.ts
+++ b/packages/core/tests/unit/services/deletion/deletion.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ObjectLockRetainedError } from '@wisecom/atlas-types';
 import { Container } from 'inversify';
 import 'reflect-metadata';
 import { DeletionService } from '@/services/deletion/deletion.service';
@@ -229,7 +230,7 @@ describe('DeletionService', () => {
         'manifests/u@t.com/snap-42.json',
       ]);
       vi.mocked(mock_context.storage.delete).mockRejectedValueOnce(
-        new Error('AccessDenied: Object Lock retention in effect'),
+        new ObjectLockRetainedError('manifests/snap-1.json'),
       );
 
       const result = await service.delete_snapshot('t', 'snap-42');
@@ -278,7 +279,7 @@ describe('DeletionService', () => {
     it('holds the DEK back until the data it protects is gone', async () => {
       vi.mocked(mock_context.storage.list).mockResolvedValueOnce(['onedrive/data/u/locked']);
       vi.mocked(mock_context.storage.delete).mockRejectedValueOnce(
-        new Error('InvalidRequest: Object is WORM protected and cannot be overwritten'),
+        new ObjectLockRetainedError('data/u/blob'),
       );
 
       const result = await service.purge_tenant('t');

--- a/packages/core/tests/unit/services/deletion/prefix-deleter.test.ts
+++ b/packages/core/tests/unit/services/deletion/prefix-deleter.test.ts
@@ -4,6 +4,7 @@
  * claim otherwise.
  */
 import { describe, it, expect, vi } from 'vitest';
+import { ObjectLockRetainedError } from '@wisecom/atlas-types';
 import { delete_scopes, type DeletionStorage } from '@/services/deletion/shared/prefix-deleter';
 
 interface StubOptions {
@@ -127,19 +128,10 @@ describe('delete_scopes', () => {
       return await delete_scopes(storage, ['data/u/']);
     }
 
-    it('reports MinIO WORM protection as retained', async () => {
-      const result = await delete_failing_with(
-        new Error('InvalidRequest: Object is WORM protected and cannot be overwritten'),
-      );
-
-      expect(result.retained_objects).toBe(1);
-      expect(result.failed_objects).toBe(0);
-    });
-
-    it('reports AWS Object Lock protection as retained', async () => {
-      const result = await delete_failing_with(
-        new Error('AccessDenied: Access Denied because object protected by object lock'),
-      );
+    it('reports a retention refusal as retained', async () => {
+      // The storage adapter names the refusal; the wording heuristic that recognises MinIO's
+      // WORM message and AWS's object-lock message lives there and is tested there (issue #40).
+      const result = await delete_failing_with(new ObjectLockRetainedError('data/u/blob'));
 
       expect(result.retained_objects).toBe(1);
       expect(result.failed_objects).toBe(0);

--- a/packages/core/tests/unit/services/shared/file-save-zip-writer.test.ts
+++ b/packages/core/tests/unit/services/shared/file-save-zip-writer.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -22,37 +22,67 @@ afterEach(async () => {
 describe('create_file_archive', () => {
   it('writes an archive and reports the byte count', async () => {
     const output_path = join(dir, 'out.zip');
-    const { archive, promise } = create_file_archive(output_path);
+    const { archive, promise, publish } = create_file_archive(output_path);
 
     await add_file_to_archive(archive, '/Documents', 'report.txt', Buffer.from('hello'));
     await finalize_file_archive(archive);
+    const total_bytes = await promise;
+    await publish();
 
-    expect(await promise).toBeGreaterThan(0);
+    expect(total_bytes).toBeGreaterThan(0);
     expect(existsSync(output_path)).toBe(true);
   });
 
-  it('removes the partial file it created when the run aborts (issue #307)', async () => {
+  it('writes nothing to the output path before it is published (issue #307)', async () => {
+    const output_path = join(dir, 'out.zip');
+    const { archive } = create_file_archive(output_path);
+
+    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+
+    // Entries land in a sibling temporary file, so a truncated zip can never be mistaken for a
+    // finished export at the path an operator was given. The temp file itself is not asserted:
+    // the stream opens lazily, so its appearance is a race, while the output path staying empty
+    // is the guarantee.
+    expect(existsSync(output_path)).toBe(false);
+    expect(readdirSync(dir).filter((name) => name === 'out.zip')).toEqual([]);
+  });
+
+  it('leaves no temporary file behind when the run aborts', async () => {
     const output_path = join(dir, 'partial.zip');
     const { archive, abort } = create_file_archive(output_path);
     await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
 
-    // A truncated zip is indistinguishable from a complete one, so a failed save must leave
-    // nothing behind rather than something that looks like an export.
     await abort();
 
     expect(existsSync(output_path)).toBe(false);
+    expect(readdirSync(dir)).toEqual([]);
   });
 
-  it('keeps a file that already existed at the output path', async () => {
+  it('leaves the bytes of a pre-existing output file untouched when the run aborts', async () => {
     const output_path = join(dir, 'existing.zip');
     writeFileSync(output_path, 'someone else data');
 
-    const { abort } = create_file_archive(output_path);
+    const { archive, abort } = create_file_archive(output_path);
+    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
     await abort();
 
-    // The caller may have been handed the path of something unrelated; deleting it would be
-    // destroying data the save was never asked to touch.
-    expect(existsSync(output_path)).toBe(true);
+    // Not just present: unchanged. Opening the output path for writing truncated it before
+    // anything was written, so checking existence alone hid the loss.
+    expect(readFileSync(output_path, 'utf-8')).toBe('someone else data');
+  });
+
+  it('replaces a pre-existing output file only on a successful publish', async () => {
+    const output_path = join(dir, 'existing.zip');
+    writeFileSync(output_path, 'someone else data');
+
+    const { archive, promise, publish } = create_file_archive(output_path);
+    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+    await finalize_file_archive(archive);
+    await promise;
+    await publish();
+
+    expect(readFileSync(output_path, 'utf-8')).not.toBe('someone else data');
+    expect(readdirSync(dir)).toEqual(['existing.zip']);
   });
 
   it('does not raise when the archive is aborted twice', async () => {

--- a/packages/core/tests/unit/services/shared/file-save-zip-writer.test.ts
+++ b/packages/core/tests/unit/services/shared/file-save-zip-writer.test.ts
@@ -1,0 +1,65 @@
+import { existsSync, writeFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  add_file_to_archive,
+  create_file_archive,
+  finalize_file_archive,
+} from '@/services/shared/file-save-zip-writer';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'atlas-zip-'));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('create_file_archive', () => {
+  it('writes an archive and reports the byte count', async () => {
+    const output_path = join(dir, 'out.zip');
+    const { archive, promise } = create_file_archive(output_path);
+
+    await add_file_to_archive(archive, '/Documents', 'report.txt', Buffer.from('hello'));
+    await finalize_file_archive(archive);
+
+    expect(await promise).toBeGreaterThan(0);
+    expect(existsSync(output_path)).toBe(true);
+  });
+
+  it('removes the partial file it created when the run aborts (issue #307)', async () => {
+    const output_path = join(dir, 'partial.zip');
+    const { archive, abort } = create_file_archive(output_path);
+    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+
+    // A truncated zip is indistinguishable from a complete one, so a failed save must leave
+    // nothing behind rather than something that looks like an export.
+    await abort();
+
+    expect(existsSync(output_path)).toBe(false);
+  });
+
+  it('keeps a file that already existed at the output path', async () => {
+    const output_path = join(dir, 'existing.zip');
+    writeFileSync(output_path, 'someone else data');
+
+    const { abort } = create_file_archive(output_path);
+    await abort();
+
+    // The caller may have been handed the path of something unrelated; deleting it would be
+    // destroying data the save was never asked to touch.
+    expect(existsSync(output_path)).toBe(true);
+  });
+
+  it('does not raise when the archive is aborted twice', async () => {
+    const output_path = join(dir, 'twice.zip');
+    const { abort } = create_file_archive(output_path);
+
+    await abort();
+    await expect(abort()).resolves.toBeUndefined();
+  });
+});

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-drive",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/drive/src/backup/change-classifier.ts
+++ b/packages/drive/src/backup/change-classifier.ts
@@ -1,0 +1,72 @@
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import type { DriveChangeType, DriveDeltaItem } from '@/drive-ports';
+
+/**
+ * Determines the type of change for a delta item based on previous state.
+ * Returns undefined if no meaningful change is detected (skip the item).
+ */
+export function classify_drive_change(
+  workload_label: string,
+  item: DriveDeltaItem,
+  previous_path_by_file_id: Record<string, string>,
+  previous_name_by_file_id: Record<string, string>,
+  previous_etag_by_file_id: Record<string, string>,
+): DriveChangeType | undefined {
+  if (item.deleted) return 'deleted';
+
+  const previous_path = previous_path_by_file_id[item.item_id];
+  const previous_name = previous_name_by_file_id[item.item_id];
+  const previous_etag = previous_etag_by_file_id[item.item_id];
+  const previously_known = Boolean(previous_path || previous_name || previous_etag);
+
+  if (!previously_known) return 'created';
+
+  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
+  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
+  const etags_missing = !previous_etag && !item.etag;
+
+  // Relocation before content: an item that moved and changed in the same delta window carries
+  // both signals, and the ETag branch used to answer first, erasing the move from the change
+  // record (issue #297). The new content blob makes the update self-evident; the old location is
+  // only recorded here. Content is downloaded either way, so the label is all that moves.
+  const relocation = relocation_label(path_changed, name_changed);
+  if (relocation) {
+    // Still worth saying when both ETags are absent: the relocation is certain, but with no ETag
+    // on either side a content change alongside it cannot be detected at all.
+    if (etags_missing) warn_missing_etag(workload_label, item.item_id);
+    return relocation;
+  }
+
+  if (is_etag_transition(previous_etag, item.etag)) {
+    if (etags_missing) warn_missing_etag(workload_label, item.item_id);
+    return 'updated';
+  }
+  return undefined;
+}
+
+/** Which relocation happened, if any: the label an operator uses to find where a file went. */
+function relocation_label(
+  path_changed: boolean,
+  name_changed: boolean,
+): DriveChangeType | undefined {
+  if (path_changed && name_changed) return 'moved_and_renamed';
+  if (path_changed) return 'moved';
+  if (name_changed) return 'renamed';
+  return undefined;
+}
+
+/** Any ETag movement for an item already known, including one absent on both sides. */
+function is_etag_transition(
+  previous_etag: string | undefined,
+  current_etag: string | undefined,
+): boolean {
+  if (previous_etag && current_etag) return previous_etag !== current_etag;
+  return true;
+}
+
+function warn_missing_etag(workload_label: string, item_id: string): void {
+  logger.warn(
+    `${workload_label} delta item ${item_id}: missing etag on prior and current snapshot; ` +
+      'a content change cannot be detected',
+  );
+}

--- a/packages/drive/src/backup/download-retry.ts
+++ b/packages/drive/src/backup/download-retry.ts
@@ -1,6 +1,7 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import { is_retryable_error, is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
 import type { DriveContentConnector, DriveDeltaItem } from '@/drive-ports';
+import { format_bytes } from '@/shared/format-bytes';
 
 const DEFAULT_MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 2_000;
@@ -60,13 +61,6 @@ function compute_file_retry_delay(attempt: number): number {
   const base = BASE_DELAY_MS * 2 ** (attempt - 1);
   const jitter = Math.random() * BASE_DELAY_MS;
   return Math.min(base + jitter, MAX_DELAY_MS);
-}
-
-function format_bytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/drive/src/backup/file-processor.ts
+++ b/packages/drive/src/backup/file-processor.ts
@@ -1,0 +1,67 @@
+import { createHash } from 'node:crypto';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import { is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
+import type { TenantContext } from '@wisecom/atlas-types';
+import { download_with_retry } from '@/backup/download-retry';
+import { LARGE_FILE_THRESHOLD } from '@/backup/large-file-threshold';
+import {
+  process_large_drive_file,
+  type DriveDownloadUrlResolver,
+  type DriveLargeFileDeps,
+} from '@/backup/large-file-pipeline';
+import type { DriveContentConnector, DriveDeltaItem } from '@/drive-ports';
+
+const HASH_CHUNK_SIZE = 64 * 1024 * 1024;
+
+export interface FileProcessResult {
+  storage_key: string;
+  checksum: string;
+  stored: boolean;
+  deduplicated: boolean;
+}
+
+/** Downloads or deduplicates a single delta file item. */
+export async function process_drive_backup_file(
+  deps: DriveLargeFileDeps,
+  connector: DriveContentConnector & DriveDownloadUrlResolver,
+  item: DriveDeltaItem,
+  owner_id: string,
+  ctx: TenantContext,
+): Promise<FileProcessResult | undefined> {
+  if (item.size_bytes >= LARGE_FILE_THRESHOLD) {
+    try {
+      return await process_large_drive_file(deps, connector, item, owner_id, ctx);
+    } catch (err) {
+      // A missing grant or a service refusal is not a skip: it must reach the caller
+      // so the run can name the cause instead of reporting a lost file (issue #246).
+      if (is_unretryable_download_failure(err)) throw err;
+      logger.warn(
+        `Skipping large file ${item.item_id} (${item.file_name}): ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  const raw_body = await download_with_retry(connector, item);
+  if (!raw_body) return undefined;
+
+  const checksum = compute_sha256_chunked(raw_body);
+  const storage_key = deps.keys.data_key(owner_id, checksum);
+  const exists = await ctx.storage.exists(storage_key);
+
+  if (!exists) {
+    await ctx.storage.put(storage_key, ctx.encrypt(raw_body));
+    return { storage_key, checksum, stored: true, deduplicated: false };
+  }
+
+  return { storage_key, checksum, stored: false, deduplicated: true };
+}
+
+/** Computes SHA-256 in chunks to avoid ERR_OUT_OF_RANGE on buffers > 2 GB. */
+function compute_sha256_chunked(data: Buffer): string {
+  const hash = createHash('sha256');
+  for (let offset = 0; offset < data.length; offset += HASH_CHUNK_SIZE) {
+    hash.update(data.subarray(offset, Math.min(offset + HASH_CHUNK_SIZE, data.length)));
+  }
+  return hash.digest('hex');
+}

--- a/packages/drive/src/backup/large-file-pipeline.ts
+++ b/packages/drive/src/backup/large-file-pipeline.ts
@@ -1,0 +1,96 @@
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import { stream_to_content_addressed_storage } from '@wisecom/atlas-core/services/shared/stream-encrypt-upload';
+import type { StorageObjectLockPolicy, TenantContext } from '@wisecom/atlas-types';
+import type { DriveDeltaItem } from '@/drive-ports';
+import { format_bytes } from '@/shared/format-bytes';
+import type { DriveStorageKeys } from '@/shared/storage-keys';
+
+export interface LargeFileResult {
+  readonly checksum: string;
+  readonly storage_key: string;
+  readonly stored: boolean;
+  readonly deduplicated: boolean;
+}
+
+/** Resolves the short-lived download URL for an item whose delta page did not carry one. */
+export interface DriveDownloadUrlResolver {
+  resolve_download_url(item: DriveDeltaItem): Promise<string | undefined>;
+}
+
+/**
+ * What a provider supplies to the shared large-file pipeline: its key layout and its chunk
+ * fetcher. The two providers reach for different chunked-download adapters, which is the only
+ * behavioural difference between the copies this replaces.
+ */
+export interface DriveLargeFileDeps {
+  readonly keys: DriveStorageKeys;
+  readonly fetch_chunks: (
+    download_url: string,
+    total_bytes: number,
+    item_id: string,
+  ) => AsyncIterable<Buffer>;
+}
+
+/**
+ * Single-download, zero-disk pipeline for files at or above the large-file threshold. Streams
+ * encrypted parts to an S3 staging key, then either aborts (dedup) or copies to the canonical
+ * content-addressed key.
+ */
+export async function process_large_drive_file(
+  deps: DriveLargeFileDeps,
+  connector: DriveDownloadUrlResolver,
+  item: DriveDeltaItem,
+  owner_id: string,
+  ctx: TenantContext,
+  object_lock_policy?: StorageObjectLockPolicy,
+): Promise<LargeFileResult> {
+  const download_url = item.download_url ?? (await connector.resolve_download_url(item));
+  if (!download_url) {
+    throw new Error(`Could not resolve download URL for large file ${item.item_id}`);
+  }
+
+  const staging_key = deps.keys.staging_key(owner_id, item.item_id);
+
+  logger.info(
+    `Streaming large file ${item.file_name} (${format_bytes(item.size_bytes)}) via staging key...`,
+  );
+
+  const result = await stream_to_content_addressed_storage(
+    ctx,
+    deps.fetch_chunks(download_url, item.size_bytes, item.item_id),
+    {
+      staging_key,
+      staging_prefix: deps.keys.staging_prefix_for(owner_id),
+      build_data_key: (checksum) => deps.keys.data_key(owner_id, checksum),
+      ...(object_lock_policy && { object_lock_policy }),
+    },
+  );
+
+  if (result.deduplicated) {
+    logger.info(`Deduplicated ${item.file_name} (already stored)`);
+  } else {
+    logger.info(`Stored ${item.file_name} (${format_bytes(item.size_bytes)})`);
+  }
+
+  return result;
+}
+
+/** Removes leftover staging objects and incomplete multipart uploads. */
+export async function cleanup_stale_drive_staging(
+  keys: DriveStorageKeys,
+  ctx: TenantContext,
+  owner_id: string,
+): Promise<void> {
+  const prefix = keys.staging_prefix_for(owner_id);
+
+  const stale_keys = await ctx.storage.list(prefix);
+  for (const key of stale_keys) {
+    logger.info(`Cleaning up stale staging object: ${key}`);
+    await ctx.storage.delete(key).catch(() => {});
+  }
+
+  const aborted = await ctx.storage.abort_incomplete_uploads(prefix);
+  if (aborted > 0) {
+    logger.info(`Aborted ${aborted} incomplete staging upload(s)`);
+  }
+}

--- a/packages/drive/src/backup/whole-file-stream.ts
+++ b/packages/drive/src/backup/whole-file-stream.ts
@@ -1,0 +1,33 @@
+/**
+ * Streams an item in one request and cuts it into fixed-size buffers.
+ *
+ * The fallback for a server that ignores `Range` and answers with the whole file (issue #301).
+ * Asking per chunk then costs the entire file every time, so a 1 GiB item moves 256 GiB to
+ * produce 1 GiB. Cutting the single response into the same buffers the caller's
+ * encrypt-and-upload pipeline expects keeps the memory ceiling at one chunk.
+ */
+export async function* stream_whole_file_in_chunks(
+  url: string,
+  item_id: string,
+  chunk_size_bytes: number,
+): AsyncGenerator<Buffer> {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`HTTP ${response.status} for the streamed download of ${item_id}`);
+  }
+
+  let pending: Buffer[] = [];
+  let pending_bytes = 0;
+  for await (const part of response.body as unknown as AsyncIterable<Uint8Array>) {
+    pending.push(Buffer.from(part));
+    pending_bytes += part.byteLength;
+    while (pending_bytes >= chunk_size_bytes) {
+      const joined = Buffer.concat(pending);
+      yield joined.subarray(0, chunk_size_bytes);
+      const rest = joined.subarray(chunk_size_bytes);
+      pending = rest.length > 0 ? [rest] : [];
+      pending_bytes = rest.length;
+    }
+  }
+  if (pending_bytes > 0) yield Buffer.concat(pending);
+}

--- a/packages/drive/src/backup/whole-file-stream.ts
+++ b/packages/drive/src/backup/whole-file-stream.ts
@@ -1,3 +1,17 @@
+/** Options for {@link stream_whole_file_in_chunks}. */
+export interface WholeFileStreamOptions {
+  /** Size of each yielded buffer; must be a positive integer. */
+  readonly chunk_size_bytes: number;
+  /**
+   * Milliseconds allowed between two reads before the request is aborted.
+   *
+   * A server that sends headers and then stalls would otherwise hold the download forever, which
+   * is the failure the Range path bounds per chunk (issue #198). The clock is reset on every
+   * part, so a slow-but-moving transfer is never cut off.
+   */
+  readonly stall_timeout_ms: number;
+}
+
 /**
  * Streams an item in one request and cuts it into fixed-size buffers.
  *
@@ -9,25 +23,49 @@
 export async function* stream_whole_file_in_chunks(
   url: string,
   item_id: string,
-  chunk_size_bytes: number,
+  options: WholeFileStreamOptions,
 ): AsyncGenerator<Buffer> {
-  const response = await fetch(url);
-  if (!response.ok || !response.body) {
-    throw new Error(`HTTP ${response.status} for the streamed download of ${item_id}`);
+  const { chunk_size_bytes, stall_timeout_ms } = options;
+  if (!Number.isSafeInteger(chunk_size_bytes) || chunk_size_bytes <= 0) {
+    throw new Error(`Invalid chunk size for the streamed download of ${item_id}`);
   }
 
-  let pending: Buffer[] = [];
-  let pending_bytes = 0;
-  for await (const part of response.body as unknown as AsyncIterable<Uint8Array>) {
-    pending.push(Buffer.from(part));
-    pending_bytes += part.byteLength;
-    while (pending_bytes >= chunk_size_bytes) {
-      const joined = Buffer.concat(pending);
-      yield joined.subarray(0, chunk_size_bytes);
-      const rest = joined.subarray(chunk_size_bytes);
-      pending = rest.length > 0 ? [rest] : [];
-      pending_bytes = rest.length;
+  const controller = new AbortController();
+  let timer = arm_stall_timer(controller, stall_timeout_ms, item_id);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok || !response.body) {
+      throw new Error(`HTTP ${response.status} for the streamed download of ${item_id}`);
     }
+
+    let pending: Buffer[] = [];
+    let pending_bytes = 0;
+    for await (const part of response.body as unknown as AsyncIterable<Uint8Array>) {
+      clearTimeout(timer);
+      timer = arm_stall_timer(controller, stall_timeout_ms, item_id);
+      pending.push(Buffer.from(part));
+      pending_bytes += part.byteLength;
+      while (pending_bytes >= chunk_size_bytes) {
+        const joined = Buffer.concat(pending);
+        yield joined.subarray(0, chunk_size_bytes);
+        const rest = joined.subarray(chunk_size_bytes);
+        pending = rest.length > 0 ? [rest] : [];
+        pending_bytes = rest.length;
+      }
+    }
+    if (pending_bytes > 0) yield Buffer.concat(pending);
+  } finally {
+    clearTimeout(timer);
   }
-  if (pending_bytes > 0) yield Buffer.concat(pending);
+}
+
+function arm_stall_timer(
+  controller: AbortController,
+  stall_timeout_ms: number,
+  item_id: string,
+): NodeJS.Timeout {
+  return setTimeout(() => {
+    controller.abort(new Error(`Streamed download of ${item_id} stalled`));
+  }, stall_timeout_ms);
 }

--- a/packages/drive/src/drive-ports.ts
+++ b/packages/drive/src/drive-ports.ts
@@ -1,4 +1,5 @@
 import type {
+  OneDriveChangeType,
   OneDriveDeltaItem,
   OneDriveFileVersion,
   OneDriveFileVersionIndex,
@@ -15,6 +16,7 @@ import type {
  * day a provider's shape diverges the callers in that package stop compiling instead of drifting
  * quietly. Aliasing beats re-declaring here: a hand-copied interface would drift in silence.
  */
+export type DriveChangeType = OneDriveChangeType;
 export type DriveDeltaItem = OneDriveDeltaItem;
 export type DriveFileVersion = OneDriveFileVersion;
 export type DriveFileVersionRecord = OneDriveFileVersionRecord;

--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -57,6 +57,7 @@ export {
   list_drive_file_versions,
   type DriveCatalogDeps,
 } from '@/catalog/catalog-queries';
+export { ensure_drive_folder_path, type DriveFolderCreator } from '@/restore/folder-path';
 export {
   restore_drive_version,
   type DriveUploadConnector,

--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -1,6 +1,7 @@
 export * from '@/drive-ports';
 export { download_with_retry, type DownloadRetryOptions } from '@/backup/download-retry';
 export { LARGE_FILE_THRESHOLD } from '@/backup/large-file-threshold';
+export { stream_whole_file_in_chunks } from '@/backup/whole-file-stream';
 export {
   should_stream_restore,
   verify_streaming_checksum,

--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -8,6 +8,7 @@ export {
   type StreamDecryptResult,
 } from '@/restore/streaming-restore';
 export { filter_drive_entries } from '@/shared/entry-filter';
+export { join_drive_path } from '@/shared/logical-path';
 export {
   load_drive_chain_entries,
   restorable_entries,

--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -1,7 +1,10 @@
 export * from '@/drive-ports';
 export { download_with_retry, type DownloadRetryOptions } from '@/backup/download-retry';
 export { LARGE_FILE_THRESHOLD } from '@/backup/large-file-threshold';
-export { stream_whole_file_in_chunks } from '@/backup/whole-file-stream';
+export {
+  stream_whole_file_in_chunks,
+  type WholeFileStreamOptions,
+} from '@/backup/whole-file-stream';
 export {
   should_stream_restore,
   verify_streaming_checksum,

--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -1,5 +1,27 @@
+/**
+ * The drive behaviour OneDrive and SharePoint share, taking each provider's values as arguments.
+ *
+ * The modules that still exist twice in the provider packages fall into two groups (#306). The
+ * ones with real differences carry a comment saying so and what the difference is:
+ * `backup.service.ts`, `restore.service.ts`, `status.service.ts`, `backup-builders.ts` and
+ * `restore-folder-path.ts`. Everything else that still pairs up by name is a binder: a class that
+ * satisfies a per-provider port, a descriptor that names the manifest lookup, or a module that
+ * supplies the key layout and a chunk fetcher to the shared code below. Those exist precisely to
+ * hold the provider's values, so deduplicating them would mean giving up the separate ports, and
+ * a near-zero diff there is the intended result rather than duplication left behind.
+ */
 export * from '@/drive-ports';
 export { download_with_retry, type DownloadRetryOptions } from '@/backup/download-retry';
+export { classify_drive_change } from '@/backup/change-classifier';
+export { process_drive_backup_file, type FileProcessResult } from '@/backup/file-processor';
+export {
+  process_large_drive_file,
+  cleanup_stale_drive_staging,
+  type DriveDownloadUrlResolver,
+  type DriveLargeFileDeps,
+  type LargeFileResult,
+} from '@/backup/large-file-pipeline';
+export { format_bytes } from '@/shared/format-bytes';
 export { LARGE_FILE_THRESHOLD } from '@/backup/large-file-threshold';
 export {
   stream_whole_file_in_chunks,

--- a/packages/drive/src/restore/folder-path.ts
+++ b/packages/drive/src/restore/folder-path.ts
@@ -1,0 +1,92 @@
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+/** The one connector call folder creation needs. */
+export interface DriveFolderCreator {
+  create_folder(
+    tenant_id: string,
+    owner_id: string,
+    drive_id: string,
+    parent_id: string,
+    name: string,
+  ): Promise<string>;
+}
+
+/**
+ * Resolves a restore-side path to a drive item id, creating the folders that are missing.
+ *
+ * `folder_ids` is the per-restore memo, so a restore root shared by every entry is created once
+ * rather than once per file. Keys are `drive_id:path`, never the path alone: one snapshot spans
+ * several drives or libraries, and the same path means a different folder in each. Keying by path
+ * made a restore write the second drive's files into the first drive's folder, silently, because
+ * the memo answered before the create call was ever made (issue #316).
+ *
+ * Returns undefined when a segment could not be created; the caller reports that entry as
+ * skipped, which is what keeps one over-long path from aborting the whole run.
+ */
+export async function ensure_drive_folder_path(
+  connector: DriveFolderCreator,
+  tenant_id: string,
+  owner_id: string,
+  drive_id: string,
+  path: string,
+  folder_ids: Map<string, string>,
+): Promise<string | undefined> {
+  const normalized = path.length === 0 || path === '.' ? '/' : path;
+  const cache_key = `${drive_id}:${normalized}`;
+  const cached = folder_ids.get(cache_key);
+  if (cached !== undefined) return cached;
+
+  if (normalized === '/') {
+    folder_ids.set(cache_key, 'root');
+    return 'root';
+  }
+
+  const segments = normalized.split('/').filter(Boolean);
+  let current_path = '';
+  let parent_id = 'root';
+
+  for (const segment of segments) {
+    current_path = current_path ? `${current_path}/${segment}` : `/${segment}`;
+    const segment_key = `${drive_id}:${current_path}`;
+    const known = folder_ids.get(segment_key);
+    if (known !== undefined) {
+      parent_id = known;
+      continue;
+    }
+
+    try {
+      const folder_id = await connector.create_folder(
+        tenant_id,
+        owner_id,
+        drive_id,
+        parent_id,
+        segment,
+      );
+      folder_ids.set(segment_key, folder_id);
+      parent_id = folder_id;
+    } catch (err) {
+      logger.warn(
+        `Failed to create folder ${current_path} in drive ${drive_id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  return parent_id;
+}
+
+/**
+ * How many folders the restore actually created, from the memo.
+ *
+ * The memo also holds one root marker per drive, keyed `<drive_id>:/` with the value `root`,
+ * which the run did not create. Both providers previously corrected for that with a constant,
+ * which was right for exactly one drive.
+ */
+export function count_created_folders(folder_ids: ReadonlyMap<string, string>): number {
+  let created = 0;
+  for (const [key, id] of folder_ids) {
+    if (id === 'root' && key.endsWith(':/')) continue;
+    created++;
+  }
+  return created;
+}

--- a/packages/drive/src/restore/version-restore.ts
+++ b/packages/drive/src/restore/version-restore.ts
@@ -109,8 +109,9 @@ export async function restore_drive_version(
 
     // The version row records the drive it came from, so a version restore needs no drive lookup
     // and stays correct for an owning segment with several drives, where "the first drive" would
-    // be a guess.
-    const folder_ids_by_drive = new Map<string, Map<string, string>>();
+    // be a guess. One memo for all of them: `ensure_folder_path` keys it by `drive_id:path`, so
+    // two drives holding the same path cannot collide in it (issue #316).
+    const folder_ids = new Map<string, string>();
     const restored: DriveRestoredVersion[] = [];
     const errors: string[] = [...selection.skipped];
     let files_skipped = selection.skipped.length;
@@ -130,7 +131,7 @@ export async function restore_drive_version(
         tenant_id,
         owner_id,
         ctx,
-        folder_ids_by_drive,
+        folder_ids,
         candidate,
         placement,
       );
@@ -179,7 +180,7 @@ async function restore_one_version(
   tenant_id: string,
   owner_id: string,
   ctx: TenantContext,
-  folder_ids_by_drive: Map<string, Map<string, string>>,
+  folder_ids: Map<string, string>,
   candidate: SelectedVersion,
   placement: DriveVersionPlacement,
 ): Promise<{ restored?: DriveRestoredVersion; error?: string }> {
@@ -189,14 +190,6 @@ async function restore_one_version(
     const content = await deps.download_blob(ctx, version);
     if (!content) {
       return { error: `${original_path}: stored version could not be read or verified` };
-    }
-
-    // Folder ids are cached per drive: the same path exists in more than one drive of the same
-    // owning segment and means a different folder in each.
-    let folder_ids = folder_ids_by_drive.get(drive_id);
-    if (!folder_ids) {
-      folder_ids = new Map<string, string>([['/', 'root']]);
-      folder_ids_by_drive.set(drive_id, folder_ids);
     }
 
     const { parent_path } = split_parent_path(original_path);

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -76,49 +76,57 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
     const output_path =
       options.output_path ?? build_default_output_path(workload, options.snapshot_id);
     const skip_integrity = options.skip_integrity_check ?? false;
-    const { archive, promise } = create_file_archive(output_path);
+    const { archive, promise, abort } = create_file_archive(output_path);
 
-    const integrity_failures: string[] = [];
-    const { files_saved, files_skipped, errors } = await save_entries_to_archive(
-      workload,
-      ctx,
-      archive,
-      restorable,
-      skip_integrity,
-      integrity_failures,
-      options,
-    );
+    try {
+      const integrity_failures: string[] = [];
+      const { files_saved, files_skipped, errors } = await save_entries_to_archive(
+        workload,
+        ctx,
+        archive,
+        restorable,
+        skip_integrity,
+        integrity_failures,
+        options,
+      );
 
-    emit_operation_progress(options, {
-      operation: 'save',
-      workload,
-      phase: 'finalizing',
-      processed: files_saved + files_skipped,
-      total: restorable.length,
-    });
-    await finalize_file_archive(archive);
-    const total_bytes = await promise;
-    await mark_downloaded_from_internet(output_path);
-    const interrupted =
-      files_saved + files_skipped < restorable.length || options.should_interrupt?.() === true;
-    emit_operation_progress(options, {
-      operation: 'save',
-      workload,
-      phase: interrupted ? 'interrupted' : 'completed',
-      processed: files_saved + files_skipped,
-      total: restorable.length,
-    });
+      emit_operation_progress(options, {
+        operation: 'save',
+        workload,
+        phase: 'finalizing',
+        processed: files_saved + files_skipped,
+        total: restorable.length,
+      });
+      await finalize_file_archive(archive);
+      const total_bytes = await promise;
+      await mark_downloaded_from_internet(output_path);
+      const interrupted =
+        files_saved + files_skipped < restorable.length || options.should_interrupt?.() === true;
+      emit_operation_progress(options, {
+        operation: 'save',
+        workload,
+        phase: interrupted ? 'interrupted' : 'completed',
+        processed: files_saved + files_skipped,
+        total: restorable.length,
+      });
 
-    return {
-      snapshot_id: options.snapshot_id,
-      files_saved,
-      files_skipped,
-      errors,
-      integrity_failures,
-      output_path,
-      total_bytes,
-      interrupted,
-    };
+      return {
+        snapshot_id: options.snapshot_id,
+        files_saved,
+        files_skipped,
+        errors,
+        integrity_failures,
+        output_path,
+        total_bytes,
+        interrupted,
+      };
+    } catch (err) {
+      // Anything between opening the archive and finalizing it can throw: the entry loop, the
+      // finalize, the size promise, the zone marking. None of them may leave a truncated zip
+      // sitting at the output path (issue #307).
+      await abort();
+      throw err;
+    }
   } finally {
     ctx.destroy();
   }

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -76,7 +76,7 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
     const output_path =
       options.output_path ?? build_default_output_path(workload, options.snapshot_id);
     const skip_integrity = options.skip_integrity_check ?? false;
-    const { archive, promise, abort } = create_file_archive(output_path);
+    const { archive, promise, publish, abort } = create_file_archive(output_path);
 
     try {
       const integrity_failures: string[] = [];
@@ -99,6 +99,9 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
       });
       await finalize_file_archive(archive);
       const total_bytes = await promise;
+      // Only now does anything appear at the output path, so a failure above cannot leave a
+      // truncated zip there and cannot destroy a file that was already sitting on it.
+      await publish();
       await mark_downloaded_from_internet(output_path);
       const interrupted =
         files_saved + files_skipped < restorable.length || options.should_interrupt?.() === true;
@@ -121,9 +124,9 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
         interrupted,
       };
     } catch (err) {
-      // Anything between opening the archive and finalizing it can throw: the entry loop, the
-      // finalize, the size promise, the zone marking. None of them may leave a truncated zip
-      // sitting at the output path (issue #307).
+      // Anything between opening the archive and publishing it can throw: the entry loop, the
+      // finalize, the byte count, the move itself. None of them may leave a partial file behind
+      // (issue #307).
       await abort();
       throw err;
     }

--- a/packages/drive/src/shared/entry-filter.ts
+++ b/packages/drive/src/shared/entry-filter.ts
@@ -1,4 +1,5 @@
 import type { DriveManifestEntry } from '@/drive-ports';
+import { join_drive_path } from '@/shared/logical-path';
 
 /** Filters manifest entries by file ID or full path, case-insensitively. */
 export function filter_drive_entries(
@@ -10,6 +11,6 @@ export function filter_drive_entries(
   return entries.filter(
     (entry) =>
       selected.has(entry.file_id.toLowerCase()) ||
-      selected.has(`${entry.parent_path}/${entry.file_name}`.toLowerCase()),
+      selected.has(join_drive_path(entry.parent_path, entry.file_name).toLowerCase()),
   );
 }

--- a/packages/drive/src/shared/format-bytes.ts
+++ b/packages/drive/src/shared/format-bytes.ts
@@ -1,0 +1,7 @@
+/** Human-readable byte size for operator-facing log lines. */
+export function format_bytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}

--- a/packages/drive/src/shared/logical-path.ts
+++ b/packages/drive/src/shared/logical-path.ts
@@ -1,0 +1,13 @@
+/**
+ * Joins a parent path and a file name into the rooted logical path an operator types.
+ *
+ * A root-level item carries `parent_path` of `/`, both when Graph omits the parent reference and
+ * when the path ends at `root:`, so concatenating produces `//Report.docx` and nothing an operator
+ * can type will match it (issue #299). One helper because the manifest filter and the version
+ * index build the same string from different record shapes.
+ */
+export function join_drive_path(parent_path: string, file_name: string): string {
+  const base = parent_path.replace(/\/+$/, '');
+  if (base === '') return `/${file_name}`;
+  return `${base}/${file_name}`;
+}

--- a/packages/drive/src/versioning/version-reference.ts
+++ b/packages/drive/src/versioning/version-reference.ts
@@ -8,7 +8,12 @@ export function resolve_file_id(
 ): string | undefined {
   const trimmed = file_ref.trim();
   if (!looks_like_path(trimmed)) {
-    if (indexes.some((idx) => idx.file_id === trimmed)) return trimmed;
+    // Case-insensitively, and the stored spelling is what comes back: Graph item ids carry
+    // uppercase and an operator may type them in any case, which is what #75 fixed for
+    // `--file-filter`. Version references were left comparing exactly.
+    const wanted_id = trimmed.toLowerCase();
+    const by_id = indexes.find((idx) => idx.file_id.toLowerCase() === wanted_id);
+    if (by_id) return by_id.file_id;
     return match_by_file_name(indexes, trimmed);
   }
   return match_by_path(indexes, normalize_path_ref(trimmed));
@@ -50,10 +55,13 @@ function match_by_file_name(
   indexes: readonly DriveFileVersionIndexView[],
   file_name: string,
 ): string | undefined {
+  const wanted = file_name.normalize('NFC').toLowerCase();
   const matches = new Map<string, string>();
   for (const idx of indexes) {
     for (const v of idx.versions) {
-      if (v.file_name === file_name) matches.set(idx.file_id, version_logical_path(v));
+      if (v.file_name.normalize('NFC').toLowerCase() === wanted) {
+        matches.set(idx.file_id, version_logical_path(v));
+      }
     }
   }
   if (matches.size > 1) {
@@ -70,11 +78,11 @@ function looks_like_path(ref: string): boolean {
   return ref.includes('/') || ref.includes('\\');
 }
 
-/** NFC-normalized path string comparable to stored manifest/index paths. */
+/** NFC-normalized, lower-cased path comparable to stored manifest and index paths. */
 function normalize_path_ref(raw: string): string {
   const unified = raw.replace(/\\/g, '/').trim();
   const with_slash = unified.startsWith('/') ? unified : `/${unified}`;
-  return with_slash.normalize('NFC');
+  return with_slash.normalize('NFC').toLowerCase();
 }
 
 /** Rooted logical path of one version record, e.g. `/Documents/Report.docx`. */

--- a/packages/drive/src/versioning/version-reference.ts
+++ b/packages/drive/src/versioning/version-reference.ts
@@ -1,4 +1,5 @@
 import type { DriveFileVersionIndexView, DriveFileVersionRecord } from '@/drive-ports';
+import { join_drive_path } from '@/shared/logical-path';
 
 /** Maps a CLI file reference (Graph item id or rooted path) to a file id, if known. */
 export function resolve_file_id(
@@ -10,13 +11,35 @@ export function resolve_file_id(
     if (indexes.some((idx) => idx.file_id === trimmed)) return trimmed;
     return match_by_file_name(indexes, trimmed);
   }
-  const want = normalize_path_ref(trimmed);
+  return match_by_path(indexes, normalize_path_ref(trimmed));
+}
+
+/**
+ * Matches a rooted path against every indexed version, and raises when it maps to more than one
+ * file, the same way a bare name does (issue #300).
+ *
+ * One path can belong to two file ids: the path is reconstructed per version record, so a file
+ * deleted and recreated at the same path, or a path reused after a move, leaves two drive items
+ * behind it. Returning whichever the iteration reached first restored a version of an
+ * arbitrarily chosen file.
+ */
+function match_by_path(
+  indexes: readonly DriveFileVersionIndexView[],
+  want: string,
+): string | undefined {
+  const matches = new Set<string>();
   for (const idx of indexes) {
     for (const v of idx.versions) {
-      if (normalize_path_ref(version_logical_path(v)) === want) return idx.file_id;
+      if (normalize_path_ref(version_logical_path(v)) === want) matches.add(idx.file_id);
     }
   }
-  return undefined;
+  if (matches.size > 1) {
+    const ids = [...matches].sort().join(', ');
+    throw new Error(
+      `'${want}' matches ${matches.size} files: ${ids}. ` + 'Pass the file id of the one you mean.',
+    );
+  }
+  return [...matches][0];
 }
 
 /**
@@ -54,8 +77,7 @@ function normalize_path_ref(raw: string): string {
   return with_slash.normalize('NFC');
 }
 
+/** Rooted logical path of one version record, e.g. `/Documents/Report.docx`. */
 export function version_logical_path(v: DriveFileVersionRecord): string {
-  const base = v.parent_path.replace(/\/+$/, '') || '';
-  if (base === '' || base === '/') return `/${v.file_name}`;
-  return `${base}/${v.file_name}`;
+  return join_drive_path(v.parent_path, v.file_name);
 }

--- a/packages/drive/tests/unit/backup/whole-file-stream.test.ts
+++ b/packages/drive/tests/unit/backup/whole-file-stream.test.ts
@@ -1,0 +1,139 @@
+import { createHash } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { stream_whole_file_in_chunks } from '@/backup/whole-file-stream';
+
+const CHUNK_SIZE = 4 * 1024 * 1024;
+
+/** A response whose body yields the given parts. */
+function streamed_response(parts: Buffer[]): Response {
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+        for (const part of parts) yield new Uint8Array(part);
+      },
+    },
+  } as unknown as Response;
+}
+
+/**
+ * A response that yields one part and then never yields again until the request is aborted,
+ * which is what a server that sends headers and then stops looks like from here.
+ */
+function stalling_response(signal_holder: { signal: AbortSignal | undefined }): Response {
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+        yield new Uint8Array(Buffer.alloc(16, 1));
+        const { promise, reject } = Promise.withResolvers<never>();
+        signal_holder.signal?.addEventListener('abort', () =>
+          reject(new Error('The operation was aborted')),
+        );
+        await promise;
+      },
+    },
+  } as unknown as Response;
+}
+
+async function collect(response: Response, stall_timeout_ms = 30_000): Promise<Buffer[]> {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((_url: string, init?: { signal?: AbortSignal }) => {
+      init?.signal?.addEventListener('abort', () => undefined);
+      return Promise.resolve(response);
+    }),
+  );
+  const parts: Buffer[] = [];
+  for await (const chunk of stream_whole_file_in_chunks('https://cdn.test/file', 'item-1', {
+    chunk_size_bytes: CHUNK_SIZE,
+    stall_timeout_ms,
+  })) {
+    parts.push(chunk);
+  }
+  return parts;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('stream_whole_file_in_chunks', () => {
+  it('re-cuts a body that arrives in unrelated sizes into fixed chunks', async () => {
+    const whole = Buffer.alloc(CHUNK_SIZE + 1024, 3);
+    const thirds = [
+      whole.subarray(0, 1_000_000),
+      whole.subarray(1_000_000, 3_500_000),
+      whole.subarray(3_500_000),
+    ];
+
+    const parts = await collect(streamed_response(thirds.map((part) => Buffer.from(part))));
+
+    expect(parts.map((part) => part.length)).toEqual([CHUNK_SIZE, 1024]);
+    const rebuilt = Buffer.concat(parts);
+    expect(createHash('sha256').update(rebuilt).digest('hex')).toBe(
+      createHash('sha256').update(whole).digest('hex'),
+    );
+  });
+
+  it('yields a body smaller than one chunk as a single buffer', async () => {
+    const parts = await collect(streamed_response([Buffer.alloc(512, 1)]));
+
+    expect(parts.map((part) => part.length)).toEqual([512]);
+  });
+
+  it('yields nothing for an empty body', async () => {
+    expect(await collect(streamed_response([]))).toEqual([]);
+  });
+
+  it('rejects a chunk size that would loop forever', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+
+    // `pending_bytes >= 0` never stops being true, so this would yield until the heap gave out.
+    await expect(
+      (async () => {
+        for await (const _ of stream_whole_file_in_chunks('https://cdn.test/file', 'item-1', {
+          chunk_size_bytes: 0,
+          stall_timeout_ms: 30_000,
+        })) {
+          void _;
+        }
+      })(),
+    ).rejects.toThrow(/Invalid chunk size/);
+  });
+
+  it('aborts a body that stops arriving', async () => {
+    // The Range path bounds every chunk (issue #198); the fallback has to bound the gaps too,
+    // or a server that sends headers and then stalls holds the backup open forever.
+    vi.useFakeTimers();
+    const holder: { signal: AbortSignal | undefined } = { signal: undefined };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((_url: string, init?: { signal?: AbortSignal }) => {
+        holder.signal = init?.signal;
+        return Promise.resolve(stalling_response(holder));
+      }),
+    );
+
+    const consumed = (async () => {
+      for await (const _ of stream_whole_file_in_chunks('https://cdn.test/file', 'item-1', {
+        chunk_size_bytes: CHUNK_SIZE,
+        stall_timeout_ms: 30_000,
+      })) {
+        void _;
+      }
+    })();
+    const settled = expect(consumed).rejects.toThrow(/aborted/);
+    await vi.advanceTimersByTimeAsync(30_001);
+    await settled;
+  });
+
+  it('rejects a refused download', async () => {
+    await expect(
+      collect({ ok: false, status: 403, body: undefined } as unknown as Response),
+    ).rejects.toThrow(/HTTP 403/);
+  });
+});

--- a/packages/drive/tests/unit/restore/folder-path.test.ts
+++ b/packages/drive/tests/unit/restore/folder-path.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  count_created_folders,
+  ensure_drive_folder_path,
+  type DriveFolderCreator,
+} from '@/restore/folder-path';
+
+const TENANT = 'tenant-1';
+const OWNER = 'owner-1';
+
+/** Hands out an id per created folder so a caller can tell two folders apart. */
+function make_connector(): DriveFolderCreator & { create_folder: ReturnType<typeof vi.fn> } {
+  let next = 0;
+  return {
+    create_folder: vi.fn(
+      (_tenant: string, _owner: string, drive_id: string, parent_id: string, name: string) => {
+        next++;
+        return Promise.resolve(`${drive_id}:${parent_id}:${name}:${next}`);
+      },
+    ),
+  };
+}
+
+describe('ensure_drive_folder_path', () => {
+  it('creates each missing segment and returns the deepest folder id', async () => {
+    const connector = make_connector();
+    const memo = new Map<string, string>();
+
+    const id = await ensure_drive_folder_path(
+      connector,
+      TENANT,
+      OWNER,
+      'drive-1',
+      '/Documents/Reports',
+      memo,
+    );
+
+    expect(connector.create_folder).toHaveBeenCalledTimes(2);
+    expect(id).toBe('drive-1:drive-1:root:Documents:1:Reports:2');
+  });
+
+  it('creates a shared parent once across entries', async () => {
+    const connector = make_connector();
+    const memo = new Map<string, string>();
+
+    await ensure_drive_folder_path(connector, TENANT, OWNER, 'drive-1', '/Restore/a', memo);
+    await ensure_drive_folder_path(connector, TENANT, OWNER, 'drive-1', '/Restore/b', memo);
+
+    // `/Restore` once, then one leaf per entry. Re-creating the root per file is what the memo
+    // exists to avoid.
+    expect(connector.create_folder).toHaveBeenCalledTimes(3);
+  });
+
+  it('resolves the same path in two drives to two folders (issue #316)', async () => {
+    const connector = make_connector();
+    const memo = new Map<string, string>();
+
+    const first = await ensure_drive_folder_path(
+      connector,
+      TENANT,
+      OWNER,
+      'drive-1',
+      '/Documents/Reports',
+      memo,
+    );
+    const second = await ensure_drive_folder_path(
+      connector,
+      TENANT,
+      OWNER,
+      'drive-2',
+      '/Documents/Reports',
+      memo,
+    );
+
+    // Keyed by path alone, the second call answered from the memo and the second drive's files
+    // were written into the first drive's folder, with a successful upload against a real id.
+    expect(second).not.toBe(first);
+    expect(connector.create_folder).toHaveBeenCalledTimes(4);
+    const drives_created = connector.create_folder.mock.calls.map((call) => call[2]);
+    expect(drives_created).toEqual(['drive-1', 'drive-1', 'drive-2', 'drive-2']);
+  });
+
+  it('treats the drive root as root without creating anything', async () => {
+    const connector = make_connector();
+
+    for (const path of ['/', '', '.']) {
+      expect(
+        await ensure_drive_folder_path(
+          connector,
+          TENANT,
+          OWNER,
+          'drive-1',
+          path,
+          new Map<string, string>(),
+        ),
+      ).toBe('root');
+    }
+    expect(connector.create_folder).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when a segment cannot be created', async () => {
+    const connector = make_connector();
+    connector.create_folder.mockRejectedValueOnce(new Error('nameAlreadyExists'));
+
+    const id = await ensure_drive_folder_path(
+      connector,
+      TENANT,
+      OWNER,
+      'drive-1',
+      '/Documents/Reports',
+      new Map<string, string>(),
+    );
+
+    // The caller reports that one entry as skipped; one over-long path must not abort the run.
+    expect(id).toBeUndefined();
+  });
+
+  it('reuses a cached parent from the same drive without recreating it', async () => {
+    const connector = make_connector();
+    const memo = new Map<string, string>([['drive-1:/Documents', 'cached-id']]);
+
+    const id = await ensure_drive_folder_path(
+      connector,
+      TENANT,
+      OWNER,
+      'drive-1',
+      '/Documents',
+      memo,
+    );
+
+    expect(id).toBe('cached-id');
+    expect(connector.create_folder).not.toHaveBeenCalled();
+  });
+});
+
+describe('count_created_folders', () => {
+  it('counts the folders created and not the per-drive root markers', async () => {
+    const connector = make_connector();
+    const memo = new Map<string, string>();
+
+    await ensure_drive_folder_path(connector, TENANT, OWNER, 'drive-1', '/Documents', memo);
+    await ensure_drive_folder_path(connector, TENANT, OWNER, 'drive-1', '/', memo);
+    await ensure_drive_folder_path(connector, TENANT, OWNER, 'drive-2', '/', memo);
+
+    // Three memo entries, one real folder. Subtracting a constant for "the root" was right for
+    // one drive and wrong for every restore that spanned two (issue #316).
+    expect(memo.size).toBe(3);
+    expect(count_created_folders(memo)).toBe(1);
+  });
+
+  it('is zero for a restore that created nothing', () => {
+    expect(count_created_folders(new Map())).toBe(0);
+  });
+});

--- a/packages/drive/tests/unit/shared/entry-filter.test.ts
+++ b/packages/drive/tests/unit/shared/entry-filter.test.ts
@@ -19,7 +19,16 @@ const ENTRY = {
   storage_key: 'onedrive/data/o/abc',
 } as DriveManifestEntry;
 
-describe('OneDrive file_filter', () => {
+const ROOT_ENTRY = {
+  file_id: '01ROOTIDROOTIDROOTID',
+  file_name: 'Report.docx',
+  // Graph reports `/` both when it omits the parent reference and when the path ends at `root:`.
+  parent_path: '/',
+  change_type: 'created',
+  storage_key: 'onedrive/data/o/def',
+} as DriveManifestEntry;
+
+describe('drive file_filter', () => {
   it('matches an item id pasted verbatim from a listing', () => {
     expect(filter_drive_entries([ENTRY], [ITEM_ID])).toHaveLength(1);
   });
@@ -38,5 +47,13 @@ describe('OneDrive file_filter', () => {
 
   it('returns everything when no filter is given', () => {
     expect(filter_drive_entries([ENTRY], [])).toHaveLength(1);
+  });
+
+  it('matches a file at the drive root by the path an operator would type (issue #299)', () => {
+    expect(filter_drive_entries([ROOT_ENTRY], ['/Report.docx'])).toHaveLength(1);
+  });
+
+  it('does not match a root-level file by the doubled-slash path it used to build', () => {
+    expect(filter_drive_entries([ROOT_ENTRY], ['//Report.docx'])).toHaveLength(0);
   });
 });

--- a/packages/drive/tests/unit/versioning/version-reference.test.ts
+++ b/packages/drive/tests/unit/versioning/version-reference.test.ts
@@ -45,6 +45,26 @@ describe('resolve_file_id', () => {
     expect(resolve_file_id([nested], 'file-a')).toBe('file-a');
   });
 
+  it('resolves a file id typed in any case and returns the stored spelling', () => {
+    const upper = index('01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3', [
+      version('Report.docx', '/Documents'),
+    ]);
+
+    // Graph item ids carry uppercase; #75 made `--file-filter` case-insensitive for the same
+    // reason, and a version reference takes the same identifiers.
+    expect(resolve_file_id([upper], '01urrjbn4naektkqyt7bbjabarsnlva5h3')).toBe(
+      '01URRJBN4NAEKTKQYT7BBJABARSNLVA5H3',
+    );
+  });
+
+  it('resolves a path typed in any case', () => {
+    expect(resolve_file_id([nested], '/documents/REPORT.docx')).toBe('file-a');
+  });
+
+  it('resolves a bare name typed in any case', () => {
+    expect(resolve_file_id([nested], 'REPORT.DOCX')).toBe('file-a');
+  });
+
   it('resolves a rooted path', () => {
     expect(resolve_file_id([nested], '/Documents/Report.docx')).toBe('file-a');
   });

--- a/packages/drive/tests/unit/versioning/version-reference.test.ts
+++ b/packages/drive/tests/unit/versioning/version-reference.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { DriveFileVersionIndexView, DriveFileVersionRecord } from '@/drive-ports';
+import { resolve_file_id, version_logical_path } from '@/versioning/version-reference';
+
+function version(
+  file_name: string,
+  parent_path: string,
+  snapshot_id = 'snap-1',
+): DriveFileVersionRecord {
+  return {
+    snapshot_id,
+    backup_at: '2026-03-01T00:00:00Z',
+    drive_id: 'drive-1',
+    file_name,
+    parent_path,
+    version_id: 'v1',
+    size_bytes: 10,
+    storage_key: 'onedrive/data/o/abc',
+    checksum: 'abc',
+    last_modified_at: '2026-03-01T00:00:00Z',
+    change_type: 'updated',
+  } as DriveFileVersionRecord;
+}
+
+function index(file_id: string, versions: DriveFileVersionRecord[]): DriveFileVersionIndexView {
+  return { file_id, versions };
+}
+
+describe('version_logical_path', () => {
+  it('does not double the slash for a file at the drive root', () => {
+    expect(version_logical_path(version('Report.docx', '/'))).toBe('/Report.docx');
+  });
+
+  it('joins a nested path', () => {
+    expect(version_logical_path(version('Report.docx', '/Documents'))).toBe(
+      '/Documents/Report.docx',
+    );
+  });
+});
+
+describe('resolve_file_id', () => {
+  const nested = index('file-a', [version('Report.docx', '/Documents')]);
+
+  it('resolves a file id given verbatim', () => {
+    expect(resolve_file_id([nested], 'file-a')).toBe('file-a');
+  });
+
+  it('resolves a rooted path', () => {
+    expect(resolve_file_id([nested], '/Documents/Report.docx')).toBe('file-a');
+  });
+
+  it('resolves a path typed with backslashes and no leading slash', () => {
+    expect(resolve_file_id([nested], 'Documents\\Report.docx')).toBe('file-a');
+  });
+
+  it('resolves a file at the drive root by its rooted path', () => {
+    expect(
+      resolve_file_id([index('file-root', [version('Report.docx', '/')])], '/Report.docx'),
+    ).toBe('file-root');
+  });
+
+  it('returns undefined for a path nothing was indexed under', () => {
+    expect(resolve_file_id([nested], '/Documents/Other.docx')).toBeUndefined();
+  });
+
+  it('raises when a path maps to two file ids instead of picking the first (issue #300)', () => {
+    // A file deleted and recreated at the same path leaves two drive items behind that path.
+    const recreated = [
+      index('file-old', [version('Report.docx', '/Documents', 'snap-1')]),
+      index('file-new', [version('Report.docx', '/Documents', 'snap-2')]),
+    ];
+
+    expect(() => resolve_file_id(recreated, '/Documents/Report.docx')).toThrow(
+      /matches 2 files: file-new, file-old/,
+    );
+  });
+
+  it('still raises for a bare name that maps to two files', () => {
+    const two = [
+      index('file-a', [version('Report.docx', '/Documents')]),
+      index('file-b', [version('Report.docx', '/Archive')]),
+    ];
+
+    expect(() => resolve_file_id(two, 'Report.docx')).toThrow(/Pass a full path instead/);
+  });
+});

--- a/packages/m365-graph/package.json
+++ b/packages/m365-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-m365-graph",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/m365-graph/src/graph-permission-errors.ts
+++ b/packages/m365-graph/src/graph-permission-errors.ts
@@ -10,7 +10,7 @@ import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
  * actionable guidance about which API permissions to grant.
  */
 export function rethrow_if_access_denied(err: unknown): void {
-  const graph_err = err as Record<string, unknown>;
+  const graph_err = as_error_fields(err);
   if (graph_err.statusCode !== 403) return;
 
   const required = [
@@ -37,7 +37,7 @@ export function rethrow_if_access_denied(err: unknown): void {
  * actionable guidance about reassigning an Exchange Online license.
  */
 export function rethrow_if_mailbox_not_licensed(err: unknown): void {
-  const graph_err = err as Record<string, unknown>;
+  const graph_err = as_error_fields(err);
   const code = String(graph_err.code ?? '');
   const message = err instanceof Error ? err.message : String(err);
 
@@ -55,4 +55,15 @@ export function rethrow_if_mailbox_not_licensed(err: unknown): void {
       { cause: err },
     );
   }
+}
+
+/**
+ * Reads a thrown value as a bag of fields.
+ *
+ * `unknown` is not `object`: a rejected promise can carry `null`, and asserting the type only
+ * silences the compiler. Both helpers are called from `catch` blocks that must fall through for
+ * an unrelated failure, so a `TypeError` here would replace the real error with a bug.
+ */
+function as_error_fields(err: unknown): Record<string, unknown> {
+  return typeof err === 'object' && err !== null ? (err as Record<string, unknown>) : {};
 }

--- a/packages/m365-graph/src/graph-permission-errors.ts
+++ b/packages/m365-graph/src/graph-permission-errors.ts
@@ -1,0 +1,58 @@
+import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
+
+/**
+ * Graph failures that an operator has to act on rather than retry: a missing application
+ * permission and an unlicensed mailbox. Both carry the remediation steps in the message and a
+ * stable class and code for callers (issue #40).
+ */
+/**
+ * Detects 403 ErrorAccessDenied from Graph and rethrows with
+ * actionable guidance about which API permissions to grant.
+ */
+export function rethrow_if_access_denied(err: unknown): void {
+  const graph_err = err as Record<string, unknown>;
+  if (graph_err.statusCode !== 403) return;
+
+  const required = [
+    'Mail.Read              -- read mailbox messages',
+    'Mail.ReadWrite         -- delta sync and full message fetch',
+    'User.Read.All          -- list tenant users / mailboxes',
+    'MailboxSettings.Read   -- enumerate mail folders',
+  ];
+
+  const hint =
+    `Microsoft Graph returned 403 Forbidden (ErrorAccessDenied).\n` +
+    `The app registration needs these Application permissions with admin consent:\n\n` +
+    required.map((p) => `  - ${p}`).join('\n') +
+    `\n\n` +
+    `Grant them in Azure Portal > App registrations > API permissions > ` +
+    `Add a permission > Microsoft Graph > Application permissions, ` +
+    `then click "Grant admin consent".`;
+
+  throw new AuthError(hint, { cause: err });
+}
+
+/**
+ * Detects MailboxNotEnabledForRESTAPI from Graph and rethrows with
+ * actionable guidance about reassigning an Exchange Online license.
+ */
+export function rethrow_if_mailbox_not_licensed(err: unknown): void {
+  const graph_err = err as Record<string, unknown>;
+  const code = String(graph_err.code ?? '');
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (code === 'MailboxNotEnabledForRESTAPI' || message.includes('MailboxNotEnabledForRESTAPI')) {
+    throw new MailboxNotLicensedError(
+      `The mailbox is not licensed for API access (MailboxNotEnabledForRESTAPI).\n` +
+        `This typically happens when the user's Exchange Online license has been removed.\n` +
+        `The mailbox data is retained for 30 days after license removal, but cannot be\n` +
+        `accessed via the Graph API until a license is reassigned.\n\n` +
+        `To back up or restore this mailbox:\n` +
+        `  1. Reassign an Exchange Online license to the user in Microsoft 365 admin center\n` +
+        `  2. Wait a few minutes for the mailbox to reconnect\n` +
+        `  3. Run the operation again\n` +
+        `  4. Remove the license after the operation completes (if desired)`,
+      { cause: err },
+    );
+  }
+}

--- a/packages/m365-graph/src/graph-request-error-handler.ts
+++ b/packages/m365-graph/src/graph-request-error-handler.ts
@@ -60,57 +60,6 @@ export function is_invalid_delta_error(err: unknown): boolean {
   );
 }
 
-/**
- * Detects 403 ErrorAccessDenied from Graph and rethrows with
- * actionable guidance about which API permissions to grant.
- */
-export function rethrow_if_access_denied(err: unknown): void {
-  const graph_err = err as Record<string, unknown>;
-  if (graph_err.statusCode !== 403) return;
-
-  const required = [
-    'Mail.Read              -- read mailbox messages',
-    'Mail.ReadWrite         -- delta sync and full message fetch',
-    'User.Read.All          -- list tenant users / mailboxes',
-    'MailboxSettings.Read   -- enumerate mail folders',
-  ];
-
-  const hint =
-    `Microsoft Graph returned 403 Forbidden (ErrorAccessDenied).\n` +
-    `The app registration needs these Application permissions with admin consent:\n\n` +
-    required.map((p) => `  - ${p}`).join('\n') +
-    `\n\n` +
-    `Grant them in Azure Portal > App registrations > API permissions > ` +
-    `Add a permission > Microsoft Graph > Application permissions, ` +
-    `then click "Grant admin consent".`;
-
-  throw new Error(hint);
-}
-
-/**
- * Detects MailboxNotEnabledForRESTAPI from Graph and rethrows with
- * actionable guidance about reassigning an Exchange Online license.
- */
-export function rethrow_if_mailbox_not_licensed(err: unknown): void {
-  const graph_err = err as Record<string, unknown>;
-  const code = String(graph_err.code ?? '');
-  const message = err instanceof Error ? err.message : String(err);
-
-  if (code === 'MailboxNotEnabledForRESTAPI' || message.includes('MailboxNotEnabledForRESTAPI')) {
-    throw new Error(
-      `The mailbox is not licensed for API access (MailboxNotEnabledForRESTAPI).\n` +
-        `This typically happens when the user's Exchange Online license has been removed.\n` +
-        `The mailbox data is retained for 30 days after license removal, but cannot be\n` +
-        `accessed via the Graph API until a license is reassigned.\n\n` +
-        `To back up or restore this mailbox:\n` +
-        `  1. Reassign an Exchange Online license to the user in Microsoft 365 admin center\n` +
-        `  2. Wait a few minutes for the mailbox to reconnect\n` +
-        `  3. Run the operation again\n` +
-        `  4. Remove the license after the operation completes (if desired)`,
-    );
-  }
-}
-
 /** Returns true when the error carries a transient HTTP status (429, 500, 502, 503, 504). */
 export function is_transient_error(err: unknown): boolean {
   const status = (err as Record<string, unknown>).statusCode;

--- a/packages/m365-graph/src/index.ts
+++ b/packages/m365-graph/src/index.ts
@@ -2,8 +2,6 @@ export { create_graph_client, GRAPH_CLIENT_TOKEN } from './graph-client.factory'
 export { parse_retry_after_ms } from './graph-retry-after';
 export {
   is_invalid_delta_error,
-  rethrow_if_access_denied,
-  rethrow_if_mailbox_not_licensed,
   is_transient_error,
   is_network_error,
   is_retryable_error,
@@ -11,6 +9,10 @@ export {
   is_content_gone_error,
   with_graph_retry,
 } from './graph-request-error-handler';
+export {
+  rethrow_if_access_denied,
+  rethrow_if_mailbox_not_licensed,
+} from './graph-permission-errors';
 export {
   classify_download_failure,
   read_graph_error_code,

--- a/packages/m365-graph/tests/unit/graph-permission-errors.test.ts
+++ b/packages/m365-graph/tests/unit/graph-permission-errors.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
+import {
+  rethrow_if_access_denied,
+  rethrow_if_mailbox_not_licensed,
+} from '@/graph-permission-errors';
+
+describe('rethrow_if_mailbox_not_licensed', () => {
+  it('throws with actionable message when error code is MailboxNotEnabledForRESTAPI', () => {
+    const err = { code: 'MailboxNotEnabledForRESTAPI', statusCode: 403, message: '' };
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).toThrow('not licensed for API access');
+  });
+
+  // Issue #40: the guidance text is for the operator, the class and code are for the caller.
+  it('throws a MailboxNotLicensedError carrying the code and the original error', () => {
+    const err = { code: 'MailboxNotEnabledForRESTAPI', statusCode: 403, message: '' };
+
+    const failure = (() => {
+      try {
+        rethrow_if_mailbox_not_licensed(err);
+        return undefined;
+      } catch (caught) {
+        return caught as MailboxNotLicensedError;
+      }
+    })();
+
+    expect(failure).toBeInstanceOf(MailboxNotLicensedError);
+    expect(failure?.code).toBe('ATLAS_MAILBOX_NOT_LICENSED');
+    expect(failure?.cause).toBe(err);
+  });
+
+  it('throws when MailboxNotEnabledForRESTAPI appears in error message', () => {
+    const err = new Error('The mailbox is not enabled (MailboxNotEnabledForRESTAPI)');
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).toThrow(
+      'Reassign an Exchange Online license',
+    );
+  });
+
+  it('does not throw for unrelated errors', () => {
+    const err = { code: 'ErrorItemNotFound', statusCode: 404, message: 'Not found' };
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).not.toThrow();
+  });
+
+  it('does not throw for access denied errors (handled separately)', () => {
+    const err = { code: 'ErrorAccessDenied', statusCode: 403, message: 'Forbidden' };
+
+    expect(() => rethrow_if_mailbox_not_licensed(err)).not.toThrow();
+  });
+});
+
+describe('rethrow_if_access_denied', () => {
+  it('throws an AuthError distinguishable from an unlicensed mailbox', () => {
+    const failure = (() => {
+      try {
+        rethrow_if_access_denied({ statusCode: 403 });
+        return undefined;
+      } catch (caught) {
+        return caught as AuthError;
+      }
+    })();
+
+    expect(failure).toBeInstanceOf(AuthError);
+    expect(failure).not.toBeInstanceOf(MailboxNotLicensedError);
+    expect(failure?.code).toBe('ATLAS_AUTH_DENIED');
+  });
+
+  it('throws with permission guidance on 403', () => {
+    const err = { statusCode: 403 };
+
+    expect(() => rethrow_if_access_denied(err)).toThrow('403 Forbidden');
+  });
+
+  it('does not throw for non-403 errors', () => {
+    const err = { statusCode: 404 };
+
+    expect(() => rethrow_if_access_denied(err)).not.toThrow();
+  });
+});

--- a/packages/m365-graph/tests/unit/graph-permission-errors.test.ts
+++ b/packages/m365-graph/tests/unit/graph-permission-errors.test.ts
@@ -79,3 +79,19 @@ describe('rethrow_if_access_denied', () => {
     expect(() => rethrow_if_access_denied(err)).not.toThrow();
   });
 });
+
+describe('non-object throwables', () => {
+  // Both helpers run inside `catch` blocks and must fall through for anything they do not
+  // recognise. A rejected promise can carry `null`, and reading a field off it would replace the
+  // real failure with a TypeError.
+  it.each([[null], [undefined], ['a string'], [42]])('falls through for %s', (value) => {
+    expect(() => rethrow_if_access_denied(value)).not.toThrow();
+    expect(() => rethrow_if_mailbox_not_licensed(value)).not.toThrow();
+  });
+
+  it('still recognises the licensing failure in a bare string', () => {
+    expect(() => rethrow_if_mailbox_not_licensed('MailboxNotEnabledForRESTAPI')).toThrow(
+      MailboxNotLicensedError,
+    );
+  });
+});

--- a/packages/m365-graph/tests/unit/graph-request-error-handler.test.ts
+++ b/packages/m365-graph/tests/unit/graph-request-error-handler.test.ts
@@ -1,55 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
-  rethrow_if_access_denied,
-  rethrow_if_mailbox_not_licensed,
   is_invalid_delta_error,
   is_transient_error,
   is_network_error,
   is_retryable_error,
   with_graph_retry,
 } from '@/graph-request-error-handler';
-
-describe('rethrow_if_mailbox_not_licensed', () => {
-  it('throws with actionable message when error code is MailboxNotEnabledForRESTAPI', () => {
-    const err = { code: 'MailboxNotEnabledForRESTAPI', statusCode: 403, message: '' };
-
-    expect(() => rethrow_if_mailbox_not_licensed(err)).toThrow('not licensed for API access');
-  });
-
-  it('throws when MailboxNotEnabledForRESTAPI appears in error message', () => {
-    const err = new Error('The mailbox is not enabled (MailboxNotEnabledForRESTAPI)');
-
-    expect(() => rethrow_if_mailbox_not_licensed(err)).toThrow(
-      'Reassign an Exchange Online license',
-    );
-  });
-
-  it('does not throw for unrelated errors', () => {
-    const err = { code: 'ErrorItemNotFound', statusCode: 404, message: 'Not found' };
-
-    expect(() => rethrow_if_mailbox_not_licensed(err)).not.toThrow();
-  });
-
-  it('does not throw for access denied errors (handled separately)', () => {
-    const err = { code: 'ErrorAccessDenied', statusCode: 403, message: 'Forbidden' };
-
-    expect(() => rethrow_if_mailbox_not_licensed(err)).not.toThrow();
-  });
-});
-
-describe('rethrow_if_access_denied', () => {
-  it('throws with permission guidance on 403', () => {
-    const err = { statusCode: 403 };
-
-    expect(() => rethrow_if_access_denied(err)).toThrow('403 Forbidden');
-  });
-
-  it('does not throw for non-403 errors', () => {
-    const err = { statusCode: 404 };
-
-    expect(() => rethrow_if_access_denied(err)).not.toThrow();
-  });
-});
 
 describe('is_invalid_delta_error', () => {
   it('detects syncStateNotFound', () => {

--- a/packages/onedrive/package.json
+++ b/packages/onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-onedrive",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
@@ -1,9 +1,23 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { stream_whole_file_in_chunks } from '@wisecom/atlas-drive/backup/whole-file-stream';
 import {
   is_retryable_error,
   is_transient_error,
   parse_retry_after_ms,
 } from '@wisecom/atlas-m365-graph';
+
+/**
+ * Raised when the server answers a Range request with the whole file.
+ *
+ * It is a property of the server, not of the chunk, so the caller stops asking for ranges
+ * entirely rather than re-discovering it once per chunk (issue #301).
+ */
+class RangeIgnoredError extends Error {
+  constructor() {
+    super('Range header ignored');
+    this.name = 'RangeIgnoredError';
+  }
+}
 
 /** Maximum bytes per HTTP Range chunk (4 MiB). */
 export const CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
@@ -37,16 +51,30 @@ export async function* fetch_file_chunks(
     const range_end = Math.min(range_start + CHUNK_SIZE_BYTES - 1, total_bytes - 1);
     const expected_length = range_end - range_start + 1;
 
-    yield await download_chunk_with_retry(
-      download_url,
-      range_start,
-      range_end,
-      expected_length,
-      item_id,
-      i + 1,
-      chunk_count,
-      total_bytes,
-    );
+    try {
+      yield await download_chunk_with_retry(
+        download_url,
+        range_start,
+        range_end,
+        expected_length,
+        item_id,
+        i + 1,
+        chunk_count,
+        total_bytes,
+        chunk_count > 1,
+      );
+    } catch (err) {
+      if (!(err instanceof RangeIgnoredError)) throw err;
+      // Every remaining chunk would fetch and discard the same whole file: a 1 GiB item costs
+      // 256 GiB transferred to produce 1 GiB. One streamed pass delivers the rest, and the
+      // chunks already yielded are re-read from the start, which is the price of finding out.
+      logger.warn(
+        `Range requests are ignored for ${item_id} (HTTP 200 with the full body); ` +
+          `falling back to one streamed download`,
+      );
+      yield* stream_whole_file_in_chunks(download_url, item_id, CHUNK_SIZE_BYTES);
+      return;
+    }
   }
 }
 
@@ -76,6 +104,7 @@ async function download_chunk_with_retry(
   chunk_index: number,
   total_chunks: number,
   total_bytes: number,
+  report_ignored_range: boolean,
 ): Promise<Buffer> {
   for (let attempt = 0; attempt <= MAX_CHUNK_RETRIES; attempt++) {
     try {
@@ -86,8 +115,11 @@ async function download_chunk_with_retry(
         expected_length,
         item_id,
         total_bytes,
+        report_ignored_range,
       );
     } catch (err) {
+      // Not retryable and not a failure: the caller switches strategy on it.
+      if (err instanceof RangeIgnoredError) throw err;
       if (!is_cdn_retryable(err) || attempt === MAX_CHUNK_RETRIES) {
         throw new Error(
           `Failed chunk ${chunk_index}/${total_chunks} of ${item_id} ` +
@@ -126,6 +158,7 @@ async function download_single_chunk(
   expected_length: number,
   item_id: string,
   total_bytes: number,
+  report_ignored_range: boolean,
 ): Promise<Buffer> {
   // Scaled to this chunk, not to the file. Passing total_bytes here gave every
   // non-final chunk a ceil(total_bytes / 256) ms budget, so one stalled CDN
@@ -159,6 +192,12 @@ async function download_single_chunk(
     // the body about to be drained is total_bytes rather than one chunk. Only
     // that case needs the whole-file budget, and by now it is known rather than
     // assumed, so re-arm before reading instead of pre-paying on every chunk.
+    if (response.status === 200 && report_ignored_range) {
+      // Drop the body unread: buffering a whole file per chunk is the cost this avoids.
+      await response.body?.cancel();
+      throw new RangeIgnoredError();
+    }
+
     if (response.status === 200) {
       clearTimeout(timer);
       timer = setTimeout(() => controller.abort(), compute_chunk_timeout_ms(total_bytes));
@@ -167,10 +206,7 @@ async function download_single_chunk(
     const buf = Buffer.from(await response.arrayBuffer());
 
     if (response.status === 200) {
-      logger.warn(
-        `CDN returned HTTP 200 instead of 206 for Range request on ${item_id} — ` +
-          `server ignored Range header, slicing ${buf.length} bytes to expected range`,
-      );
+      // A single-chunk item legitimately comes back whole, so the slice is a no-op there.
       if (buf.length < range_end + 1) {
         throw new CdnHttpError(
           `CDN returned 200 with ${buf.length} bytes but range_end is ${range_end} for ${item_id}`,

--- a/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
@@ -72,7 +72,12 @@ export async function* fetch_file_chunks(
         `Range requests are ignored for ${item_id} (HTTP 200 with the full body); ` +
           `falling back to one streamed download`,
       );
-      yield* stream_whole_file_in_chunks(download_url, item_id, CHUNK_SIZE_BYTES);
+      yield* stream_whole_file_in_chunks(download_url, item_id, {
+        chunk_size_bytes: CHUNK_SIZE_BYTES,
+        // Same per-chunk budget the Range path uses, applied between reads rather than to the
+        // whole transfer, so a stalled body is cut off but a slow one is not (issue #198).
+        stall_timeout_ms: compute_chunk_timeout_ms(CHUNK_SIZE_BYTES),
+      });
       return;
     }
   }

--- a/packages/onedrive/src/services/backup/backup-builders.ts
+++ b/packages/onedrive/src/services/backup/backup-builders.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the SharePoint copy (#306): 68 differing lines of 432. The
+// manifests they build differ in their identity fields and in what each provider records per
+// entry, so the shared version would be generic over almost every line.
 import type {
   OneDriveBackupResult,
   OneDriveChangeType,

--- a/packages/onedrive/src/services/backup/backup-file-processor.ts
+++ b/packages/onedrive/src/services/backup/backup-file-processor.ts
@@ -1,19 +1,11 @@
-import { createHash } from 'node:crypto';
 import type { OneDriveConnector, OneDriveDeltaItem, TenantContext } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
-import { is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
-import { download_with_retry } from '@wisecom/atlas-drive/backup/download-retry';
-import { LARGE_FILE_THRESHOLD, process_large_file } from '@/services/backup/large-file-pipeline';
-import { onedrive_data_key } from '@/services/shared/storage-keys';
+import {
+  process_drive_backup_file,
+  type FileProcessResult,
+} from '@wisecom/atlas-drive/backup/file-processor';
+import { ONEDRIVE_LARGE_FILE_DEPS } from '@/services/backup/large-file-pipeline';
 
-const HASH_CHUNK_SIZE = 64 * 1024 * 1024;
-
-export interface FileProcessResult {
-  storage_key: string;
-  checksum: string;
-  stored: boolean;
-  deduplicated: boolean;
-}
+export type { FileProcessResult } from '@wisecom/atlas-drive/backup/file-processor';
 
 /** Downloads or deduplicates a single delta file item. */
 export async function process_backup_file(
@@ -22,33 +14,7 @@ export async function process_backup_file(
   owner_id: string,
   ctx: TenantContext,
 ): Promise<FileProcessResult | undefined> {
-  if (item.size_bytes >= LARGE_FILE_THRESHOLD) {
-    try {
-      return await process_large_file(connector, item, owner_id, ctx);
-    } catch (err) {
-      // A missing grant or a service refusal is not a skip: it must reach the caller
-      // so the run can name the cause instead of reporting a lost file (issue #246).
-      if (is_unretryable_download_failure(err)) throw err;
-      logger.warn(
-        `Skipping large file ${item.item_id} (${item.file_name}): ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-
-  const raw_body = await download_with_retry(connector, item);
-  if (!raw_body) return undefined;
-
-  const checksum = compute_sha256_chunked(raw_body);
-  const storage_key = onedrive_data_key(owner_id, checksum);
-  const exists = await ctx.storage.exists(storage_key);
-
-  if (!exists) {
-    await ctx.storage.put(storage_key, ctx.encrypt(raw_body));
-    return { storage_key, checksum, stored: true, deduplicated: false };
-  }
-
-  return { storage_key, checksum, stored: false, deduplicated: true };
+  return process_drive_backup_file(ONEDRIVE_LARGE_FILE_DEPS, connector, item, owner_id, ctx);
 }
 
 /** @throws Error when no drives are returned (likely missing Graph permissions). */
@@ -57,13 +23,4 @@ export function ensure_drives_discovered(drive_count: number): void {
   throw new Error(
     'Missing Microsoft Graph application permissions for OneDrive: Files.Read.All, Sites.Read.All.',
   );
-}
-
-/** Computes SHA-256 in chunks to avoid ERR_OUT_OF_RANGE on buffers > 2 GB. */
-function compute_sha256_chunked(data: Buffer): string {
-  const hash = createHash('sha256');
-  for (let offset = 0; offset < data.length; offset += HASH_CHUNK_SIZE) {
-    hash.update(data.subarray(offset, Math.min(offset + HASH_CHUNK_SIZE, data.length)));
-  }
-  return hash.digest('hex');
 }

--- a/packages/onedrive/src/services/backup/backup.service.ts
+++ b/packages/onedrive/src/services/backup/backup.service.ts
@@ -1,3 +1,7 @@
+// Deliberately not shared with the SharePoint copy (#306): 306 differing lines of 604. OneDrive
+// enumerates an owner's drives and carries a folder scope and a per-drive delta cursor;
+// SharePoint walks a site tree, then libraries within it, and has no folder scope. Unifying
+// them means a parameter per branch, which is the shape that made the copies hard to change.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { randomBytes } from 'node:crypto';
 import {

--- a/packages/onedrive/src/services/backup/change-classifier.ts
+++ b/packages/onedrive/src/services/backup/change-classifier.ts
@@ -16,30 +16,55 @@ export function classify_change_type(
   const previous_path = previous_path_by_file_id[item.item_id];
   const previous_name = previous_name_by_file_id[item.item_id];
   const previous_etag = previous_etag_by_file_id[item.item_id];
-  const current_path = item.parent_path;
-  const path_changed = Boolean(previous_path && previous_path !== current_path);
-  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
-  const etag_changed = Boolean(previous_etag && item.etag && previous_etag !== item.etag);
-  const etag_presence_changed = Boolean(previous_etag) !== Boolean(item.etag);
-  const both_etags_missing =
-    Boolean(previous_path || previous_name || previous_etag) && !previous_etag && !item.etag;
   const previously_known = Boolean(previous_path || previous_name || previous_etag);
 
   if (!previously_known) return 'created';
+
+  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
+  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
+  const etags_missing = !previous_etag && !item.etag;
+
   // Relocation before content: an item that moved and changed in the same delta window carries
   // both signals, and the ETag branch used to answer first, erasing the move from the change
   // record (issue #297). The new content blob makes the update self-evident; the old location
   // is only recorded here. Content is downloaded either way, so the label is all that moves.
-  if (path_changed && name_changed) return 'moved_and_renamed';
-  if (path_changed) return 'moved';
-  if (name_changed) return 'renamed';
-  if (etag_changed || etag_presence_changed || both_etags_missing) {
-    if (both_etags_missing) {
-      logger.warn(
-        `OneDrive delta item ${item.item_id}: missing etag on prior and current snapshot; classifying as updated`,
-      );
-    }
+  const relocation = relocation_label(path_changed, name_changed);
+  if (relocation) {
+    // Still worth saying when both ETags are absent: the relocation is certain, but with no ETag
+    // on either side a content change alongside it cannot be detected at all.
+    if (etags_missing) warn_missing_etag(item.item_id);
+    return relocation;
+  }
+
+  if (is_etag_transition(previous_etag, item.etag)) {
+    if (etags_missing) warn_missing_etag(item.item_id);
     return 'updated';
   }
   return undefined;
+}
+
+/** Which relocation happened, if any: the label an operator uses to find where a file went. */
+function relocation_label(
+  path_changed: boolean,
+  name_changed: boolean,
+): OneDriveChangeType | undefined {
+  if (path_changed && name_changed) return 'moved_and_renamed';
+  if (path_changed) return 'moved';
+  if (name_changed) return 'renamed';
+  return undefined;
+}
+
+/** Any ETag movement for an item already known, including one absent on both sides. */
+function is_etag_transition(
+  previous_etag: string | undefined,
+  current_etag: string | undefined,
+): boolean {
+  if (previous_etag && current_etag) return previous_etag !== current_etag;
+  return true;
+}
+
+function warn_missing_etag(item_id: string): void {
+  logger.warn(
+    `OneDrive delta item ${item_id}: missing etag on prior and current snapshot; a content change cannot be detected`,
+  );
 }

--- a/packages/onedrive/src/services/backup/change-classifier.ts
+++ b/packages/onedrive/src/services/backup/change-classifier.ts
@@ -1,5 +1,5 @@
 import type { OneDriveChangeType, OneDriveDeltaItem } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
+import { classify_drive_change } from '@wisecom/atlas-drive/backup/change-classifier';
 
 /**
  * Determines the type of change for a delta item based on previous state.
@@ -11,60 +11,11 @@ export function classify_change_type(
   previous_name_by_file_id: Record<string, string>,
   previous_etag_by_file_id: Record<string, string>,
 ): OneDriveChangeType | undefined {
-  if (item.deleted) return 'deleted';
-
-  const previous_path = previous_path_by_file_id[item.item_id];
-  const previous_name = previous_name_by_file_id[item.item_id];
-  const previous_etag = previous_etag_by_file_id[item.item_id];
-  const previously_known = Boolean(previous_path || previous_name || previous_etag);
-
-  if (!previously_known) return 'created';
-
-  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
-  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
-  const etags_missing = !previous_etag && !item.etag;
-
-  // Relocation before content: an item that moved and changed in the same delta window carries
-  // both signals, and the ETag branch used to answer first, erasing the move from the change
-  // record (issue #297). The new content blob makes the update self-evident; the old location
-  // is only recorded here. Content is downloaded either way, so the label is all that moves.
-  const relocation = relocation_label(path_changed, name_changed);
-  if (relocation) {
-    // Still worth saying when both ETags are absent: the relocation is certain, but with no ETag
-    // on either side a content change alongside it cannot be detected at all.
-    if (etags_missing) warn_missing_etag(item.item_id);
-    return relocation;
-  }
-
-  if (is_etag_transition(previous_etag, item.etag)) {
-    if (etags_missing) warn_missing_etag(item.item_id);
-    return 'updated';
-  }
-  return undefined;
-}
-
-/** Which relocation happened, if any: the label an operator uses to find where a file went. */
-function relocation_label(
-  path_changed: boolean,
-  name_changed: boolean,
-): OneDriveChangeType | undefined {
-  if (path_changed && name_changed) return 'moved_and_renamed';
-  if (path_changed) return 'moved';
-  if (name_changed) return 'renamed';
-  return undefined;
-}
-
-/** Any ETag movement for an item already known, including one absent on both sides. */
-function is_etag_transition(
-  previous_etag: string | undefined,
-  current_etag: string | undefined,
-): boolean {
-  if (previous_etag && current_etag) return previous_etag !== current_etag;
-  return true;
-}
-
-function warn_missing_etag(item_id: string): void {
-  logger.warn(
-    `OneDrive delta item ${item_id}: missing etag on prior and current snapshot; a content change cannot be detected`,
+  return classify_drive_change(
+    'OneDrive',
+    item,
+    previous_path_by_file_id,
+    previous_name_by_file_id,
+    previous_etag_by_file_id,
   );
 }

--- a/packages/onedrive/src/services/backup/change-classifier.ts
+++ b/packages/onedrive/src/services/backup/change-classifier.ts
@@ -26,6 +26,13 @@ export function classify_change_type(
   const previously_known = Boolean(previous_path || previous_name || previous_etag);
 
   if (!previously_known) return 'created';
+  // Relocation before content: an item that moved and changed in the same delta window carries
+  // both signals, and the ETag branch used to answer first, erasing the move from the change
+  // record (issue #297). The new content blob makes the update self-evident; the old location
+  // is only recorded here. Content is downloaded either way, so the label is all that moves.
+  if (path_changed && name_changed) return 'moved_and_renamed';
+  if (path_changed) return 'moved';
+  if (name_changed) return 'renamed';
   if (etag_changed || etag_presence_changed || both_etags_missing) {
     if (both_etags_missing) {
       logger.warn(
@@ -34,8 +41,5 @@ export function classify_change_type(
     }
     return 'updated';
   }
-  if (path_changed && name_changed) return 'moved_and_renamed';
-  if (path_changed) return 'moved';
-  if (name_changed) return 'renamed';
   return undefined;
 }

--- a/packages/onedrive/src/services/backup/large-file-pipeline.ts
+++ b/packages/onedrive/src/services/backup/large-file-pipeline.ts
@@ -1,32 +1,24 @@
-import { fetch_file_chunks } from '@/adapters/graph-onedrive-chunked-download';
+import type { StorageObjectLockPolicy, TenantContext } from '@wisecom/atlas-types';
+import type { OneDriveConnector, OneDriveDeltaItem } from '@wisecom/atlas-types';
 import {
-  onedrive_data_key,
-  onedrive_staging_key,
-  onedrive_staging_prefix,
-} from '@/services/shared/storage-keys';
-import { logger } from '@wisecom/atlas-core/utils/logger';
-import { stream_to_content_addressed_storage } from '@wisecom/atlas-core/services/shared/stream-encrypt-upload';
-import type {
-  OneDriveConnector,
-  OneDriveDeltaItem,
-  StorageObjectLockPolicy,
-  TenantContext,
-} from '@wisecom/atlas-types';
+  cleanup_stale_drive_staging,
+  process_large_drive_file,
+  type DriveLargeFileDeps,
+  type LargeFileResult,
+} from '@wisecom/atlas-drive/backup/large-file-pipeline';
+import { fetch_file_chunks } from '@/adapters/graph-onedrive-chunked-download';
+import { ONEDRIVE_KEYS } from '@/services/shared/storage-keys';
 
 export { LARGE_FILE_THRESHOLD } from '@wisecom/atlas-drive/backup/large-file-threshold';
+export type { LargeFileResult } from '@wisecom/atlas-drive/backup/large-file-pipeline';
 
-export interface LargeFileResult {
-  readonly checksum: string;
-  readonly storage_key: string;
-  readonly stored: boolean;
-  readonly deduplicated: boolean;
-}
+/** OneDrive's half of the shared large-file pipeline: its key layout and its chunk fetcher. */
+export const ONEDRIVE_LARGE_FILE_DEPS: DriveLargeFileDeps = {
+  keys: ONEDRIVE_KEYS,
+  fetch_chunks: fetch_file_chunks,
+};
 
-/**
- * Single-download, zero-disk pipeline for files at or above
- * {@link LARGE_FILE_THRESHOLD}. Streams encrypted parts to an S3 staging key,
- * then either aborts (dedup) or copies to the canonical content-addressed key.
- */
+/** Streams a large file to storage through a staging key, deduplicating by content hash. */
 export async function process_large_file(
   connector: OneDriveConnector,
   item: OneDriveDeltaItem,
@@ -34,56 +26,17 @@ export async function process_large_file(
   ctx: TenantContext,
   object_lock_policy?: StorageObjectLockPolicy,
 ): Promise<LargeFileResult> {
-  const download_url = item.download_url ?? (await connector.resolve_download_url(item));
-  if (!download_url) {
-    throw new Error(`Could not resolve download URL for large file ${item.item_id}`);
-  }
-
-  const staging_key = onedrive_staging_key(owner_id, item.item_id);
-
-  logger.info(
-    `Streaming large file ${item.file_name} (${format_bytes(item.size_bytes)}) via staging key...`,
-  );
-
-  const result = await stream_to_content_addressed_storage(
+  return process_large_drive_file(
+    ONEDRIVE_LARGE_FILE_DEPS,
+    connector,
+    item,
+    owner_id,
     ctx,
-    fetch_file_chunks(download_url, item.size_bytes, item.item_id),
-    {
-      staging_key,
-      staging_prefix: onedrive_staging_prefix(owner_id),
-      build_data_key: (checksum) => onedrive_data_key(owner_id, checksum),
-      ...(object_lock_policy && { object_lock_policy }),
-    },
+    object_lock_policy,
   );
-
-  if (result.deduplicated) {
-    logger.info(`Deduplicated ${item.file_name} (already stored)`);
-  } else {
-    logger.info(`Stored ${item.file_name} (${format_bytes(item.size_bytes)})`);
-  }
-
-  return result;
 }
 
 /** Removes leftover staging objects and incomplete multipart uploads. */
 export async function cleanup_stale_staging(ctx: TenantContext, owner_id: string): Promise<void> {
-  const prefix = onedrive_staging_prefix(owner_id);
-
-  const stale_keys = await ctx.storage.list(prefix);
-  for (const key of stale_keys) {
-    logger.info(`Cleaning up stale staging object: ${key}`);
-    await ctx.storage.delete(key).catch(() => {});
-  }
-
-  const aborted = await ctx.storage.abort_incomplete_uploads(prefix);
-  if (aborted > 0) {
-    logger.info(`Aborted ${aborted} incomplete staging upload(s)`);
-  }
-}
-
-function format_bytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+  return cleanup_stale_drive_staging(ONEDRIVE_KEYS, ctx, owner_id);
 }

--- a/packages/onedrive/src/services/restore/restore-folder-path.ts
+++ b/packages/onedrive/src/services/restore/restore-folder-path.ts
@@ -1,17 +1,11 @@
-// Deliberately not shared with the SharePoint copy (#306): 28 differing lines of 106. The memo
-// keys differ, path here against `drive_id:path` there, which is a behavioural difference
-// rather than a naming one and is tracked separately.
 import type { OneDriveConnector } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
+import { ensure_drive_folder_path } from '@wisecom/atlas-drive/restore/folder-path';
 
 /**
  * Resolves a restore-side path to a drive item id, creating the folders that are missing.
  *
- * `folder_ids` is the per-restore memo, keyed by path, so a restore root shared by every entry is
- * created once rather than once per file. Returns undefined when a segment could not be created;
- * the caller reports that entry as skipped, which is what keeps one over-long path from aborting
- * the run. Mirrors `ensure_sharepoint_folder_path`, which keys by `drive_id:path` because a
- * SharePoint snapshot spans several libraries.
+ * `folder_ids` is the per-restore memo, keyed by `drive_id:path` so that two of the owner's
+ * drives holding the same path do not resolve to one folder (issue #316).
  */
 export async function ensure_onedrive_folder_path(
   connector: OneDriveConnector,
@@ -21,39 +15,5 @@ export async function ensure_onedrive_folder_path(
   path: string,
   folder_ids: Map<string, string>,
 ): Promise<string | undefined> {
-  const normalized = path.length === 0 || path === '.' ? '/' : path;
-  const cached = folder_ids.get(normalized);
-  if (cached !== undefined) return cached;
-
-  const segments = normalized.split('/').filter(Boolean);
-  let current_path = '';
-  let parent_id = 'root';
-
-  for (const segment of segments) {
-    current_path = current_path ? `${current_path}/${segment}` : `/${segment}`;
-    const known = folder_ids.get(current_path);
-    if (known !== undefined) {
-      parent_id = known;
-      continue;
-    }
-
-    try {
-      const folder_id = await connector.create_folder(
-        tenant_id,
-        owner_id,
-        drive_id,
-        parent_id,
-        segment,
-      );
-      folder_ids.set(current_path, folder_id);
-      parent_id = folder_id;
-    } catch (err) {
-      logger.warn(
-        `Failed to create folder ${current_path}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-
-  return parent_id;
+  return ensure_drive_folder_path(connector, tenant_id, owner_id, drive_id, path, folder_ids);
 }

--- a/packages/onedrive/src/services/restore/restore-folder-path.ts
+++ b/packages/onedrive/src/services/restore/restore-folder-path.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the SharePoint copy (#306): 28 differing lines of 106. The memo
+// keys differ, path here against `drive_id:path` there, which is a behavioural difference
+// rather than a naming one and is tracked separately.
 import type { OneDriveConnector } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 

--- a/packages/onedrive/src/services/restore/restore.service.ts
+++ b/packages/onedrive/src/services/restore/restore.service.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the SharePoint copy (#306): 194 differing lines of 496. The
+// restore target differs in kind, an owner's drive against a resolved site and library, and
+// so does the conflict handling around the restore root.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import {
   begin_operation_progress,

--- a/packages/onedrive/src/services/restore/restore.service.ts
+++ b/packages/onedrive/src/services/restore/restore.service.ts
@@ -38,6 +38,7 @@ import {
   resolve_restore_root,
   restore_parent_path,
 } from '@wisecom/atlas-core/services/shared/restore-destination';
+import { count_created_folders } from '@wisecom/atlas-drive/restore/folder-path';
 import { ensure_onedrive_folder_path } from '@/services/restore/restore-folder-path';
 
 const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
@@ -87,7 +88,6 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       assert_renameable(options.rename_to, restorable.length);
       const restore_root = resolve_restore_root(options);
       const folder_ids = new Map<string, string>();
-      folder_ids.set('/', 'root');
 
       let files_restored = 0;
       let files_skipped = 0;
@@ -129,7 +129,7 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
         });
       }
 
-      const folders_created = Math.max(0, folder_ids.size - 1);
+      const folders_created = count_created_folders(folder_ids);
       const interrupted = finish_operation_progress(
         options,
         'restore',

--- a/packages/onedrive/src/services/status/status.service.ts
+++ b/packages/onedrive/src/services/status/status.service.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the SharePoint copy (#306): 71 differing lines of 247. Both
+// peek at delta state, but over drives against libraries, with different discovery calls and
+// different result shapes exposed through the ports.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {

--- a/packages/onedrive/src/services/status/status.service.ts
+++ b/packages/onedrive/src/services/status/status.service.ts
@@ -56,7 +56,10 @@ export class OneDriveStatusService implements OneDriveStatusUseCase {
         last_snapshot_id: previous?.snapshot_id,
         total_drives: all_drives.length,
         drives: drive_statuses,
-        is_up_to_date: total_pending === 0 && drive_statuses.every((d) => d.has_backup),
+        // Every drive's own flag, not the pending total: a drive with no saved delta link and a
+        // drive whose peek threw both report `pending_changes: 0`, and the second also reports
+        // `has_backup: true`, so a Graph error used to read as a clean "up to date" (issue #298).
+        is_up_to_date: drive_statuses.every((d) => d.is_up_to_date),
         total_pending_changes: total_pending,
       };
     } finally {

--- a/packages/onedrive/tests/unit/adapters/graph-chunked-download.test.ts
+++ b/packages/onedrive/tests/unit/adapters/graph-chunked-download.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { download_file_chunked } from '@/adapters/graph-onedrive-chunked-download';
 
@@ -13,9 +14,17 @@ function to_array_buffer(body: Buffer): ArrayBuffer {
 function range_response(status: number, body = Buffer.alloc(0)): Response {
   return {
     status,
+    ok: status >= 200 && status < 300,
     headers: { get: (): string | null => null },
     arrayBuffer: (): Promise<ArrayBuffer> => Promise.resolve(to_array_buffer(body)),
     text: (): Promise<string> => Promise.resolve(''),
+    // The Range-ignored path cancels the body unread, and the streamed fallback iterates it.
+    body: {
+      cancel: (): Promise<void> => Promise.resolve(),
+      async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+        yield new Uint8Array(body);
+      },
+    },
   } as unknown as Response;
 }
 
@@ -53,5 +62,24 @@ describe('download_file_chunked', () => {
       download_file_chunked('https://cdn.test/file', payload.length, 'item-1'),
     ).rejects.toThrow('HTTP 404');
     expect(fetch_mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops asking for ranges once the CDN answers one with the whole file (issue #301)', async () => {
+    vi.useRealTimers();
+    const chunk_size = 4 * 1024 * 1024;
+    const whole = Buffer.alloc(chunk_size + 1024, 1);
+    const fetch_mock = vi.fn().mockResolvedValue(range_response(200, whole));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    const body = await download_file_chunked('https://cdn.test/file', whole.length, 'item-1');
+
+    // Two requests, not one per chunk: the Range probe, then one streamed download. Asking per
+    // chunk fetched the whole file every time, so a 1 GiB item moved 256 GiB.
+    expect(fetch_mock).toHaveBeenCalledTimes(2);
+    expect((fetch_mock.mock.calls[1] as unknown[])[1]).toBeUndefined();
+    expect(body.length).toBe(whole.length);
+    expect(createHash('sha256').update(body).digest('hex')).toBe(
+      createHash('sha256').update(whole).digest('hex'),
+    );
   });
 });

--- a/packages/onedrive/tests/unit/adapters/graph-chunked-download.test.ts
+++ b/packages/onedrive/tests/unit/adapters/graph-chunked-download.test.ts
@@ -76,7 +76,13 @@ describe('download_file_chunked', () => {
     // Two requests, not one per chunk: the Range probe, then one streamed download. Asking per
     // chunk fetched the whole file every time, so a 1 GiB item moved 256 GiB.
     expect(fetch_mock).toHaveBeenCalledTimes(2);
-    expect((fetch_mock.mock.calls[1] as unknown[])[1]).toBeUndefined();
+    // The streamed request carries no Range header, only the stall-abort signal.
+    const streamed_init = (fetch_mock.mock.calls[1] as unknown[])[1] as {
+      headers?: Record<string, string>;
+      signal?: AbortSignal;
+    };
+    expect(streamed_init.headers).toBeUndefined();
+    expect(streamed_init.signal).toBeInstanceOf(AbortSignal);
     expect(body.length).toBe(whole.length);
     expect(createHash('sha256').update(body).digest('hex')).toBe(
       createHash('sha256').update(whole).digest('hex'),

--- a/packages/onedrive/tests/unit/adapters/s3-delta-cursor-repository.test.ts
+++ b/packages/onedrive/tests/unit/adapters/s3-delta-cursor-repository.test.ts
@@ -82,14 +82,23 @@ describe('S3OneDriveDeltaCursorRepository', () => {
   });
 
   it('reads an undecryptable cursor as absent rather than throwing', async () => {
-    const { ctx } = make_ctx(
-      { [CURSOR_KEY]: make_cursor() },
-      {
-        [CURSOR_KEY]: new Error('unable to authenticate data'),
-      },
-    );
+    const { ctx } = make_ctx({ [CURSOR_KEY]: make_cursor() });
+    // The object reads back fine and fails to decrypt, which is the case a wrong or rotated key
+    // produces. Failing the read instead would exercise the storage path, not this one.
+    (ctx as unknown as { decrypt: () => Buffer }).decrypt = () => {
+      throw new Error('unable to authenticate data');
+    };
 
     // A full re-enumeration is recoverable; a crash on every run is not.
+    await expect(repo.load(ctx, OWNER)).resolves.toBeUndefined();
+  });
+
+  it('reads a cursor whose object cannot be fetched as absent rather than throwing', async () => {
+    const { ctx } = make_ctx(
+      { [CURSOR_KEY]: make_cursor() },
+      { [CURSOR_KEY]: new Error('connection reset') },
+    );
+
     await expect(repo.load(ctx, OWNER)).resolves.toBeUndefined();
   });
 

--- a/packages/onedrive/tests/unit/adapters/s3-manifest-repository.test.ts
+++ b/packages/onedrive/tests/unit/adapters/s3-manifest-repository.test.ts
@@ -127,6 +127,12 @@ describe('S3OneDriveManifestRepository', () => {
       {
         'onedrive/manifests/owner-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
         'onedrive/manifests/owner-1/snap-corrupt.json': 'not-json',
+        // Listed so the injected get() failure below is actually reached: list() is derived
+        // from the stored keys, so a key present only in get_error is never read.
+        'onedrive/manifests/owner-1/snap-unreadable.json': make_manifest(
+          'snap-unreadable',
+          '2026-03-02T00:00:00Z',
+        ),
       },
       { 'onedrive/manifests/owner-1/snap-unreadable.json': new Error('decrypt failed') },
     );

--- a/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
@@ -79,7 +79,11 @@ describe('classify_change_type', () => {
 
     // No etag on either side: the move is certain, a content change alongside it is invisible.
     expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, {})).toBe('moved');
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing etag'));
+    // The whole line, not a substring: a message change should show up here as a diff.
+    expect(warn).toHaveBeenCalledWith(
+      'OneDrive delta item item-1: missing etag on prior and current snapshot; ' +
+        'a content change cannot be detected',
+    );
 
     warn.mockRestore();
   });

--- a/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
+import { classify_change_type } from '@/services/backup/change-classifier';
+
+function make_item(overrides: Partial<OneDriveDeltaItem> = {}): OneDriveDeltaItem {
+  return {
+    item_id: 'item-1',
+    drive_id: 'drive-1',
+    file_name: 'report.docx',
+    parent_path: '/Documents',
+    size_bytes: 2048,
+    kind: 'file',
+    deleted: false,
+    ...overrides,
+  } as OneDriveDeltaItem;
+}
+
+const PREVIOUS_PATH = { 'item-1': '/Documents' };
+const PREVIOUS_NAME = { 'item-1': 'report.docx' };
+const PREVIOUS_ETAG = { 'item-1': '"e1"' };
+
+describe('classify_change_type', () => {
+  it('returns "created" when no prior state exists', () => {
+    expect(classify_change_type(make_item({ etag: '"e1"' }), {}, {}, {})).toBe('created');
+  });
+
+  it('returns "updated" when only the etag changed', () => {
+    const item = make_item({ etag: '"e2"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('updated');
+  });
+
+  it('returns "moved" when only the path changed', () => {
+    const item = make_item({ parent_path: '/Archive', etag: '"e1"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('moved');
+  });
+
+  it('returns "moved" when the item moved and its content changed in one delta (issue #297)', () => {
+    const item = make_item({ parent_path: '/Archive', etag: '"e2"' });
+    // The new content blob records the update; nothing but this label records the old location.
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('moved');
+  });
+
+  it('returns "moved_and_renamed" when path, name and content all changed', () => {
+    const item = make_item({ parent_path: '/Archive', file_name: 'report-v2.docx', etag: '"e2"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe(
+      'moved_and_renamed',
+    );
+  });
+
+  it('returns "renamed" when the name and the content changed together', () => {
+    const item = make_item({ file_name: 'report-v2.docx', etag: '"e2"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('renamed');
+  });
+
+  it('returns "deleted" for a removed item regardless of prior state', () => {
+    const item = make_item({ deleted: true, parent_path: '/Archive' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('deleted');
+  });
+
+  it('returns undefined when nothing changed', () => {
+    const item = make_item({ etag: '"e1"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBeUndefined();
+  });
+
+  it('returns "updated" when the etag appears where none was recorded', () => {
+    const item = make_item({ etag: '"e1"' });
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, {})).toBe('updated');
+  });
+
+  it('returns "updated" when the etag disappears', () => {
+    const item = make_item();
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('updated');
+  });
+});

--- a/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/change-classifier.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { logger } from '@wisecom/atlas-core/utils/logger';
 import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
 import { classify_change_type } from '@/services/backup/change-classifier';
 
@@ -70,5 +71,16 @@ describe('classify_change_type', () => {
   it('returns "updated" when the etag disappears', () => {
     const item = make_item();
     expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, PREVIOUS_ETAG)).toBe('updated');
+  });
+
+  it('warns about the missing etags but still reports the move (issue #297)', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const item = make_item({ parent_path: '/Archive' });
+
+    // No etag on either side: the move is certain, a content change alongside it is invisible.
+    expect(classify_change_type(item, PREVIOUS_PATH, PREVIOUS_NAME, {})).toBe('moved');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing etag'));
+
+    warn.mockRestore();
   });
 });

--- a/packages/onedrive/tests/unit/services/save/save.service.test.ts
+++ b/packages/onedrive/tests/unit/services/save/save.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
 import { Container } from 'inversify';
 import 'reflect-metadata';
 import { OneDriveSaveService } from '@/services/save/save.service';
@@ -13,17 +14,6 @@ import type {
   TenantContext,
   TenantContextFactory,
 } from '@wisecom/atlas-types';
-
-/** Fixture overrides may blank an optional field; an explicit `undefined` drops the key. */
-type Overrides<T> = { [K in keyof T]?: T[K] | undefined };
-
-function apply_overrides<T extends object>(base: T, overrides: Overrides<T>): T {
-  const merged: Record<string, unknown> = { ...base, ...overrides };
-  for (const [key, value] of Object.entries(overrides)) {
-    if (value === undefined) delete merged[key];
-  }
-  return merged as T;
-}
 
 vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
   const mock_archive = {

--- a/packages/onedrive/tests/unit/services/save/save.service.test.ts
+++ b/packages/onedrive/tests/unit/services/save/save.service.test.ts
@@ -39,6 +39,7 @@ vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
     create_file_archive: vi.fn().mockReturnValue({
       archive: mock_archive,
       promise: Promise.resolve(4096),
+      publish: vi.fn().mockResolvedValue(undefined),
       abort: vi.fn().mockResolvedValue(undefined),
     }),
     add_file_to_archive: vi.fn().mockResolvedValue(undefined),

--- a/packages/onedrive/tests/unit/services/save/save.service.test.ts
+++ b/packages/onedrive/tests/unit/services/save/save.service.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Container } from 'inversify';
 import 'reflect-metadata';
+import {
+  create_file_archive,
+  finalize_file_archive,
+} from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
 import { OneDriveSaveService } from '@/services/save/save.service';
 import {
   ONEDRIVE_MANIFEST_REPOSITORY_TOKEN,
@@ -35,6 +39,7 @@ vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
     create_file_archive: vi.fn().mockReturnValue({
       archive: mock_archive,
       promise: Promise.resolve(4096),
+      abort: vi.fn().mockResolvedValue(undefined),
     }),
     add_file_to_archive: vi.fn().mockResolvedValue(undefined),
     finalize_file_archive: vi.fn().mockResolvedValue(undefined),
@@ -136,6 +141,25 @@ describe('OneDriveSaveService', () => {
       expect(result.files_skipped).toBe(0);
       expect(result.errors).toHaveLength(0);
       expect(result.output_path).toBe('/tmp/test-save.zip');
+    });
+
+    // #307: a failure between opening the archive and finalizing it used to leave a truncated
+    // zip at the output path, which is indistinguishable from a finished export.
+    it('aborts the archive when finalizing fails, and rethrows', async () => {
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(make_manifest([make_entry()]));
+      vi.mocked(finalize_file_archive).mockRejectedValueOnce(new Error('disk full'));
+
+      await expect(
+        service.save_snapshot('test-tenant', 'owner-1', {
+          snapshot_id: 'od-snap-1',
+          output_path: '/tmp/test-save.zip',
+        }),
+      ).rejects.toThrow('disk full');
+
+      const created = vi.mocked(create_file_archive).mock.results.at(-1)?.value as {
+        abort: () => Promise<void>;
+      };
+      expect(created.abort).toHaveBeenCalledTimes(1);
     });
 
     // #173: a delta snapshot lists only what changed, so an export that reads one manifest loses

--- a/packages/onedrive/tests/unit/services/status/status.service.test.ts
+++ b/packages/onedrive/tests/unit/services/status/status.service.test.ts
@@ -171,18 +171,33 @@ describe('OneDriveStatusService', () => {
     });
   });
 
-  it('currently rolls a failed peek up as up to date, which is wrong', async () => {
+  it('does not report the owner as up to date when a peek failed (issue #298)', async () => {
     vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('drive-1') as never);
     vi.mocked(mocks.connector.fetch_delta).mockRejectedValue(new Error('throttled'));
 
     const result = await check();
 
-    // Pins today's behaviour, it is not an endorsement. The roll-up is
-    // `total_pending === 0 && every(has_backup)`, which ignores each drive's
-    // own `is_up_to_date`, so a throttled peek counts as clean. Expected to
-    // flip to false when that is fixed; see the follow-up issue.
+    // The roll-up reads each drive's own flag. A throttled peek reports zero pending and
+    // `has_backup: true`, so the old `total_pending === 0 && every(has_backup)` called it clean.
     expect(result.drives[0]?.is_up_to_date).toBe(false);
-    expect(result.is_up_to_date).toBe(true);
+    expect(result.is_up_to_date).toBe(false);
+  });
+
+  it('does not report the owner as up to date when one drive of several failed', async () => {
+    vi.mocked(mocks.connector.list_drives).mockResolvedValue([
+      { drive_id: 'drive-1', drive_name: 'OneDrive' },
+      { drive_id: 'drive-2', drive_name: 'Second' },
+    ]);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('drive-1', 'drive-2') as never);
+    vi.mocked(mocks.connector.fetch_delta)
+      .mockRejectedValueOnce(new Error('throttled'))
+      .mockResolvedValueOnce({ items: [], delta_link: 'b' } as never);
+
+    const result = await check();
+
+    // The clean second drive must not mask the first: total pending is still zero here.
+    expect(result.total_pending_changes).toBe(0);
+    expect(result.is_up_to_date).toBe(false);
   });
 
   it('does not fail the whole check when one drive of several fails to peek', async () => {

--- a/packages/onedrive/tests/unit/services/verification/verification.service.test.ts
+++ b/packages/onedrive/tests/unit/services/verification/verification.service.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type {
   OneDriveFileVersionIndex,
@@ -11,17 +12,6 @@ import type {
 } from '@wisecom/atlas-types';
 import { stub_encrypted_object_store } from '@wisecom/atlas-types/testing/stub-encrypted-object-store';
 import { OneDriveVerificationService } from '@/services/verification/verification.service';
-
-/** Fixture overrides may blank an optional field; an explicit `undefined` drops the key. */
-type Overrides<T> = { [K in keyof T]?: T[K] | undefined };
-
-function apply_overrides<T extends object>(base: T, overrides: Overrides<T>): T {
-  const merged: Record<string, unknown> = { ...base, ...overrides };
-  for (const [key, value] of Object.entries(overrides)) {
-    if (value === undefined) delete merged[key];
-  }
-  return merged as T;
-}
 
 const TENANT_ID = 'tenant-1';
 const OWNER_ID = '00000000-0000-0000-0000-000000000001';

--- a/packages/outlook/package.json
+++ b/packages/outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-outlook",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -30,83 +30,90 @@ export async function save_entries_to_archive(
   is_interrupted: () => boolean,
   control: OperationControlOptions,
 ): Promise<Omit<SaveResult, 'snapshot_id'> & { processed: number }> {
-  const { archive, promise } = create_save_archive(output_path);
+  const { archive, promise, abort } = create_save_archive(output_path);
 
-  let global_saved = 0;
-  let global_att = 0;
-  let global_errors = 0;
-  let global_processed = 0;
-  const all_errors: string[] = [];
-  const integrity_failures: string[] = [];
-  let interrupted = false;
-  const should_interrupt = (): boolean => {
-    interrupted ||= is_interrupted();
-    return interrupted;
-  };
-  const start = Date.now();
-  const global_total = [...groups.values()].reduce((s, g) => s + g.length, 0);
+  try {
+    let global_saved = 0;
+    let global_att = 0;
+    let global_errors = 0;
+    let global_processed = 0;
+    const all_errors: string[] = [];
+    const integrity_failures: string[] = [];
+    let interrupted = false;
+    const should_interrupt = (): boolean => {
+      interrupted ||= is_interrupted();
+      return interrupted;
+    };
+    const start = Date.now();
+    const global_total = [...groups.values()].reduce((s, g) => s + g.length, 0);
 
-  let folder_index = 0;
-  for (const [fid, folder_items] of groups) {
-    if (should_interrupt()) break;
-    dashboard.mark_active(folder_index);
+    let folder_index = 0;
+    for (const [fid, folder_items] of groups) {
+      if (should_interrupt()) break;
+      dashboard.mark_active(folder_index);
 
-    const folder_name = folder_map.get(fid) ?? 'Unknown';
-    const used_names = new Set<string>();
+      const folder_name = folder_map.get(fid) ?? 'Unknown';
+      const used_names = new Set<string>();
 
-    const folder_result = await process_folder_entries(
-      ctx,
-      folder_items,
-      folder_name,
-      folder_index,
-      skip_integrity,
-      archive,
-      used_names,
-      groups,
-      global_total,
-      start,
-      dashboard,
-      should_interrupt,
-      { all_errors, integrity_failures },
-      control,
-    );
+      const folder_result = await process_folder_entries(
+        ctx,
+        folder_items,
+        folder_name,
+        folder_index,
+        skip_integrity,
+        archive,
+        used_names,
+        groups,
+        global_total,
+        start,
+        dashboard,
+        should_interrupt,
+        { all_errors, integrity_failures },
+        control,
+      );
 
-    global_errors += folder_result.error_count;
-    if (!should_interrupt()) {
-      dashboard.mark_done(folder_index, folder_result.folder_saved, folder_result.folder_att);
+      global_errors += folder_result.error_count;
+      if (!should_interrupt()) {
+        dashboard.mark_done(folder_index, folder_result.folder_saved, folder_result.folder_att);
+      }
+
+      global_saved += folder_result.folder_saved;
+      global_att += folder_result.folder_att;
+      global_processed += folder_result.folder_processed;
+      folder_index++;
     }
 
-    global_saved += folder_result.folder_saved;
-    global_att += folder_result.folder_att;
-    global_processed += folder_result.folder_processed;
-    folder_index++;
+    dashboard.show_finalizing();
+    emit_operation_progress(control, {
+      operation: 'save',
+      workload: 'outlook',
+      phase: 'finalizing',
+      processed: global_processed,
+      total: global_total,
+    });
+    await finalize_archive(archive);
+    const total_bytes = await promise;
+    await mark_downloaded_from_internet(output_path);
+
+    log_save_summary(global_saved, global_att, global_errors, total_bytes, start);
+
+    return {
+      saved_count: global_saved,
+      attachment_count: global_att,
+      error_count: global_errors,
+      errors: all_errors,
+      output_path,
+      total_bytes,
+      integrity_failures,
+      processed: global_processed,
+      interrupted: should_interrupt(),
+    };
+  } catch (err) {
+    // Anything between opening the archive and finalizing it can throw. None of it may leave
+    // a truncated zip sitting at the output path (issue #307).
+    await abort();
+    throw err;
   }
-
-  dashboard.show_finalizing();
-  emit_operation_progress(control, {
-    operation: 'save',
-    workload: 'outlook',
-    phase: 'finalizing',
-    processed: global_processed,
-    total: global_total,
-  });
-  await finalize_archive(archive);
-  const total_bytes = await promise;
-  await mark_downloaded_from_internet(output_path);
-
-  log_save_summary(global_saved, global_att, global_errors, total_bytes, start);
-
-  return {
-    saved_count: global_saved,
-    attachment_count: global_att,
-    error_count: global_errors,
-    errors: all_errors,
-    output_path,
-    total_bytes,
-    integrity_failures,
-    processed: global_processed,
-    interrupted: should_interrupt(),
-  };
 }
 
 interface FolderEntryCounters {

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -30,7 +30,7 @@ export async function save_entries_to_archive(
   is_interrupted: () => boolean,
   control: OperationControlOptions,
 ): Promise<Omit<SaveResult, 'snapshot_id'> & { processed: number }> {
-  const { archive, promise, abort } = create_save_archive(output_path);
+  const { archive, promise, publish, abort } = create_save_archive(output_path);
 
   try {
     let global_saved = 0;
@@ -93,6 +93,9 @@ export async function save_entries_to_archive(
     });
     await finalize_archive(archive);
     const total_bytes = await promise;
+    // Only now does anything appear at the output path, so a failure above cannot leave a
+    // truncated zip there and cannot destroy a file that was already sitting on it.
+    await publish();
     await mark_downloaded_from_internet(output_path);
 
     log_save_summary(global_saved, global_att, global_errors, total_bytes, start);
@@ -109,8 +112,8 @@ export async function save_entries_to_archive(
       interrupted: should_interrupt(),
     };
   } catch (err) {
-    // Anything between opening the archive and finalizing it can throw. None of it may leave
-    // a truncated zip sitting at the output path (issue #307).
+    // Anything between opening the archive and publishing it can throw. None of it may leave a
+    // partial file behind (issue #307).
     await abort();
     throw err;
   }

--- a/packages/outlook/src/services/save/save-zip-writer.ts
+++ b/packages/outlook/src/services/save/save-zip-writer.ts
@@ -1,9 +1,20 @@
-import { createWriteStream } from 'node:fs';
+import { createWriteStream, existsSync, type WriteStream } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { ZipArchive, type Archiver } from 'archiver';
+import { logger } from '@wisecom/atlas-core/utils/logger';
 
 export interface SaveArchive {
   readonly archive: ArchiveWriter;
   readonly promise: Promise<number>;
+  /**
+   * Destroys the stream and removes the partial file, for a run that failed before finalizing.
+   *
+   * A truncated zip left at the output path is indistinguishable from a complete one, which is
+   * worse than no file at all when the reason an operator ran a save is that they need the bytes
+   * (issue #307). A path that already held a file is never removed: the caller may have been
+   * handed the path of something unrelated.
+   */
+  abort(): Promise<void>;
 }
 
 /** The archiver instance EML entries are appended to. */
@@ -11,6 +22,7 @@ export type ArchiveWriter = Archiver;
 
 /** Creates a zip archive with maximum compression, streaming to the output path. */
 export function create_save_archive(output_path: string): SaveArchive {
+  const pre_existing = existsSync(output_path);
   const output = createWriteStream(output_path);
   const archive = new ZipArchive({ zlib: { level: 9 } });
 
@@ -19,9 +31,38 @@ export function create_save_archive(output_path: string): SaveArchive {
     archive.on('error', reject);
     output.on('error', reject);
   });
+  // Attach a handler now, so an error raised while entries are still being appended is not an
+  // unhandled rejection. Awaiting `promise` later still sees the rejection.
+  promise.catch(() => undefined);
 
   archive.pipe(output);
-  return { archive, promise };
+  return {
+    archive,
+    promise,
+    abort: () => abort_save_archive(archive, output, output_path, pre_existing),
+  };
+}
+
+async function abort_save_archive(
+  archive: ArchiveWriter,
+  output: WriteStream,
+  output_path: string,
+  pre_existing: boolean,
+): Promise<void> {
+  try {
+    archive.abort();
+  } catch {
+    // Already destroyed or never started; the stream teardown below is what matters.
+  }
+  output.destroy();
+  if (pre_existing) return;
+  try {
+    await rm(output_path, { force: true });
+  } catch (err) {
+    logger.warn(
+      `Could not remove the partial archive at ${output_path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 /**

--- a/packages/outlook/src/services/save/save-zip-writer.ts
+++ b/packages/outlook/src/services/save/save-zip-writer.ts
@@ -1,5 +1,6 @@
-import { createWriteStream, existsSync, type WriteStream } from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import { createWriteStream, type WriteStream } from 'node:fs';
+import { rename, rm } from 'node:fs/promises';
 import { ZipArchive, type Archiver } from 'archiver';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -7,23 +8,27 @@ export interface SaveArchive {
   readonly archive: ArchiveWriter;
   readonly promise: Promise<number>;
   /**
-   * Destroys the stream and removes the partial file, for a run that failed before finalizing.
-   *
-   * A truncated zip left at the output path is indistinguishable from a complete one, which is
-   * worse than no file at all when the reason an operator ran a save is that they need the bytes
-   * (issue #307). A path that already held a file is never removed: the caller may have been
-   * handed the path of something unrelated.
+   * Moves the finished archive onto the output path. Call it after the archive is finalized and
+   * the byte count has resolved; until then the output path is untouched.
    */
+  publish(): Promise<void>;
+  /** Destroys the stream and removes the temporary file, for a run that failed before publishing. */
   abort(): Promise<void>;
 }
 
 /** The archiver instance EML entries are appended to. */
 export type ArchiveWriter = Archiver;
 
-/** Creates a zip archive with maximum compression, streaming to the output path. */
+/**
+ * Creates a zip archive with maximum compression, streaming to a sibling temporary file.
+ *
+ * The archive is moved onto the output path by {@link SaveArchive.publish}, so nothing appears
+ * there until it is complete. A truncated zip is indistinguishable from a finished one (issue
+ * #307), and a failed save must not destroy a file that was already at the path it was given.
+ */
 export function create_save_archive(output_path: string): SaveArchive {
-  const pre_existing = existsSync(output_path);
-  const output = createWriteStream(output_path);
+  const staging_path = `${output_path}.part-${randomBytes(6).toString('hex')}`;
+  const output = createWriteStream(staging_path);
   const archive = new ZipArchive({ zlib: { level: 9 } });
 
   const promise = new Promise<number>((resolve, reject) => {
@@ -39,15 +44,15 @@ export function create_save_archive(output_path: string): SaveArchive {
   return {
     archive,
     promise,
-    abort: () => abort_save_archive(archive, output, output_path, pre_existing),
+    publish: () => rename(staging_path, output_path),
+    abort: () => abort_save_archive(archive, output, staging_path),
   };
 }
 
 async function abort_save_archive(
   archive: ArchiveWriter,
   output: WriteStream,
-  output_path: string,
-  pre_existing: boolean,
+  staging_path: string,
 ): Promise<void> {
   try {
     archive.abort();
@@ -55,12 +60,11 @@ async function abort_save_archive(
     // Already destroyed or never started; the stream teardown below is what matters.
   }
   output.destroy();
-  if (pre_existing) return;
   try {
-    await rm(output_path, { force: true });
+    await rm(staging_path, { force: true });
   } catch (err) {
     logger.warn(
-      `Could not remove the partial archive at ${output_path}: ${err instanceof Error ? err.message : String(err)}`,
+      `Could not remove the partial archive at ${staging_path}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }

--- a/packages/outlook/tests/unit/services/save/mime-passthrough.test.ts
+++ b/packages/outlook/tests/unit/services/save/mime-passthrough.test.ts
@@ -14,7 +14,12 @@ interface AppendedEml {
 const { appended } = vi.hoisted(() => ({ appended: [] as AppendedEml[] }));
 
 vi.mock('@/services/save/save-zip-writer', () => ({
-  create_save_archive: vi.fn(() => ({ archive: {}, promise: Promise.resolve(2048) })),
+  create_save_archive: vi.fn(() => ({
+    archive: {},
+    promise: Promise.resolve(2048),
+    publish: (): Promise<void> => Promise.resolve(),
+    abort: (): Promise<void> => Promise.resolve(),
+  })),
   add_eml_to_archive: vi.fn(
     (_archive: unknown, folder: string, filename: string, content: Buffer) => {
       appended.push({ folder, filename, content });

--- a/packages/outlook/tests/unit/services/save/zip-writer.test.ts
+++ b/packages/outlook/tests/unit/services/save/zip-writer.test.ts
@@ -31,10 +31,11 @@ describe('save-zip-writer', () => {
     const path = temp_path('create');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     await add_eml_to_archive(archive, 'Inbox', 'test.eml', Buffer.from('EML content'));
     await finalize_archive(archive);
     const bytes = await promise;
+    await publish();
 
     expect(existsSync(path)).toBe(true);
     expect(bytes).toBeGreaterThan(0);
@@ -44,12 +45,13 @@ describe('save-zip-writer', () => {
     const path = temp_path('multi');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     await add_eml_to_archive(archive, 'Inbox', 'a.eml', Buffer.from('Message A'));
     await add_eml_to_archive(archive, 'Sent Items', 'b.eml', Buffer.from('Message B'));
     await add_eml_to_archive(archive, 'Inbox', 'c.eml', Buffer.from('Message C'));
     await finalize_archive(archive);
     const bytes = await promise;
+    await publish();
 
     expect(bytes).toBeGreaterThan(0);
   });
@@ -58,9 +60,10 @@ describe('save-zip-writer', () => {
     const path = temp_path('empty');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     await finalize_archive(archive);
     const bytes = await promise;
+    await publish();
 
     expect(bytes).toBeGreaterThan(0);
   });
@@ -69,7 +72,7 @@ describe('save-zip-writer', () => {
     const path = temp_path('nested');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
@@ -77,6 +80,7 @@ describe('save-zip-writer', () => {
     await add_eml_to_archive(archive, 'Archive/Projects/2026', 'b.eml', Buffer.from('B'));
     await finalize_archive(archive);
     await promise;
+    await publish();
 
     expect(entries).toEqual(['Inbox/Projects/2026/a.eml', 'Archive/Projects/2026/b.eml']);
   });
@@ -85,13 +89,14 @@ describe('save-zip-writer', () => {
     const path = temp_path('sanitize');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
     await add_eml_to_archive(archive, 'Inbox/Q1:Q2/..', 'a.eml', Buffer.from('A'));
     await finalize_archive(archive);
     await promise;
+    await publish();
 
     expect(entries).toEqual(['Inbox/Q1_Q2/Unknown/a.eml']);
   });
@@ -103,13 +108,14 @@ describe('save-zip-writer', () => {
     const path = temp_path('traversal');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
     await add_eml_to_archive(archive, 'Inbox', '../../../etc/passwd', Buffer.from('A'));
     await finalize_archive(archive);
     await promise;
+    await publish();
 
     // Separators become underscores and `..` collapses to a single dot that is then
     // stripped from the front, so the whole name lands as one segment under the folder.
@@ -122,13 +128,14 @@ describe('save-zip-writer', () => {
     const path = temp_path('flatten');
     created_files.push(path);
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
     await add_eml_to_archive(archive, 'Inbox', 'a/b\\c\x01d.eml', Buffer.from('A'));
     await finalize_archive(archive);
     await promise;
+    await publish();
 
     // One folder level plus one file: the name contributes no extra depth.
     expect(entries).toEqual(['Inbox/a_b_c_d.eml']);
@@ -148,7 +155,7 @@ describe('save-zip-writer', () => {
       deduplicate_filename(build_eml_filename('2026-03-10T14:30:22Z', 'Same'), new Set(['x'])),
     ];
 
-    const { archive, promise } = create_save_archive(path);
+    const { archive, promise, publish } = create_save_archive(path);
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
@@ -157,6 +164,7 @@ describe('save-zip-writer', () => {
     }
     await finalize_archive(archive);
     await promise;
+    await publish();
 
     expect(entries).toEqual(generated.map((n) => `Inbox/${n}`));
     expect(generated[1]).toContain('untitled');

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-s3",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/s3/src/adapters/object-lock.errors.ts
+++ b/packages/s3/src/adapters/object-lock.errors.ts
@@ -1,36 +1,42 @@
-export class ObjectLockVersioningDisabledError extends Error {
+import { AtlasError, ConfigError, StorageError } from '@wisecom/atlas-types';
+
+/**
+ * These are storage-configuration failures, so they carry `ATLAS_CONFIG_INVALID` or
+ * `ATLAS_STORAGE_FAILURE` and are reachable as {@link AtlasError} by an SDK consumer that only
+ * wants to know which category it is in (issue #40). The classes stay, because the operator-facing
+ * remediation text differs per case and is the point of each one.
+ */
+export class ObjectLockVersioningDisabledError extends ConfigError {
   constructor(bucket: string) {
     super(
       `Immutability requested, but bucket versioning is disabled for ${bucket}. ` +
         'Enable bucket versioning and Object Lock, or run backup without retention.',
     );
-    this.name = 'ObjectLockVersioningDisabledError';
   }
 }
 
-export class ObjectLockUnsupportedError extends Error {
+export class ObjectLockUnsupportedError extends ConfigError {
   constructor(bucket: string) {
     super(
       `Immutability requested, but Object Lock is not supported or not enabled for bucket ${bucket}.`,
     );
-    this.name = 'ObjectLockUnsupportedError';
   }
 }
 
-export class ObjectLockModeRejectedError extends Error {
+export class ObjectLockModeRejectedError extends ConfigError {
   constructor(bucket: string, mode: string, cause?: unknown) {
     const cause_text = cause instanceof Error ? ` (${cause.message})` : '';
-    super(`Backend rejected Object Lock mode ${mode} for bucket ${bucket}.${cause_text}`);
-    this.name = 'ObjectLockModeRejectedError';
+    super(`Backend rejected Object Lock mode ${mode} for bucket ${bucket}.${cause_text}`, {
+      cause,
+    });
   }
 }
 
 /** Thrown when a conditional put fails (ETag mismatch or create-only key already exists). */
-export class PreconditionFailedError extends Error {
+export class PreconditionFailedError extends StorageError {
   constructor(key: string) {
     super(
-      `Conditional write failed for key ${key} — precondition not met (412 Precondition Failed)`,
+      `Conditional write failed for key ${key} -- precondition not met (412 Precondition Failed)`,
     );
-    this.name = 'PreconditionFailedError';
   }
 }

--- a/packages/s3/src/adapters/object-lock.errors.ts
+++ b/packages/s3/src/adapters/object-lock.errors.ts
@@ -36,7 +36,7 @@ export class ObjectLockModeRejectedError extends ConfigError {
 export class PreconditionFailedError extends StorageError {
   constructor(key: string) {
     super(
-      `Conditional write failed for key ${key} -- precondition not met (412 Precondition Failed)`,
+      `Conditional write failed for key ${key} — precondition not met (412 Precondition Failed)`,
     );
   }
 }

--- a/packages/s3/src/adapters/s3-error-classifier.ts
+++ b/packages/s3/src/adapters/s3-error-classifier.ts
@@ -11,6 +11,29 @@ export function is_precondition_failed(err: unknown): boolean {
   return (err as { name?: string }).name === 'PreconditionFailed';
 }
 
+/**
+ * True only for errors that name Object Lock as the reason a delete was refused.
+ *
+ * Backends word it differently: MinIO raises `InvalidRequest` "Object is WORM protected and
+ * cannot be overwritten", AWS raises `AccessDenied` "Access Denied because object protected by
+ * object lock". Both name the mechanism. A bare `AccessDenied` from a missing IAM permission does
+ * not, and must not be filed as "retained, deletable once retention expires": on an erasure
+ * report a false alarm costs an investigation, a false all-clear costs the erasure.
+ *
+ * The wording heuristic lives here, at the boundary that speaks S3, so callers can branch on
+ * `ObjectLockRetainedError` instead of grepping messages of their own (issue #40).
+ */
+export function is_object_lock_refusal(err: unknown): boolean {
+  const message = err instanceof Error ? `${err.name} ${err.message}`.toLowerCase() : '';
+  return (
+    message.includes('object lock') ||
+    message.includes('objectlock') ||
+    message.includes('worm protected') ||
+    message.includes('retention') ||
+    message.includes('legal hold')
+  );
+}
+
 export function is_backend_mode_rejection(err: unknown, mode?: string): boolean {
   if (!mode) return false;
   if (!(err instanceof S3ServiceException)) return false;

--- a/packages/s3/src/adapters/s3-object-storage.adapter.ts
+++ b/packages/s3/src/adapters/s3-object-storage.adapter.ts
@@ -12,6 +12,7 @@ import {
   AbortMultipartUploadCommand,
   type S3Client,
 } from '@aws-sdk/client-s3';
+import { ObjectLockRetainedError } from '@wisecom/atlas-types';
 import type {
   ObjectStorage,
   ObjectStorageEtagResult,
@@ -28,6 +29,7 @@ import {
 import type { BucketCache } from '@/adapters/bucket-cache';
 import { abort_incomplete_multipart_uploads } from '@/adapters/s3-multipart-cleanup';
 import { S3MultipartUploadHandle } from '@/adapters/s3-multipart-upload-handle';
+import { is_object_lock_refusal } from '@/adapters/s3-error-classifier';
 import {
   ObjectLockModeRejectedError,
   ObjectLockUnsupportedError,
@@ -135,16 +137,28 @@ export class S3ObjectStorage implements ObjectStorage {
     return { data, etag };
   }
 
-  /** Removes a single object. */
+  /** Removes a single object. @throws ObjectLockRetainedError when retention refuses the delete. */
   async delete(key: string): Promise<void> {
-    await this._client.send(new DeleteObjectCommand({ Bucket: this._bucket, Key: key }));
+    try {
+      await this._client.send(new DeleteObjectCommand({ Bucket: this._bucket, Key: key }));
+    } catch (err) {
+      throw as_delete_failure(key, err);
+    }
   }
 
-  /** Removes a specific object version (or delete marker) by version id. */
+  /**
+   * Removes a specific object version (or delete marker) by version id.
+   *
+   * @throws ObjectLockRetainedError when retention or a legal hold refuses the delete.
+   */
   async delete_version(key: string, version_id: string): Promise<void> {
-    await this._client.send(
-      new DeleteObjectCommand({ Bucket: this._bucket, Key: key, VersionId: version_id }),
-    );
+    try {
+      await this._client.send(
+        new DeleteObjectCommand({ Bucket: this._bucket, Key: key, VersionId: version_id }),
+      );
+    } catch (err) {
+      throw as_delete_failure(key, err);
+    }
   }
 
   /** Returns true if the object exists (HEAD request). */
@@ -319,4 +333,13 @@ export class S3ObjectStorage implements ObjectStorage {
     if (!probe.mode_supported)
       throw new ObjectLockModeRejectedError(this._bucket, policy.mode ?? 'UNKNOWN');
   }
+}
+
+/**
+ * Names a refused delete for what it is. Retention and legal holds are an expected outcome a
+ * caller reports as retained; anything else is a failure it must not file as recoverable.
+ */
+function as_delete_failure(key: string, err: unknown): Error {
+  if (is_object_lock_refusal(err)) return new ObjectLockRetainedError(key, { cause: err });
+  return err instanceof Error ? err : new Error(String(err));
 }

--- a/packages/s3/tests/unit/s3-object-storage.test.ts
+++ b/packages/s3/tests/unit/s3-object-storage.test.ts
@@ -1,5 +1,6 @@
 import { BucketCache } from '@/adapters/bucket-cache';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ObjectLockRetainedError } from '@wisecom/atlas-types';
 import { S3ObjectStorage } from '@/adapters/s3-object-storage.adapter';
 import {
   ObjectLockUnsupportedError,
@@ -162,6 +163,48 @@ describe('S3ObjectStorage', () => {
       const cmd = mock_s3.send.mock.calls[0][0];
       expect(cmd.input.Bucket).toBe(bucket);
       expect(cmd.input.Key).toBe('key');
+    });
+
+    // Issue #40: callers used to grep the message themselves. The wording heuristic belongs to
+    // the layer that speaks S3, and only retention may be reported as retained: filing an IAM
+    // gap that way tells an operator an erasure is on track when it is not.
+    it.each([
+      ['InvalidRequest: Object is WORM protected and cannot be overwritten'],
+      ['AccessDenied: Access Denied because object protected by object lock'],
+      ['AccessDenied: Object Lock retention in effect'],
+      ['InvalidRequest: a legal hold is in place'],
+    ])('raises ObjectLockRetainedError for %s', async (message) => {
+      mock_s3.send.mockRejectedValueOnce(new Error(message));
+
+      await expect(storage.delete('key')).rejects.toBeInstanceOf(ObjectLockRetainedError);
+    });
+
+    it('leaves a bare permission denial as it is, never as retained', async () => {
+      mock_s3.send.mockRejectedValueOnce(new Error('AccessDenied: Access Denied'));
+
+      const failure = await storage.delete('key').catch((err: unknown) => err);
+      expect(failure).not.toBeInstanceOf(ObjectLockRetainedError);
+      expect((failure as Error).message).toContain('Access Denied');
+    });
+
+    it('carries the original error as the cause of a retention refusal', async () => {
+      const raw = new Error('AccessDenied: Access Denied because object protected by object lock');
+      mock_s3.send.mockRejectedValueOnce(raw);
+
+      const failure = (await storage.delete('key').catch((err: unknown) => err)) as Error;
+      expect(failure.cause).toBe(raw);
+    });
+  });
+
+  describe('delete_version', () => {
+    it('raises ObjectLockRetainedError when a version is under retention', async () => {
+      mock_s3.send.mockRejectedValueOnce(
+        new Error('AccessDenied: Object Lock retention in effect'),
+      );
+
+      await expect(storage.delete_version('key', 'v1')).rejects.toBeInstanceOf(
+        ObjectLockRetainedError,
+      );
     });
   });
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-sdk",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Programmatic API for embedding Atlas M365 backup and restore in Node.js applications.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,11 @@
 export * from '@wisecom/atlas-types';
 export type { StorageTargetSdkConfig } from '@wisecom/atlas-s3';
+export {
+  ObjectLockVersioningDisabledError,
+  ObjectLockUnsupportedError,
+  ObjectLockModeRejectedError,
+  PreconditionFailedError,
+} from '@wisecom/atlas-s3';
 export { createAtlasInstance } from './atlas-instance.adapter';
 export { create_storage_target as createStorageTarget } from '@wisecom/atlas-s3';
 export { get_graph_cost as getGraphCost } from '@wisecom/atlas-core/services/shared/graph-request-context';

--- a/packages/sharepoint/package.json
+++ b/packages/sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-sharepoint",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sharepoint/src/services/backup/backup-builders.ts
+++ b/packages/sharepoint/src/services/backup/backup-builders.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the OneDrive copy (#306): 68 differing lines of 432. The
+// manifests they build differ in their identity fields and in what each provider records per
+// entry, so the shared version would be generic over almost every line.
 import type {
   SharePointBackupResult,
   SharePointChangeType,

--- a/packages/sharepoint/src/services/backup/backup-file-processor.ts
+++ b/packages/sharepoint/src/services/backup/backup-file-processor.ts
@@ -1,23 +1,15 @@
-import { createHash } from 'node:crypto';
 import type {
-  SharePointSiteConnector,
   SharePointDeltaItem,
+  SharePointSiteConnector,
   TenantContext,
 } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
-import { is_unretryable_download_failure } from '@wisecom/atlas-m365-graph';
-import { download_with_retry } from '@wisecom/atlas-drive/backup/download-retry';
-import { LARGE_FILE_THRESHOLD, process_large_file } from '@/services/backup/large-file-pipeline';
-import { sharepoint_data_key } from '@/services/shared/storage-keys';
+import {
+  process_drive_backup_file,
+  type FileProcessResult,
+} from '@wisecom/atlas-drive/backup/file-processor';
+import { SHAREPOINT_LARGE_FILE_DEPS } from '@/services/backup/large-file-pipeline';
 
-const HASH_CHUNK_SIZE = 64 * 1024 * 1024;
-
-export interface FileProcessResult {
-  storage_key: string;
-  checksum: string;
-  stored: boolean;
-  deduplicated: boolean;
-}
+export type { FileProcessResult } from '@wisecom/atlas-drive/backup/file-processor';
 
 /** Downloads or deduplicates a single delta file item. */
 export async function process_backup_file(
@@ -26,33 +18,7 @@ export async function process_backup_file(
   site_id: string,
   ctx: TenantContext,
 ): Promise<FileProcessResult | undefined> {
-  if (item.size_bytes >= LARGE_FILE_THRESHOLD) {
-    try {
-      return await process_large_file(connector, item, site_id, ctx);
-    } catch (err) {
-      // A missing grant or a service refusal is not a skip: it must reach the caller
-      // so the run can name the cause instead of reporting a lost file (issue #246).
-      if (is_unretryable_download_failure(err)) throw err;
-      logger.warn(
-        `Skipping large file ${item.item_id} (${item.file_name}): ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-
-  const raw_body = await download_with_retry(connector, item);
-  if (!raw_body) return undefined;
-
-  const checksum = compute_sha256_chunked(raw_body);
-  const storage_key = sharepoint_data_key(site_id, checksum);
-  const exists = await ctx.storage.exists(storage_key);
-
-  if (!exists) {
-    await ctx.storage.put(storage_key, ctx.encrypt(raw_body));
-    return { storage_key, checksum, stored: true, deduplicated: false };
-  }
-
-  return { storage_key, checksum, stored: false, deduplicated: true };
+  return process_drive_backup_file(SHAREPOINT_LARGE_FILE_DEPS, connector, item, site_id, ctx);
 }
 
 /** @throws Error when no document libraries are returned (likely missing Graph permissions). */
@@ -61,13 +27,4 @@ export function ensure_libraries_discovered(library_count: number): void {
   throw new Error(
     'Missing Microsoft Graph application permissions for SharePoint: Sites.Read.All.',
   );
-}
-
-/** Computes SHA-256 in chunks to avoid ERR_OUT_OF_RANGE on buffers > 2 GB. */
-function compute_sha256_chunked(data: Buffer): string {
-  const hash = createHash('sha256');
-  for (let offset = 0; offset < data.length; offset += HASH_CHUNK_SIZE) {
-    hash.update(data.subarray(offset, Math.min(offset + HASH_CHUNK_SIZE, data.length)));
-  }
-  return hash.digest('hex');
 }

--- a/packages/sharepoint/src/services/backup/backup.service.ts
+++ b/packages/sharepoint/src/services/backup/backup.service.ts
@@ -1,3 +1,7 @@
+// Deliberately not shared with the OneDrive copy (#306): 306 differing lines of 604. SharePoint
+// walks a site tree, then libraries within it; OneDrive enumerates an owner's drives and
+// carries a folder scope and a per-drive delta cursor. Unifying them means a parameter per
+// branch, which is the shape that made the copies hard to change.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { randomBytes } from 'node:crypto';
 import {

--- a/packages/sharepoint/src/services/backup/change-classifier.ts
+++ b/packages/sharepoint/src/services/backup/change-classifier.ts
@@ -1,5 +1,5 @@
 import type { SharePointChangeType, SharePointDeltaItem } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
+import { classify_drive_change } from '@wisecom/atlas-drive/backup/change-classifier';
 
 /**
  * Determines the type of change for a delta item based on previous state.
@@ -11,54 +11,11 @@ export function classify_change_type(
   previous_name_by_file_id: Record<string, string>,
   previous_etag_by_file_id: Record<string, string>,
 ): SharePointChangeType | undefined {
-  if (item.deleted) return 'deleted';
-
-  const previous_path = previous_path_by_file_id[item.item_id];
-  const previous_name = previous_name_by_file_id[item.item_id];
-  const previous_etag = previous_etag_by_file_id[item.item_id];
-  const previously_known = Boolean(previous_path || previous_name || previous_etag);
-
-  if (!previously_known) return 'created';
-
-  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
-  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
-  // Relocation before content: an item that moved and changed in the same delta window carries
-  // both signals, and the ETag branch used to answer first, erasing the move from the change
-  // record (issue #297). The new content blob makes the update self-evident; the old location is
-  // only recorded here. Content is downloaded either way, so the label is all that moves.
-  if (path_changed || name_changed) {
-    // Still worth saying when both ETags are absent: the relocation is certain, but with no ETag
-    // on either side a content change alongside it cannot be detected at all.
-    warn_missing_etag(item.item_id, previous_etag, item.etag);
-    if (path_changed && name_changed) return 'moved_and_renamed';
-    return path_changed ? 'moved' : 'renamed';
-  }
-
-  if (is_etag_transition(previous_etag, item.etag, previously_known)) {
-    warn_missing_etag(item.item_id, previous_etag, item.etag);
-    return 'updated';
-  }
-  return undefined;
-}
-
-function is_etag_transition(
-  previous_etag: string | undefined,
-  current_etag: string | undefined,
-  previously_known: boolean,
-): boolean {
-  if (previous_etag && !current_etag) return true;
-  if (!previous_etag && current_etag) return true;
-  if (previous_etag && current_etag && previous_etag !== current_etag) return true;
-  return previously_known && !previous_etag && !current_etag;
-}
-
-function warn_missing_etag(
-  item_id: string,
-  previous_etag: string | undefined,
-  current_etag: string | undefined,
-): void {
-  if (previous_etag || current_etag) return;
-  logger.warn(
-    `SharePoint delta item ${item_id}: missing etag on prior and current snapshot; a content change cannot be detected`,
+  return classify_drive_change(
+    'SharePoint',
+    item,
+    previous_path_by_file_id,
+    previous_name_by_file_id,
+    previous_etag_by_file_id,
   );
 }

--- a/packages/sharepoint/src/services/backup/change-classifier.ts
+++ b/packages/sharepoint/src/services/backup/change-classifier.ts
@@ -19,16 +19,21 @@ export function classify_change_type(
   const previously_known = Boolean(previous_path || previous_name || previous_etag);
 
   if (!previously_known) return 'created';
+
+  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
+  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
+  // Relocation before content: an item that moved and changed in the same delta window carries
+  // both signals, and the ETag branch used to answer first, erasing the move from the change
+  // record (issue #297). The new content blob makes the update self-evident; the old location is
+  // only recorded here. Content is downloaded either way, so the label is all that moves.
+  if (path_changed && name_changed) return 'moved_and_renamed';
+  if (path_changed) return 'moved';
+  if (name_changed) return 'renamed';
+
   if (is_etag_transition(previous_etag, item.etag, previously_known)) {
     warn_missing_etag(item.item_id, previous_etag, item.etag);
     return 'updated';
   }
-
-  const path_changed = Boolean(previous_path && previous_path !== item.parent_path);
-  const name_changed = Boolean(previous_name && previous_name !== item.file_name);
-  if (path_changed && name_changed) return 'moved_and_renamed';
-  if (path_changed) return 'moved';
-  if (name_changed) return 'renamed';
   return undefined;
 }
 

--- a/packages/sharepoint/src/services/backup/change-classifier.ts
+++ b/packages/sharepoint/src/services/backup/change-classifier.ts
@@ -26,9 +26,13 @@ export function classify_change_type(
   // both signals, and the ETag branch used to answer first, erasing the move from the change
   // record (issue #297). The new content blob makes the update self-evident; the old location is
   // only recorded here. Content is downloaded either way, so the label is all that moves.
-  if (path_changed && name_changed) return 'moved_and_renamed';
-  if (path_changed) return 'moved';
-  if (name_changed) return 'renamed';
+  if (path_changed || name_changed) {
+    // Still worth saying when both ETags are absent: the relocation is certain, but with no ETag
+    // on either side a content change alongside it cannot be detected at all.
+    warn_missing_etag(item.item_id, previous_etag, item.etag);
+    if (path_changed && name_changed) return 'moved_and_renamed';
+    return path_changed ? 'moved' : 'renamed';
+  }
 
   if (is_etag_transition(previous_etag, item.etag, previously_known)) {
     warn_missing_etag(item.item_id, previous_etag, item.etag);
@@ -55,6 +59,6 @@ function warn_missing_etag(
 ): void {
   if (previous_etag || current_etag) return;
   logger.warn(
-    `SharePoint delta item ${item_id}: missing etag on prior and current snapshot; classifying as updated`,
+    `SharePoint delta item ${item_id}: missing etag on prior and current snapshot; a content change cannot be detected`,
   );
 }

--- a/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
+++ b/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
@@ -1,10 +1,24 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { stream_whole_file_in_chunks } from '@wisecom/atlas-drive/backup/whole-file-stream';
 
 const CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
 const MAX_CHUNK_RETRIES = 5;
 const CHUNK_BASE_DELAY_MS = 1_000;
 const CHUNK_MAX_DELAY_MS = 30_000;
 const MIN_THROUGHPUT_BYTES_PER_MS = 256;
+
+/**
+ * Raised when the server answers a Range request with the whole file.
+ *
+ * It is a property of the server, not of the chunk, so the caller stops asking for ranges
+ * entirely rather than re-discovering it 255 more times (issue #301).
+ */
+class RangeIgnoredError extends Error {
+  constructor() {
+    super('Range header ignored');
+    this.name = 'RangeIgnoredError';
+  }
+}
 
 /** Async generator that yields 4 MiB buffers fetched via HTTP Range requests. */
 export async function* fetch_file_chunks(
@@ -19,15 +33,29 @@ export async function* fetch_file_chunks(
     const range_end = Math.min(range_start + CHUNK_SIZE_BYTES - 1, total_bytes - 1);
     const expected_length = range_end - range_start + 1;
 
-    yield await download_chunk_with_retry(
-      download_url,
-      range_start,
-      range_end,
-      expected_length,
-      item_id,
-      i + 1,
-      chunk_count,
-    );
+    try {
+      yield await download_chunk_with_retry(
+        download_url,
+        range_start,
+        range_end,
+        expected_length,
+        item_id,
+        i + 1,
+        chunk_count,
+        chunk_count > 1,
+      );
+    } catch (err) {
+      if (!(err instanceof RangeIgnoredError)) throw err;
+      // Every remaining chunk would fetch and discard the same whole file: a 1 GiB item costs
+      // 256 GiB transferred to produce 1 GiB. One streamed pass delivers the rest, and the
+      // chunks already yielded are re-read from the start, which is the price of finding out.
+      logger.warn(
+        `Range requests are ignored for ${item_id} (HTTP 200 with the full body); ` +
+          `falling back to one streamed download`,
+      );
+      yield* stream_whole_file_in_chunks(download_url, item_id, CHUNK_SIZE_BYTES);
+      return;
+    }
   }
 }
 
@@ -39,11 +67,21 @@ async function download_chunk_with_retry(
   item_id: string,
   chunk_index: number,
   total_chunks: number,
+  report_ignored_range: boolean,
 ): Promise<Buffer> {
   for (let attempt = 0; attempt <= MAX_CHUNK_RETRIES; attempt++) {
     try {
-      return await download_single_chunk(url, range_start, range_end, expected_length, item_id);
+      return await download_single_chunk(
+        url,
+        range_start,
+        range_end,
+        expected_length,
+        item_id,
+        report_ignored_range,
+      );
     } catch (err) {
+      // Not retryable and not a failure: the caller switches strategy on it.
+      if (err instanceof RangeIgnoredError) throw err;
       if (!is_cdn_retryable(err) || attempt === MAX_CHUNK_RETRIES) {
         throw new Error(
           `Failed chunk ${chunk_index}/${total_chunks} of ${item_id} ` +
@@ -69,6 +107,7 @@ async function download_single_chunk(
   range_end: number,
   expected_length: number,
   item_id: string,
+  report_ignored_range: boolean,
 ): Promise<Buffer> {
   const timeout_ms = Math.max(30_000, Math.ceil(expected_length / MIN_THROUGHPUT_BYTES_PER_MS));
   const controller = new AbortController();
@@ -92,13 +131,16 @@ async function download_single_chunk(
       );
     }
 
+    if (response.status === 200 && report_ignored_range) {
+      // Drop the body unread: buffering a whole file per chunk is the cost this avoids.
+      await response.body?.cancel();
+      throw new RangeIgnoredError();
+    }
+
     const buf = Buffer.from(await response.arrayBuffer());
 
     if (response.status === 200) {
-      logger.warn(
-        `CDN returned HTTP 200 instead of 206 for Range request on ${item_id} — ` +
-          `server ignored Range header, slicing ${buf.length} bytes to expected range`,
-      );
+      // A single-chunk item legitimately comes back whole, so the slice is a no-op there.
       if (buf.length < range_end + 1) {
         throw new Error(
           `CDN returned 200 with ${buf.length} bytes but range_end is ${range_end} for ${item_id}`,
@@ -125,5 +167,7 @@ function compute_retry_delay(attempt: number): number {
 }
 
 function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
 }

--- a/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
+++ b/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
@@ -7,6 +7,11 @@ const CHUNK_BASE_DELAY_MS = 1_000;
 const CHUNK_MAX_DELAY_MS = 30_000;
 const MIN_THROUGHPUT_BYTES_PER_MS = 256;
 
+/** Milliseconds a single 4 MiB read may stall before the transfer is abandoned. */
+function chunk_stall_timeout_ms(): number {
+  return Math.max(30_000, Math.ceil(CHUNK_SIZE_BYTES / MIN_THROUGHPUT_BYTES_PER_MS));
+}
+
 /**
  * Raised when the server answers a Range request with the whole file.
  *
@@ -53,7 +58,12 @@ export async function* fetch_file_chunks(
         `Range requests are ignored for ${item_id} (HTTP 200 with the full body); ` +
           `falling back to one streamed download`,
       );
-      yield* stream_whole_file_in_chunks(download_url, item_id, CHUNK_SIZE_BYTES);
+      yield* stream_whole_file_in_chunks(download_url, item_id, {
+        chunk_size_bytes: CHUNK_SIZE_BYTES,
+        // Same per-chunk budget the Range path uses, applied between reads rather than to the
+        // whole transfer, so a stalled body is cut off but a slow one is not.
+        stall_timeout_ms: chunk_stall_timeout_ms(),
+      });
       return;
     }
   }

--- a/packages/sharepoint/src/services/backup/large-file-pipeline.ts
+++ b/packages/sharepoint/src/services/backup/large-file-pipeline.ts
@@ -1,32 +1,24 @@
-import { logger } from '@wisecom/atlas-core/utils/logger';
-import { stream_to_content_addressed_storage } from '@wisecom/atlas-core/services/shared/stream-encrypt-upload';
-import type {
-  SharePointSiteConnector,
-  SharePointDeltaItem,
-  StorageObjectLockPolicy,
-  TenantContext,
-} from '@wisecom/atlas-types';
-import { fetch_file_chunks } from '@/services/backup/large-file-chunk-download';
+import type { StorageObjectLockPolicy, TenantContext } from '@wisecom/atlas-types';
+import type { SharePointDeltaItem, SharePointSiteConnector } from '@wisecom/atlas-types';
 import {
-  sharepoint_data_key,
-  sharepoint_staging_key,
-  sharepoint_staging_prefix,
-} from '@/services/shared/storage-keys';
+  cleanup_stale_drive_staging,
+  process_large_drive_file,
+  type DriveLargeFileDeps,
+  type LargeFileResult,
+} from '@wisecom/atlas-drive/backup/large-file-pipeline';
+import { fetch_file_chunks } from '@/services/backup/large-file-chunk-download';
+import { SHAREPOINT_KEYS } from '@/services/shared/storage-keys';
 
 export { LARGE_FILE_THRESHOLD } from '@wisecom/atlas-drive/backup/large-file-threshold';
+export type { LargeFileResult } from '@wisecom/atlas-drive/backup/large-file-pipeline';
 
-export interface LargeFileResult {
-  readonly checksum: string;
-  readonly storage_key: string;
-  readonly stored: boolean;
-  readonly deduplicated: boolean;
-}
+/** SharePoint's half of the shared large-file pipeline: its key layout and its chunk fetcher. */
+export const SHAREPOINT_LARGE_FILE_DEPS: DriveLargeFileDeps = {
+  keys: SHAREPOINT_KEYS,
+  fetch_chunks: fetch_file_chunks,
+};
 
-/**
- * Single-download, zero-disk pipeline for files at or above
- * {@link LARGE_FILE_THRESHOLD}. Streams encrypted parts to an S3 staging key,
- * then either aborts (dedup) or copies to the canonical content-addressed key.
- */
+/** Streams a large file to storage through a staging key, deduplicating by content hash. */
 export async function process_large_file(
   connector: SharePointSiteConnector,
   item: SharePointDeltaItem,
@@ -34,56 +26,17 @@ export async function process_large_file(
   ctx: TenantContext,
   object_lock_policy?: StorageObjectLockPolicy,
 ): Promise<LargeFileResult> {
-  const download_url = item.download_url ?? (await connector.resolve_download_url(item));
-  if (!download_url) {
-    throw new Error(`Could not resolve download URL for large file ${item.item_id}`);
-  }
-
-  const staging_key = sharepoint_staging_key(site_id, item.item_id);
-
-  logger.info(
-    `Streaming large file ${item.file_name} (${format_bytes(item.size_bytes)}) via staging key...`,
-  );
-
-  const result = await stream_to_content_addressed_storage(
+  return process_large_drive_file(
+    SHAREPOINT_LARGE_FILE_DEPS,
+    connector,
+    item,
+    site_id,
     ctx,
-    fetch_file_chunks(download_url, item.size_bytes, item.item_id),
-    {
-      staging_key,
-      staging_prefix: sharepoint_staging_prefix(site_id),
-      build_data_key: (checksum) => sharepoint_data_key(site_id, checksum),
-      ...(object_lock_policy && { object_lock_policy }),
-    },
+    object_lock_policy,
   );
-
-  if (result.deduplicated) {
-    logger.info(`Deduplicated ${item.file_name} (already stored)`);
-  } else {
-    logger.info(`Stored ${item.file_name} (${format_bytes(item.size_bytes)})`);
-  }
-
-  return result;
 }
 
 /** Removes leftover staging objects and incomplete multipart uploads. */
 export async function cleanup_stale_staging(ctx: TenantContext, site_id: string): Promise<void> {
-  const prefix = sharepoint_staging_prefix(site_id);
-
-  const stale_keys = await ctx.storage.list(prefix);
-  for (const key of stale_keys) {
-    logger.info(`Cleaning up stale staging object: ${key}`);
-    await ctx.storage.delete(key).catch(() => {});
-  }
-
-  const aborted = await ctx.storage.abort_incomplete_uploads(prefix);
-  if (aborted > 0) {
-    logger.info(`Aborted ${aborted} incomplete staging upload(s)`);
-  }
-}
-
-function format_bytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+  return cleanup_stale_drive_staging(SHAREPOINT_KEYS, ctx, site_id);
 }

--- a/packages/sharepoint/src/services/restore/restore-folder-path.ts
+++ b/packages/sharepoint/src/services/restore/restore-folder-path.ts
@@ -1,15 +1,11 @@
-// Deliberately not shared with the OneDrive copy (#306): 28 differing lines of 106. The memo
-// keys differ, `drive_id:path` here against path alone there, which is a behavioural
-// difference rather than a naming one and is tracked separately.
 import type { SharePointSiteConnector } from '@wisecom/atlas-types';
-import { logger } from '@wisecom/atlas-core/utils/logger';
+import { ensure_drive_folder_path } from '@wisecom/atlas-drive/restore/folder-path';
 
 /**
  * Resolves a manifest `parent_path` to a drive item id, creating the folders that are missing.
  *
- * `folder_ids` is the per-restore memo. Keys are `drive_id:path` because one snapshot spans several
- * document libraries and the same path means a different folder in each. Returns undefined when a
- * segment could not be created; the caller reports the entry as skipped.
+ * `folder_ids` is the per-restore memo, keyed by `drive_id:path` because one snapshot spans
+ * several document libraries and the same path means a different folder in each.
  */
 export async function ensure_sharepoint_folder_path(
   connector: SharePointSiteConnector,
@@ -19,46 +15,5 @@ export async function ensure_sharepoint_folder_path(
   path: string,
   folder_ids: Map<string, string>,
 ): Promise<string | undefined> {
-  const normalized = path.length === 0 || path === '.' ? '/' : path;
-  const cache_key = `${drive_id}:${normalized}`;
-  const cached = folder_ids.get(cache_key);
-  if (cached !== undefined) return cached;
-
-  if (normalized === '/') {
-    folder_ids.set(cache_key, 'root');
-    return 'root';
-  }
-
-  const segments = normalized.split('/').filter(Boolean);
-  let current_path = '';
-  let parent_id = 'root';
-
-  for (const segment of segments) {
-    current_path = current_path ? `${current_path}/${segment}` : `/${segment}`;
-    const segment_key = `${drive_id}:${current_path}`;
-    const known = folder_ids.get(segment_key);
-    if (known !== undefined) {
-      parent_id = known;
-      continue;
-    }
-
-    try {
-      const folder_id = await connector.create_folder(
-        tenant_id,
-        site_id,
-        drive_id,
-        parent_id,
-        segment,
-      );
-      folder_ids.set(segment_key, folder_id);
-      parent_id = folder_id;
-    } catch (err) {
-      logger.warn(
-        `Failed to create folder ${current_path} in drive ${drive_id}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return undefined;
-    }
-  }
-
-  return parent_id;
+  return ensure_drive_folder_path(connector, tenant_id, site_id, drive_id, path, folder_ids);
 }

--- a/packages/sharepoint/src/services/restore/restore-folder-path.ts
+++ b/packages/sharepoint/src/services/restore/restore-folder-path.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the OneDrive copy (#306): 28 differing lines of 106. The memo
+// keys differ, `drive_id:path` here against path alone there, which is a behavioural
+// difference rather than a naming one and is tracked separately.
 import type { SharePointSiteConnector } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 

--- a/packages/sharepoint/src/services/restore/restore.service.ts
+++ b/packages/sharepoint/src/services/restore/restore.service.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the OneDrive copy (#306): 194 differing lines of 496. The
+// restore target differs in kind, a resolved site and library against an owner's drive, and
+// so does the conflict handling around the restore root.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import {
   begin_operation_progress,

--- a/packages/sharepoint/src/services/restore/restore.service.ts
+++ b/packages/sharepoint/src/services/restore/restore.service.ts
@@ -39,6 +39,7 @@ import {
   load_drive_chain_entries,
   restorable_entries,
 } from '@wisecom/atlas-drive/shared/manifest-chain';
+import { count_created_folders } from '@wisecom/atlas-drive/restore/folder-path';
 import { ensure_sharepoint_folder_path } from '@/services/restore/restore-folder-path';
 import {
   assert_renameable,
@@ -161,7 +162,7 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
         });
       }
 
-      const folders_created = folder_ids.size;
+      const folders_created = count_created_folders(folder_ids);
       const interrupted = finish_operation_progress(
         options,
         'restore',

--- a/packages/sharepoint/src/services/status/status.service.ts
+++ b/packages/sharepoint/src/services/status/status.service.ts
@@ -59,7 +59,10 @@ export class SharePointStatusService implements SharePointStatusUseCase {
         last_snapshot_id: previous_manifest?.snapshot_id,
         total_libraries: all_libraries.length,
         libraries: library_statuses,
-        is_up_to_date: total_pending === 0 && library_statuses.every((lib) => lib.has_backup),
+        // Every library's own flag, not the pending total: a library with no saved delta link and
+        // a library whose peek threw both report `pending_changes: 0`, and the second also reports
+        // `has_backup: true`, so a Graph error used to read as a clean "up to date" (issue #298).
+        is_up_to_date: library_statuses.every((lib) => lib.is_up_to_date),
         total_pending_changes: total_pending,
       };
     } finally {

--- a/packages/sharepoint/src/services/status/status.service.ts
+++ b/packages/sharepoint/src/services/status/status.service.ts
@@ -1,3 +1,6 @@
+// Deliberately not shared with the OneDrive copy (#306): 71 differing lines of 247. Both peek
+// at delta state, but over libraries against drives, with different discovery calls and
+// different result shapes exposed through the ports.
 import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifier-normalization';
 import { inject, injectable } from 'inversify';
 import type {

--- a/packages/sharepoint/tests/unit/adapters/s3-delta-cursor-repository.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/s3-delta-cursor-repository.test.ts
@@ -82,14 +82,23 @@ describe('S3SharePointDeltaCursorRepository', () => {
   });
 
   it('reads an undecryptable cursor as absent rather than throwing', async () => {
-    const { ctx } = make_ctx(
-      { [CURSOR_KEY]: make_cursor() },
-      {
-        [CURSOR_KEY]: new Error('unable to authenticate data'),
-      },
-    );
+    const { ctx } = make_ctx({ [CURSOR_KEY]: make_cursor() });
+    // The object reads back fine and fails to decrypt, which is the case a wrong or rotated key
+    // produces. Failing the read instead would exercise the storage path, not this one.
+    (ctx as unknown as { decrypt: () => Buffer }).decrypt = () => {
+      throw new Error('unable to authenticate data');
+    };
 
     // A full re-enumeration is recoverable; a crash on every run is not.
+    await expect(repo.load(ctx, SITE)).resolves.toBeUndefined();
+  });
+
+  it('reads a cursor whose object cannot be fetched as absent rather than throwing', async () => {
+    const { ctx } = make_ctx(
+      { [CURSOR_KEY]: make_cursor() },
+      { [CURSOR_KEY]: new Error('connection reset') },
+    );
+
     await expect(repo.load(ctx, SITE)).resolves.toBeUndefined();
   });
 

--- a/packages/sharepoint/tests/unit/adapters/s3-manifest-repository.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/s3-manifest-repository.test.ts
@@ -136,6 +136,12 @@ describe('S3SharePointManifestRepository', () => {
       {
         'sharepoint/manifests/site-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
         'sharepoint/manifests/site-1/snap-corrupt.json': 'not-json',
+        // Listed so the injected get() failure below is actually reached: list() is derived
+        // from the stored keys, so a key present only in get_error is never read.
+        'sharepoint/manifests/site-1/snap-unreadable.json': make_manifest(
+          'snap-unreadable',
+          '2026-03-02T00:00:00Z',
+        ),
       },
       { 'sharepoint/manifests/site-1/snap-unreadable.json': new Error('decrypt failed') },
     );

--- a/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
@@ -74,6 +74,47 @@ describe('classify_change_type', () => {
     ).toBe('moved_and_renamed');
   });
 
+  it('returns "moved" when the item moved and its content changed in one delta (issue #297)', () => {
+    const item = make_item({ parent_path: '/Archive', etag: '"e2"' });
+    // The new content blob records the update; nothing but this label records the old location.
+    expect(
+      classify_change_type(
+        item,
+        { 'item-1': '/Documents' },
+        { 'item-1': 'report.docx' },
+        { 'item-1': '"e1"' },
+      ),
+    ).toBe('moved');
+  });
+
+  it('returns "moved_and_renamed" when path, name and content all changed', () => {
+    const item = make_item({
+      parent_path: '/Archive',
+      file_name: 'report-v2.docx',
+      etag: '"e2"',
+    });
+    expect(
+      classify_change_type(
+        item,
+        { 'item-1': '/Documents' },
+        { 'item-1': 'report.docx' },
+        { 'item-1': '"e1"' },
+      ),
+    ).toBe('moved_and_renamed');
+  });
+
+  it('returns "renamed" when the name and the content changed together', () => {
+    const item = make_item({ file_name: 'report-v2.docx', etag: '"e2"' });
+    expect(
+      classify_change_type(
+        item,
+        { 'item-1': '/Documents' },
+        { 'item-1': 'report.docx' },
+        { 'item-1': '"e1"' },
+      ),
+    ).toBe('renamed');
+  });
+
   it('returns undefined when nothing changed', () => {
     const item = make_item({ etag: '"same"' });
     expect(

--- a/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
@@ -160,7 +160,11 @@ describe('classify_change_type', () => {
     expect(
       classify_change_type(item, { 'item-1': '/Documents' }, { 'item-1': 'report.docx' }, {}),
     ).toBe('moved');
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing etag'));
+    // The whole line, not a substring: a message change should show up here as a diff.
+    expect(warn).toHaveBeenCalledWith(
+      'SharePoint delta item item-1: missing etag on prior and current snapshot; ' +
+        'a content change cannot be detected',
+    );
 
     warn.mockRestore();
   });

--- a/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/change-classifier.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { logger } from '@wisecom/atlas-core/utils/logger';
 import type { SharePointDeltaItem } from '@wisecom/atlas-types';
 import { classify_change_type } from '@/services/backup/change-classifier';
 
@@ -149,5 +150,18 @@ describe('classify_change_type', () => {
   it('returns "updated" when both prior and current etag are missing but item is known', () => {
     const item = make_item();
     expect(classify_change_type(item, { 'item-1': '/Documents' }, {}, {})).toBe('updated');
+  });
+
+  it('warns about the missing etags but still reports the move (issue #297)', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const item = make_item({ parent_path: '/Archive' });
+
+    // No etag on either side: the move is certain, a content change alongside it is invisible.
+    expect(
+      classify_change_type(item, { 'item-1': '/Documents' }, { 'item-1': 'report.docx' }, {}),
+    ).toBe('moved');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing etag'));
+
+    warn.mockRestore();
   });
 });

--- a/packages/sharepoint/tests/unit/services/backup/large-file-chunk-download.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/large-file-chunk-download.test.ts
@@ -127,7 +127,13 @@ describe('fetch_file_chunks', () => {
     // Two requests, not one per chunk: the Range probe, then one streamed download. Fetching
     // per chunk cost the whole file every time, so a 1 GiB item moved 256 GiB.
     expect(fetch_mock).toHaveBeenCalledTimes(2);
-    expect((fetch_mock.mock.calls[1] as unknown[])[1]).toBeUndefined();
+    // The streamed request carries no Range header, only the stall-abort signal.
+    const streamed_init = (fetch_mock.mock.calls[1] as unknown[])[1] as {
+      headers?: Record<string, string>;
+      signal?: AbortSignal;
+    };
+    expect(streamed_init.headers).toBeUndefined();
+    expect(streamed_init.signal).toBeInstanceOf(AbortSignal);
     // Compared by digest, not by `toEqual`: a deep equality over 4 MiB of bytes takes seconds.
     const rebuilt = Buffer.concat(parts);
     expect(rebuilt.length).toBe(whole.length);

--- a/packages/sharepoint/tests/unit/services/backup/large-file-chunk-download.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/large-file-chunk-download.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fetch_file_chunks } from '@/services/backup/large-file-chunk-download';
 
 // The OneDrive twin of this file has had tests since issue #36; this one had
@@ -16,9 +17,19 @@ function to_array_buffer(body: Buffer): ArrayBuffer {
 function range_response(status: number, body = Buffer.alloc(0)): Response {
   return {
     status,
+    ok: status >= 200 && status < 300,
     headers: { get: (): string | null => null },
     arrayBuffer: (): Promise<ArrayBuffer> => Promise.resolve(to_array_buffer(body)),
     text: (): Promise<string> => Promise.resolve(''),
+    // The Range-ignored path cancels the body unread, and the streamed fallback iterates it.
+    body: {
+      cancel: (): Promise<void> => Promise.resolve(),
+      async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+        // Two parts, so the re-cut has to join across reads rather than pass one buffer through.
+        yield new Uint8Array(body.subarray(0, Math.ceil(body.length / 2)));
+        yield new Uint8Array(body.subarray(Math.ceil(body.length / 2)));
+      },
+    },
   } as unknown as Response;
 }
 
@@ -28,10 +39,8 @@ async function collect(url: string, total: number, item = 'item-1'): Promise<Buf
   return Buffer.concat(parts);
 }
 
-beforeEach(() => {
-  vi.useFakeTimers();
-});
-
+// Fake timers are installed per test, not globally: leaving them on for the streamed fallback
+// routes every promise resolution through the faked queue and turns a 4 MiB re-cut into seconds.
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
@@ -62,6 +71,7 @@ describe('fetch_file_chunks', () => {
   });
 
   it.each([429, 503, 504])('retries a chunk the CDN refused with HTTP %i', async (status) => {
+    vi.useFakeTimers();
     const payload = Buffer.from('chunk-payload');
     const fetch_mock = vi
       .fn()
@@ -87,6 +97,7 @@ describe('fetch_file_chunks', () => {
   });
 
   it('gives up after the retry budget is spent', async () => {
+    vi.useFakeTimers();
     const fetch_mock = vi.fn().mockResolvedValue(range_response(503));
     vi.stubGlobal('fetch', fetch_mock);
 
@@ -99,9 +110,7 @@ describe('fetch_file_chunks', () => {
     expect(fetch_mock).toHaveBeenCalledTimes(6);
   });
 
-  it('slices the whole body when the CDN ignores the Range header', async () => {
-    // A 200 means the server sent everything; taking it as the chunk would
-    // duplicate the head of the file into every later chunk.
+  it('stops asking for ranges once the CDN answers one with the whole file (issue #301)', async () => {
     const whole = Buffer.concat([Buffer.alloc(CHUNK_SIZE, 1), Buffer.alloc(1024, 2)]);
     const fetch_mock = vi.fn().mockResolvedValue(range_response(200, whole));
     vi.stubGlobal('fetch', fetch_mock);
@@ -115,18 +124,48 @@ describe('fetch_file_chunks', () => {
       parts.push(chunk);
     }
 
+    // Two requests, not one per chunk: the Range probe, then one streamed download. Fetching
+    // per chunk cost the whole file every time, so a 1 GiB item moved 256 GiB.
+    expect(fetch_mock).toHaveBeenCalledTimes(2);
+    expect((fetch_mock.mock.calls[1] as unknown[])[1]).toBeUndefined();
+    // Compared by digest, not by `toEqual`: a deep equality over 4 MiB of bytes takes seconds.
+    const rebuilt = Buffer.concat(parts);
+    expect(rebuilt.length).toBe(whole.length);
+    expect(createHash('sha256').update(rebuilt).digest('hex')).toBe(
+      createHash('sha256').update(whole).digest('hex'),
+    );
     expect(parts[0]?.length).toBe(CHUNK_SIZE);
     expect(parts[1]?.length).toBe(1024);
-    expect(parts[1]?.[0]).toBe(2);
   });
 
-  it('rejects a 200 body too short to satisfy the requested range', async () => {
-    const fetch_mock = vi.fn().mockResolvedValue(range_response(200, Buffer.alloc(10, 1)));
+  it('fails the streamed fallback when the plain download is refused', async () => {
+    const fetch_mock = vi
+      .fn()
+      .mockResolvedValueOnce(range_response(200, Buffer.alloc(CHUNK_SIZE + 1024, 1)))
+      .mockResolvedValueOnce(range_response(403));
     vi.stubGlobal('fetch', fetch_mock);
 
     await expect(collect('https://cdn.test/file', CHUNK_SIZE + 1024)).rejects.toThrow(
-      /returned 200 with 10 bytes/,
+      /HTTP 403 for the streamed download/,
     );
+  });
+
+  it('accepts a 200 for a single-chunk item, where the whole file is the chunk', async () => {
+    const whole = Buffer.alloc(1024, 7);
+    const fetch_mock = vi.fn().mockResolvedValue(range_response(200, whole));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    // One chunk means a 200 is not the server ignoring Range, so there is nothing to fall back
+    // to and no second request to make.
+    expect(await collect('https://cdn.test/file', 1024)).toEqual(whole);
+    expect(fetch_mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a single-chunk 200 body too short to satisfy the requested range', async () => {
+    const fetch_mock = vi.fn().mockResolvedValue(range_response(200, Buffer.alloc(5, 1)));
+    vi.stubGlobal('fetch', fetch_mock);
+
+    await expect(collect('https://cdn.test/file', 10)).rejects.toThrow(/returned 200 with 5 bytes/);
   });
 
   it('yields nothing for a zero-byte file', async () => {

--- a/packages/sharepoint/tests/unit/services/save/save.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/save/save.service.test.ts
@@ -35,6 +35,8 @@ vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
     create_file_archive: vi.fn().mockReturnValue({
       archive: mock_archive,
       promise: Promise.resolve(8192),
+      publish: vi.fn().mockResolvedValue(undefined),
+      abort: vi.fn().mockResolvedValue(undefined),
     }),
     add_file_to_archive: vi.fn().mockResolvedValue(undefined),
     finalize_file_archive: vi.fn().mockResolvedValue(undefined),

--- a/packages/sharepoint/tests/unit/services/save/save.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/save/save.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
 import { Container } from 'inversify';
 import 'reflect-metadata';
 import { SharePointSaveService } from '@/services/save/save.service';
@@ -13,17 +14,6 @@ import type {
   TenantContext,
   TenantContextFactory,
 } from '@wisecom/atlas-types';
-
-/** Fixture overrides may blank an optional field; an explicit `undefined` drops the key. */
-type Overrides<T> = { [K in keyof T]?: T[K] | undefined };
-
-function apply_overrides<T extends object>(base: T, overrides: Overrides<T>): T {
-  const merged: Record<string, unknown> = { ...base, ...overrides };
-  for (const [key, value] of Object.entries(overrides)) {
-    if (value === undefined) delete merged[key];
-  }
-  return merged as T;
-}
 
 vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
   const mock_archive = {

--- a/packages/sharepoint/tests/unit/services/status/status.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/status/status.service.test.ts
@@ -176,18 +176,33 @@ describe('SharePointStatusService', () => {
     });
   });
 
-  it('currently rolls a failed peek up as up to date, which is wrong', async () => {
+  it('does not report the site as up to date when a peek failed (issue #298)', async () => {
     vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('library-1') as never);
     vi.mocked(mocks.connector.fetch_delta).mockRejectedValue(new Error('throttled'));
 
     const result = await check();
 
-    // Pins today's behaviour, it is not an endorsement. The roll-up is
-    // `total_pending === 0 && every(has_backup)`, which ignores each library's
-    // own `is_up_to_date`, so a throttled peek counts as clean. Expected to
-    // flip to false when that is fixed; see the follow-up issue.
+    // The roll-up reads each library's own flag. A throttled peek reports zero pending and
+    // `has_backup: true`, so the old `total_pending === 0 && every(has_backup)` called it clean.
     expect(result.libraries[0]?.is_up_to_date).toBe(false);
-    expect(result.is_up_to_date).toBe(true);
+    expect(result.is_up_to_date).toBe(false);
+  });
+
+  it('does not report the site as up to date when one library of several failed', async () => {
+    vi.mocked(mocks.connector.list_document_libraries).mockResolvedValue([
+      { drive_id: 'library-1', drive_name: 'Documents' },
+      { drive_id: 'library-2', drive_name: 'Shared Documents' },
+    ]);
+    vi.mocked(mocks.cursors.load).mockResolvedValue(cursor_for('library-1', 'library-2') as never);
+    vi.mocked(mocks.connector.fetch_delta)
+      .mockRejectedValueOnce(new Error('throttled'))
+      .mockResolvedValueOnce({ items: [], delta_link: 'b' } as never);
+
+    const result = await check();
+
+    // The clean second library must not mask the first: total pending is still zero here.
+    expect(result.total_pending_changes).toBe(0);
+    expect(result.is_up_to_date).toBe(false);
   });
 
   it('does not fail the whole check when one library of several fails to peek', async () => {

--- a/packages/sharepoint/tests/unit/services/verification/verification.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/verification/verification.service.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type {
   SharePointManifestEntry,
@@ -11,17 +12,6 @@ import type {
 } from '@wisecom/atlas-types';
 import { stub_encrypted_object_store } from '@wisecom/atlas-types/testing/stub-encrypted-object-store';
 import { SharePointVerificationService } from '@/services/verification/verification.service';
-
-/** Fixture overrides may blank an optional field; an explicit `undefined` drops the key. */
-type Overrides<T> = { [K in keyof T]?: T[K] | undefined };
-
-function apply_overrides<T extends object>(base: T, overrides: Overrides<T>): T {
-  const merged: Record<string, unknown> = { ...base, ...overrides };
-  for (const [key, value] of Object.entries(overrides)) {
-    if (value === undefined) delete merged[key];
-  }
-  return merged as T;
-}
 
 const TENANT_ID = 'tenant-1';
 const SITE_ID = 'site-1';

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-types",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/types/src/errors/atlas-errors.ts
+++ b/packages/types/src/errors/atlas-errors.ts
@@ -1,0 +1,104 @@
+/**
+ * Stable machine-readable codes. The string values are the contract: they are safe to switch on,
+ * to log, and to compare across versions. Prose messages are not, and never were.
+ */
+export type AtlasErrorCode =
+  | 'ATLAS_AUTH_DENIED'
+  | 'ATLAS_MAILBOX_NOT_LICENSED'
+  | 'ATLAS_NOT_FOUND'
+  | 'ATLAS_THROTTLED'
+  | 'ATLAS_WRONG_PASSPHRASE'
+  | 'ATLAS_OBJECT_LOCK_RETAINED'
+  | 'ATLAS_STORAGE_FAILURE'
+  | 'ATLAS_CONFIG_INVALID';
+
+/**
+ * Base class for every failure Atlas raises on purpose.
+ *
+ * Consumers branch on `instanceof AtlasError` or on `code`. Before this existed, the only way to
+ * tell an unlicensed mailbox from a missing permission was to match on message text, which made
+ * every wording change a silent breaking change: the CLI's own diagnostics and the deletion
+ * services did exactly that (issue #40).
+ */
+export class AtlasError extends Error {
+  readonly code: AtlasErrorCode;
+
+  constructor(code: AtlasErrorCode, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.code = code;
+    this.name = new.target.name;
+  }
+}
+
+/** Graph or storage refused the operation for lack of permission or consent. */
+export class AuthError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_AUTH_DENIED', message, options);
+  }
+}
+
+/** The mailbox has no Exchange Online license, so Graph will not serve it. */
+export class MailboxNotLicensedError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_MAILBOX_NOT_LICENSED', message, options);
+  }
+}
+
+/** A snapshot, mailbox, drive, site or object that does not exist. */
+export class NotFoundError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_NOT_FOUND', message, options);
+  }
+}
+
+/** The service throttled the operation and the retry budget was exhausted. */
+export class ThrottledError extends AtlasError {
+  /** Milliseconds the service asked the caller to wait, when it said. */
+  readonly retry_after_ms: number | undefined;
+
+  constructor(message: string, retry_after_ms?: number, options?: { cause?: unknown }) {
+    super('ATLAS_THROTTLED', message, options);
+    this.retry_after_ms = retry_after_ms;
+  }
+}
+
+/**
+ * The passphrase could not unwrap the data key.
+ *
+ * Distinct from data corruption on purpose: AES-GCM reports both as one authentication failure,
+ * and the raw Node message ("Unsupported state or unable to authenticate data") sent operators
+ * looking for a corrupt backup when the real cause was a typo.
+ */
+export class WrongPassphraseError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_WRONG_PASSPHRASE', message, options);
+  }
+}
+
+/** The object is under an Object Lock retention or legal hold, so it cannot be deleted yet. */
+export class ObjectLockRetainedError extends AtlasError {
+  constructor(
+    readonly key: string,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      'ATLAS_OBJECT_LOCK_RETAINED',
+      `Object ${key} is protected by Object Lock retention or a legal hold and was not deleted.`,
+      options,
+    );
+  }
+}
+
+/** The storage backend failed for a reason that is not permission, retention or absence. */
+export class StorageError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_STORAGE_FAILURE', message, options);
+  }
+}
+
+/** Configuration is missing or unusable: credentials, endpoint, passphrase, tenant. */
+export class ConfigError extends AtlasError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super('ATLAS_CONFIG_INVALID', message, options);
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,2 +1,3 @@
 export * from './domain/index';
 export * from './ports/index';
+export * from './errors/atlas-errors';


### PR DESCRIPTION
Releases `v4.4.0`. Merging this PR tags `v4.4.0` on `main` and publishes `@wisecom/atlas-sdk` and `@wisecom/atlas-cli` to npm.

## Summary

The v4.4.0 milestone, closed at 10 of 10. Unlike v4.3.0, which was internal shape, this one ships operator-visible fixes and one real SDK feature. Everything in the drive set was found by inspection while v4.3.0 reorganised that code, so none of it came from a reported incident, which is why it was held back rather than folded into a refactor release.

**New in the SDK**

- Typed error taxonomy (#40): `AtlasError` with a stable `code`, plus `AuthError`, `MailboxNotLicensedError`, `NotFoundError`, `ThrottledError`, `WrongPassphraseError`, `ObjectLockRetainedError`, `StorageError` and `ConfigError`, all exported from `@wisecom/atlas-sdk`. Consumers can branch on a class instead of matching on message text, which every wording change used to break silently. The four Object Lock and precondition errors now extend the taxonomy and are exported for the first time.

**Fixes an operator can notice**

- A wrong passphrase now raises `WrongPassphraseError` instead of the raw `Unsupported state or unable to authenticate data`, which read like a corrupt backup and sent people hunting data loss over a typo (#40).
- `--file-filter /Report.docx` matches a file at the drive or library root. The comparison path was built as `//Report.docx`, so root-level files were unselectable on both restore and save (#299).
- A version path that belongs to two drive items now names both and stops, instead of restoring a version of whichever one the index reached first (#300).
- A failed save leaves no file behind. The archive is written to a sibling temporary file and moved onto the output path only when complete, so a truncated zip can no longer look like a finished export, and an existing file at the output path survives a failed run (#307).
- `status` no longer reports an owner or site as up to date when a drive's delta peek failed. A throttled peek contributed zero pending changes and read as a clean bill of health (#298).
- A file that moved and changed content in one delta window keeps its `moved` classification instead of being recorded as `updated`, which erased where the file went (#297).
- An OneDrive restore spanning two of an owner's drives no longer writes into the wrong drive's folder. The folder-id memo was keyed by path alone, so the same path in a second drive resolved to the first drive's folder, silently (#316). `folders_created` in a restore result is also now exact rather than off by one per drive.
- A CDN that ignores `Range` no longer causes the whole file to be re-downloaded per chunk. A 1 GiB item was moving 256 GiB; it is now recognised once and finished with a single streamed pass, bounded by a stall timeout (#301).

**Internal**

- The drive file processor, large-file pipeline and change classifier are shared through `packages/drive`, and every pair still kept as two copies carries a recorded reason (#306, closing out #151).
- Drive adapter tests no longer inject failures the code never sees (#304).

## Checklist

- Milestone v4.4.0: 10 closed, 0 open.
- Version bump covers all ten packages in lockstep, `4.3.0` to `4.4.0`, and touches nothing else.
- Every PR in the release carries a label, so the generated notes categorise: `bug` for the six fixes, `enhancement` for the SDK feature and the two refactors, `documentation` for the release-docs correction.
- E2E dispatched against `dev` at this exact content and green (run 33642064398), since the release moves backup, restore, save and storage paths.
- Documentation governance: `docs/reference/sdk.md` gains an Errors section with the class-and-code table and the exports list; `docs/reference/cli.md` covers the root-level `--file-filter` path form, the ambiguous-path behaviour and the failed-save cleanup; `docs/onedrive-backup.md` and `docs/sharepoint-backup.md` state what `is_up_to_date` actually means. No CLI flag, SDK method signature or config variable changed.
