### PR TITLE
feat(sdk): export snapshots to a stream target

### DIFF
--- a/docs/migration/v5.md
+++ b/docs/migration/v5.md
@@ -105,6 +105,17 @@ Replace checks that only recognize `1` as failure. A script using `if [ "$status
 
 `Atlas code:` now identifies the Atlas category; `Transport code:`, `HTTP status:`, `Error name:` and `Body:` describe its underlying cause. Fatal details that previously went to stdout now go to stderr. Update log collectors accordingly, and use exit codes rather than parsing message wording. The [CLI reference](/reference/cli#exit-codes) lists the full mapping, precedence and command-reported exceptions.
 
+## SDK: exports can stream
+
+Additive, not breaking. `save()` and `saveMailbox()` now accept `output`, a Node `Writable`, so an export can go straight to an HTTP response or an upload instead of a local file. Existing `outputPath` callers are unaffected.
+
+```typescript
+// v5, no local file involved
+await atlas.outlook.save(snapshotId, { output: res });
+```
+
+Passing both `output` and `outputPath` throws `ConfigError`. For a stream export the result reports `outputPath: ''`, and a failed run destroys the stream rather than ending it. See [Exporting to a Stream](/reference/sdk#exporting-to-a-stream), which closes [issue #44](https://github.com/wisecom-oy/atlas/issues/44).
+
 ## Next
 
 The CLI flag changes land in the same release and are documented here as they merge.

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -389,17 +389,20 @@ async function export_mailbox_archive(atlas: AtlasInstance, mailbox: string, out
 
 Hand a user their own mailbox export without staging it on the app server. The archive streams to the response as it is built, so a read-only or ephemeral filesystem is no obstacle and disk use does not scale with mailbox size.
 
+The mailbox comes from the authenticated session, never from the request. A route parameter would let any caller export any mailbox in the tenant, and Atlas authenticates as an application: it has tenant-wide access and cannot tell whose request this is.
+
 ```typescript
 import express from 'express';
 
 const app = express();
 
