### PR TITLE
fix(sdk): abort interrupted stream exports

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -569,9 +569,10 @@ What changes compared with a file export:
 | `outputPath` in the result | Empty string. There is no file, so Atlas reports no path. |
 | Counts, errors, `integrityFailures` | Reported exactly as for a file export. |
 | A failed run | The stream is destroyed rather than ended. |
+| An interrupted run | The stream is destroyed without finalizing the archive. The result reports `interrupted: true`. |
 | `output` with `outputPath` | Rejected with `ConfigError`. Atlas writes one archive, and silently dropping the other value is how an export goes missing. |
 
-**A destroyed stream is the point.** Ending it would hand the consumer a short archive that opens like a complete one, which is the failure mode file exports avoid by staging. Over HTTP the client sees the transfer break, so treat a body that arrived without a completed request as a failed export rather than a partial one. Headers are already sent by then, so the status code cannot report the failure: check the result, or the absence of one, on the server.
+**A destroyed stream is the point.** Ending a failed or interrupted stream would hand the consumer a short archive that opens like a complete one, which is the failure mode file exports avoid by staging. Over HTTP the client sees the transfer break, so treat a body that arrived without a completed request as a failed export rather than a partial one. Headers are already sent by then, so the status code cannot report the failure: check the result, or the absence of one, on the server.
 
 Memory is bounded to one message or file at a time in either mode. Each entry is fetched, decrypted, compressed and flushed before the next one starts, so a slow consumer applies backpressure rather than accumulating the archive in the heap.
 

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -128,17 +128,23 @@ async function write_drive_snapshot_to_archive(
       processed: files_saved + files_skipped,
       total: entries.length,
     });
-    await finalize_file_archive(archive);
-    const total_bytes = await promise;
-    // Only now does anything appear at the output path, so a failure above cannot leave a
-    // truncated zip there and cannot destroy a file that was already sitting on it.
-    await publish();
-    // Mark only applies to a path target; a stream target has no local file.
-    if (output_path !== '') {
-      await mark_downloaded_from_internet(output_path);
-    }
     const interrupted =
       files_saved + files_skipped < entries.length || options.should_interrupt?.() === true;
+    let total_bytes: number;
+    if (interrupted && typeof target !== 'string') {
+      total_bytes = archive.pointer();
+      await abort();
+    } else {
+      await finalize_file_archive(archive);
+      total_bytes = await promise;
+      // Only now does anything appear at the output path, so a failure above cannot leave a
+      // truncated zip there and cannot destroy a file that was already sitting on it.
+      await publish();
+      // Mark only applies to a path target; a stream target has no local file.
+      if (output_path !== '') {
+        await mark_downloaded_from_internet(output_path);
+      }
+    }
     emit_operation_progress(options, {
       operation: 'save',
       workload,

--- a/packages/onedrive/tests/unit/services/save/stream-save-target.test.ts
+++ b/packages/onedrive/tests/unit/services/save/stream-save-target.test.ts
@@ -1,0 +1,72 @@
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveSaveService } from '@/services/save/save.service';
+
+const CONTENT = Buffer.from('file-content');
+
+function make_entry(): OneDriveManifestEntry {
+  return {
+    file_id: 'file-1',
+    drive_id: 'drive-1',
+    file_name: 'report.txt',
+    parent_path: '/Documents',
+    size_bytes: CONTENT.length,
+    change_type: 'updated',
+    backup_at: '2026-03-15T10:00:00.000Z',
+    storage_key: 'onedrive/data/owner-1/file-1',
+    checksum: '',
+  };
+}
+
+describe('OneDrive save to a stream target', () => {
+  it('destroys an interrupted stream without finalizing a complete archive', async () => {
+    const sink = new PassThrough();
+    sink.resume();
+    let interrupted = false;
+    const ctx = {
+      storage: {
+        get: vi.fn().mockImplementation(async () => {
+          interrupted = true;
+          return CONTENT;
+        }),
+      },
+      decrypt: vi.fn((content: Buffer) => content),
+      destroy: vi.fn(),
+    } as unknown as TenantContext;
+    const manifest: OneDriveSnapshotManifest = {
+      id: 'manifest-1',
+      tenant_id: 'tenant-1',
+      snapshot_id: 'snapshot-1',
+      owner_id: 'owner-1',
+      total_size_bytes: CONTENT.length,
+      created_at: new Date('2026-03-15T10:00:00.000Z'),
+      total_files: 1,
+      entries: [make_entry()],
+    };
+    const service = new OneDriveSaveService(
+      { create: vi.fn().mockResolvedValue(ctx) } as unknown as TenantContextFactory,
+      {
+        find_by_snapshot: vi.fn().mockResolvedValue(manifest),
+        list_snapshots_by_owner: vi.fn().mockResolvedValue([manifest]),
+      } as unknown as OneDriveManifestRepository,
+    );
+
+    const result = await service.save_snapshot('tenant-1', 'owner-1', {
+      snapshot_id: 'snapshot-1',
+      output: sink,
+      skip_integrity_check: true,
+      should_interrupt: () => interrupted,
+    });
+
+    expect(result).toMatchObject({ files_saved: 1, interrupted: true });
+    expect(sink.destroyed).toBe(true);
+    expect(sink.writableEnded).toBe(false);
+  });
+});

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -96,12 +96,19 @@ export async function save_entries_to_archive(
       processed: global_processed,
       total: global_total,
     });
