### PR TITLE
feat(cli)!: typed failure classification and distinct exit codes

### DIFF
--- a/docs/migration/v5.md
+++ b/docs/migration/v5.md
@@ -85,6 +85,26 @@ The optional `await atlas.validate()` checks an existing tenant bucket with `Hea
 
 Together with the camelCase surface and enumerated exports in PR #323, this completes [issue #45](https://github.com/wisecom-oy/atlas/issues/45). The error classes were already available from v4.4.0; this change uses them at construction and in the explicit connectivity probe.
 
+## CLI failure exit codes
+
+v4 returned `1` for every fatal exception. v5 uses the typed error categories introduced in v4.4.0, with the original Graph, AWS or Node failure reported separately on stderr.
+
+| Failure | v4 | v5 |
+| ------- | -- | -- |
+| Throttle exhaustion or recognized network/transient HTTP failure | `1` | `3` |
+| Authentication, permission or mailbox-license failure | `1` | `4` |
+| Wrong encryption passphrase | `1` | `5` |
+| Typed configuration failure or failure to load CLI configuration | `1` | `6` |
+| Missing resource | `1` | `7` |
+| Typed Object Lock retention refusal | `1` | `8` |
+| Unexpected or unclassified failure, usage error, command-reported failure without a typed exception | `1` | `1` |
+| Complete operation | `0` | `0` |
+| Partial operation or soft interrupt | `2` | `2` |
+
+Replace checks that only recognize `1` as failure. A script using `if [ "$status" -eq 1 ]` would miss the new failure categories; test for nonzero first, then branch on the documented category when deciding whether to retry. Codes `4` through `8` require operator action rather than an unchanged retry. Code `3` permits scheduling a later attempt, but a timed-out write may already have committed.
+
+`Atlas code:` now identifies the Atlas category; `Transport code:`, `HTTP status:`, `Error name:` and `Body:` describe its underlying cause. Fatal details that previously went to stdout now go to stderr. Update log collectors accordingly, and use exit codes rather than parsing message wording. The [CLI reference](/reference/cli#exit-codes) lists the full mapping, precedence and command-reported exceptions.
+
 ## Next
 
-The CLI flag changes and exit-code changes land in the same release and are documented here as they merge.
+The CLI flag changes land in the same release and are documented here as they merge.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,6 +24,51 @@ COLUMNS=200 atlas sharepoint list-sites > sites.txt
 
 This matters beyond readability. Anything that post-processes the output, a log scrubber, a grep for an id, a parser, sees a wrapped value as two unrelated fragments and misses it.
 
+## Exit codes
+
+```bash
+status=0
+atlas outlook backup --mailbox "$mailbox" || status=$?
+case "$status" in
+  0) echo "Complete" ;;
+  2) echo "Incomplete run: inspect the reported items" >&2 ;;
+  3) echo "Transient failure: schedule a later attempt" >&2 ;;
+  4|5|6|7|8) echo "Operator action required; do not retry unchanged" >&2 ;;
+  *) echo "Command failed; inspect stderr" >&2 ;;
+esac
+exit "$status"
+```
+
+| Code | Meaning | Action |
+| ---- | ------- | ------ |
+| `0` | Success, help, or a command with no failure reported | Continue normally. |
+| `1` | Unexpected or unclassified failure, invalid command usage, or a command-reported failure without a typed exception | Inspect stderr. Do not assume the failure is transient. |
+| `2` | Partial backup, restore or save: item errors, skipped files, integrity failures or a soft interrupt | Inspect the partial result before relying on it. |
+| `3` | Throttling exhausted its retry budget, a recognized network error, or transient HTTP `429`, `500`, `502`, `503`, `504` | Schedule a later attempt. A timeout does not prove a write was never committed; inspect partial work before repeating a restore. |
+| `4` | `ATLAS_AUTH_DENIED`, `ATLAS_MAILBOX_NOT_LICENSED`, or an unwrapped HTTP `401`/`403` | Correct credentials, permissions, admin consent or licensing before retrying. |
+| `5` | `ATLAS_WRONG_PASSPHRASE` | Supply the original tenant passphrase. Never pad it or delete the wrapped key. If it is correct, investigate possible corruption. |
+| `6` | `ATLAS_CONFIG_INVALID`, including failure to load the CLI configuration | Correct the configuration or its storage access. |
+| `7` | `ATLAS_NOT_FOUND` or an unwrapped HTTP `404` | Check the selected resource and identifiers. |
+| `8` | `ATLAS_OBJECT_LOCK_RETAINED` | Respect retention or legal hold; repeating the same deletion cannot bypass it. |
+
+Fatal exceptions use this category mapping. Existing command-reported failures remain `1`, including failed verification, `storage-check` reporting an unready bucket, and `config validate` reporting a failed probe. Per-item failures already reported as partial remain `2`; their messages are not reclassified.
+
+An explicit Atlas category takes precedence over transport details. A generic `StorageError` can still resolve to a more specific HTTP or network category. Network detection reads structured Node error codes, including nested `cause`, never message text. An error that merely says “socket hang up” is unclassified unless it carries a recognized code. Hard process termination may be reported by the shell as `128 + signal`; that is separate from Atlas's exit categories.
+
+### Fatal error diagnostics
+
+```text
+[x] Consent required
+[x]   Atlas code: ATLAS_AUTH_DENIED
+[x]   Cause: Permission denied
+[x]   HTTP status: 403
+[x]   Transport code: ErrorAccessDenied
+```
+
+The CLI prints the Atlas code separately from the underlying Graph code, HTTP status, response body or AWS error name. Unwrapped HTTP `401`/`403`, `404` and `429` also receive the corresponding Atlas category in the diagnostic. Fatal diagnostics, including `DEBUG` stacks, go to stderr rather than contaminating redirected stdout.
+
+Provider diagnostics can contain tenant identifiers and sensitive content. Redact them before sharing logs. See [Migrating to v5](/migration/v5#cli-failure-exit-codes) before updating scripts that branch on exit `1` or parse the old output.
+
 ## `atlas outlook`
 
 Outlook mailbox backup, restore, and management commands. All mailbox operations live under this group; cross-cutting storage and replication commands remain at the root level.
@@ -142,7 +187,7 @@ Storing purged mail has compliance consequences. See
 [Recoverable Items and legal hold](../security.md#recoverable-items-and-legal-hold).
 
 ::: warning Exit codes (all backup commands: Outlook, OneDrive, SharePoint)
-`0`: complete, every folder/file/mailbox processed without error. `1`: hard failure, the run aborted (auth, storage, unhandled error). `2`: **partial**, a snapshot was saved but the run is incomplete because of per-folder/per-file errors or a soft interrupt (Ctrl+C). Failed items are listed on stderr. Schedulers should treat `1` as "page me" and `2` as "warn me": a partial backup is restorable but is missing the listed items. A run is reported complete only when every error bucket is empty (corso's fault-model contract).
+`0` means complete, with every error bucket empty. `2` means **partial**: a snapshot was saved but the run is incomplete because of per-folder/per-file errors or a soft interrupt (Ctrl+C). Failed items are listed on stderr. Fatal failures now use the [category exit codes](#exit-codes), rather than always returning `1`. A partial backup is restorable but is missing the listed items.
 
 `restore` and `save` follow the same contract: a file they could not decrypt or write is counted as skipped, and any skipped file exits `2`. An export that produced an archive missing some of its files is not a success, and a cron job that only checks for `0` has to be able to see the difference.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,6 +56,12 @@ atlas sharepoint backup --site https://contoso.sharepoint.com/sites/Engineering
 
 Run `atlas --help` or `atlas <command> --help` for full flag reference.
 
+## Exit codes
+
+v5 preserves `0` for success, `1` for unclassified or command-reported failure, and `2` for partial results. Fatal failures now use `3` for retryable network/throttle errors, `4` for auth/licensing, `5` for a wrong passphrase, `6` for configuration, `7` for a missing resource and `8` for retention.
+
+Treat every nonzero code as a failure or incomplete run. Fatal diagnostics go to stderr and include both the Atlas category and the underlying provider details. See the [exit-code reference](https://wisecom-oy.github.io/atlas/reference/cli#exit-codes) and [v5 migration guide](https://wisecom-oy.github.io/atlas/migration/v5#cli-failure-exit-codes) before updating scheduled jobs.
+
 ## Programmatic use
 
 For embedding Atlas in Node.js applications, use [`@wisecom/atlas-sdk`](https://www.npmjs.com/package/@wisecom/atlas-sdk) instead.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -13,7 +13,7 @@ import { register_replicate_command } from '@/commands/replicate.command';
 import { register_rehydrate_command } from '@/commands/rehydrate.command';
 import { register_list_users_command } from '@/commands/list-users.command';
 import { register_config_command } from '@/commands/config.command';
-import { logger } from '@wisecom/atlas-core';
+import { handle_fatal_error } from '@/fatal-error';
 import type { Container } from 'inversify';
 
 let _container: Container | undefined;
@@ -50,46 +50,6 @@ function register_commands(program: Command): void {
   register_rehydrate_command(program, get_container);
   register_list_users_command(program, get_container);
   register_config_command(program);
-}
-
-/** Handles top-level unhandled errors from command execution. */
-function handle_fatal_error(err: unknown): void {
-  const message = err instanceof Error ? err.message : String(err);
-  logger.error(message);
-
-  if (err && typeof err === 'object') {
-    const graph_err = err as Record<string, unknown>;
-    if (graph_err.statusCode) logger.info(`  HTTP status: ${graph_err.statusCode}`);
-    if (graph_err.code) logger.info(`  Error code: ${graph_err.code}`);
-    if (graph_err.body) logger.info(`  Body: ${JSON.stringify(graph_err.body)}`);
-    log_s3_connection_hint(graph_err, message);
-    if (graph_err.stack && process.env.DEBUG) logger.info(String(graph_err.stack));
-  }
-
-  process.exitCode = 1;
-}
-
-function log_s3_connection_hint(err: Record<string, unknown>, message: string): void {
-  const code = String(err.code ?? '');
-  const lower_message = message.toLowerCase();
-  const is_connection_error =
-    code === 'ECONNREFUSED' ||
-    code === 'ENOTFOUND' ||
-    code === 'ETIMEDOUT' ||
-    lower_message.includes('econnrefused') ||
-    lower_message.includes('econnreset') ||
-    lower_message.includes('socket hang up');
-
-  if (!is_connection_error) return;
-
-  const endpoint = process.env.ATLAS_S3_ENDPOINT;
-  const endpoint_text = endpoint ? `"${endpoint}"` : 'ATLAS_S3_ENDPOINT';
-
-  logger.error(
-    `Cannot connect to S3 endpoint ${endpoint_text}. ` +
-      `Check that your S3/MinIO service is running and reachable.`,
-  );
-  logger.info('  If using local MinIO: cd docker && docker compose up -d');
 }
 
 const program = create_program();

--- a/packages/cli/src/command-run-outcome.ts
+++ b/packages/cli/src/command-run-outcome.ts
@@ -2,8 +2,8 @@ import { logger } from '@wisecom/atlas-core';
 
 /**
  * Exit code for a run that produced a snapshot but is incomplete (per-item
- * errors or an interrupt). Distinct from 1 (hard failure) so schedulers can
- * separate "page me" from "warn me". Corso's fault model: a backup is
+ * errors or an interrupt). Distinct from fatal category exits so schedulers can
+ * separate an incomplete result from an aborted run. Corso's fault model: a backup is
  * complete only when every error bucket is empty.
  */
 export const EXIT_PARTIAL = 2;
@@ -25,7 +25,7 @@ export interface RunOutcome {
  * Prints per-item errors/warnings on stderr and sets the partial exit code
  * when the run is incomplete. Shared by Outlook, OneDrive, and SharePoint
  * backup, save, and restore commands so all three domains report identically.
- * Hard failures throw and exit 1 upstream; this only handles the partial bucket.
+ * Fatal failures throw and receive a category exit upstream; this only handles partial results.
  */
 export function report_run_outcome(outcome: RunOutcome, item_noun: string): void {
   for (const warning of outcome.warnings) {

--- a/packages/cli/src/container.ts
+++ b/packages/cli/src/container.ts
@@ -7,7 +7,7 @@ import {
   CachingIdentityResolver,
 } from '@wisecom/atlas-core';
 import { bind_core_services } from '@wisecom/atlas-core';
-import { USER_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-types';
+import { ConfigError, USER_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-types';
 import { bind_graph_client } from '@wisecom/atlas-m365-graph';
 import { bind_s3_storage } from '@wisecom/atlas-s3';
 import { bind_outlook } from '@wisecom/atlas-outlook';
@@ -16,7 +16,12 @@ import { bind_sharepoint } from '@wisecom/atlas-sharepoint';
 
 /** Builds the DI container with Graph, S3, core services, and Outlook use cases. */
 export function compose_container(): Container {
-  const config = load_config();
+  let config: AtlasConfig;
+  try {
+    config = load_config();
+  } catch (cause) {
+    throw new ConfigError('Cannot load Atlas configuration.', { cause });
+  }
   return compose_container_from_config(config);
 }
 

--- a/packages/cli/src/fatal-error.ts
+++ b/packages/cli/src/fatal-error.ts
@@ -1,0 +1,147 @@
+import { inspect } from 'node:util';
+import { logger } from '@wisecom/atlas-core';
+import { AtlasError, type AtlasErrorCode } from '@wisecom/atlas-types';
+
+const ATLAS_EXIT_CODES = {
+  ATLAS_AUTH_DENIED: 4,
+  ATLAS_MAILBOX_NOT_LICENSED: 4,
+  ATLAS_NOT_FOUND: 7,
+  ATLAS_THROTTLED: 3,
+  ATLAS_WRONG_PASSPHRASE: 5,
+  ATLAS_OBJECT_LOCK_RETAINED: 8,
+  ATLAS_STORAGE_FAILURE: 1,
+  ATLAS_CONFIG_INVALID: 6,
+} satisfies Record<AtlasErrorCode, number>;
+
+const NETWORK_CODES: Readonly<Record<string, true>> = {
+  ECONNREFUSED: true,
+  ECONNRESET: true,
+  ETIMEDOUT: true,
+  ENOTFOUND: true,
+  EAI_AGAIN: true,
+  EHOSTUNREACH: true,
+  ENETUNREACH: true,
+  EPIPE: true,
+  UND_ERR_CONNECT_TIMEOUT: true,
+  UND_ERR_HEADERS_TIMEOUT: true,
+  UND_ERR_BODY_TIMEOUT: true,
+  UND_ERR_SOCKET: true,
+};
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+
+type ErrorFields = Record<string, unknown>;
+
+/** Reports a fatal command failure and selects its v5 exit category without parsing prose. */
+export function handle_fatal_error(err: unknown): void {
+  const chain = error_chain(err);
+  const atlas_error = chain.find((error) => error instanceof AtlasError);
+  const statuses = chain.map(http_status);
+  const atlas_code = atlas_error?.code ?? transport_atlas_code(statuses);
+  const network_error = chain.some(
+    (error) => typeof error.code === 'string' && NETWORK_CODES[error.code] === true,
+  );
+  process.exitCode = failure_exit_code(statuses, atlas_code, network_error);
+
+  logger.error(err instanceof Error ? err.message : String(err));
+  if (atlas_code) logger.error(`  Atlas code: ${atlas_code}`);
+  if (atlas_error) log_remediation(atlas_error);
+  for (const [index, error] of chain.entries()) {
+    if (index > 0 && typeof error.message === 'string') {
+      logger.error(`  Cause: ${error.message}`);
+    }
+    log_transport_details(error);
+  }
+  if (network_error) log_connection_hint(chain);
+  if (process.env.DEBUG && chain[0]?.stack) logger.error(String(chain[0].stack));
+}
+
+function error_chain(err: unknown): ErrorFields[] {
+  const chain: ErrorFields[] = [];
+  const seen = new Set<object>();
+  while (err !== null && typeof err === 'object' && !seen.has(err)) {
+    seen.add(err);
+    const fields = err as ErrorFields;
+    chain.push(fields);
+    err = fields.cause;
+  }
+  return chain;
+}
+
+function failure_exit_code(
+  statuses: number[],
+  atlas_code: AtlasErrorCode | undefined,
+  network_error: boolean,
+): number {
+  // A specific Atlas classification wins over incidental transport details. StorageError is
+  // deliberately broad, so its cause can still identify a permission or transient failure.
+  if (atlas_code && atlas_code !== 'ATLAS_STORAGE_FAILURE') {
+    return ATLAS_EXIT_CODES[atlas_code];
+  }
+  if (statuses.some((status) => status === 401 || status === 403)) return 4;
+  if (statuses.includes(404)) return 7;
+  if (network_error || statuses.some((status) => RETRYABLE_STATUS_CODES.has(status))) {
+    return 3;
+  }
+  return 1;
+}
+
+function transport_atlas_code(statuses: number[]): AtlasErrorCode | undefined {
+  if (statuses.some((status) => status === 401 || status === 403)) return 'ATLAS_AUTH_DENIED';
+  if (statuses.includes(404)) return 'ATLAS_NOT_FOUND';
+  if (statuses.includes(429)) return 'ATLAS_THROTTLED';
+  return undefined;
+}
+
+function http_status(error: ErrorFields): number {
+  const metadata = error.$metadata;
+  const status =
+    error.statusCode ??
+    error.status ??
+    (metadata !== null && typeof metadata === 'object'
+      ? (metadata as ErrorFields).httpStatusCode
+      : undefined);
+  return typeof status === 'number' ? status : 0;
+}
+
+function log_transport_details(error: ErrorFields): void {
+  const status = http_status(error);
+  if (status) logger.error(`  HTTP status: ${status}`);
+  if (!(error instanceof AtlasError) && typeof error.code === 'string') {
+    logger.error(`  Transport code: ${error.code}`);
+  }
+  if (!(error instanceof AtlasError) && typeof error.name === 'string') {
+    logger.error(`  Error name: ${error.name}`);
+  }
+  if (error.body !== undefined) {
+    logger.error(`  Body: ${inspect(error.body, { depth: 4, colors: false })}`);
+  }
+}
+
+function log_remediation(error: AtlasError): void {
+  if (error.code === 'ATLAS_WRONG_PASSPHRASE') {
+    logger.error(
+      'Use the original encryption passphrase for this tenant. Do not replace or pad it, or ' +
+        'delete the wrapped data key. If the passphrase is correct, investigate possible corruption.',
+    );
+  }
+  if (error.code === 'ATLAS_THROTTLED') {
+    const retry_after_ms = (error as AtlasError & { retry_after_ms?: unknown }).retry_after_ms;
+    if (typeof retry_after_ms === 'number' && Number.isFinite(retry_after_ms)) {
+      logger.error(`  Retry after: ${retry_after_ms} ms`);
+    }
+  }
+}
+
+function log_connection_hint(chain: ErrorFields[]): void {
+  const is_storage = chain.some(
+    (error) =>
+      (error instanceof AtlasError && error.code === 'ATLAS_STORAGE_FAILURE') ||
+      (error.$metadata !== null && typeof error.$metadata === 'object'),
+  );
+  if (is_storage) {
+    logger.error('Cannot connect to S3. Check the configured endpoint and S3/MinIO service.');
+    logger.error('  If using local MinIO: cd docker && docker compose up -d');
+  } else {
+    logger.error('Cannot reach the remote service. Check DNS, network connectivity and endpoints.');
+  }
+}

--- a/packages/cli/tests/unit/fatal-error.test.ts
+++ b/packages/cli/tests/unit/fatal-error.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AuthError,
+  ConfigError,
+  MailboxNotLicensedError,
+  NotFoundError,
+  ObjectLockRetainedError,
+  StorageError,
+  ThrottledError,
+  WrongPassphraseError,
+} from '@wisecom/atlas-types';
+import { handle_fatal_error } from '@/fatal-error';
+
+let previous_exit_code: typeof process.exitCode;
+let diagnostics: string[];
+
+beforeEach(() => {
+  previous_exit_code = process.exitCode;
+  process.exitCode = undefined;
+  diagnostics = [];
+  vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    diagnostics.push(args.join(' '));
+  });
+  vi.spyOn(console, 'log').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  process.exitCode = previous_exit_code;
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('fatal CLI errors', () => {
+  it('keeps the wrong-passphrase code, crypto cause and recovery guidance on stderr', () => {
+    const cause = Object.assign(new Error('Authentication tag mismatch'), {
+      code: 'ERR_OSSL_BAD_DECRYPT',
+    });
+    handle_fatal_error(new WrongPassphraseError('Key could not be unwrapped', { cause }));
+
+    expect(process.exitCode).toBe(5);
+    const output = diagnostics.join('\n');
+    expect(output).toContain('ATLAS_WRONG_PASSPHRASE');
+    expect(output).toContain('ERR_OSSL_BAD_DECRYPT');
+    expect(output).toContain(cause.message);
+    expect(output).toMatch(/original.*passphrase/);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('prints both Atlas and Graph codes, HTTP status and response body for a 403', () => {
+    const cause = Object.assign(new Error('Permission denied'), {
+      statusCode: 403,
+      code: 'ErrorAccessDenied',
+      body: { error: { code: 'ErrorAccessDenied' } },
+    });
+    handle_fatal_error(new AuthError('Consent required', { cause }));
+
+    expect(process.exitCode).toBe(4);
+    const output = diagnostics.join('\n');
+    expect(output).toContain('Atlas code: ATLAS_AUTH_DENIED');
+    expect(output).toContain('Transport code: ErrorAccessDenied');
+    expect(output).toContain('HTTP status: 403');
+    expect(output).toContain('Body:');
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('reports throttle exhaustion separately and preserves retry timing and the transport cause', () => {
+    const cause = { statusCode: 429, code: 'TooManyRequests' };
+    handle_fatal_error(new ThrottledError('Retry budget exhausted', 12000, { cause }));
+
+    expect(process.exitCode).toBe(3);
+    const output = diagnostics.join('\n');
+    expect(output).toContain('ATLAS_THROTTLED');
+    expect(output).toContain('TooManyRequests');
+    expect(output).toContain('429');
+    expect(output).toContain('12000');
+  });
+
+  it.each([
+    [new ConfigError('Invalid configuration'), 6],
+    [new MailboxNotLicensedError('License required'), 4],
+    [new NotFoundError('Backup not found'), 7],
+    [new ObjectLockRetainedError('object-example'), 8],
+    [new StorageError('Storage failed'), 1],
+  ])('gives %s its documented category', (error, code) => {
+    handle_fatal_error(error);
+    expect(process.exitCode).toBe(code);
+    expect(diagnostics.join('\n')).toContain(error.code);
+  });
+
+  it('finds nested Node codes without guessing from message text or labelling Graph as S3', () => {
+    const cause = Object.assign(new Error('Connection failed'), { code: 'ECONNRESET' });
+    handle_fatal_error(new TypeError('Request failed', { cause }));
+    expect(process.exitCode).toBe(3);
+    expect(diagnostics.join('\n')).toContain('ECONNRESET');
+    expect(diagnostics.join('\n')).not.toContain('S3');
+
+    diagnostics = [];
+    handle_fatal_error(new Error('ECONNRESET: socket hang up'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('recognizes a nested storage connection failure and preserves AWS error details', () => {
+    const cause = Object.assign(new Error('Connection failed'), {
+      code: 'ENOTFOUND',
+      name: 'NetworkingError',
+      $metadata: { attempts: 3 },
+    });
+    handle_fatal_error(new StorageError('Storage request failed', { cause }));
+    expect(process.exitCode).toBe(3);
+    expect(diagnostics.join('\n')).toContain('NetworkingError');
+    expect(diagnostics.join('\n')).toContain('S3');
+  });
+
+  it.each([
+    [{ statusCode: 403, code: 'ErrorAccessDenied' }, 4, 'ATLAS_AUTH_DENIED'],
+    [{ statusCode: 429, code: 'TooManyRequests' }, 3, 'ATLAS_THROTTLED'],
+    [{ name: 'NoSuchKey', $metadata: { httpStatusCode: 404 } }, 7, 'ATLAS_NOT_FOUND'],
+  ])('classifies unwrapped provider failures by status, not prose', (error, code, atlas_code) => {
+    handle_fatal_error(error);
+    expect(process.exitCode).toBe(code);
+    expect(diagnostics.join('\n')).toContain(atlas_code);
+  });
+
+  it('does not override an operator-action failure with a transient cause', () => {
+    const cause = Object.assign(new Error('Connection failed'), { code: 'ETIMEDOUT' });
+    handle_fatal_error(new ConfigError('Configuration unavailable', { cause }));
+    expect(process.exitCode).toBe(6);
+  });
+
+  it('classifies AWS server errors as retryable without treating every 5xx as transient', () => {
+    handle_fatal_error({ name: 'ServiceUnavailable', $metadata: { httpStatusCode: 503 } });
+    expect(process.exitCode).toBe(3);
+    handle_fatal_error({ name: 'NotImplemented', $metadata: { httpStatusCode: 501 } });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports unexpected values and cyclic diagnostic bodies without masking the failure', () => {
+    handle_fatal_error(null);
+    expect(process.exitCode).toBe(1);
+    expect(diagnostics.join('\n')).toContain('null');
+
+    const error = Object.assign(new Error('Unexpected failure'), {
+      cause: {} as unknown,
+      body: {},
+    });
+    error.cause = error;
+    error.body = error;
+    handle_fatal_error(error);
+    expect(process.exitCode).toBe(1);
+    expect(diagnostics.join('\n')).toContain('Unexpected failure');
+  });
+
+  it('keeps debug stacks on stderr rather than corrupting stdout', () => {
+    vi.stubEnv('DEBUG', '1');
+    const error = new Error('Unexpected failure');
+    error.stack = 'Error: Unexpected failure\n    at example';
+    handle_fatal_error(error);
+    expect(diagnostics.join('\n')).toContain(error.stack);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

I completed #321 for the v5.0.0 milestone. Fatal CLI failures now keep the Atlas category and the underlying provider details separate, and schedulers can distinguish retryable failures from authentication, passphrase and configuration problems.

Closes #321.

## Changes

- Move fatal reporting out of the CLI entry point. Follow structured causes, print Atlas codes separately from Graph codes, HTTP statuses, response bodies and AWS error names, and keep all fatal diagnostics on stderr.
- Add explicit original-passphrase remediation without suggesting key replacement or deletion.
- Remove error-message matching from CLI source. Network detection uses Node codes, including nested causes; Graph failures no longer receive an S3 hint merely because their message mentions a connection error.
- Preserve exits 0, 1 and 2. Add 3 for retryable failures, 4 for auth/licensing, 5 for a wrong passphrase, 6 for configuration, 7 for missing resources and 8 for retention. Existing command-reported failures remain unchanged.
- Classify CLI configuration-loading failures at the CLI boundary, without changing the SDK, services or core configuration loader.
- Document the full mapping, precedence and old-to-new migration in the CLI reference, package README and v5 guide. This completes the exit-code section of #322, not its remaining CLI flag work.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no errors
- [x] `pnpm run format:check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes, including 190 CLI tests
- [x] `pnpm run docs:build` passes with the existing env/cron highlighting warnings
- [x] Regression coverage checks category boundaries, cause details, stderr isolation and classification without message parsing
- [x] No version bump; targets dev and labelled enhancement

I launched the built CLI with controlled failures injected at container composition. Before the change every scenario exited 1; afterwards:

```text
wrong passphrase: 5, Atlas and crypto codes on stderr
auth HTTP 403: 4, Atlas and Graph codes on stderr
throttle HTTP 429: 3, Atlas and Graph codes on stderr
nested network error: 3, Node code on stderr
unexpected error: 1
```

Separate runs without injected failures verified help exits 0, invalid usage exits 1, and missing configuration exits 6 with its original cause. No live tenant operations were run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added categorized CLI exit codes for fatal failures, while preserving codes for success and partial results.
  - Added detailed diagnostics to stderr, including network, HTTP, provider, remediation, and optional debug information.
  - Configuration-loading failures now produce clearer categorized errors.

- **Documentation**
  - Updated migration, CLI reference, and package documentation with exit-code behavior, scripting guidance, precedence, and stderr handling.

- **Tests**
  - Added coverage for error classification, nested causes, diagnostics, retry details, transport failures, and debug output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->