### PR TITLE
fix(sdk): settle failed stream exports

### DIFF
--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -410,13 +410,13 @@ app.get('/exports/my-mailbox', require_authenticated_user, async (req, res) => {
       console.warn(`[warn] ${result.integrityFailures.length} integrity failure(s)`);
     }
   } catch (err) {
-    // Atlas destroyed the response, so the client sees a broken transfer rather than a short zip.
+    // Atlas destroyed the response, even if setup failed before writing any bytes.
     console.error('[export] failed', err);
   }
 });
 ```
 
-`outputPath` is empty in the result, because nothing was written to disk. An export with no messages still ends the stream with a valid empty archive; an interrupted one destroys it. The drive workloads take the same option: `atlas.onedrive.save(ownerId, { snapshotId, output: res })`.
+`outputPath` is empty in the result, because nothing was written to disk. An export with no messages still ends the stream with a valid empty archive. A failed setup or an interrupted run destroys it. The drive workloads take the same option: `atlas.onedrive.save(ownerId, { snapshotId, output: res })`.
 
 ## Maintenance and monitoring
 

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -568,7 +568,7 @@ What changes compared with a file export:
 | --------- | ------------- |
 | `outputPath` in the result | Empty string. There is no file, so Atlas reports no path. |
 | Counts, errors, `integrityFailures` | Reported exactly as for a file export. |
-| A failed run | The stream is destroyed rather than ended. |
+| A failed run | The stream is destroyed rather than ended, including when setup fails before any bytes are written. |
 | An interrupted run | The stream is destroyed without finalizing the archive. The result reports `interrupted: true`. |
 | `output` with `outputPath` | Rejected with `ConfigError`. Atlas writes one archive, and silently dropping the other value is how an export goes missing. |
 

--- a/packages/core/src/services/shared/save-archive-target.ts
+++ b/packages/core/src/services/shared/save-archive-target.ts
@@ -38,6 +38,11 @@ export function resolve_save_target(
   return { target: output_path, output_path };
 }
 
+/** Destroys a failed stream export while leaving path targets untouched. */
+export function settle_failed_save_target(target: ArchiveTarget): void {
+  if (typeof target !== 'string') target.destroy();
+}
+
 /**
  * Settles a caller's stream for a save that opened no archive, so the consumer is never left
  * waiting on a response that will not arrive.

--- a/packages/core/tests/unit/services/shared/save-archive-stream-target.test.ts
+++ b/packages/core/tests/unit/services/shared/save-archive-stream-target.test.ts
@@ -85,6 +85,7 @@ describe('resolve_save_target', () => {
     expect(() =>
       resolve_save_target({ output: sink, output_path: join(dir, 'out.zip') }, () => 'default.zip'),
     ).toThrow(ConfigError);
+    expect(sink.destroyed).toBe(false);
   });
 
   it('reports no output path for a stream, and the resolved path otherwise', () => {

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -14,6 +14,7 @@ import {
 import {
   resolve_save_target,
   settle_empty_save_target,
+  settle_failed_save_target,
 } from '@wisecom/atlas-core/services/shared/save-archive-target';
 import { mark_downloaded_from_internet } from '@wisecom/atlas-core/utils/zone-identifier';
 import type {
@@ -63,37 +64,46 @@ export async function save_drive_snapshot<TManifest extends DriveChainManifest>(
   const { target, output_path: resolved_output_path } = resolve_save_target(options, () =>
     build_default_output_path(workload, options.snapshot_id),
   );
-  if (begin_operation_progress(options, 'save', workload)) {
-    finish_operation_progress(options, 'save', workload, 0, 0);
-    await settle_empty_save_target(target, true);
-    return empty_save_result(options.snapshot_id, options.output_path ?? '', true);
-  }
-  const ctx = await deps.tenant_factory.create(tenant_id);
+
   try {
-    const chain = await load_drive_chain_entries(
-      deps.manifests,
-      ctx,
-      owner_id,
-      options.snapshot_id,
-    );
-    const restorable = filter_drive_entries(restorable_entries(chain.entries), options.file_filter);
-
-    if (restorable.length === 0) {
-      const interrupted = finish_operation_progress(options, 'save', workload, 0, 0);
-      await settle_empty_save_target(target, interrupted);
-      return empty_save_result(options.snapshot_id, options.output_path ?? '', interrupted);
+    if (begin_operation_progress(options, 'save', workload)) {
+      finish_operation_progress(options, 'save', workload, 0, 0);
+      await settle_empty_save_target(target, true);
+      return empty_save_result(options.snapshot_id, options.output_path ?? '', true);
     }
+    const ctx = await deps.tenant_factory.create(tenant_id);
+    try {
+      const chain = await load_drive_chain_entries(
+        deps.manifests,
+        ctx,
+        owner_id,
+        options.snapshot_id,
+      );
+      const restorable = filter_drive_entries(
+        restorable_entries(chain.entries),
+        options.file_filter,
+      );
 
-    return await write_drive_snapshot_to_archive(
-      workload,
-      ctx,
-      target,
-      resolved_output_path,
-      restorable,
-      options,
-    );
-  } finally {
-    ctx.destroy();
+      if (restorable.length === 0) {
+        const interrupted = finish_operation_progress(options, 'save', workload, 0, 0);
+        await settle_empty_save_target(target, interrupted);
+        return empty_save_result(options.snapshot_id, options.output_path ?? '', interrupted);
+      }
+
+      return await write_drive_snapshot_to_archive(
+        workload,
+        ctx,
+        target,
+        resolved_output_path,
+        restorable,
+        options,
+      );
+    } finally {
+      ctx.destroy();
+    }
+  } catch (err) {
+    settle_failed_save_target(target);
+    throw err;
   }
 }
 

--- a/packages/onedrive/tests/unit/services/save/stream-save-target.test.ts
+++ b/packages/onedrive/tests/unit/services/save/stream-save-target.test.ts
@@ -69,4 +69,45 @@ describe('OneDrive save to a stream target', () => {
     expect(sink.destroyed).toBe(true);
     expect(sink.writableEnded).toBe(false);
   });
+
+  it('destroys the stream when tenant setup fails', async () => {
+    const sink = new PassThrough();
+    const service = new OneDriveSaveService(
+      {
+        create: vi.fn().mockRejectedValue(new Error('tenant unavailable')),
+      } as unknown as TenantContextFactory,
+      {} as OneDriveManifestRepository,
+    );
+
+    await expect(
+      service.save_snapshot('tenant-1', 'owner-1', {
+        snapshot_id: 'snapshot-1',
+        output: sink,
+      }),
+    ).rejects.toThrow('tenant unavailable');
+
+    expect(sink.destroyed).toBe(true);
+    expect(sink.writableEnded).toBe(false);
+  });
+
+  it('destroys the stream when reading the manifest fails', async () => {
+    const sink = new PassThrough();
+    const ctx = { destroy: vi.fn() } as unknown as TenantContext;
+    const service = new OneDriveSaveService(
+      { create: vi.fn().mockResolvedValue(ctx) } as unknown as TenantContextFactory,
+      {
+        find_by_snapshot: vi.fn().mockRejectedValue(new Error('manifest unavailable')),
+      } as unknown as OneDriveManifestRepository,
+    );
+
+    await expect(
+      service.save_snapshot('tenant-1', 'owner-1', {
+        snapshot_id: 'snapshot-1',
+        output: sink,
+      }),
+    ).rejects.toThrow('manifest unavailable');
+
+    expect(sink.destroyed).toBe(true);
+    expect(sink.writableEnded).toBe(false);
+  });
 });

--- a/packages/outlook/src/services/save/save.service.ts
+++ b/packages/outlook/src/services/save/save.service.ts
@@ -33,6 +33,7 @@ import {
 import {
   resolve_save_target,
   settle_empty_save_target,
+  settle_failed_save_target,
 } from '@wisecom/atlas-core/services/shared/save-archive-target';
 import { save_entries_to_archive } from '@/services/save/save-entry-processor';
 import type { ArchiveTarget } from '@/services/save/save-zip-writer';
@@ -50,23 +51,38 @@ export class SaveService implements SaveUseCase {
     snapshot_id: string,
     options: SaveOptions = {},
   ): Promise<SaveResult> {
-    if (begin_operation_progress(options, 'save', 'outlook')) {
-      return await this.finish_empty_result(snapshot_id, options);
-    }
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const { target, output_path } = resolve_save_target(options, build_default_output_path);
     try {
-      const manifest = await this.load_manifest(ctx, snapshot_id);
-      const owner_id = manifest.owner_id;
-
-      const entries = await this.resolve_entries(ctx, manifest, owner_id, tenant_id, options);
-      if (entries.length === 0) {
-        logger.warn('No entries to save');
-        return await this.finish_empty_result(snapshot_id, options);
+      if (begin_operation_progress(options, 'save', 'outlook')) {
+        return await this.finish_empty_result(snapshot_id, options, target);
       }
+      const ctx = await this._tenant_factory.create(tenant_id);
+      try {
+        const manifest = await this.load_manifest(ctx, snapshot_id);
+        const owner_id = manifest.owner_id;
 
-      return this.save_batch(ctx, tenant_id, owner_id, snapshot_id, entries, options);
-    } finally {
-      ctx.destroy();
+        const entries = await this.resolve_entries(ctx, manifest, owner_id, tenant_id, options);
+        if (entries.length === 0) {
+          logger.warn('No entries to save');
+          return await this.finish_empty_result(snapshot_id, options, target);
+        }
+
+        return this.save_batch(
+          ctx,
+          tenant_id,
+          owner_id,
+          snapshot_id,
+          entries,
+          options,
+          target,
+          output_path,
+        );
+      } finally {
+        ctx.destroy();
+      }
+    } catch (err) {
+      settle_failed_save_target(target);
+      throw err;
     }
   }
 
@@ -75,35 +91,52 @@ export class SaveService implements SaveUseCase {
     owner_id: string,
     options: SaveOptions = {},
   ): Promise<SaveResult> {
-    if (begin_operation_progress(options, 'save', 'outlook')) {
-      return await this.finish_empty_result('mailbox', options);
-    }
-    const ctx = await this._tenant_factory.create(tenant_id);
+    const { target, output_path } = resolve_save_target(options, build_default_output_path);
     try {
-      const manifests = await this.load_mailbox_manifests(ctx, owner_id, options);
-
-      if (manifests.length === 0) {
-        logger.warn('No snapshots found for this mailbox in the given date range');
-        return await this.finish_empty_result('mailbox', options);
+      if (begin_operation_progress(options, 'save', 'outlook')) {
+        return await this.finish_empty_result('mailbox', options, target);
       }
+      const ctx = await this._tenant_factory.create(tenant_id);
+      try {
+        const manifests = await this.load_mailbox_manifests(ctx, owner_id, options);
 
-      const entries = merge_snapshot_entries(manifests);
+        if (manifests.length === 0) {
+          logger.warn('No snapshots found for this mailbox in the given date range');
+          return await this.finish_empty_result('mailbox', options, target);
+        }
 
-      if (options.folder_name) {
-        await backfill_missing_folder_ids(ctx, entries);
+        const entries = merge_snapshot_entries(manifests);
+
+        if (options.folder_name) {
+          await backfill_missing_folder_ids(ctx, entries);
+        }
+
+        const filtered = await this.apply_entry_filters(entries, owner_id, tenant_id, options);
+        if (filtered.length === 0) {
+          logger.warn('No entries to save after filtering');
+          return await this.finish_empty_result('mailbox', options, target);
+        }
+
+        logger.info(
+          `Aggregated ${manifests.length} snapshots -- ${filtered.length} unique messages`,
+        );
+
+        return this.save_batch(
+          ctx,
+          tenant_id,
+          owner_id,
+          'mailbox',
+          filtered,
+          options,
+          target,
+          output_path,
+        );
+      } finally {
+        ctx.destroy();
       }
-
-      const filtered = await this.apply_entry_filters(entries, owner_id, tenant_id, options);
-      if (filtered.length === 0) {
-        logger.warn('No entries to save after filtering');
-        return await this.finish_empty_result('mailbox', options);
-      }
-
-      logger.info(`Aggregated ${manifests.length} snapshots -- ${filtered.length} unique messages`);
-
-      return this.save_batch(ctx, tenant_id, owner_id, 'mailbox', filtered, options);
-    } finally {
-      ctx.destroy();
+    } catch (err) {
+      settle_failed_save_target(target);
+      throw err;
     }
   }
 
@@ -178,12 +211,13 @@ export class SaveService implements SaveUseCase {
     snapshot_id: string,
     entries: ManifestEntry[],
     options: SaveOptions,
+    target: ArchiveTarget,
+    output_path: string,
   ): Promise<SaveResult> {
     const folder_map = await build_folder_map(this._connector, tenant_id, owner_id);
     await backfill_missing_folder_ids(ctx, entries);
 
     const groups = group_entries_by_folder(entries);
-    const { target, output_path } = resolve_save_target(options, build_default_output_path);
     const skip_integrity = options.skip_integrity_check ?? false;
 
     logger.info(
@@ -268,11 +302,9 @@ export class SaveService implements SaveUseCase {
   private async finish_empty_result(
     snapshot_id: string,
     options: SaveOptions,
+    target: ArchiveTarget,
   ): Promise<SaveResult> {
     const interrupted = finish_operation_progress(options, 'save', 'outlook', 0, 0);
-    // Resolved even here, so a conflicting options pair is refused on every path, and a caller's
-    // stream is settled rather than left open on an export that produced nothing.
-    const { target } = resolve_save_target(options, build_default_output_path);
     await settle_empty_save_target(target, interrupted);
     // No archive landed anywhere, so there is no path to report even when one was requested.
     return this.empty_result(snapshot_id, options.output_path ?? '', interrupted);

--- a/packages/outlook/tests/unit/services/save/save.service.test.ts
+++ b/packages/outlook/tests/unit/services/save/save.service.test.ts
@@ -1,3 +1,4 @@
+import { PassThrough } from 'node:stream';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Container } from 'inversify';
 import 'reflect-metadata';
@@ -192,14 +193,18 @@ describe('SaveService', () => {
       expect(result.saved_count).toBe(0);
     });
 
-    it('throws when manifest not found', async () => {
+    it('destroys the stream when the requested snapshot has no manifest', async () => {
+      const sink = new PassThrough();
       vi.mocked(mock_manifests.find_by_snapshot).mockResolvedValue(
         undefined as unknown as Manifest,
       );
 
-      await expect(service.save_snapshot('test-tenant', 'snap-bad')).rejects.toThrow(
-        'No manifest found',
-      );
+      await expect(
+        service.save_snapshot('test-tenant', 'snap-bad', { output: sink }),
+      ).rejects.toThrow('No manifest found');
+
+      expect(sink.destroyed).toBe(true);
+      expect(sink.writableEnded).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

I traced the hang to save setup running before the stream target entered the archive lifecycle. A missing manifest, tenant setup failure, or manifest read failure rejected the SDK call but left the caller's `Writable` open.

I now resolve the target at each save entry point and settle every later failure through one shared rule. Stream targets are destroyed, while path targets remain untouched. Conflicting `output` and `outputPath` options still fail before either target is used.

Closes #328

## Changes

- Add shared failed-target settlement that destroys streams and leaves paths alone.
- Cover the full Outlook and shared drive setup phase with failure cleanup.
- Exercise missing manifests, unavailable tenant contexts, manifest read failures, and conflicting targets.
- Clarify setup failure behavior in the SDK reference and HTTP example.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run format:check` passes
- [x] `pnpm run test` passes with no regressions
- [x] `pnpm run typecheck` passes
- [x] New and changed behavior has regression coverage
- [x] No file exceeds 300 effective lines
- [x] No relative imports were added
- [x] Secrets and credentials are not committed
- [x] Targets `dev`
- [x] No package version was changed
- [x] Labelled for release notes