-    await finalize_archive(archive);
-    const total_bytes = await promise;
-    // Only now does anything appear at the output path, so a failure above cannot leave a
-    // truncated zip there and cannot destroy a file that was already sitting on it.
-    await publish();
-    if (output_path) await mark_downloaded_from_internet(output_path);
+    const run_interrupted = should_interrupt();
+    let total_bytes: number;
+    if (run_interrupted && typeof target !== 'string') {
+      total_bytes = archive.pointer();
+      await abort();
+    } else {
+      await finalize_archive(archive);
+      total_bytes = await promise;
+      // Only now does anything appear at the output path, so a failure above cannot leave a
+      // truncated zip there and cannot destroy a file that was already sitting on it.
+      await publish();
+      if (output_path) await mark_downloaded_from_internet(output_path);
+    }
 
     log_save_summary(global_saved, global_att, global_errors, total_bytes, start);
 
@@ -114,7 +121,7 @@ export async function save_entries_to_archive(
       total_bytes,
       integrity_failures,
       processed: global_processed,
-      interrupted: should_interrupt(),
+      interrupted: run_interrupted,
     };
   } catch (err) {
     // Anything between opening the archive and publishing it can throw. None of it may leave a

--- a/packages/outlook/tests/unit/services/save/stream-save-target.test.ts
+++ b/packages/outlook/tests/unit/services/save/stream-save-target.test.ts
@@ -88,6 +88,32 @@ describe('outlook save to a stream target', () => {
     expect(readdirSync(process.cwd())).toEqual(before);
   });
 
+  it('destroys an interrupted stream without finalizing a complete archive', async () => {
+    const sink = new PassThrough();
+    const ctx = make_context();
+    let interrupted = false;
+    vi.mocked(ctx.storage.get).mockImplementation(async () => {
+      interrupted = true;
+      return MIME_BLOB;
+    });
+
+    const result = await save_entries_to_archive(
+      ctx,
+      sink,
+      '',
+      true,
+      new Map([['f1', [make_entry()]]]),
+      new Map([['f1', 'Inbox']]),
+      make_dashboard(),
+      () => interrupted,
+      control,
+    );
+
+    expect(result).toMatchObject({ saved_count: 1, interrupted: true });
+    expect(sink.destroyed).toBe(true);
+    expect(sink.writableEnded).toBe(false);
+  });
+
   it('destroys the stream when the run fails, so a short archive is never a success', async () => {
     const sink = new PassThrough();
     const ctx = {


### PR DESCRIPTION
## Summary

I moved interruption detection ahead of archive finalization. Interrupted stream exports now destroy the caller stream, so consumers cannot receive a valid but incomplete archive. Path exports still publish their partial archive and report `interrupted: true`.

Closes #329

## Changes

- Check the final interruption state before finalizing Outlook and shared drive archives.
- Abort interrupted stream targets while retaining the existing path target behavior.
- Cover Outlook and OneDrive stream interruption with the real archive writer.
- Document what stream consumers observe when an export is interrupted.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run format:check` passes
- [x] `pnpm run test` passes with no regressions
- [x] `pnpm run typecheck` passes
- [x] New and changed behavior has regression coverage
- [x] No file exceeds 300 effective lines
- [x] No relative imports were added
- [x] Secrets and credentials are not committed
- [x] Targets `dev`
- [x] No package version was changed
- [x] Labelled for release notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interrupted saves sent to a stream now stop cleanly without producing an incomplete archive that appears valid.
  * Interrupted saves to a file path are finalized and published normally.
  * Save results now accurately report whether the operation was interrupted and the number of bytes written.

* **Documentation**
  * Updated SDK reference documentation to explain interrupted stream behavior and archive handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->