-app.get('/exports/:mailbox', async (req, res) => {
+app.get('/exports/my-mailbox', require_authenticated_user, async (req, res) => {
+  const mailbox = req.user.mailbox; // resolved from the session, and tenant-checked
   res.setHeader('Content-Type', 'application/zip');
-  res.setHeader('Content-Disposition', `attachment; filename="${req.params.mailbox}.zip"`);
+  res.setHeader('Content-Disposition', `attachment; filename="${mailbox}.zip"`);
 
   try {
-    const result = await atlas.outlook.saveMailbox(req.params.mailbox, { output: res });
+    const result = await atlas.outlook.saveMailbox(mailbox, { output: res });
     console.log(`[export] ${result.savedCount} messages, ${result.totalBytes} bytes`);
 
     if (result.integrityFailures.length > 0) {
@@ -413,7 +416,7 @@ app.get('/exports/:mailbox', async (req, res) => {
 });
 ```
 
-`outputPath` is empty in the result, because nothing was written to disk. The drive workloads take the same option: `atlas.onedrive.save(ownerId, { snapshotId, output: res })`.
+`outputPath` is empty in the result, because nothing was written to disk. An export with no messages still ends the stream with a valid empty archive; an interrupted one destroys it. The drive workloads take the same option: `atlas.onedrive.save(ownerId, { snapshotId, output: res })`.
 
 ## Maintenance and monitoring
 

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -385,6 +385,36 @@ async function export_mailbox_archive(atlas: AtlasInstance, mailbox: string, out
 }
 ```
 
+### Serving an export over HTTP
+
+Hand a user their own mailbox export without staging it on the app server. The archive streams to the response as it is built, so a read-only or ephemeral filesystem is no obstacle and disk use does not scale with mailbox size.
+
+```typescript
+import express from 'express';
+
+const app = express();
+
+app.get('/exports/:mailbox', async (req, res) => {
+  res.setHeader('Content-Type', 'application/zip');
+  res.setHeader('Content-Disposition', `attachment; filename="${req.params.mailbox}.zip"`);
+
+  try {
+    const result = await atlas.outlook.saveMailbox(req.params.mailbox, { output: res });
+    console.log(`[export] ${result.savedCount} messages, ${result.totalBytes} bytes`);
+
+    if (result.integrityFailures.length > 0) {
+      // The client already has the bytes: record this rather than trying to unsend it.
+      console.warn(`[warn] ${result.integrityFailures.length} integrity failure(s)`);
+    }
+  } catch (err) {
+    // Atlas destroyed the response, so the client sees a broken transfer rather than a short zip.
+    console.error('[export] failed', err);
+  }
+});
+```
+
+`outputPath` is empty in the result, because nothing was written to disk. The drive workloads take the same option: `atlas.onedrive.save(ownerId, { snapshotId, output: res })`.
+
 ## Maintenance and monitoring
 
 ### Periodic integrity verification

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -507,6 +507,7 @@ Graph **item** IDs (`fileId`, `itemId`) are case-sensitive and never folded. `fi
 | `endDate`            | `Date`    | Include snapshots on or before this date                  |
 | `outputPath`         | `string`  | Output zip file path (default: `Restore-<timestamp>.zip`) |
 | `skipIntegrityCheck` | `boolean` | Skip SHA-256 verification (default: `false`)              |
+| `output`             | `Writable` | Stream the archive to this destination instead of a file  |
 
 Both methods return a `SaveResult`:
 
@@ -523,6 +524,56 @@ interface SaveResult {
   interrupted: boolean;
 }
 ```
+
+## Exporting to a Stream
+
+`save()` and `saveMailbox()` take an `output` stream instead of a path, so an export reaches its consumer without staging on the exporting machine's disk. That matters for a read-only or ephemeral filesystem, and for exports large enough that writing them twice costs real time.
+
+```typescript
+import express from 'express';
+import { createAtlasInstance } from '@wisecom/atlas-sdk';
+
+const app = express();
+const atlas = createAtlasInstance({ /* ...credentials... */ });
+
+app.get('/export/:snapshotId', async (req, res) => {
+  res.setHeader('Content-Type', 'application/zip');
+  res.setHeader('Content-Disposition', 'attachment; filename="export.zip"');
+
+  try {
+    const result = await atlas.outlook.save(req.params.snapshotId, { output: res });
+    log.info({ saved: result.savedCount, failures: result.integrityFailures }, 'export served');
+  } catch (err) {
+    // Atlas has already destroyed the response, so the client sees a failed transfer.
+    log.error({ err }, 'export failed');
+  }
+});
+```
+
+The same option works for the drive workloads:
+
+```typescript
+await atlas.onedrive.save('user@company.com', { snapshotId, output: res });
+await atlas.sharepoint.save('https://contoso.sharepoint.com/sites/Engineering', {
+  snapshotId,
+  output: res,
+});
+```
+
+Anything implementing Node's `Writable` works: an HTTP response, an upload stream, a compressor.
+
+What changes compared with a file export:
+
+| Behaviour | Stream export |
+| --------- | ------------- |
+| `outputPath` in the result | Empty string. There is no file, so Atlas reports no path. |
+| Counts, errors, `integrityFailures` | Reported exactly as for a file export. |
+| A failed run | The stream is destroyed rather than ended. |
+| `output` with `outputPath` | Rejected with `ConfigError`. Atlas writes one archive, and silently dropping the other value is how an export goes missing. |
+
+**A destroyed stream is the point.** Ending it would hand the consumer a short archive that opens like a complete one, which is the failure mode file exports avoid by staging. Over HTTP the client sees the transfer break, so treat a body that arrived without a completed request as a failed export rather than a partial one. Headers are already sent by then, so the status code cannot report the failure: check the result, or the absence of one, on the server.
+
+Memory is bounded to one message or file at a time in either mode. Each entry is fetched, decrypted, compressed and flushed before the next one starts, so a slow consumer applies backpressure rather than accumulating the archive in the heap.
 
 ## Restore Options
 

--- a/packages/core/src/services/shared/file-save-zip-writer.ts
+++ b/packages/core/src/services/shared/file-save-zip-writer.ts
@@ -1,41 +1,70 @@
 import { randomBytes } from 'node:crypto';
-import { createWriteStream, type WriteStream } from 'node:fs';
+import { createWriteStream } from 'node:fs';
 import { rename, rm } from 'node:fs/promises';
+import type { Writable } from 'node:stream';
 import { ZipArchive, type Archiver } from 'archiver';
 import { logger } from '@/utils/logger';
 
 /** The archiver instance file entries are appended to. */
 export type FileArchiveWriter = Archiver;
 
+/**
+ * Where a save archive is written: a filesystem path, or a caller's stream.
+ *
+ * A stream target exports without touching local disk, which is what an embedder piping to an
+ * HTTP response or an upload needs (issue #44). It also has no staging step, because there is no
+ * path to move the bytes onto.
+ */
+export type ArchiveTarget = string | Writable;
+
 export interface FileArchive {
   readonly archive: FileArchiveWriter;
   readonly promise: Promise<number>;
   /**
-   * Moves the finished archive onto the output path. Call it after the archive is finalized and
-   * the byte count has resolved; until then the output path is untouched.
+   * Makes the completed archive available to its consumer. For a path target this moves the
+   * finished archive onto the output path, which is untouched until then. For a stream target the
+   * bytes were already delivered as they were written, so there is nothing left to do.
+   *
+   * Call it after the archive is finalized and the byte count has resolved.
    */
   publish(): Promise<void>;
-  /** Destroys the stream and removes the temporary file, for a run that failed before publishing. */
+  /**
+   * Tears down a run that failed before publishing.
+   *
+   * A path target loses its temporary file and leaves any pre-existing file at the output path
+   * intact. A stream target is destroyed, so a consumer sees a failed transfer rather than a
+   * truncated archive delivered as a success.
+   */
   abort(): Promise<void>;
 }
 
 /**
- * Creates a zip archive for the given output path. Returns the archiver and a promise that
+ * Creates a zip archive for the given target. Returns the archiver and a promise that
  * resolves with total bytes written.
  *
- * Entries are written to a sibling temporary file and moved onto the output path by
- * {@link FileArchive.publish}, so nothing appears there until the archive is complete. A
+ * Entries bound for a path are written to a sibling temporary file and moved onto the output path
+ * by {@link FileArchive.publish}, so nothing appears there until the archive is complete. A
  * truncated zip is indistinguishable from a finished one, which is worse than no file at all when
  * the reason an operator ran a save is that they need the bytes (issue #307), and a save that
  * fails must not destroy a file that was already sitting at the path it was pointed at.
+ *
+ * A stream target cannot stage: its consumer receives bytes as they are produced, which is the
+ * point of streaming an export. `abort()` therefore destroys it instead.
  */
-export function create_file_archive(output_path: string): FileArchive {
-  const staging_path = `${output_path}.part-${randomBytes(6).toString('hex')}`;
-  const output = createWriteStream(staging_path);
-  const archive = new ZipArchive({ zlib: { level: 6 } });
+export function create_file_archive(
+  target: ArchiveTarget,
+  options: { readonly compression_level?: number } = {},
+): FileArchive {
+  const staging_path =
+    typeof target === 'string' ? `${target}.part-${randomBytes(6).toString('hex')}` : undefined;
+  const output =
+    staging_path === undefined ? (target as Writable) : createWriteStream(staging_path);
+  const archive = new ZipArchive({ zlib: { level: options.compression_level ?? 6 } });
 
   const promise = new Promise<number>((resolve, reject) => {
-    output.on('close', () => resolve(archive.pointer()));
+    // A staged file is only safe to rename once its descriptor is closed. A caller's stream may
+    // never emit `close` at all, so for those the flush is what completion means.
+    output.on(staging_path === undefined ? 'finish' : 'close', () => resolve(archive.pointer()));
     archive.on('error', reject);
     // Errors on the destination are not forwarded through pipe(), so without this a failed write
     // resolves on `close` and the caller reports a successful save.
@@ -49,15 +78,17 @@ export function create_file_archive(output_path: string): FileArchive {
   return {
     archive,
     promise,
-    publish: () => rename(staging_path, output_path),
+    publish: async () => {
+      if (staging_path !== undefined) await rename(staging_path, target as string);
+    },
     abort: () => abort_archive(archive, output, staging_path),
   };
 }
 
 async function abort_archive(
   archive: FileArchiveWriter,
-  output: WriteStream,
-  staging_path: string,
+  output: Writable,
+  staging_path: string | undefined,
 ): Promise<void> {
   try {
     archive.abort();
@@ -65,6 +96,7 @@ async function abort_archive(
     // Already destroyed or never started; the stream teardown below is what matters.
   }
   output.destroy();
+  if (staging_path === undefined) return;
   try {
     await rm(staging_path, { force: true });
   } catch (err) {

--- a/packages/core/src/services/shared/index.ts
+++ b/packages/core/src/services/shared/index.ts
@@ -4,7 +4,9 @@ export {
   add_file_to_archive,
   finalize_file_archive,
 } from '@/services/shared/file-save-zip-writer';
-export type { FileArchive } from '@/services/shared/file-save-zip-writer';
+export type { ArchiveTarget, FileArchive } from '@/services/shared/file-save-zip-writer';
+export { resolve_save_target } from '@/services/shared/save-archive-target';
+export type { ResolvedSaveTarget, SaveTargetOptions } from '@/services/shared/save-archive-target';
 export {
   filter_manifests_by_date,
   merge_snapshot_entries,

--- a/packages/core/src/services/shared/save-archive-target.ts
+++ b/packages/core/src/services/shared/save-archive-target.ts
@@ -1,0 +1,35 @@
+import type { Writable } from 'node:stream';
+import { ConfigError } from '@wisecom/atlas-types';
+import type { ArchiveTarget } from '@/services/shared/file-save-zip-writer';
+
+export interface SaveTargetOptions {
+  readonly output?: Writable;
+  readonly output_path?: string;
+}
+
+export interface ResolvedSaveTarget {
+  readonly target: ArchiveTarget;
+  /** The path the archive lands on, or an empty string when the caller supplied a stream. */
+  readonly output_path: string;
+}
+
+/**
+ * Resolves where a save writes: the caller's stream, an explicit path, or the generated default.
+ *
+ * Shared by every workload so one rule governs all of them. Passing both a stream and a path is
+ * refused rather than resolved by precedence: whichever one lost would be somewhere an operator
+ * expected the export to be, and a silently ignored `output_path` is how an export goes missing.
+ */
+export function resolve_save_target(
+  options: SaveTargetOptions,
+  default_path: () => string,
+): ResolvedSaveTarget {
+  if (options.output && options.output_path !== undefined) {
+    throw new ConfigError(
+      'Specify either output (a stream) or outputPath (a file), not both. Atlas writes one archive.',
+    );
+  }
+  if (options.output) return { target: options.output, output_path: '' };
+  const output_path = options.output_path ?? default_path();
+  return { target: output_path, output_path };
+}

--- a/packages/core/src/services/shared/save-archive-target.ts
+++ b/packages/core/src/services/shared/save-archive-target.ts
@@ -1,6 +1,10 @@
 import type { Writable } from 'node:stream';
 import { ConfigError } from '@wisecom/atlas-types';
-import type { ArchiveTarget } from '@/services/shared/file-save-zip-writer';
+import {
+  create_file_archive,
+  finalize_file_archive,
+  type ArchiveTarget,
+} from '@/services/shared/file-save-zip-writer';
 
 export interface SaveTargetOptions {
   readonly output?: Writable;
@@ -32,4 +36,29 @@ export function resolve_save_target(
   if (options.output) return { target: options.output, output_path: '' };
   const output_path = options.output_path ?? default_path();
   return { target: output_path, output_path };
+}
+
+/**
+ * Settles a caller's stream for a save that opened no archive, so the consumer is never left
+ * waiting on a response that will not arrive.
+ *
+ * A completed export with nothing in it produces a valid empty archive: for an HTTP download the
+ * alternative is a zero-byte body served as a zip, which is a corrupt file rather than an empty
+ * one. An interrupted export destroys the stream instead, because its content is unknowable and a
+ * consumer must be able to tell the difference. A path target is untouched: a file export that
+ * found nothing has always left no file behind.
+ */
+export async function settle_empty_save_target(
+  target: ArchiveTarget,
+  interrupted: boolean,
+): Promise<void> {
+  if (typeof target === 'string') return;
+  if (interrupted) {
+    target.destroy();
+    return;
+  }
+  const { archive, promise, publish } = create_file_archive(target);
+  await finalize_file_archive(archive);
+  await promise;
+  await publish();
 }

--- a/packages/core/tests/unit/services/shared/save-archive-stream-target.test.ts
+++ b/packages/core/tests/unit/services/shared/save-archive-stream-target.test.ts
@@ -10,7 +10,10 @@ import {
   create_file_archive,
   finalize_file_archive,
 } from '@/services/shared/file-save-zip-writer';
-import { resolve_save_target } from '@/services/shared/save-archive-target';
+import {
+  resolve_save_target,
+  settle_empty_save_target,
+} from '@/services/shared/save-archive-target';
 
 const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
 
@@ -98,6 +101,35 @@ describe('resolve_save_target', () => {
       target: 'default.zip',
       output_path: 'default.zip',
     });
+  });
+});
+
+describe('settle_empty_save_target', () => {
+  it('hands a completed empty export a valid empty archive rather than a zero-byte body', async () => {
+    const sink = new PassThrough();
+    const received = collect(sink);
+
+    await settle_empty_save_target(sink, false);
+    const body = await received;
+
+    // An archive with no entries is exactly one end-of-central-directory record, which is what
+    // makes it a zip an extractor opens rather than an empty download.
+    expect(body).toEqual(Buffer.from([0x50, 0x4b, 0x05, 0x06, ...new Array(18).fill(0)]));
+    expect(sink.writableEnded).toBe(true);
+  });
+
+  it('destroys the stream for an interrupted empty export', async () => {
+    const sink = new PassThrough();
+
+    await settle_empty_save_target(sink, true);
+
+    expect(sink.destroyed).toBe(true);
+    expect(sink.writableEnded).toBe(false);
+  });
+
+  it('creates no file for a path target that produced nothing', async () => {
+    await settle_empty_save_target(join(dir, 'out.zip'), false);
+    expect(readdirSync(dir)).toEqual([]);
   });
 });
 

--- a/packages/core/tests/unit/services/shared/save-archive-stream-target.test.ts
+++ b/packages/core/tests/unit/services/shared/save-archive-stream-target.test.ts
@@ -1,0 +1,119 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ConfigError } from '@wisecom/atlas-types';
+import {
+  add_file_to_archive,
+  create_file_archive,
+  finalize_file_archive,
+} from '@/services/shared/file-save-zip-writer';
+import { resolve_save_target } from '@/services/shared/save-archive-target';
+
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'atlas-zip-stream-'));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function collect(stream: PassThrough): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  const { promise, resolve, reject } = Promise.withResolvers<Buffer>();
+  stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+  stream.on('end', () => resolve(Buffer.concat(chunks)));
+  stream.on('error', reject);
+  return promise;
+}
+describe('create_file_archive with a stream target', () => {
+  it('delivers the archive to the caller stream and writes no file (issue #44)', async () => {
+    const sink = new PassThrough();
+    const received = collect(sink);
+    const { archive, promise, publish } = create_file_archive(sink);
+
+    await add_file_to_archive(archive, '/Documents', 'report.txt', Buffer.from('hello'));
+    await finalize_file_archive(archive);
+    const total_bytes = await promise;
+    await publish();
+    const body = await received;
+
+    expect(total_bytes).toBeGreaterThan(0);
+    expect(body.length).toBe(total_bytes);
+    expect(body.subarray(0, 4)).toEqual(ZIP_MAGIC);
+    // A stream export exists so the bytes never land on the exporting machine's disk.
+    expect(readdirSync(dir)).toEqual([]);
+  });
+
+  it('destroys the stream on abort, so a truncated archive is never a successful transfer', async () => {
+    const sink = new PassThrough();
+    const { archive, abort } = create_file_archive(sink);
+    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+
+    await abort();
+
+    expect(sink.destroyed).toBe(true);
+    // `end()` would have handed the consumer a valid-looking short zip instead.
+    expect(sink.writableEnded).toBe(false);
+  });
+
+  it('reports a destination failure rather than a successful save', async () => {
+    const sink = new PassThrough();
+    const { archive, promise } = create_file_archive(sink);
+    const failure = new Error('consumer went away');
+    sink.destroy(failure);
+
+    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello')).catch(
+      () => undefined,
+    );
+    await expect(promise).rejects.toThrow(failure.message);
+  });
+});
+
+describe('resolve_save_target', () => {
+  it('refuses a stream and a path together instead of silently dropping one', () => {
+    const sink = new PassThrough();
+    expect(() =>
+      resolve_save_target({ output: sink, output_path: join(dir, 'out.zip') }, () => 'default.zip'),
+    ).toThrow(ConfigError);
+  });
+
+  it('reports no output path for a stream, and the resolved path otherwise', () => {
+    const sink = new PassThrough();
+    expect(resolve_save_target({ output: sink }, () => 'default.zip')).toEqual({
+      target: sink,
+      output_path: '',
+    });
+    expect(resolve_save_target({ output_path: 'chosen.zip' }, () => 'default.zip')).toEqual({
+      target: 'chosen.zip',
+      output_path: 'chosen.zip',
+    });
+    expect(resolve_save_target({}, () => 'default.zip')).toEqual({
+      target: 'default.zip',
+      output_path: 'default.zip',
+    });
+  });
+});
+
+describe('create_file_archive with a path target', () => {
+  it('still stages and publishes, so #307 holds for file exports', async () => {
+    const output_path = join(dir, 'out.zip');
+    const { archive, promise, publish } = create_file_archive(output_path);
+
+    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+    await finalize_file_archive(archive);
+    expect(existsSync(output_path)).toBe(false);
+
+    await promise;
+    await publish();
+
+    expect(existsSync(output_path)).toBe(true);
+    expect(readdirSync(dir)).toEqual(['out.zip']);
+  });
+});

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -11,7 +11,10 @@ import {
   create_file_archive,
   finalize_file_archive,
 } from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
-import { resolve_save_target } from '@wisecom/atlas-core/services/shared/save-archive-target';
+import {
+  resolve_save_target,
+  settle_empty_save_target,
+} from '@wisecom/atlas-core/services/shared/save-archive-target';
 import { mark_downloaded_from_internet } from '@wisecom/atlas-core/utils/zone-identifier';
 import type {
   FileSaveOptions,
@@ -62,6 +65,7 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
   );
   if (begin_operation_progress(options, 'save', workload)) {
     finish_operation_progress(options, 'save', workload, 0, 0);
+    await settle_empty_save_target(target, true);
     return empty_save_result(options.snapshot_id, options.output_path ?? '', true);
   }
   const ctx = await deps.tenant_factory.create(tenant_id);
@@ -76,6 +80,7 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
 
     if (restorable.length === 0) {
       const interrupted = finish_operation_progress(options, 'save', workload, 0, 0);
+      await settle_empty_save_target(target, interrupted);
       return empty_save_result(options.snapshot_id, options.output_path ?? '', interrupted);
     }
 

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -11,6 +11,7 @@ import {
   create_file_archive,
   finalize_file_archive,
 } from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
+import { resolve_save_target } from '@wisecom/atlas-core/services/shared/save-archive-target';
 import { mark_downloaded_from_internet } from '@wisecom/atlas-core/utils/zone-identifier';
 import type {
   FileSaveOptions,
@@ -54,6 +55,11 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
 ): Promise<FileSaveResult> {
   const { workload } = deps;
   owner_id = normalize_owner_id(owner_id);
+  // Resolved up front so a conflicting options pair is refused before the caller's stream is
+  // touched. The empty results below report no path at all: no archive was opened.
+  const { target, output_path: resolved_output_path } = resolve_save_target(options, () =>
+    build_default_output_path(workload, options.snapshot_id),
+  );
   if (begin_operation_progress(options, 'save', workload)) {
     finish_operation_progress(options, 'save', workload, 0, 0);
     return empty_save_result(options.snapshot_id, options.output_path ?? '', true);
@@ -73,65 +79,85 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
       return empty_save_result(options.snapshot_id, options.output_path ?? '', interrupted);
     }
 
-    const output_path =
-      options.output_path ?? build_default_output_path(workload, options.snapshot_id);
-    const skip_integrity = options.skip_integrity_check ?? false;
-    const { archive, promise, publish, abort } = create_file_archive(output_path);
-
-    try {
-      const integrity_failures: string[] = [];
-      const { files_saved, files_skipped, errors } = await save_entries_to_archive(
-        workload,
-        ctx,
-        archive,
-        restorable,
-        skip_integrity,
-        integrity_failures,
-        options,
-      );
-
-      emit_operation_progress(options, {
-        operation: 'save',
-        workload,
-        phase: 'finalizing',
-        processed: files_saved + files_skipped,
-        total: restorable.length,
-      });
-      await finalize_file_archive(archive);
-      const total_bytes = await promise;
-      // Only now does anything appear at the output path, so a failure above cannot leave a
-      // truncated zip there and cannot destroy a file that was already sitting on it.
-      await publish();
-      await mark_downloaded_from_internet(output_path);
-      const interrupted =
-        files_saved + files_skipped < restorable.length || options.should_interrupt?.() === true;
-      emit_operation_progress(options, {
-        operation: 'save',
-        workload,
-        phase: interrupted ? 'interrupted' : 'completed',
-        processed: files_saved + files_skipped,
-        total: restorable.length,
-      });
-
-      return {
-        snapshot_id: options.snapshot_id,
-        files_saved,
-        files_skipped,
-        errors,
-        integrity_failures,
-        output_path,
-        total_bytes,
-        interrupted,
-      };
-    } catch (err) {
-      // Anything between opening the archive and publishing it can throw: the entry loop, the
-      // finalize, the byte count, the move itself. None of them may leave a partial file behind
-      // (issue #307).
-      await abort();
-      throw err;
-    }
+    return await write_drive_snapshot_to_archive(
+      workload,
+      ctx,
+      target,
+      resolved_output_path,
+      restorable,
+      options,
+    );
   } finally {
     ctx.destroy();
+  }
+}
+
+/** Writes snapshot entries to an archive and publishes the result. */
+async function write_drive_snapshot_to_archive(
+  workload: DriveWorkload,
+  ctx: TenantContext,
+  target: Parameters<typeof create_file_archive>[0],
+  output_path: string,
+  entries: DriveManifestEntry[],
+  options: FileSaveOptions,
+): Promise<FileSaveResult> {
+  const skip_integrity = options.skip_integrity_check ?? false;
+  const { archive, promise, publish, abort } = create_file_archive(target);
+
+  try {
+    const integrity_failures: string[] = [];
+    const { files_saved, files_skipped, errors } = await save_entries_to_archive(
+      workload,
+      ctx,
+      archive,
+      entries,
+      skip_integrity,
+      integrity_failures,
+      options,
+    );
+
+    emit_operation_progress(options, {
+      operation: 'save',
+      workload,
+      phase: 'finalizing',
+      processed: files_saved + files_skipped,
+      total: entries.length,
+    });
+    await finalize_file_archive(archive);
+    const total_bytes = await promise;
+    // Only now does anything appear at the output path, so a failure above cannot leave a
+    // truncated zip there and cannot destroy a file that was already sitting on it.
+    await publish();
+    // Mark only applies to a path target; a stream target has no local file.
+    if (output_path !== '') {
+      await mark_downloaded_from_internet(output_path);
+    }
+    const interrupted =
+      files_saved + files_skipped < entries.length || options.should_interrupt?.() === true;
+    emit_operation_progress(options, {
+      operation: 'save',
+      workload,
+      phase: interrupted ? 'interrupted' : 'completed',
+      processed: files_saved + files_skipped,
+      total: entries.length,
+    });
+
+    return {
+      snapshot_id: options.snapshot_id,
+      files_saved,
+      files_skipped,
+      errors,
+      integrity_failures,
+      output_path,
+      total_bytes,
+      interrupted,
+    };
+  } catch (err) {
+    // Anything between opening the archive and publishing it can throw: the entry loop, the
+    // finalize, the byte count, the move itself. None of them may leave a partial file behind
+    // (issue #307).
+    await abort();
+    throw err;
   }
 }
 

--- a/packages/onedrive/tests/unit/services/save/save.service.test.ts
+++ b/packages/onedrive/tests/unit/services/save/save.service.test.ts
@@ -1,3 +1,4 @@
+import type { Writable } from 'node:stream';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { apply_overrides, type Overrides } from '@wisecom/atlas-types/testing/apply-overrides';
 import { Container } from 'inversify';
@@ -36,11 +37,17 @@ vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
     finalize_file_archive: vi.fn().mockResolvedValue(undefined),
   };
 });
-
 vi.mock('@wisecom/atlas-drive/restore/streaming-restore', () => ({
   should_stream_restore: vi.fn().mockReturnValue(false),
   stream_decrypt_from_storage: vi.fn(),
   verify_streaming_checksum: vi.fn().mockReturnValue(true),
+}));
+
+const { mock_mark_downloaded } = vi.hoisted(() => ({
+  mock_mark_downloaded: vi.fn<(path: string) => Promise<void>>().mockResolvedValue(undefined),
+}));
+vi.mock('@wisecom/atlas-core/utils/zone-identifier', () => ({
+  mark_downloaded_from_internet: mock_mark_downloaded,
 }));
 
 function make_entry(overrides: Overrides<OneDriveManifestEntry> = {}): OneDriveManifestEntry {
@@ -313,6 +320,25 @@ describe('OneDriveSaveService', () => {
       expect(on_progress).toHaveBeenLastCalledWith(
         expect.objectContaining({ operation: 'save', workload: 'onedrive', phase: 'interrupted' }),
       );
+    });
+
+    it('accepts a stream target and reports empty output_path', async () => {
+      const entries = [make_entry(), make_entry({ file_id: 'file-2', file_name: 'budget.xlsx' })];
+      const manifest = make_manifest(entries);
+      vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(manifest);
+      const mock_stream = { write: vi.fn() } as unknown as Writable;
+      mock_mark_downloaded.mockClear();
+
+      const result = await service.save_snapshot('test-tenant', 'owner-1', {
+        snapshot_id: 'od-snap-1',
+        output: mock_stream,
+      });
+
+      expect(result.files_saved).toBe(2);
+      expect(result.output_path).toBe('');
+      expect(result.total_bytes).toBeGreaterThan(0);
+      // A stream export has no local file, so there is nothing to mark as downloaded.
+      expect(mock_mark_downloaded).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -6,7 +6,11 @@ import type { EntryResult } from '@/services/save/save-entry-writer';
 import { save_json_entry, save_mime_entry } from '@/services/save/save-entry-writer';
 import { verify_checksum } from '@/services/save/save-integrity-validator';
 import type { ArchiveWriter } from '@/services/save/save-zip-writer';
-import { create_save_archive, finalize_archive } from '@/services/save/save-zip-writer';
+import {
+  create_save_archive,
+  finalize_archive,
+  type ArchiveTarget,
+} from '@/services/save/save-zip-writer';
 import type { OperationControlOptions, TransferProgressReporter } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { logger } from '@wisecom/atlas-core/utils/logger';
@@ -22,6 +26,7 @@ import { emit_operation_progress } from '@wisecom/atlas-core/services/shared/ope
  */
 export async function save_entries_to_archive(
   ctx: TenantContext,
+  target: ArchiveTarget,
   output_path: string,
   skip_integrity: boolean,
   groups: Map<string, ManifestEntry[]>,
@@ -30,7 +35,7 @@ export async function save_entries_to_archive(
   is_interrupted: () => boolean,
   control: OperationControlOptions,
 ): Promise<Omit<SaveResult, 'snapshot_id'> & { processed: number }> {
-  const { archive, promise, publish, abort } = create_save_archive(output_path);
+  const { archive, promise, publish, abort } = create_save_archive(target);
 
   try {
     let global_saved = 0;
@@ -96,7 +101,7 @@ export async function save_entries_to_archive(
     // Only now does anything appear at the output path, so a failure above cannot leave a
     // truncated zip there and cannot destroy a file that was already sitting on it.
     await publish();
-    await mark_downloaded_from_internet(output_path);
+    if (output_path) await mark_downloaded_from_internet(output_path);
 
     log_save_summary(global_saved, global_att, global_errors, total_bytes, start);
 

--- a/packages/outlook/src/services/save/save-zip-writer.ts
+++ b/packages/outlook/src/services/save/save-zip-writer.ts
@@ -1,18 +1,18 @@
-import { randomBytes } from 'node:crypto';
-import { createWriteStream, type WriteStream } from 'node:fs';
-import { rename, rm } from 'node:fs/promises';
-import { ZipArchive, type Archiver } from 'archiver';
-import { logger } from '@wisecom/atlas-core/utils/logger';
+import { type Archiver } from 'archiver';
+import { create_file_archive } from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
+import type { ArchiveTarget } from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
+
+export type { ArchiveTarget };
 
 export interface SaveArchive {
   readonly archive: ArchiveWriter;
   readonly promise: Promise<number>;
   /**
-   * Moves the finished archive onto the output path. Call it after the archive is finalized and
-   * the byte count has resolved; until then the output path is untouched.
+   * Makes the completed archive available: a rename onto the output path for a file target,
+   * nothing for a stream target, whose consumer already has the bytes.
    */
   publish(): Promise<void>;
-  /** Destroys the stream and removes the temporary file, for a run that failed before publishing. */
+  /** Discards a run that failed before publishing, leaving no partial archive behind. */
   abort(): Promise<void>;
 }
 
@@ -20,53 +20,16 @@ export interface SaveArchive {
 export type ArchiveWriter = Archiver;
 
 /**
- * Creates a zip archive with maximum compression, streaming to a sibling temporary file.
+ * Creates a zip archive with maximum compression for the given target.
  *
- * The archive is moved onto the output path by {@link SaveArchive.publish}, so nothing appears
- * there until it is complete. A truncated zip is indistinguishable from a finished one (issue
- * #307), and a failed save must not destroy a file that was already at the path it was given.
+ * For a path target, streams to a sibling temporary file and publishes it via rename (issue #307).
+ * For a stream target, pipes directly to the caller's Writable without staging.
  */
-export function create_save_archive(output_path: string): SaveArchive {
-  const staging_path = `${output_path}.part-${randomBytes(6).toString('hex')}`;
-  const output = createWriteStream(staging_path);
-  const archive = new ZipArchive({ zlib: { level: 9 } });
-
-  const promise = new Promise<number>((resolve, reject) => {
-    output.on('close', () => resolve(archive.pointer()));
-    archive.on('error', reject);
-    output.on('error', reject);
+export function create_save_archive(target: ArchiveTarget): SaveArchive {
+  const { archive, promise, publish, abort } = create_file_archive(target, {
+    compression_level: 9,
   });
-  // Attach a handler now, so an error raised while entries are still being appended is not an
-  // unhandled rejection. Awaiting `promise` later still sees the rejection.
-  promise.catch(() => undefined);
-
-  archive.pipe(output);
-  return {
-    archive,
-    promise,
-    publish: () => rename(staging_path, output_path),
-    abort: () => abort_save_archive(archive, output, staging_path),
-  };
-}
-
-async function abort_save_archive(
-  archive: ArchiveWriter,
-  output: WriteStream,
-  staging_path: string,
-): Promise<void> {
-  try {
-    archive.abort();
-  } catch {
-    // Already destroyed or never started; the stream teardown below is what matters.
-  }
-  output.destroy();
-  try {
-    await rm(staging_path, { force: true });
-  } catch (err) {
-    logger.warn(
-      `Could not remove the partial archive at ${staging_path}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  return { archive, promise, publish, abort };
 }
 
 /**

--- a/packages/outlook/src/services/save/save.service.ts
+++ b/packages/outlook/src/services/save/save.service.ts
@@ -30,7 +30,9 @@ import {
   emit_operation_progress,
   finish_operation_progress,
 } from '@wisecom/atlas-core/services/shared/operation-progress';
+import { resolve_save_target } from '@wisecom/atlas-core/services/shared/save-archive-target';
 import { save_entries_to_archive } from '@/services/save/save-entry-processor';
+import type { ArchiveTarget } from '@/services/save/save-zip-writer';
 
 @injectable()
 export class SaveService implements SaveUseCase {
@@ -178,12 +180,12 @@ export class SaveService implements SaveUseCase {
     await backfill_missing_folder_ids(ctx, entries);
 
     const groups = group_entries_by_folder(entries);
-    const output_path = options.output_path ?? build_default_output_path();
+    const { target, output_path } = resolve_save_target(options, build_default_output_path);
     const skip_integrity = options.skip_integrity_check ?? false;
 
     logger.info(
       `Saving ${entries.length} messages across ` +
-        `${count_unique_folders(entries)} folders to ${output_path}`,
+        `${count_unique_folders(entries)} folders to ${output_path || '(stream)'}`,
     );
 
     if (skip_integrity) {
@@ -200,6 +202,7 @@ export class SaveService implements SaveUseCase {
     return this.execute_save_loop(
       ctx,
       snapshot_id,
+      target,
       output_path,
       skip_integrity,
       groups,
@@ -212,6 +215,7 @@ export class SaveService implements SaveUseCase {
   private async execute_save_loop(
     ctx: TenantContext,
     snapshot_id: string,
+    target: ArchiveTarget,
     output_path: string,
     skip_integrity: boolean,
     groups: Map<string, ManifestEntry[]>,
@@ -230,6 +234,7 @@ export class SaveService implements SaveUseCase {
     try {
       const result = await save_entries_to_archive(
         ctx,
+        target,
         output_path,
         skip_integrity,
         groups,
@@ -259,6 +264,7 @@ export class SaveService implements SaveUseCase {
 
   private finish_empty_result(snapshot_id: string, options: SaveOptions): SaveResult {
     const interrupted = finish_operation_progress(options, 'save', 'outlook', 0, 0);
+    // No archive was opened, so there is no path to report even when one was requested.
     return this.empty_result(snapshot_id, options.output_path ?? '', interrupted);
   }
 

--- a/packages/outlook/src/services/save/save.service.ts
+++ b/packages/outlook/src/services/save/save.service.ts
@@ -30,7 +30,10 @@ import {
   emit_operation_progress,
   finish_operation_progress,
 } from '@wisecom/atlas-core/services/shared/operation-progress';
-import { resolve_save_target } from '@wisecom/atlas-core/services/shared/save-archive-target';
+import {
+  resolve_save_target,
+  settle_empty_save_target,
+} from '@wisecom/atlas-core/services/shared/save-archive-target';
 import { save_entries_to_archive } from '@/services/save/save-entry-processor';
 import type { ArchiveTarget } from '@/services/save/save-zip-writer';
 
@@ -48,7 +51,7 @@ export class SaveService implements SaveUseCase {
     options: SaveOptions = {},
   ): Promise<SaveResult> {
     if (begin_operation_progress(options, 'save', 'outlook')) {
-      return this.finish_empty_result(snapshot_id, options);
+      return await this.finish_empty_result(snapshot_id, options);
     }
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
@@ -58,7 +61,7 @@ export class SaveService implements SaveUseCase {
       const entries = await this.resolve_entries(ctx, manifest, owner_id, tenant_id, options);
       if (entries.length === 0) {
         logger.warn('No entries to save');
-        return this.finish_empty_result(snapshot_id, options);
+        return await this.finish_empty_result(snapshot_id, options);
       }
 
       return this.save_batch(ctx, tenant_id, owner_id, snapshot_id, entries, options);
@@ -73,7 +76,7 @@ export class SaveService implements SaveUseCase {
     options: SaveOptions = {},
   ): Promise<SaveResult> {
     if (begin_operation_progress(options, 'save', 'outlook')) {
-      return this.finish_empty_result('mailbox', options);
+      return await this.finish_empty_result('mailbox', options);
     }
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
@@ -81,7 +84,7 @@ export class SaveService implements SaveUseCase {
 
       if (manifests.length === 0) {
         logger.warn('No snapshots found for this mailbox in the given date range');
-        return this.finish_empty_result('mailbox', options);
+        return await this.finish_empty_result('mailbox', options);
       }
 
       const entries = merge_snapshot_entries(manifests);
@@ -93,7 +96,7 @@ export class SaveService implements SaveUseCase {
       const filtered = await this.apply_entry_filters(entries, owner_id, tenant_id, options);
       if (filtered.length === 0) {
         logger.warn('No entries to save after filtering');
-        return this.finish_empty_result('mailbox', options);
+        return await this.finish_empty_result('mailbox', options);
       }
 
       logger.info(`Aggregated ${manifests.length} snapshots -- ${filtered.length} unique messages`);
@@ -262,9 +265,16 @@ export class SaveService implements SaveUseCase {
     }
   }
 
-  private finish_empty_result(snapshot_id: string, options: SaveOptions): SaveResult {
+  private async finish_empty_result(
+    snapshot_id: string,
+    options: SaveOptions,
+  ): Promise<SaveResult> {
     const interrupted = finish_operation_progress(options, 'save', 'outlook', 0, 0);
-    // No archive was opened, so there is no path to report even when one was requested.
+    // Resolved even here, so a conflicting options pair is refused on every path, and a caller's
+    // stream is settled rather than left open on an export that produced nothing.
+    const { target } = resolve_save_target(options, build_default_output_path);
+    await settle_empty_save_target(target, interrupted);
+    // No archive landed anywhere, so there is no path to report even when one was requested.
     return this.empty_result(snapshot_id, options.output_path ?? '', interrupted);
   }
 

--- a/packages/outlook/tests/unit/services/save/mime-passthrough.test.ts
+++ b/packages/outlook/tests/unit/services/save/mime-passthrough.test.ts
@@ -142,6 +142,7 @@ describe('save archive payload_format routing', () => {
     await save_entries_to_archive(
       ctx,
       'out.zip',
+      'out.zip',
       false,
       new Map([['f1', entries]]),
       new Map([['f1', 'Inbox']]),
@@ -183,6 +184,7 @@ describe('save archive payload_format routing', () => {
   it('still rebuilds a legacy JSON entry through build_eml with its attachments', async () => {
     const result_count = await save_entries_to_archive(
       ctx,
+      'out.zip',
       'out.zip',
       false,
       new Map([['f1', [make_json_entry()]]]),

--- a/packages/outlook/tests/unit/services/save/save.service.test.ts
+++ b/packages/outlook/tests/unit/services/save/save.service.test.ts
@@ -128,8 +128,8 @@ describe('SaveService', () => {
       vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(manifest);
       let interrupted = false;
       vi.mocked(save_entries_to_archive).mockImplementationOnce(async (...args) => {
-        const dashboard = args[5];
-        const is_interrupted = args[6];
+        const dashboard = args[6];
+        const is_interrupted = args[7];
         dashboard.update_total(1, 2, 1, 1);
         interrupted = true;
         expect(is_interrupted()).toBe(true);

--- a/packages/outlook/tests/unit/services/save/stream-save-target.test.ts
+++ b/packages/outlook/tests/unit/services/save/stream-save-target.test.ts
@@ -1,0 +1,120 @@
+import { readdirSync } from 'node:fs';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  ManifestEntry,
+  OperationControlOptions,
+  TenantContext,
+  TransferProgressReporter,
+} from '@wisecom/atlas-types';
+import { save_entries_to_archive } from '@/services/save/save-entry-processor';
+
+/**
+ * The stream export path with the real archive writer, not a mocked one: the point of issue #44
+ * is that the bytes reach the caller and never the exporting machine's disk, and a mocked writer
+ * cannot show either.
+ */
+const MIME_BLOB = Buffer.from(
+  ['Message-ID: <original@partner.example>', 'Subject: Quarterly Review', '', 'Numbers.'].join(
+    '\r\n',
+  ),
+  'utf-8',
+);
+
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+
+function make_entry(): ManifestEntry {
+  return {
+    object_id: 'msg-mime',
+    storage_key: 'content/mime-blob',
+    checksum: '',
+    size_bytes: MIME_BLOB.length,
+    subject: 'Quarterly Review',
+    folder_id: 'f1',
+    payload_format: 'mime',
+    received_at: '2026-03-10T14:30:22Z',
+  };
+}
+
+function make_context(): TenantContext {
+  return {
+    storage: { get: vi.fn().mockResolvedValue(MIME_BLOB) },
+    decrypt: vi.fn((buf: Buffer) => buf),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+function make_dashboard(): TransferProgressReporter {
+  return {
+    mark_active: vi.fn(),
+    update_active: vi.fn(),
+    update_total: vi.fn(),
+    mark_done: vi.fn(),
+    mark_error: vi.fn(),
+    mark_all_pending_interrupted: vi.fn(),
+    show_finalizing: vi.fn(),
+    finish: vi.fn(),
+  } as unknown as TransferProgressReporter;
+}
+
+const control: OperationControlOptions = {};
+
+describe('outlook save to a stream target', () => {
+  it('writes a complete archive to the caller stream and no file (issue #44)', async () => {
+    const sink = new PassThrough();
+    const chunks: Buffer[] = [];
+    sink.on('data', (chunk: Buffer) => chunks.push(chunk));
+    const before = readdirSync(process.cwd());
+
+    const result = await save_entries_to_archive(
+      make_context(),
+      sink,
+      '',
+      true,
+      new Map([['f1', [make_entry()]]]),
+      new Map([['f1', 'Inbox']]),
+      make_dashboard(),
+      () => false,
+      control,
+    );
+
+    const body = Buffer.concat(chunks);
+    expect(body.subarray(0, 4)).toEqual(ZIP_MAGIC);
+    expect(body.length).toBe(result.total_bytes);
+    expect(result.saved_count).toBe(1);
+    expect(result.integrity_failures).toEqual([]);
+    // No path is reported, because there is no file: a caller that logged one would be lying.
+    expect(result.output_path).toBe('');
+    expect(readdirSync(process.cwd())).toEqual(before);
+  });
+
+  it('destroys the stream when the run fails, so a short archive is never a success', async () => {
+    const sink = new PassThrough();
+    const ctx = {
+      storage: { get: vi.fn().mockRejectedValue(new Error('storage unavailable')) },
+      decrypt: vi.fn(),
+      destroy: vi.fn(),
+    } as unknown as TenantContext;
+    const dashboard = make_dashboard();
+    vi.mocked(dashboard.show_finalizing).mockImplementation(() => {
+      throw new Error('finalize failed');
+    });
+
+    await expect(
+      save_entries_to_archive(
+        ctx,
+        sink,
+        '',
+        true,
+        new Map([['f1', [make_entry()]]]),
+        new Map([['f1', 'Inbox']]),
+        dashboard,
+        () => false,
+        control,
+      ),
+    ).rejects.toThrow('finalize failed');
+
+    expect(sink.destroyed).toBe(true);
+    expect(sink.writableEnded).toBe(false);
+  });
+});

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -53,6 +53,8 @@ Construction validates required fields, a minimum passphrase length of 14 UTF-8 
 
 After provisioning the tenant bucket, call `await atlas.validate()` for an optional read-only S3 `HeadBucket` and Graph token probe. S3 failures throw `StorageError`; Graph-token failures throw `AuthError`. The probe does not test the encryption key, write permissions or workload-specific Graph consent. See the [SDK reference](https://wisecom-oy.github.io/atlas/reference/sdk#configuration-validation) and [v5 migration guide](https://wisecom-oy.github.io/atlas/migration/v5#eager-configuration-validation).
 
+Exports can stream instead of writing a file: `atlas.outlook.save(snapshotId, { output: res })` pipes the archive to any Node `Writable`, so an HTTP download never stages on local disk. See [exporting to a stream](https://wisecom-oy.github.io/atlas/reference/sdk#exporting-to-a-stream).
+
 ## API overview
 
 | Namespace / method          | Purpose                                  |

--- a/packages/sdk/tests/unit/public-surface-camel-case.test.ts
+++ b/packages/sdk/tests/unit/public-surface-camel-case.test.ts
@@ -1,3 +1,5 @@
+import type { Writable } from 'node:stream';
+
 import { describe, expect, it } from 'vitest';
 import type {
   AtlasInstanceConfig,
@@ -40,7 +42,7 @@ import { GRAPH_SERVICE_LIMITS } from '@/public-values';
  */
 type SnakeKeys<T> = T extends readonly (infer Item)[]
   ? SnakeKeys<Item>
-  : T extends Date | Buffer | AbortSignal | ((...args: never[]) => unknown)
+  : T extends Date | Buffer | AbortSignal | Writable | ((...args: never[]) => unknown)
     ? never
     : T extends object
       ? {

--- a/packages/sdk/tests/unit/stream-save-option.test.ts
+++ b/packages/sdk/tests/unit/stream-save-option.test.ts
@@ -1,0 +1,51 @@
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type { Container } from 'inversify';
+import { SAVE_USE_CASE_TOKEN, ONEDRIVE_SAVE_USE_CASE_TOKEN } from '@wisecom/atlas-types';
+import { create_outlook_api } from '@/outlook-api.factory';
+import { create_onedrive_api } from '@/onedrive-api.factory';
+
+/**
+ * Issue #44: an export can be streamed. The boundary converts option names, and a stream is not
+ * data: cloning it or renaming its members would hand the service something that no longer writes
+ * to the caller's destination.
+ */
+const TENANT = '00000000-0000-0000-0000-000000000000';
+
+function container_with(token: symbol, service: unknown): Container {
+  return {
+    get: vi.fn((requested: symbol) => (requested === token ? service : {})),
+  } as unknown as Container;
+}
+
+describe('save with a stream target', () => {
+  it('hands the outlook service the caller stream itself', async () => {
+    const sink = new PassThrough();
+    const save_snapshot = vi.fn().mockResolvedValue({ output_path: '', saved_count: 1 });
+    const api = create_outlook_api(TENANT, container_with(SAVE_USE_CASE_TOKEN, { save_snapshot }));
+
+    const result = await api.save('snap-example-1', { output: sink });
+
+    const options = save_snapshot.mock.calls[0]![2] as { output?: unknown };
+    expect(options.output).toBe(sink);
+    expect(result.outputPath).toBe('');
+  });
+
+  it('hands the drive services the caller stream itself', async () => {
+    const sink = new PassThrough();
+    const save_snapshot = vi.fn().mockResolvedValue({ output_path: '', files_saved: 1 });
+    const api = create_onedrive_api(
+      TENANT,
+      container_with(ONEDRIVE_SAVE_USE_CASE_TOKEN, { save_snapshot }),
+    );
+
+    await api.save('11111111-1111-1111-1111-111111111111', {
+      snapshotId: 'snap-example-1',
+      output: sink,
+    });
+
+    const options = save_snapshot.mock.calls[0]![2] as { output?: unknown; snapshot_id?: string };
+    expect(options.output).toBe(sink);
+    expect(options.snapshot_id).toBe('snap-example-1');
+  });
+});

--- a/packages/sharepoint/tests/unit/services/save/save.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/save/save.service.test.ts
@@ -14,7 +14,6 @@ import type {
   TenantContext,
   TenantContextFactory,
 } from '@wisecom/atlas-types';
-
 vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
   const mock_archive = {
     append: vi.fn(),

--- a/packages/types/src/ports/save/file-save.port.ts
+++ b/packages/types/src/ports/save/file-save.port.ts
@@ -1,11 +1,17 @@
+import type { Writable } from 'node:stream';
 import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
 
 export interface FileSaveOptions extends OperationControlOptions {
   readonly snapshot_id: string;
   /** Only save specific files (by file ID or full path). */
   readonly file_filter?: string[];
-  /** Output zip file path (default: auto-generated). */
+  /** Output zip file path (default: auto-generated). Mutually exclusive with `output`. */
   readonly output_path?: string;
+  /**
+   * A stream to write the archive to instead of a file, for exports that must not touch local
+   * disk (issue #44). Ended when the archive finalizes, destroyed when the run fails.
+   */
+  readonly output?: Writable;
   /** Skip SHA-256 integrity checks. */
   readonly skip_integrity_check?: boolean;
 }
@@ -16,6 +22,7 @@ export interface FileSaveResult {
   readonly files_skipped: number;
   readonly errors: string[];
   readonly integrity_failures: string[];
+  /** The path the archive landed on, or an empty string when it was written to a stream. */
   readonly output_path: string;
   readonly total_bytes: number;
   readonly interrupted: boolean;

--- a/packages/types/src/ports/save/use-case.port.ts
+++ b/packages/types/src/ports/save/use-case.port.ts
@@ -1,3 +1,4 @@
+import type { Writable } from 'node:stream';
 import type { TransferProgressReporter } from '@/ports/shared/transfer-progress.port';
 import type { OperationControlOptions } from '@/ports/atlas/progress-event.port';
 
@@ -6,7 +7,16 @@ export interface SaveOptions extends OperationControlOptions {
   readonly message_ref?: string;
   readonly start_date?: Date;
   readonly end_date?: Date;
+  /** Where the archive lands on disk. Mutually exclusive with {@link SaveOptions.output}. */
   readonly output_path?: string;
+  /**
+   * A stream to write the archive to instead of a file, so an export can be piped straight to an
+   * HTTP response or an upload without staging tens of gigabytes on local disk (issue #44).
+   *
+   * The stream receives bytes as they are produced and is ended when the archive finalizes. A run
+   * that fails destroys it, so a consumer never receives a truncated archive as a success.
+   */
+  readonly output?: Writable;
   readonly skip_integrity_check?: boolean;
   /**
    * Also export items captured from Recoverable Items. Off by default, so an
@@ -25,6 +35,7 @@ export interface SaveResult {
   readonly attachment_count: number;
   readonly error_count: number;
   readonly errors: string[];
+  /** The path the archive landed on, or an empty string when it was written to a stream. */
   readonly output_path: string;
   readonly total_bytes: number;
   readonly interrupted: boolean;

--- a/packages/types/src/public/case-convert.ts
+++ b/packages/types/src/public/case-convert.ts
@@ -1,16 +1,12 @@
 /**
  * Case conversion for the public SDK surface.
  *
- * Atlas is snake_case internally, which `.claude/CLAUDE.md` mandates and every service and domain
- * model follows. The SDK is camelCase, which its methods and config already were and its docs
- * always claimed. Before v5.0.0 only the *methods* honoured that, so consumers read
- * `createAtlasInstance` and then guessed at `force_full`, `restored_count` and `graph_cost`
- * (issue #45).
- *
- * The conversion is one mapped type plus one recursive function rather than sixty hand-mirrored
- * interfaces. Hand-mirroring drifts the first time somebody adds a field to a manifest and forgets
- * the copy; a mapped type cannot.
+ * Camelizes snake_case property names and their nested objects to the camelCase the
+ * public SDK uses; snakeizes back for the internal services. Class instances (including
+ * Node streams, Buffers, Dates, AbortSignal) are passed through untouched.
  */
+
+import type { Writable } from 'node:stream';
 
 /** Snake to camel for a single key. */
 export type CamelKey<S extends string> = S extends `${infer Head}_${infer Tail}`
@@ -32,7 +28,7 @@ export type SnakeKey<S extends string> = S extends `${infer Head}${infer Tail}`
  * `Buffer` and `Date` are objects with their own keys, and a converted `Date` would be an empty
  * object. Functions are progress hooks and reporter factories.
  */
-type Passthrough = Date | Buffer | AbortSignal | ((...args: never[]) => unknown);
+type Passthrough = Date | Buffer | AbortSignal | Writable | ((...args: never[]) => unknown);
 
 /**
  * Keys whose value is somebody else's data and is never touched at all.


### PR DESCRIPTION
## Summary

I made SDK exports streamable. `save()` and `saveMailbox()` now take `output`, a Node `Writable`, so an embedder can pipe a mailbox or drive export straight to an HTTP response or an upload instead of writing a file, re-reading it and deleting it. That was the whole cost of an export on a read-only or ephemeral filesystem, and double the I/O everywhere else.

Additive: every existing `outputPath` caller behaves exactly as before, including the staging and rename from #307. The CLI is untouched.

Closes #44.

## Changes

- `create_file_archive` takes an archive target that is either a path or a `Writable`, plus an optional compression level. A path target still stages to a sibling temp file and publishes by rename; a stream target has no staging, because its consumer receives bytes as they are produced.
- `abort()` destroys a stream target rather than ending it. Ending it would hand the consumer a short archive that opens like a complete one, which is the exact failure #307 removed for file exports.
- Added `resolve_save_target`, shared by all three workloads, so one rule decides where a save writes. Passing both `output` and `outputPath` throws `ConfigError` instead of silently dropping one.
- Threaded the target through the Outlook save flow and the shared drive save flow. Zone-identifier marking is skipped for a stream, since there is no file to mark, and a stream export reports `outputPath: ''` rather than a path that does not exist.
- Deleted the duplicated staging and abort logic in `packages/outlook`: its writer now delegates to the shared one and keeps only the EML-specific append and path sanitising.
- Added `Writable` to the case-conversion passthrough list, so the public boundary hands the service the caller's stream itself rather than a renamed copy of its members. The SDK drift guard mirrors it, otherwise Node's `_write` members read as snake_case violations.
- Documented it in `docs/reference/sdk.md` (Express handler first), `docs/reference/examples.md`, `docs/migration/v5.md` and `packages/sdk/README.md`.

## Decision, since the issue asked for one

The issue noted that #307 gave the writer a `publish()`/`abort()` contract with no meaning for a stream, and asked whether to add `saveStream()` instead. I kept one method and one option. `publish()` already means "make the completed archive available to its consumer": a rename for a file, nothing for a stream that already has the bytes. A second entry point would have duplicated the option handling and the result shape to express one difference in destination.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no errors
- [x] `pnpm run format:check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes
- [x] `pnpm run docs:build` passes
- [x] New behavior has unit tests
- [x] No version bump; targets `dev` and labelled `enhancement`

Proof for the acceptance criterion: I ran a real `http.createServer` handler that calls the Outlook save service with `output: res`, fetched it, and checked the response bytes. The body starts with a local file header and contains an end-of-central-directory record, so it is a complete zip; the result reported both messages and no integrity failures; and the working directory and `os.tmpdir()` listings were identical before and after, so nothing was written to disk. That harness was a throwaway and is not in the diff. The permanent regressions cover the same behaviour at the writer and service level, including that a failed run destroys the stream instead of ending it.

While running the gates I hit a poisoned turbo build cache: `packages/core/dist` and `packages/outlook/dist` were restored from cache entries missing their emitted output, which is the `tsconfig.tsbuildinfo` desync `.claude/CLAUDE.md` warns about. Clearing `.turbo` and rebuilding fixed it. No repository change was needed, but it is worth knowing if CI ever replays one of those entries.

One unrelated flake: `throttle-fence.test.ts` failed once under parallel load with a negative elapsed time, then passed on its own. That file is untouched on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added streaming export support for Outlook, OneDrive, and SharePoint using Node.js writable streams.
  - Exports can be sent directly to HTTP responses or other destinations without creating a local archive file.
  - Streamed results report an empty output path while preserving counts, byte totals, and integrity details.
  - Added validation to prevent using a stream and file path simultaneously.
  - Streams are completed on success and destroyed if an export fails or is interrupted.

- **Documentation**
  - Added migration guidance, reference documentation, examples, and quick-start information for streaming exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->