### PR TITLE
feat(sdk)!: eager configuration validation and connectivity probe

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Atlas merges configuration from four sources, in this order. Later sources win.
+The Atlas CLI merges configuration from four sources, in this order. Later sources win.
 
 1. **Config file**: `atlas.config.json` or `.atlas/config.json`, searched in cwd, then `~/.atlas/`
 2. **Encrypted secure store**: `~/.atlas/config.enc`, managed with `atlas config`
@@ -8,6 +8,8 @@ Atlas merges configuration from four sources, in this order. Later sources win.
 4. **Environment variables**: always take precedence
 
 This lets you keep defaults in a config file, credentials in the encrypted store on operator workstations, and environment variables for CI/CD or container orchestration where secrets are injected at runtime.
+
+The SDK does not use this discovery chain. Pass credentials and tenant configuration explicitly to `createAtlasInstance`; v5 rejects missing or blank required fields, passphrases shorter than 14 UTF-8 bytes, and malformed HTTP(S) S3 endpoints before creating clients. The optional `atlas.validate()` probes an existing tenant bucket and Graph token acquisition without provisioning storage. See [SDK configuration validation](/reference/sdk#configuration-validation) for endpoint constraints and typed failures.
 
 ## Variables
 

--- a/docs/migration/v5.md
+++ b/docs/migration/v5.md
@@ -73,8 +73,18 @@ createStorageTarget({ s3Endpoint: '...', encryptionPassphrase: '...' });
 
 v4's entry point re-exported all of `@wisecom/atlas-types`, which published every internal port, DI token and service interface as public API. v5 exports a named list: the instance and its three workload APIs, their option and result types, the progress and error types, and the two value exports. If you imported an internal port, a token, or a use-case interface, it is no longer public. Those were never intended as API and had no stability guarantee; open an issue if you were relying on one and it will be considered on its merits.
 
-`create_container` and `create_container_from_config` are no longer exported. They read `.env` and `atlas.config.json` from the current directory, which contradicted the SDK's documented promise that it reads no environment or config files. They were CLI internals that happened to be reachable.
+`create_container` and `create_container_from_config` are no longer exported, as completed in [PR #323](https://github.com/wisecom-oy/atlas/pull/323). The former discovered `.env` and `atlas.config.json`, contradicting the SDK's explicit-configuration contract; the latter was an internal DI factory. Pass every credential to `createAtlasInstance` instead. The unused environment-loading factory has also been removed from the SDK source.
+
+### Eager configuration validation
+
+`createAtlasInstance` now throws `ConfigError` synchronously for missing or blank required fields, passphrases shorter than 14 UTF-8 bytes, and malformed S3 endpoints. Endpoints must be absolute HTTP(S) URLs without embedded credentials, a query or a fragment. Previously some invalid values survived construction and failed only during an operation.
+
+**Existing short-passphrase backups need care.** Do not pad or replace the passphrase to satisfy the new check: that changes the key and makes existing data unreadable. Keep the original passphrase and use the previous SDK release or the CLI to recover those backups. This change does not rotate keys or rewrite stored data; the CLI's existing passphrase handling is unchanged.
+
+The optional `await atlas.validate()` checks an existing tenant bucket with `HeadBucket`, then acquires a Graph token. It creates no storage and does not verify the stored encryption key or workload permissions. S3-stage failures are `StorageError`; Graph-token failures are `AuthError`. See [Configuration validation](/reference/sdk#configuration-validation) for prerequisites and error codes.
+
+Together with the camelCase surface and enumerated exports in PR #323, this completes [issue #45](https://github.com/wisecom-oy/atlas/issues/45). The error classes were already available from v4.4.0; this change uses them at construction and in the explicit connectivity probe.
 
 ## Next
 
-The CLI flag changes, the exit-code changes, and the eager configuration validation land in the same release and are documented here as they merge.
+The CLI flag changes and exit-code changes land in the same release and are documented here as they merge.

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -33,13 +33,44 @@ const atlas = createAtlasInstance({
 });
 ```
 
-All config is explicit. The SDK **does not read environment variables or config files**, a deliberate security choice for multi-tenant environments: no credentials picked up from a stale `.env` file, no environment variables inherited from a different tenant. Every value is passed at construction time.
+All credentials and tenant configuration are explicit. The SDK does not discover them in environment variables, `.env`, or config files, so a stale file or another tenant's inherited configuration cannot select credentials. The environment-loading container factory is not exported. Standard runtime controls such as TLS certificate validation still apply.
 
 The tenant is bound at creation time, so every method operates within that tenant scope. Methods are async and return Promises.
 
 Everything on the public surface is camelCase: methods, config, option fields and result fields alike. Before v5.0.0 the methods were camelCase and every option and result field was snake_case, because the internal model leaked through as the public API. Atlas is still snake_case internally, and the conversion happens at the SDK boundary, so `atlas.outlook.backup(id, { forceFull: true })` returns `{ summary: { attachmentsStored } }` and never a mixture of the two. See [Migrating to v5](/migration/v5) for the full list of renamed fields.
 
 Two kinds of key stay verbatim, because they are data rather than field names: the keys of a map Atlas did not choose (`deltaLinks` keyed by Graph folder id, `requestsByType` keyed by request label, `byService` keyed by pool name), and the raw Graph payload in `readMessage().message`, which has to keep matching what Graph returned and what the stored blob contains.
+
+### Configuration validation
+
+```typescript
+import { AuthError, StorageError } from '@wisecom/atlas-sdk';
+
+// Optional, after creating the instance and provisioning its tenant bucket.
+try {
+  await atlas.validate();
+} catch (error) {
+  if (error instanceof StorageError) {
+    console.error('Check S3 endpoint, credentials and tenant-bucket access.');
+  } else if (error instanceof AuthError) {
+    console.error('Check Microsoft Entra credentials and connectivity.');
+  }
+  throw error;
+}
+```
+
+`createAtlasInstance(config)` validates locally and synchronously, before creating clients. Missing or blank required fields, a passphrase shorter than **14 UTF-8 bytes**, or an invalid `s3Endpoint` throw `ConfigError` (`ATLAS_CONFIG_INVALID`). The endpoint must be an absolute HTTP or HTTPS URL with a hostname and no embedded credentials, query or fragment. HTTP supports local S3-compatible storage; use HTTPS across untrusted networks. Construction makes no network requests.
+
+`atlas.validate(): Promise<void>` is opt-in. It sends `HeadBucket` for `atlas-{tenantId}`, then requests a Graph token with the instance's shared authentication provider and `https://graph.microsoft.com/.default` scope. A cached valid token may be reused. Success resolves without returning a token or other data.
+
+| Validation stage | Failure | Operator action |
+| ---------------- | ------- | --------------- |
+| S3 `HeadBucket` | `StorageError`, `ATLAS_STORAGE_FAILURE` | Check endpoint, region, credentials, bucket existence and `s3:ListBucket` access. A missing bucket fails; provision it separately. |
+| Graph token acquisition | `AuthError`, `ATLAS_AUTH_DENIED` | Check tenant ID, client ID, client secret and connectivity to Microsoft Entra ID. |
+
+These codes identify the failed validation stage, not necessarily bad credentials: DNS, TLS and transport failures can also cause rejection. The S3 stage runs first; if it fails, Graph is not probed. Each error retains the original failure as `cause`. Do not publish raw provider diagnostics without redacting tenant and credential details.
+
+The probe never creates buckets, loads or wraps encryption keys, or writes objects. It does not verify write permissions, Object Lock readiness, workload-specific Graph consent or whether the passphrase can unwrap existing backups. Use `checkStorage()` for Object Lock readiness; an incorrect existing passphrase still raises `WrongPassphraseError` when a backup or restore loads the key. See [Security](/security#kek-derivation-scrypt) for passphrase guidance and [v5 migration](/migration/v5#eager-configuration-validation) before upgrading an existing tenant.
 
 ### Logging
 
@@ -854,16 +885,12 @@ Every error carries the underlying failure as `cause`, so the Graph or AWS SDK e
 
 ## Exports
 
-`@wisecom/atlas-sdk` re-exports all domain types, port interfaces, and result types, so everything below is available from a single `@wisecom/atlas-sdk` import.
+`@wisecom/atlas-sdk` exports an explicit public list, not all internal domain types or ports. Workload options and results use the camelCase types below; infer other method results from `AtlasInstance` rather than importing internal models. See [v5 exports](/migration/v5#exports-are-now-enumerated).
 
 - Instance types: `AtlasInstance`, `AtlasInstanceConfig`
 - Sub-API types: `OutlookApi`, `OneDriveApi`, `SharePointApi`
-- Stats types: `BucketStats`, `MailboxStats`, `FolderStats`, `MonthlyBreakdown`
-- Status types: `MailboxStatusResult`, `FolderStatus`, `OneDriveStatusResult`, `OneDriveDriveStatus`, `SharePointStatusResult`, `SharePointLibraryStatus`
-- Identity types: `ResolvedUserIdentity`, `IdentityRegistry`, `IdentityRegistryEntry`
-- Discovery types: `TenantMailbox`, `MailboxDiscoveryOptions`
-- Deletion types: `DeletionResult`
-- Replication types: `ReplicationResult`, `ReplicationStatusRecord`, `StorageTarget`, `StorageTargetConfig`
+- Workload options and results: the named `Outlook*`, `OneDriveSdk*` and `SharePointSdk*` types used by each API
+- Storage targets: `StorageTarget`, `StorageTargetSdkConfig`
 - Factory functions: `createAtlasInstance`, `createStorageTarget`
 - Operation control types: `SdkOperationOptions`, `OperationProgressEvent`, `OperationProgressCallback`, `OperationProgressPhase`
 - Cost helpers: `getGraphCost`
@@ -877,10 +904,7 @@ Every error carries the underlying failure as `cause`, so the Graph or AWS SDK e
 | `ServicePoolCost`         | type  | Cost for a single service pool                                              |
 | `GraphServicePool`        | type  | Pool identifier union type                                                  |
 | `GraphServiceLimits`      | type  | Type for the full limits constant                                           |
-| `OutlookServiceLimits`    | type  | Outlook pool limits type                                                    |
-| `SharePointServiceLimits` | type  | SharePoint/OneDrive pool limits type                                        |
-| `IdentityServiceLimits`   | type  | Identity pool limits type                                                   |
 | `GRAPH_SERVICE_LIMITS`    | value | Frozen official limits constant                                             |
 | `getGraphCost`            | value | Reads the cost burned before a failed operation threw                       |
-| `SyncResult`              | type  | Result of `atlas.outlook.backup` (includes `graphCost`)                     |
-| `RestoreResult`           | type  | Result of `atlas.outlook.restore` / `restoreMailbox` (includes `graphCost`) |
+| `OutlookBackupResult`     | type  | Result of `atlas.outlook.backup` (includes `graphCost`)                       |
+| `OutlookRestoreResult`    | type  | Result of `atlas.outlook.restore` / `restoreMailbox` (includes `graphCost`)    |

--- a/docs/security.md
+++ b/docs/security.md
@@ -44,6 +44,10 @@ Parameters used by Atlas for **new** DEK wraps:
 
 The **tenant-domain salt** ensures that the same passphrase and random salt produce different KEKs for different tenants. A fresh random salt is generated on every DEK wrap, so re-wrapping the DEK after a passphrase change uses new scrypt parameters without relying on a separate `_meta/kek_params.json` file.
 
+The v5 SDK rejects passphrases shorter than 14 UTF-8 bytes at construction, matching the existing KDF warning threshold. Byte length is only a minimum, not an entropy guarantee: use at least five random words or 20 random characters for production. The CLI's existing passphrase handling is unchanged. Never pad or replace an existing passphrase without migrating its wrapped DEK; use the previous SDK or CLI to recover short-passphrase backups.
+
+The optional SDK `validate()` probe performs only S3 `HeadBucket` and Graph token acquisition. It writes no bucket or key material and returns no token. Success does not establish encryption-key correctness, object-write permissions or workload-specific Graph consent. HTTP S3 endpoints remain available for local deployments; use HTTPS across untrusted networks to protect credentials and traffic.
+
 ### DEK: Data Encryption Key
 
 - **Generated once** per tenant: a cryptographically random 256-bit key.

--- a/packages/m365-graph/src/container.ts
+++ b/packages/m365-graph/src/container.ts
@@ -1,11 +1,19 @@
 import { type Container } from 'inversify';
 import type { GraphConfig } from '@wisecom/atlas-core/utils/config';
 import { GRAPH_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-core';
-import { create_graph_client, GRAPH_CLIENT_TOKEN } from '@/graph-client.factory';
+import {
+  create_graph_auth_provider,
+  create_graph_client,
+  GRAPH_AUTH_PROVIDER_TOKEN,
+  GRAPH_CLIENT_TOKEN,
+} from '@/graph-client.factory';
 import { GraphUserIdentityResolver } from '@/graph-user-identity-resolver.adapter';
 
+/** Binds a Graph client and its shared authentication provider without acquiring a token. */
 export function bind_graph_client(container: Container, config: GraphConfig): void {
-  const graph_client = create_graph_client(config);
+  const auth_provider = create_graph_auth_provider(config);
+  const graph_client = create_graph_client(auth_provider);
+  container.bind(GRAPH_AUTH_PROVIDER_TOKEN).toConstantValue(auth_provider);
   container.bind(GRAPH_CLIENT_TOKEN).toConstantValue(graph_client);
   container.bind(GRAPH_IDENTITY_RESOLVER_TOKEN).to(GraphUserIdentityResolver).inSingletonScope();
 }

--- a/packages/m365-graph/src/graph-client.factory.ts
+++ b/packages/m365-graph/src/graph-client.factory.ts
@@ -13,6 +13,7 @@ import { GraphCostMiddleware } from '@/graph-cost-middleware';
 import type { GraphConfig } from '@wisecom/atlas-core/utils/config';
 
 export const GRAPH_CLIENT_TOKEN = Symbol.for('GraphClient');
+export const GRAPH_AUTH_PROVIDER_TOKEN = Symbol.for('GraphAuthProvider');
 
 const GRAPH_BASE_URL = 'https://graph.microsoft.com';
 
@@ -32,10 +33,8 @@ const GRAPH_BASE_URL = 'https://graph.microsoft.com';
  * any downstream override to a non-TLS endpoint. Refuses to start
  * if NODE_TLS_REJECT_UNAUTHORIZED=0 would disable certificate validation.
  */
-export function create_graph_client(config: GraphConfig): Client {
+export function create_graph_client(auth_provider: TokenCredentialAuthenticationProvider): Client {
   assert_tls_not_disabled();
-  const credential = build_credential(config);
-  const auth_provider = build_auth_provider(credential);
   return Client.initWithMiddleware({
     middleware: build_middleware_chain(auth_provider),
     baseUrl: GRAPH_BASE_URL,
@@ -85,15 +84,15 @@ function assert_tls_not_disabled(): void {
   }
 }
 
-/** Builds an Azure AD client-secret credential for the given tenant. */
-function build_credential(config: GraphConfig): ClientSecretCredential {
-  return new ClientSecretCredential(config.tenant_id, config.client_id, config.client_secret);
-}
-
-/** Wraps the credential in a Graph-compatible authentication provider. */
-function build_auth_provider(
-  credential: ClientSecretCredential,
+/** Creates the shared, caching authentication provider for Graph requests and validation. */
+export function create_graph_auth_provider(
+  config: GraphConfig,
 ): TokenCredentialAuthenticationProvider {
+  const credential = new ClientSecretCredential(
+    config.tenant_id,
+    config.client_id,
+    config.client_secret,
+  );
   return new TokenCredentialAuthenticationProvider(credential, {
     scopes: ['https://graph.microsoft.com/.default'],
   });

--- a/packages/m365-graph/src/index.ts
+++ b/packages/m365-graph/src/index.ts
@@ -1,4 +1,8 @@
-export { create_graph_client, GRAPH_CLIENT_TOKEN } from './graph-client.factory';
+export {
+  create_graph_client,
+  GRAPH_CLIENT_TOKEN,
+  GRAPH_AUTH_PROVIDER_TOKEN,
+} from '@/graph-client.factory';
 export { parse_retry_after_ms } from './graph-retry-after';
 export {
   is_invalid_delta_error,

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -22,7 +22,7 @@ npm add @wisecom/atlas-sdk@beta
 
 ## Quick start
 
-Config is explicit at construction time. The SDK does **not** read `.env` files or environment variables.
+Credentials and tenant configuration are explicit at construction time. The SDK does not discover them in environment variables, `.env` or config files.
 
 ```typescript
 import { createAtlasInstance } from '@wisecom/atlas-sdk';
@@ -49,6 +49,10 @@ await atlas.sharepoint.backup('https://contoso.sharepoint.com/sites/Engineering'
 });
 ```
 
+Construction validates required fields, a minimum passphrase length of 14 UTF-8 bytes, and an absolute HTTP(S) S3 endpoint without embedded credentials, query or fragment. Invalid values throw `ConfigError` synchronously, without network requests.
+
+After provisioning the tenant bucket, call `await atlas.validate()` for an optional read-only S3 `HeadBucket` and Graph token probe. S3 failures throw `StorageError`; Graph-token failures throw `AuthError`. The probe does not test the encryption key, write permissions or workload-specific Graph consent. See the [SDK reference](https://wisecom-oy.github.io/atlas/reference/sdk#configuration-validation) and [v5 migration guide](https://wisecom-oy.github.io/atlas/migration/v5#eager-configuration-validation).
+
 ## API overview
 
 | Namespace / method          | Purpose                                  |
@@ -58,10 +62,11 @@ await atlas.sharepoint.backup('https://contoso.sharepoint.com/sites/Engineering'
 | `atlas.sharepoint`          | SharePoint site backup and restore       |
 | `atlas.getBucketStats()`    | Storage statistics                       |
 | `atlas.checkStorage()`      | S3 Object Lock readiness                 |
+| `atlas.validate()`          | S3 access and Graph token validation      |
 | `atlas.replicateSnapshot()` | Cross-region replication                 |
 | `createStorageTarget()`     | Configure secondary S3 targets           |
 
-The SDK re-exports domain types, port interfaces, and `GRAPH_SERVICE_LIMITS` from a single import.
+The SDK exports named public option/result types, error classes and `GRAPH_SERVICE_LIMITS`. Internal ports, DI tokens and container factories are not public API.
 
 ## CLI alternative
 

--- a/packages/sdk/src/atlas-instance.adapter.ts
+++ b/packages/sdk/src/atlas-instance.adapter.ts
@@ -1,6 +1,5 @@
 import { camelize, snakeize } from '@wisecom/atlas-types/public/case-convert';
 import { create_container_from_config } from '@/container';
-import type { AtlasConfig } from '@wisecom/atlas-core';
 import type {
   AtlasInstance,
   AtlasInstanceConfig,
@@ -24,10 +23,12 @@ import { create_onedrive_api } from '@/onedrive-api.factory';
 import { create_sharepoint_api } from '@/sharepoint-api.factory';
 import { create_disposer } from '@/instance-disposal';
 import { resolve_log_sink, scope_api_logging } from '@/log-scope';
+import { normalize_config } from '@/instance-config';
+import { validate_instance } from '@/instance-validation';
 
 /** Creates a tenant-bound Atlas SDK instance from explicit configuration values. */
 export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance {
-  const atlas_config = normalizeConfig(config);
+  const atlas_config = normalize_config(config);
   const container = create_container_from_config(atlas_config);
   const tenant_id = atlas_config.tenant_id;
 
@@ -50,6 +51,9 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     onedrive: scoped(create_onedrive_api(tenant_id, container)),
     sharepoint: scoped(create_sharepoint_api(tenant_id, container)),
 
+    async validate() {
+      await validate_instance(container, tenant_id);
+    },
     async checkStorage(request) {
       return camelize(await storage_check.check_storage(tenant_id, snakeize(request)));
     },
@@ -98,31 +102,4 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
   // Pointing at the scoped `dispose` also keeps both entry points identical,
   // including where their teardown warnings are logged.
   return { ...instance, [Symbol.asyncDispose]: instance.dispose };
-}
-
-function normalizeConfig(config: AtlasInstanceConfig): AtlasConfig {
-  assertRequiredField(config.tenantId, 'tenantId');
-  assertRequiredField(config.clientId, 'clientId');
-  assertRequiredField(config.clientSecret, 'clientSecret');
-  assertRequiredField(config.s3Endpoint, 's3Endpoint');
-  assertRequiredField(config.s3AccessKey, 's3AccessKey');
-  assertRequiredField(config.s3SecretKey, 's3SecretKey');
-  assertRequiredField(config.encryptionPassphrase, 'encryptionPassphrase');
-
-  return {
-    tenant_id: config.tenantId,
-    client_id: config.clientId,
-    client_secret: config.clientSecret,
-    s3_endpoint: config.s3Endpoint,
-    s3_access_key: config.s3AccessKey,
-    s3_secret_key: config.s3SecretKey,
-    s3_region: config.s3Region || 'us-east-1',
-    encryption_passphrase: config.encryptionPassphrase,
-  };
-}
-
-function assertRequiredField(value: string, field_name: keyof AtlasInstanceConfig): void {
-  if (!value) {
-    throw new Error(`Missing required Atlas instance config field: ${field_name}`);
-  }
 }

--- a/packages/sdk/src/container.ts
+++ b/packages/sdk/src/container.ts
@@ -1,11 +1,6 @@
 import 'reflect-metadata';
 import { Container } from 'inversify';
-import {
-  type AtlasConfig,
-  load_config,
-  ATLAS_CONFIG_TOKEN,
-  CachingIdentityResolver,
-} from '@wisecom/atlas-core';
+import { type AtlasConfig, ATLAS_CONFIG_TOKEN, CachingIdentityResolver } from '@wisecom/atlas-core';
 import { bind_core_services } from '@wisecom/atlas-core';
 import { USER_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-types';
 import { bind_graph_client } from '@wisecom/atlas-m365-graph';
@@ -14,11 +9,7 @@ import { bind_outlook } from '@wisecom/atlas-outlook';
 import { bind_onedrive } from '@wisecom/atlas-onedrive';
 import { bind_sharepoint } from '@wisecom/atlas-sharepoint';
 
-export function create_container(): Container {
-  const config = load_config();
-  return create_container_from_config(config);
-}
-
+/** Builds the SDK container exclusively from explicit configuration. */
 export function create_container_from_config(config: AtlasConfig): Container {
   const container = new Container();
   container.bind<AtlasConfig>(ATLAS_CONFIG_TOKEN).toConstantValue(config);

--- a/packages/sdk/src/instance-config.ts
+++ b/packages/sdk/src/instance-config.ts
@@ -1,0 +1,61 @@
+import { Buffer } from 'node:buffer';
+import type { AtlasConfig } from '@wisecom/atlas-core';
+import { ConfigError } from '@wisecom/atlas-types';
+import type { AtlasInstanceConfig } from '@wisecom/atlas-types';
+
+/** Validates explicit instance configuration without I/O and maps it to the internal config. */
+export function normalize_config(config: AtlasInstanceConfig): AtlasConfig {
+  if (!config || typeof config !== 'object') {
+    throw new ConfigError('Atlas instance configuration must be an object.');
+  }
+  assert_required_field(config.tenantId, 'tenantId');
+  assert_required_field(config.clientId, 'clientId');
+  assert_required_field(config.clientSecret, 'clientSecret');
+  assert_required_field(config.s3Endpoint, 's3Endpoint');
+  assert_required_field(config.s3AccessKey, 's3AccessKey');
+  assert_required_field(config.s3SecretKey, 's3SecretKey');
+  assert_required_field(config.encryptionPassphrase, 'encryptionPassphrase');
+  validate_endpoint(config.s3Endpoint);
+  if (Buffer.byteLength(config.encryptionPassphrase, 'utf8') < 14) {
+    throw new ConfigError('encryptionPassphrase must contain at least 14 UTF-8 bytes.');
+  }
+
+  return {
+    tenant_id: config.tenantId,
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+    s3_endpoint: config.s3Endpoint,
+    s3_access_key: config.s3AccessKey,
+    s3_secret_key: config.s3SecretKey,
+    s3_region: config.s3Region || 'us-east-1',
+    encryption_passphrase: config.encryptionPassphrase,
+  };
+}
+
+function assert_required_field(value: unknown, field_name: keyof AtlasInstanceConfig): void {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new ConfigError(`${field_name} must be a nonblank string.`);
+  }
+}
+
+function validate_endpoint(endpoint: string): void {
+  const message =
+    's3Endpoint must be an absolute HTTP(S) URL with a hostname and no credentials, query or fragment.';
+  let url: URL;
+  try {
+    url = new URL(endpoint);
+  } catch {
+    throw new ConfigError(message);
+  }
+  if (
+    !/^https?:\/\/[^/\\\s]/i.test(endpoint) ||
+    (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+    !url.hostname ||
+    url.username ||
+    url.password ||
+    endpoint.includes('?') ||
+    endpoint.includes('#')
+  ) {
+    throw new ConfigError(message);
+  }
+}

--- a/packages/sdk/src/instance-validation.ts
+++ b/packages/sdk/src/instance-validation.ts
@@ -1,0 +1,32 @@
+import { HeadBucketCommand, type S3Client } from '@aws-sdk/client-s3';
+import type { TokenCredentialAuthenticationProvider } from '@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials/index.js';
+import type { Container } from 'inversify';
+import { GRAPH_AUTH_PROVIDER_TOKEN } from '@wisecom/atlas-m365-graph';
+import { S3_CLIENT_TOKEN, tenant_bucket_name } from '@wisecom/atlas-s3';
+import { AuthError, StorageError } from '@wisecom/atlas-types';
+
+/** Checks bucket access, then Graph token issuance, without provisioning storage or loading keys. */
+export async function validate_instance(container: Container, tenant_id: string): Promise<void> {
+  try {
+    const client = container.get<S3Client>(S3_CLIENT_TOKEN);
+    await client.send(new HeadBucketCommand({ Bucket: tenant_bucket_name(tenant_id) }));
+  } catch (cause) {
+    throw new StorageError(
+      'S3 validation failed. Check the endpoint, region, credentials and tenant-bucket access. ' +
+        'If the tenant bucket does not exist, provision it before validating.',
+      { cause },
+    );
+  }
+
+  try {
+    const auth_provider =
+      container.get<TokenCredentialAuthenticationProvider>(GRAPH_AUTH_PROVIDER_TOKEN);
+    await auth_provider.getAccessToken();
+  } catch (cause) {
+    throw new AuthError(
+      'Graph token validation failed. Check the tenant ID, client ID, client secret and ' +
+        'connectivity to Microsoft Entra ID.',
+      { cause },
+    );
+  }
+}

--- a/packages/sdk/tests/unit/atlas-instance-async-contract.test.ts
+++ b/packages/sdk/tests/unit/atlas-instance-async-contract.test.ts
@@ -9,7 +9,7 @@ const VALID_CONFIG: AtlasInstanceConfig = {
   s3Endpoint: 'http://localhost:9000',
   s3AccessKey: 'ak',
   s3SecretKey: 'sk',
-  encryptionPassphrase: 'passphrase',
+  encryptionPassphrase: '<redacted>'.repeat(2),
 };
 
 const resolved = (value: unknown) => vi.fn().mockResolvedValue(value);

--- a/packages/sdk/tests/unit/atlas-instance.adapter.test.ts
+++ b/packages/sdk/tests/unit/atlas-instance.adapter.test.ts
@@ -22,7 +22,7 @@ const VALID_CONFIG: AtlasInstanceConfig = {
   s3Endpoint: 'http://localhost:9000',
   s3AccessKey: 'ak',
   s3SecretKey: 'sk',
-  encryptionPassphrase: 'passphrase',
+  encryptionPassphrase: '<redacted>'.repeat(2),
 };
 
 const mock_backup = { sync_mailbox: vi.fn() };
@@ -144,19 +144,6 @@ describe('createAtlasInstance', () => {
 
   beforeEach(() => {
     atlas = createAtlasInstance(VALID_CONFIG);
-  });
-
-  it('validates config and maps camelCase fields to snake_case AtlasConfig', async () => {
-    expect(() => createAtlasInstance({ ...VALID_CONFIG, tenantId: '' })).toThrow(/tenantId/);
-
-    const { create_container_from_config } = await import('@/container');
-    createAtlasInstance(VALID_CONFIG);
-    const config_arg = vi.mocked(create_container_from_config).mock.calls[0]![0];
-    expect(config_arg.s3_region).toBe('us-east-1');
-    expect(config_arg.tenant_id).toBe(TENANT_ID);
-    expect(config_arg.client_id).toBe('cid');
-    expect(config_arg.s3_endpoint).toBe('http://localhost:9000');
-    expect(config_arg.encryption_passphrase).toBe('passphrase');
   });
 
   describe('outlook', () => {

--- a/packages/sdk/tests/unit/drive-stats-and-object-lock.test.ts
+++ b/packages/sdk/tests/unit/drive-stats-and-object-lock.test.ts
@@ -13,7 +13,7 @@ const VALID_CONFIG: AtlasInstanceConfig = {
   s3Endpoint: 'http://localhost:9000',
   s3AccessKey: 'ak',
   s3SecretKey: 'sk',
-  encryptionPassphrase: 'passphrase',
+  encryptionPassphrase: '<redacted>'.repeat(2),
 };
 
 const resolved = (value: unknown): Mock => vi.fn().mockResolvedValue(value);

--- a/packages/sdk/tests/unit/instance-config.test.ts
+++ b/packages/sdk/tests/unit/instance-config.test.ts
@@ -1,0 +1,97 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import http from 'node:http';
+import https from 'node:https';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConfigError } from '@wisecom/atlas-types';
+import type { AtlasInstance, AtlasInstanceConfig } from '@wisecom/atlas-types';
+import { createAtlasInstance } from '@/atlas-instance.adapter';
+
+const valid_config: AtlasInstanceConfig = {
+  tenantId: randomUUID(),
+  clientId: randomUUID(),
+  clientSecret: '<redacted>',
+  s3Endpoint: 'http://localhost:9000',
+  s3AccessKey: '<redacted>',
+  s3SecretKey: '<redacted>',
+  encryptionPassphrase: '<redacted>'.repeat(2),
+};
+
+let instance: AtlasInstance | undefined;
+
+beforeEach(() => {
+  vi.spyOn(http, 'request').mockImplementation(() => {
+    throw new Error('Unexpected HTTP request during construction');
+  });
+  vi.spyOn(https, 'request').mockImplementation(() => {
+    throw new Error('Unexpected HTTPS request during construction');
+  });
+  vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+    new Error('Unexpected fetch during construction'),
+  );
+});
+
+afterEach(async () => {
+  await instance?.dispose();
+  instance = undefined;
+  expect(http.request).not.toHaveBeenCalled();
+  expect(https.request).not.toHaveBeenCalled();
+  expect(globalThis.fetch).not.toHaveBeenCalled();
+  vi.restoreAllMocks();
+});
+
+describe('instance configuration', () => {
+  it.each<[keyof AtlasInstanceConfig, unknown]>([
+    ['tenantId', undefined],
+    ['clientId', ' '],
+    ['clientSecret', 42],
+    ['s3Endpoint', ''],
+    ['s3AccessKey', null],
+    ['s3SecretKey', '\t\n'],
+    ['encryptionPassphrase', ' '.repeat(14)],
+  ])('rejects invalid required field %s synchronously', (field, value) => {
+    expect(() =>
+      createAtlasInstance({ ...valid_config, [field]: value } as AtlasInstanceConfig),
+    ).toThrow(ConfigError);
+  });
+
+  it('rejects a missing configuration object as ConfigError', () => {
+    expect(() => createAtlasInstance(undefined as unknown as AtlasInstanceConfig)).toThrow(
+      ConfigError,
+    );
+  });
+
+  it.each([
+    'not-a-url',
+    'ftp://localhost',
+    'https://',
+    'http:localhost',
+    'http://<redacted>@localhost',
+    'http://:<redacted>@localhost',
+    'http://localhost?',
+    'http://localhost#section',
+  ])('rejects an unusable S3 endpoint: %s', (endpoint) => {
+    expect(() => createAtlasInstance({ ...valid_config, s3Endpoint: endpoint })).toThrow(
+      ConfigError,
+    );
+  });
+
+  it('enforces the 14-byte boundary while accepting localhost HTTP without I/O', () => {
+    const passphrase = randomBytes(7).toString('hex');
+    expect(() =>
+      createAtlasInstance({ ...valid_config, encryptionPassphrase: passphrase.slice(1) }),
+    ).toThrow(ConfigError);
+    expect(() => {
+      instance = createAtlasInstance({ ...valid_config, encryptionPassphrase: passphrase });
+    }).not.toThrow();
+  });
+
+  it('measures passphrase strength in UTF-8 bytes, not JavaScript characters', () => {
+    const passphrase = String.fromCodePoint(0xe9).repeat(7);
+    expect(() =>
+      createAtlasInstance({ ...valid_config, encryptionPassphrase: passphrase.slice(1) }),
+    ).toThrow(ConfigError);
+    expect(() => {
+      instance = createAtlasInstance({ ...valid_config, encryptionPassphrase: passphrase });
+    }).not.toThrow();
+  });
+});

--- a/packages/sdk/tests/unit/instance-validation.test.ts
+++ b/packages/sdk/tests/unit/instance-validation.test.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from 'node:crypto';
+import { HeadBucketCommand } from '@aws-sdk/client-s3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthError, StorageError } from '@wisecom/atlas-types';
+import { createAtlasInstance } from '@/atlas-instance.adapter';
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  get_access_token: vi.fn(),
+  create_context: vi.fn(),
+  log: vi.fn(),
+}));
+
+vi.mock('@/container', () => ({
+  create_container_from_config: () => ({
+    get: (token: symbol) => {
+      switch (token.description) {
+        case 'S3Client':
+          return { send: mocks.send };
+        case 'GraphAuthProvider':
+          return { getAccessToken: mocks.get_access_token };
+        case 'TenantContextFactory':
+          return { create: mocks.create_context };
+        default:
+          return {};
+      }
+    },
+  }),
+}));
+
+function create_instance() {
+  return createAtlasInstance({
+    tenantId: 'tenant-example',
+    clientId: 'client-example',
+    clientSecret: '<redacted>',
+    s3Endpoint: 'https://storage.example.com',
+    s3AccessKey: '<redacted>',
+    s3SecretKey: '<redacted>',
+    encryptionPassphrase: '<redacted>'.repeat(2),
+    logger: {
+      debug: mocks.log,
+      info: mocks.log,
+      warn: mocks.log,
+      error: mocks.log,
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.send.mockResolvedValue({});
+  mocks.get_access_token.mockResolvedValue(randomUUID());
+});
+
+describe('atlas.validate', () => {
+  it('is opt-in, checks only the existing bucket before token issuance, and exposes no token', async () => {
+    const atlas = create_instance();
+    expect(mocks.send).not.toHaveBeenCalled();
+    expect(mocks.get_access_token).not.toHaveBeenCalled();
+
+    const head = Promise.withResolvers<object>();
+    mocks.send.mockReturnValueOnce(head.promise);
+    const validation = atlas.validate();
+    expect(mocks.get_access_token).not.toHaveBeenCalled();
+    head.resolve({});
+
+    await expect(validation).resolves.toBeUndefined();
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+    const command = mocks.send.mock.calls[0]![0];
+    expect(command).toBeInstanceOf(HeadBucketCommand);
+    expect(command.input).toEqual({ Bucket: 'atlas-tenant-example' });
+    expect(mocks.get_access_token).toHaveBeenCalledTimes(1);
+    expect(mocks.create_context).not.toHaveBeenCalled();
+    expect(mocks.log).not.toHaveBeenCalled();
+  });
+
+  it('reports S3 denial as a storage failure and does not acquire a Graph token', async () => {
+    const cause = Object.assign(new Error(randomUUID()), { name: 'AccessDenied' });
+    mocks.send.mockRejectedValue(cause);
+
+    const error = await create_instance()
+      .validate()
+      .catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(StorageError);
+    expect(error).toMatchObject({ code: 'ATLAS_STORAGE_FAILURE', cause });
+    expect((error as Error).message).not.toContain(cause.message);
+    expect(mocks.get_access_token).not.toHaveBeenCalled();
+    expect(mocks.create_context).not.toHaveBeenCalled();
+    expect(mocks.log).not.toHaveBeenCalled();
+  });
+
+  it('does not provision a missing bucket', async () => {
+    const cause = Object.assign(new Error(), {
+      name: 'NotFound',
+      $metadata: { httpStatusCode: 404 },
+    });
+    mocks.send.mockRejectedValue(cause);
+
+    const error = await create_instance()
+      .validate()
+      .catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(StorageError);
+    expect(error).toMatchObject({ code: 'ATLAS_STORAGE_FAILURE', cause });
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+    expect(mocks.send.mock.calls[0]![0]).toBeInstanceOf(HeadBucketCommand);
+    expect(mocks.create_context).not.toHaveBeenCalled();
+    expect(mocks.get_access_token).not.toHaveBeenCalled();
+  });
+
+  it('distinguishes Graph token rejection from storage failure without exposing diagnostics', async () => {
+    const cause = new Error(randomUUID());
+    mocks.get_access_token.mockRejectedValue(cause);
+
+    const error = await create_instance()
+      .validate()
+      .catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(AuthError);
+    expect(error).toMatchObject({ code: 'ATLAS_AUTH_DENIED', cause });
+    expect((error as Error).message).not.toContain(cause.message);
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+    expect(mocks.create_context).not.toHaveBeenCalled();
+    expect(mocks.log).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
@@ -12,9 +13,23 @@ const onedrive_src = resolve(root_dir, '../onedrive/src');
 const sharepoint_src = resolve(root_dir, '../sharepoint/src');
 
 export default defineConfig({
+  // Match the CLI's importer-scoped resolver: each workspace package owns its `@/`.
+  plugins: [
+    {
+      name: 'atlas-vitest-workspace-at-alias',
+      enforce: 'pre',
+      resolveId(id, importer) {
+        if (!id.startsWith('@/') || !importer) return null;
+        const from_file = importer.replace(/^file:\/\//, '');
+        const package_name = from_file.match(/\/packages\/([^/]+)\/(?:src|tests)\//)?.[1];
+        if (!package_name) return null;
+        const base = resolve(root_dir, '..', package_name, 'src', id.slice(2));
+        return [base, `${base}.ts`, `${base}.tsx`, `${base}.js`].find(existsSync) ?? null;
+      },
+    },
+  ],
   resolve: {
     alias: [
-      { find: '@', replacement: resolve(root_dir, 'src') },
       { find: /^@wisecom\/atlas-types\/(.+)$/, replacement: `${types_src}/$1` },
       { find: '@wisecom/atlas-types', replacement: resolve(types_src, 'index.ts') },
       { find: /^@wisecom\/atlas-core\/(.+)$/, replacement: `${core_src}/$1` },

--- a/packages/types/src/ports/atlas/use-case.port.ts
+++ b/packages/types/src/ports/atlas/use-case.port.ts
@@ -35,6 +35,12 @@ export interface AtlasInstance extends AsyncDisposable {
   readonly onedrive: OneDriveApi;
   readonly sharepoint: SharePointApi;
 
+  /**
+   * Checks existing tenant-bucket access and Graph token issuance without provisioning storage.
+   * Rejects with StorageError for S3 failures or AuthError for token failures.
+   * Does not verify workload permissions or the encryption passphrase.
+   */
+  validate(): Promise<void>;
   checkStorage(request?: Camelize<StorageCheckRequest>): Promise<Camelize<StorageCheckResult>>;
   getBucketStats(): Promise<Camelize<BucketStats>>;
   resolveUser(email: string): Promise<Camelize<ResolvedUserIdentity>>;


### PR DESCRIPTION
## Summary

I completed the remaining SDK validation work in #45. PR #323 already delivered the camelCase public surface and removed container factories from the public exports; I retained that contract and corrected the remaining stale export descriptions.

Closes #45.

## Changes

- Reject missing or blank required values, passphrases shorter than 14 UTF-8 bytes, and malformed HTTP(S) S3 endpoints synchronously with the existing `ConfigError`. Construction makes no network requests.
- Add optional `atlas.validate()`: read-only `HeadBucket` for the existing tenant bucket, followed by Graph token acquisition through the instance's shared authentication provider. S3-stage failures are `StorageError`; Graph-token failures are `AuthError`. Both retain the original cause without copying provider diagnostics into the message.
- Remove the unused environment-loading SDK container factory. The CLI keeps its own configuration discovery.
- Add constructor and probe regression coverage, update the affected fixtures, and use the CLI's importer-scoped workspace alias pattern so SDK tests exercise real construction.
- Update SDK, configuration, security and v5 migration documentation, including the completed work in #323 and the limits of the probe. Existing short-passphrase backups must be recovered with the previous SDK or CLI; padding the passphrase changes the key and is not a migration.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no errors
- [x] `pnpm run format:check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes, including 92 SDK tests
- [x] `pnpm run docs:build` passes; it reports `env`/`cron` syntax-highlighting fallback warnings
- [x] Exported functions and the new public method have JSDoc
- [x] No version bump; targets `dev` and labelled `enhancement`

Built-package smoke result, using a local HTTP S3 endpoint and controlled Graph token issuance:

```text
PASS: synchronous ConfigError, explicit exports, network-free construction, real S3 HEAD rejection, Graph failure distinction, read-only successful validation
S3 requests: 3 HEAD; Graph token provider calls: 2; writes: 0
```

I have not verified successful authentication against a live Microsoft 365 tenant. The probe does not verify workload permissions, write access, Object Lock readiness or the stored encryption key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `atlas.validate()` to check tenant storage access and Microsoft Graph authentication without provisioning storage.
  - Added clear synchronous configuration validation for required fields, S3 endpoints, and encryption passphrases.
  - Added a default S3 region when none is provided.

- **Bug Fixes**
  - SDK configuration is no longer implicitly loaded from environment variables, `.env` files, or configuration files; credentials and tenant settings must be provided explicitly.

- **Documentation**
  - Updated SDK, migration, security, and configuration guidance to describe validation behavior, errors, limitations, and public exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->