### PR TITLE
feat(cli): one vocabulary for flags, verbs, and banners

### DIFF
--- a/docs/azure-ad-setup.md
+++ b/docs/azure-ad-setup.md
@@ -51,7 +51,7 @@ Rotate the client secret every 90 days at minimum for production environments.
 
 1. In **Certificates & secrets** on the app registration, add a new client secret.
 2. Copy the secret **Value** immediately. The portal shows it only once, and the Secret ID is not the secret.
-3. Update Atlas with the new value, either `ATLAS_CLIENT_SECRET` or `atlas config set client.secret` (see [Configuration](/configuration)).
+3. Update Atlas with the new value, either `ATLAS_CLIENT_SECRET` or by piping it to `atlas config set client.secret -`, which reads the value from stdin so it never reaches shell history (see [Configuration](/configuration)).
 4. Confirm authentication works, then delete the old secret in **Certificates & secrets**.
 
 An expired or mistyped secret surfaces as `AADSTS7000215`. See [Troubleshooting](/troubleshooting#aadsts-error-codes).

--- a/docs/azure-ad-setup.md
+++ b/docs/azure-ad-setup.md
@@ -51,7 +51,7 @@ Rotate the client secret every 90 days at minimum for production environments.
 
 1. In **Certificates & secrets** on the app registration, add a new client secret.
 2. Copy the secret **Value** immediately. The portal shows it only once, and the Secret ID is not the secret.
-3. Update Atlas with the new value, either `ATLAS_CLIENT_SECRET` or `atlas config client.secret` (see [Configuration](/configuration)).
+3. Update Atlas with the new value, either `ATLAS_CLIENT_SECRET` or `atlas config set client.secret` (see [Configuration](/configuration)).
 4. Confirm authentication works, then delete the old secret in **Certificates & secrets**.
 
 An expired or mistyped secret surfaces as `AADSTS7000215`. See [Troubleshooting](/troubleshooting#aadsts-error-codes).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,10 +41,10 @@ Every setting has three equivalent forms: an environment variable, a config file
 ## The Encrypted Secure Store (`atlas config`)
 
 ```bash
-atlas config tenant.id 4fa2a706-b26a-4bbe-9b1c-1e671b586b8f
-atlas config client.id 11112222-3333-4444-5555-666677778888
-pbpaste | atlas config client.secret -   # "-" reads from stdin, keeping secrets out of shell history
-atlas config s3.endpoint https://s3.example.com
+atlas config set tenant.id 4fa2a706-b26a-4bbe-9b1c-1e671b586b8f
+atlas config set client.id 11112222-3333-4444-5555-666677778888
+pbpaste | atlas config set client.secret -   # "-" reads from stdin, keeping secrets out of shell history
+atlas config set s3.endpoint https://s3.example.com
 atlas config list          # every key, secrets masked, source annotated
 atlas config validate      # live-check Graph and S3 connectivity
 atlas config unset client.secret

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,7 +90,7 @@ atlas outlook list
 atlas outlook restore -m user@company.com -f Inbox
 
 # save as EML zip archive
-atlas outlook save -m user@company.com -o backup.zip
+atlas outlook save -m user@company.com --output backup.zip
 
 # list OneDrive snapshots
 atlas onedrive list-snapshots -o user@company.com

--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -288,7 +288,7 @@ On Windows the archive is stamped with Mark-of-the-Web (`Zone.Identifier`, `Zone
 | `-o, --owner <id>`         | User email or Entra object ID            | Required       |
 | `-s, --snapshot <id>`      | Snapshot ID to save from                 | Required       |
 | `--file-filter <paths...>` | Only save specific files (by ID or path) | All files      |
-| `-O, --output <path>`      | Output zip file path                     | Auto-generated |
+| `--output <path>`          | Output zip file path                     | Auto-generated |
 | `--skip-verify`            | Skip SHA-256 integrity checks            | `false`        |
 | `-t, --tenant <id>`        | Tenant identifier                        | Config default |
 
@@ -425,7 +425,7 @@ Files larger than 4 MiB use a streaming decrypt pipeline: the encrypted blob is 
 
 ```bash
 atlas onedrive save -o user@company.com -s od-snap-123
-atlas onedrive save -o user@company.com -s od-snap-123 -O ~/Downloads/backup.zip
+atlas onedrive save -o user@company.com -s od-snap-123 --output ~/Downloads/backup.zip
 atlas onedrive save -o user@company.com -s od-snap-123 --file-filter "/Documents/report.docx"
 ```
 

--- a/docs/operations/replication.md
+++ b/docs/operations/replication.md
@@ -108,10 +108,10 @@ atlas-{tenant_id}/
 Each sidecar records the target ID, status (COMPLETED/PARTIAL/FAILED), object counts, byte counts, timestamps, manifest checksums, and the last error.
 
 ```bash
-atlas replicate --status                          # all snapshots, all targets
-atlas replicate --status -m user@company.com      # filter by mailbox
-atlas replicate --status --site <site-id>         # filter by SharePoint site
-atlas replicate --status -s <snapshot-id>         # filter by snapshot
+atlas replicate status                          # all snapshots, all targets
+atlas replicate status -m user@company.com      # filter by mailbox
+atlas replicate status --site <site-id>         # filter by SharePoint site
+atlas replicate status -s <snapshot-id>         # filter by snapshot
 ```
 
 ## CLI usage

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -73,13 +73,13 @@ Provider diagnostics can contain tenant identifiers and sensitive content. Redac
 
 A short flag means one thing across the whole CLI. Before v5.0.0 three of them meant two things, and the pair that mattered was `atlas stats -s <site>` against `atlas onedrive verify -s <snapshot>`.
 
-| Flag | Meaning                                       | Notes                                                                                         |
-| ---- | --------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `-s` | `--snapshot`                                  | Every command that acts on a snapshot, including `stats`, which no longer accepts `-s` at all |
-| `-o` | `--owner`                                     | A drive owner; `--output` has no short flag on any command                                    |
-| `-f` | `--folder` on Outlook, `--file` on the drives | One value each; repeat `-f` to name several Outlook folders                                   |
-| `-t` | `--tenant`                                    | Every command                                                                                 |
-| `-m` | `--mailbox`                                   | Every command that acts on a mailbox                                                          |
+| Flag | Meaning                                       | Notes                                                                              |
+| ---- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `-s` | `--snapshot`                                  | Every command that acts on a snapshot; `stats` does not, and rejects `-s` outright |
+| `-o` | `--owner`                                     | A drive owner; `--output` has no short flag on any command                         |
+| `-f` | `--folder` on Outlook, `--file` on the drives | One value each; repeat `-f` to name several Outlook folders                        |
+| `-t` | `--tenant`                                    | Every command                                                                      |
+| `-m` | `--mailbox`                                   | Every command that acts on a mailbox                                               |
 
 A retired spelling is rejected rather than reinterpreted, naming its replacement:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,17 +39,17 @@ esac
 exit "$status"
 ```
 
-| Code | Meaning | Action |
-| ---- | ------- | ------ |
-| `0` | Success, help, or a command with no failure reported | Continue normally. |
-| `1` | Unexpected or unclassified failure, invalid command usage, or a command-reported failure without a typed exception | Inspect stderr. Do not assume the failure is transient. |
-| `2` | Partial backup, restore or save: item errors, skipped files, integrity failures or a soft interrupt | Inspect the partial result before relying on it. |
-| `3` | Throttling exhausted its retry budget, a recognized network error, or transient HTTP `429`, `500`, `502`, `503`, `504` | Schedule a later attempt. A timeout does not prove a write was never committed; inspect partial work before repeating a restore. |
-| `4` | `ATLAS_AUTH_DENIED`, `ATLAS_MAILBOX_NOT_LICENSED`, or an unwrapped HTTP `401`/`403` | Correct credentials, permissions, admin consent or licensing before retrying. |
-| `5` | `ATLAS_WRONG_PASSPHRASE` | Supply the original tenant passphrase. Never pad it or delete the wrapped key. If it is correct, investigate possible corruption. |
-| `6` | `ATLAS_CONFIG_INVALID`, including failure to load the CLI configuration | Correct the configuration or its storage access. |
-| `7` | `ATLAS_NOT_FOUND` or an unwrapped HTTP `404` | Check the selected resource and identifiers. |
-| `8` | `ATLAS_OBJECT_LOCK_RETAINED` | Respect retention or legal hold; repeating the same deletion cannot bypass it. |
+| Code | Meaning                                                                                                                | Action                                                                                                                            |
+| ---- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | Success, help, or a command with no failure reported                                                                   | Continue normally.                                                                                                                |
+| `1`  | Unexpected or unclassified failure, invalid command usage, or a command-reported failure without a typed exception     | Inspect stderr. Do not assume the failure is transient.                                                                           |
+| `2`  | Partial backup, restore or save: item errors, skipped files, integrity failures or a soft interrupt                    | Inspect the partial result before relying on it.                                                                                  |
+| `3`  | Throttling exhausted its retry budget, a recognized network error, or transient HTTP `429`, `500`, `502`, `503`, `504` | Schedule a later attempt. A timeout does not prove a write was never committed; inspect partial work before repeating a restore.  |
+| `4`  | `ATLAS_AUTH_DENIED`, `ATLAS_MAILBOX_NOT_LICENSED`, or an unwrapped HTTP `401`/`403`                                    | Correct credentials, permissions, admin consent or licensing before retrying.                                                     |
+| `5`  | `ATLAS_WRONG_PASSPHRASE`                                                                                               | Supply the original tenant passphrase. Never pad it or delete the wrapped key. If it is correct, investigate possible corruption. |
+| `6`  | `ATLAS_CONFIG_INVALID`, including failure to load the CLI configuration                                                | Correct the configuration or its storage access.                                                                                  |
+| `7`  | `ATLAS_NOT_FOUND` or an unwrapped HTTP `404`                                                                           | Check the selected resource and identifiers.                                                                                      |
+| `8`  | `ATLAS_OBJECT_LOCK_RETAINED`                                                                                           | Respect retention or legal hold; repeating the same deletion cannot bypass it.                                                    |
 
 Fatal exceptions use this category mapping. Existing command-reported failures remain `1`, including failed verification, `storage-check` reporting an unready bucket, and `config validate` reporting a failed probe. Per-item failures already reported as partial remain `2`; their messages are not reclassified.
 
@@ -68,6 +68,27 @@ An explicit Atlas category takes precedence over transport details. A generic `S
 The CLI prints the Atlas code separately from the underlying Graph code, HTTP status, response body or AWS error name. Unwrapped HTTP `401`/`403`, `404` and `429` also receive the corresponding Atlas category in the diagnostic. Fatal diagnostics, including `DEBUG` stacks, go to stderr rather than contaminating redirected stdout.
 
 Provider diagnostics can contain tenant identifiers and sensitive content. Redact them before sharing logs. See [Migrating to v5](/migration/v5#cli-failure-exit-codes) before updating scripts that branch on exit `1` or parse the old output.
+
+## Short flags
+
+A short flag means one thing across the whole CLI. Before v5.0.0 three of them meant two things, and the pair that mattered was `atlas stats -s <site>` against `atlas onedrive verify -s <snapshot>`.
+
+| Flag | Meaning                                       | Notes                                                                                         |
+| ---- | --------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `-s` | `--snapshot`                                  | Every command that acts on a snapshot, including `stats`, which no longer accepts `-s` at all |
+| `-o` | `--owner`                                     | A drive owner; `--output` has no short flag on any command                                    |
+| `-f` | `--folder` on Outlook, `--file` on the drives | One value each; repeat `-f` to name several Outlook folders                                   |
+| `-t` | `--tenant`                                    | Every command                                                                                 |
+| `-m` | `--mailbox`                                   | Every command that acts on a mailbox                                                          |
+
+A retired spelling is rejected rather than reinterpreted, naming its replacement:
+
+```console
+$ atlas stats -s https://contoso.sharepoint.com/sites/Engineering
+error: option '-s <value>' argument 'https://...' is invalid. -s no longer means --site in v5.0.0. Pass --site instead.
+```
+
+`--site` carries no short flag, so nothing can shadow `-s` again. See [Migrating to v5](/migration/v5) for the full old-to-new table.
 
 ## `atlas outlook`
 
@@ -92,7 +113,7 @@ Back up one mailbox from an M365 tenant to object storage, with a per-folder pro
 ```bash
 atlas outlook backup -m user@company.com                      # incremental backup
 atlas outlook backup -m user@company.com --full                # force full sync (ignore delta state)
-atlas outlook backup -m user@company.com -f Inbox Sent         # specific folders only
+atlas outlook backup -m user@company.com -f Inbox -f "Sent Items"   # specific folders only
 atlas outlook backup -m user@company.com -P 50                 # larger page size for fewer API round-trips
 atlas outlook backup -m user@company.com --retention-days 30 --lock-mode governance
 atlas outlook backup -m user@company.com --retention-days 365 --lock-mode compliance
@@ -102,7 +123,7 @@ atlas outlook backup -t <tenant-id> -m user@company.com        # explicit tenant
 | Option                        | Description                                                                  |
 | ----------------------------- | ---------------------------------------------------------------------------- |
 | `-m, --mailbox <id>`          | Mailbox to back up (required)                                                |
-| `-f, --folder <name...>`      | Filter to specific folder(s) by name or path (see below)                     |
+| `-f, --folder <name>`         | Filter to one folder by name or path; repeat for several (see below)         |
 | `--full`                      | Ignore saved delta links, run full enumeration                               |
 | `-P, --page-size <n>`         | Graph API page size per delta request (1--100, default 10)                   |
 | `--retention-days <n>`        | Apply Object Lock retention for `n` days                                     |
@@ -347,7 +368,7 @@ Nothing is written on macOS or Linux, which have no equivalent. If the target fi
 atlas outlook save -s <snapshot-id>
 atlas outlook save -s <snapshot-id> -f Inbox
 atlas outlook save -s <snapshot-id> --message 42
-atlas outlook save -s <snapshot-id> -o ~/Downloads/backup.zip
+atlas outlook save -s <snapshot-id> --output ~/Downloads/backup.zip
 atlas outlook save -s <snapshot-id> --skip-verify
 ```
 
@@ -368,7 +389,7 @@ atlas outlook save -m user@company.com --start-date 2026-01-01 --end-date 2026-0
 | `--message <ref>`             | Save a single message by `#` index from `atlas outlook list`          |
 | `--start-date <YYYY-MM-DD>`   | Include snapshots created on or after this date                       |
 | `--end-date <YYYY-MM-DD>`     | Include snapshots created on or before this date                      |
-| `-o, --output <path>`         | Output file path (default: `Restore-<timestamp>.zip`)                 |
+| `--output <path>`             | Output file path (default: `Restore-<timestamp>.zip`)                 |
 | `--skip-verify`               | Skip SHA-256 integrity checks (faster on low-power systems)           |
 | `-t, --tenant <id>`           | Override tenant ID                                                    |
 | `--include-recoverable-items` | Also include hard-deleted and hold-retained mail; excluded by default |
@@ -669,7 +690,7 @@ The archive is written to a temporary file next to the output path and moved ont
 
 ```bash
 atlas onedrive save -o user@company.com -s od-snap-1735689600000-a1b2c3
-atlas onedrive save -o user@company.com -s od-snap-123 -O ~/Downloads/backup.zip
+atlas onedrive save -o user@company.com -s od-snap-123 --output ~/Downloads/backup.zip
 atlas onedrive save -o user@company.com -s od-snap-123 --file-filter "/Documents/report.docx"
 atlas onedrive save -o user@company.com -s od-snap-123 --skip-verify
 ```
@@ -679,7 +700,7 @@ atlas onedrive save -o user@company.com -s od-snap-123 --skip-verify
 | `-o, --owner <id>`         | User email or Entra object ID (required)       |
 | `-s, --snapshot <id>`      | OneDrive snapshot ID (required)                |
 | `--file-filter <paths...>` | Only save specific files (by ID or path)       |
-| `-O, --output <path>`      | Output zip file path (default: auto-generated) |
+| `--output <path>`          | Output zip file path (default: auto-generated) |
 | `--skip-verify`            | Skip SHA-256 integrity checks                  |
 | `-t, --tenant <id>`        | Override tenant ID from config                 |
 
@@ -845,7 +866,7 @@ Save decrypted files from a SharePoint snapshot to a local zip archive. The arch
 
 ```bash
 atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123
-atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 -O ~/Downloads/backup.zip
+atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 --output ~/Downloads/backup.zip
 atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 --file-filter "/Documents/report.docx"
 atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 --skip-verify
 ```
@@ -855,7 +876,7 @@ atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s
 | `--site <url-or-id>`       | SharePoint site URL or Graph site ID (required) |
 | `-s, --snapshot <id>`      | SharePoint snapshot ID (required)               |
 | `--file-filter <paths...>` | Only save specific files (by ID or path)        |
-| `-O, --output <path>`      | Output zip file path (default: auto-generated)  |
+| `--output <path>`          | Output zip file path (default: auto-generated)  |
 | `--skip-verify`            | Skip SHA-256 integrity checks                   |
 | `-t, --tenant <id>`        | Override tenant ID from config                  |
 
@@ -916,7 +937,7 @@ atlas stats                            # all services: Outlook, OneDrive, ShareP
 atlas stats --service outlook          # Outlook bucket-level overview only
 atlas stats -m user@company.com        # Outlook mailbox-level breakdown
 atlas stats -o user@company.com        # OneDrive statistics for one owner
-atlas stats -s https://contoso.sharepoint.com/sites/Engineering   # one site
+atlas stats --site https://contoso.sharepoint.com/sites/Engineering   # one site
 atlas stats --top 5                    # limit owner/site tables to 5 rows
 atlas stats --json                     # raw JSON output
 ```
@@ -925,7 +946,7 @@ atlas stats --json                     # raw JSON output
 | ------------------------- | ------------------------------------------------------------------------------------------ |
 | `-m, --mailbox <email>`   | Outlook statistics for a specific mailbox (implies `--service outlook`)                    |
 | `-o, --owner <email\|id>` | OneDrive statistics for a specific owner (implies `--service onedrive`)                    |
-| `-s, --site <url\|id>`    | SharePoint statistics for a specific site (implies `--service sharepoint`)                 |
+| `--site <url\|id>`        | SharePoint statistics for a specific site (implies `--service sharepoint`)                 |
 | `--service <name>`        | Limit output to one service: `outlook`, `onedrive`, `sharepoint`, or `all` (default `all`) |
 | `--top <n>`               | Maximum owner/site rows in OneDrive/SharePoint tables (default 20)                         |
 | `--json`                  | Output raw JSON instead of formatted tables                                                |
@@ -938,27 +959,29 @@ Only one of `--mailbox`, `--owner`, or `--site` may be used at a time; each scop
 Manage Atlas configuration in an encrypted local store, git-config style. Values are written to `~/.atlas/config.enc` (AES-256-GCM); the store key lives in the OS keyring (macOS Keychain or libsecret), so credentials never sit on disk or in the environment in plaintext. See [Configuration](../configuration.md) for precedence and [Security](../security.md) for the threat model.
 
 ```bash
-atlas config tenant.id 4fa2a706-b26a-4bbe-9b1c-1e671b586b8f   # set + validate
-pbpaste | atlas config client.secret -                        # "-" reads from stdin (no shell history)
-atlas config client.secret                                    # get (secrets masked)
-atlas config list                                             # all keys, values, sources
-atlas config unset client.secret                              # remove from the store
-atlas config validate                                         # live Graph + S3 connectivity check
+atlas config set tenant.id 4fa2a706-b26a-4bbe-9b1c-1e671b586b8f   # set + validate
+pbpaste | atlas config set client.secret -                        # "-" reads from stdin (no shell history)
+atlas config get client.secret                                    # get (secrets masked)
+atlas config list                                                 # all keys, values, sources
+atlas config unset client.secret                                  # remove from the store
+atlas config validate                                             # live Graph + S3 connectivity check
 ```
 
-| Usage                  | Description                                                                                                       |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `config <key> <value>` | Validate and save a value to the encrypted store                                                                  |
-| `config <key>`         | Print the current effective value (secrets masked)                                                                |
-| `config list`          | Print every key with its value and source (`env`, `secure store`, `config file`)                                  |
-| `config unset <key>`   | Remove a key from the encrypted store                                                                             |
-| `config validate`      | Probe Microsoft Graph (token request) and S3 (`ListBuckets`) with the effective config; exits non-zero on failure |
+| Subcommand                 | Description                                                                                                       |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `config set <key> <value>` | Validate and save a value to the encrypted store; `-` reads the value from stdin                                  |
+| `config get <key>`         | Print the current effective value (secrets masked)                                                                |
+| `config list`              | Print every key with its value and source (`env`, `secure store`, `config file`)                                  |
+| `config unset <key>`       | Remove a key from the encrypted store                                                                             |
+| `config validate`          | Probe Microsoft Graph (token request) and S3 (`ListBuckets`) with the effective config; exits non-zero on failure |
+
+Each verb is a subcommand, so `atlas config set --help` documents itself. Before v5.0.0 the key and value were positional and `list`, `unset` and `validate` were recognised as key names, which left `atlas config list --help` documenting nothing.
 
 Keys: `tenant.id`, `client.id`, `client.secret`, `s3.endpoint`, `s3.access-key`, `s3.secret-key`, `s3.region`, `encryption.passphrase`. Each value is format-checked on save (GUIDs, URL scheme, 12-character passphrase minimum), and once a credential group is complete the matching live probe runs automatically. Note that `ATLAS_*` environment variables still override stored values; the command warns when a saved value is shadowed.
 
 ## `atlas replicate`
 
-Replicate snapshots to a secondary S3-compatible storage target. Ciphertext is copied as-is (no decryption). Only unreplicated snapshots and missing objects are transferred.
+Replicate snapshots to a secondary S3-compatible storage target. Ciphertext is copied as-is (no decryption). Only unreplicated snapshots and missing objects are transferred. Reporting is the `status` subcommand rather than a flag: it reads the same scope flags and writes no data.
 
 ```bash
 atlas replicate -s <snapshot-id> \
@@ -974,11 +997,11 @@ atlas replicate --site contoso.sharepoint.com,guid,guid -s sp-snap-1735689600000
 atlas replicate -o user@company.com --target-config ./offsite.json
 atlas replicate -o user@company.com -s od-snap-1735689600000-a1b2c3 --target-config ./offsite.json
 
-atlas replicate --status
-atlas replicate --status -m user@company.com
-atlas replicate --status -s <snapshot-id>
-atlas replicate --status --site https://contoso.sharepoint.com/sites/Engineering
-atlas replicate --status -o user@company.com
+atlas replicate status
+atlas replicate status -m user@company.com
+atlas replicate status -s <snapshot-id>
+atlas replicate status --site https://contoso.sharepoint.com/sites/Engineering
+atlas replicate status -o user@company.com
 ```
 
 | Option                      | Description                                                |
@@ -992,7 +1015,6 @@ atlas replicate --status -o user@company.com
 | `--target-secret-key <key>` | Target S3 secret key; `-` reads it from stdin              |
 | `--target-region <region>`  | Target S3 region (default: `us-east-1`)                    |
 | `--target-config <path>`    | Path to JSON file with target S3 credentials               |
-| `--status`                  | Show replication status instead of replicating             |
 | `-t, --tenant <id>`         | Override tenant ID                                         |
 
 ::: tip Target Config File

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -260,7 +260,7 @@ On Windows the archive is stamped with Mark-of-the-Web (`Zone.Identifier`, `Zone
 | `--site <url-or-id>`       | SharePoint site URL or Graph site ID     | Required       |
 | `-s, --snapshot <id>`      | Snapshot ID to save from                 | Required       |
 | `--file-filter <paths...>` | Only save specific files (by ID or path) | All files      |
-| `-O, --output <path>`      | Output zip file path                     | Auto-generated |
+| `--output <path>`          | Output zip file path                     | Auto-generated |
 | `--skip-verify`            | Skip SHA-256 integrity checks            | `false`        |
 | `-t, --tenant <id>`        | Tenant identifier                        | Config default |
 
@@ -394,7 +394,7 @@ Library names were not recorded in older manifests, so rule 1 cannot apply to th
 
 ```bash
 atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123
-atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 -O ~/Downloads/backup.zip
+atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123 --output ~/Downloads/backup.zip
 ```
 
 ## Verification

--- a/packages/cli/src/commands/config.command.ts
+++ b/packages/cli/src/commands/config.command.ts
@@ -27,31 +27,66 @@ type ConfigSources = {
 const GRAPH_FIELDS: (keyof AtlasConfig)[] = ['tenant_id', 'client_id', 'client_secret'];
 const S3_FIELDS: (keyof AtlasConfig)[] = ['s3_endpoint', 's3_access_key', 's3_secret_key'];
 
-/** Registers the "atlas config" command (git-config style key/value store). */
+/**
+ * Registers the `atlas config` group.
+ *
+ * The verbs are subcommands rather than magic values smuggled into a positional argument, so
+ * `atlas config list --help` documents itself the way every other command does (issue #162).
+ */
 export function register_config_command(program: Command): void {
-  program
+  const group = program
     .command('config')
     .description('Get and set Atlas configuration in the encrypted local store')
-    .argument('[key]', 'config key (e.g. tenant.id), or: list | unset | validate')
-    .argument('[value]', 'value to set; "-" reads from stdin; omit to print the current value')
     .addHelpText(
       'after',
       ['', 'Keys:', ...CONFIG_KEYS.map((k) => `  ${k.key.padEnd(24)} ${k.description}`)].join('\n'),
-    )
-    .action(async (key: string | undefined, value: string | undefined) => {
-      load_dotenv({ quiet: true });
-      if (key === undefined || key === 'list') return execute_list();
-      if (key === 'validate') return execute_validate();
-      if (key === 'unset') return execute_unset(value);
+    );
+  // Inherited by every subcommand, so each verb sees ATLAS_* overrides from the environment.
+  group.hook('preAction', () => {
+    load_dotenv({ quiet: true });
+  });
 
-      const spec = find_config_key(key);
-      if (spec === undefined) {
-        throw new Error(`Unknown config key "${key}". Run "atlas config list" to see all keys.`);
-      }
-      if (value === undefined) return execute_get(spec);
+  group
+    .command('list')
+    .description('Print every key with its masked value and the source it resolves from')
+    .action(() => execute_list());
+
+  group
+    .command('get')
+    .description('Print the effective value of one key')
+    .argument('<key>', 'config key (e.g. tenant.id)')
+    .action((key: string) => execute_get(require_config_key(key)));
+
+  group
+    .command('set')
+    .description('Store a value in the encrypted local store')
+    .argument('<key>', 'config key (e.g. tenant.id)')
+    .argument('<value>', 'value to set; "-" reads it from stdin')
+    .action(async (key: string, value: string) => {
       // "-" reads the value from stdin so secrets never land in shell history.
-      return execute_set(spec, value === '-' ? readFileSync(0, 'utf-8').trim() : value);
+      const resolved = value === '-' ? readFileSync(0, 'utf-8').trim() : value;
+      await execute_set(require_config_key(key), resolved);
     });
+
+  group
+    .command('unset')
+    .description('Remove a key from the encrypted local store')
+    .argument('<key>', 'config key (e.g. tenant.id)')
+    .action((key: string) => execute_unset(key));
+
+  group
+    .command('validate')
+    .description('Live-validate Graph and S3 connectivity with the effective config')
+    .action(async () => execute_validate());
+}
+
+/** Resolves a key spec, naming the discovery command when the key is unknown. */
+function require_config_key(key: string): ConfigKeySpec {
+  const spec = find_config_key(key);
+  if (spec === undefined) {
+    throw new Error(`Unknown config key "${key}". Run "atlas config list" to see all keys.`);
+  }
+  return spec;
 }
 
 /** Prints every key with its masked value and the source it resolves from. */
@@ -102,10 +137,8 @@ async function execute_set(spec: ConfigKeySpec, value: string): Promise<void> {
 }
 
 /** Removes a key from the encrypted store. */
-function execute_unset(key: string | undefined): void {
-  if (key === undefined) throw new Error('Usage: atlas config unset <key>');
-  const spec = find_config_key(key);
-  if (spec === undefined) throw new Error(`Unknown config key "${key}"`);
+function execute_unset(key: string): void {
+  const spec = require_config_key(key);
 
   const stored = read_secure_config();
   if (stored[spec.field] === undefined) {

--- a/packages/cli/src/commands/deletion-presenter.tsx
+++ b/packages/cli/src/commands/deletion-presenter.tsx
@@ -1,12 +1,13 @@
 import type { DeletionResult } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { ask_confirmation } from '@/ui/components/confirm-prompt';
 import { render_static_view } from '@/ui/render';
 
 /** Renders the shared delete banner every deletion command starts with. */
 export async function render_delete_banner(): Promise<void> {
-  await render_static_view(<Banner title="Atlas Delete" />);
+  await render_static_view(<Banner title={banner_title('tenant', 'Delete')} />);
 }
 
 /**

--- a/packages/cli/src/commands/drive-version-restore.handlers.tsx
+++ b/packages/cli/src/commands/drive-version-restore.handlers.tsx
@@ -21,6 +21,7 @@ import {
   type SharePointTenantOptions,
 } from '@/commands/sharepoint-command.handlers';
 import { format_bytes } from '@/command-formatters';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { render_static_view } from '@/ui/render';
@@ -103,7 +104,7 @@ export async function execute_onedrive_restore_version(
     owner.object_id,
     build_version_restore_options(options),
   );
-  await report_version_restore('Atlas OneDrive Version Restore', result);
+  await report_version_restore(banner_title('onedrive', 'Version Restore'), result);
 }
 
 /** Runs `atlas sharepoint restore-version`. */
@@ -121,7 +122,7 @@ export async function execute_sharepoint_restore_version(
     site_id,
     build_version_restore_options(options),
   );
-  await report_version_restore('Atlas SharePoint Version Restore', result);
+  await report_version_restore(banner_title('sharepoint', 'Version Restore'), result);
 }
 
 /** Prints what was written, then what was not, then the placement guarantee. */

--- a/packages/cli/src/commands/list-users.command.tsx
+++ b/packages/cli/src/commands/list-users.command.tsx
@@ -7,6 +7,8 @@ import {
   IDENTITY_REGISTRY_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
+import { with_tenant } from '@/commands/shared-options';
+import { banner_title } from '@/ui/banner-title';
 import { Box, Text } from 'ink';
 import { Banner } from '@/ui/components/banner';
 import { KeyValueList } from '@/ui/components/key-value-list';
@@ -48,11 +50,12 @@ export function register_list_users_command(
   program: Command,
   get_container: ContainerFactory,
 ): void {
-  program
+  const command = program
     .command('list-users')
-    .description('List all backed-up users from the local identity registry')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: ListUsersOptions) => execute_list_users(get_container(), options));
+    .description('List all backed-up users from the local identity registry');
+  with_tenant(command).action((options: ListUsersOptions) =>
+    execute_list_users(get_container(), options),
+  );
 }
 
 async function execute_list_users(container: Container, options: ListUsersOptions): Promise<void> {
@@ -66,7 +69,7 @@ async function execute_list_users(container: Container, options: ListUsersOption
   const registry = await registry_repo.load(ctx);
 
   if (!registry || registry.entries.length === 0) {
-    await render_static_view(<Banner title="Atlas Identity Registry" />);
+    await render_static_view(<Banner title={banner_title('tenant', 'Identity Registry')} />);
     logger.info('No users registered yet. Run a backup to populate the registry.');
     return;
   }
@@ -93,7 +96,10 @@ async function execute_list_users(container: Container, options: ListUsersOption
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Identity Registry" subtitle={`Tenant: ${registry.tenant_id}`} />
+      <Banner
+        title={banner_title('tenant', 'Identity Registry')}
+        subtitle={`Tenant: ${registry.tenant_id}`}
+      />
       <KeyValueList
         items={[
           { label: 'Active', value: String(active.length) },

--- a/packages/cli/src/commands/onedrive-catalog-command.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-catalog-command.handlers.tsx
@@ -8,6 +8,7 @@ import {
   resolve_tenant_id,
   type OneDriveTenantOptions,
 } from '@/commands/onedrive-command.handlers';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { render_static_view } from '@/ui/render';
@@ -64,7 +65,7 @@ export async function execute_onedrive_list_snapshots(
   const catalog = container.get<OneDriveCatalogUseCase>(ONEDRIVE_CATALOG_USE_CASE_TOKEN);
   const snapshots = await catalog.list_onedrive_snapshots(tenant_id, owner.object_id);
 
-  await render_static_view(<Banner title="Atlas OneDrive Snapshots" />);
+  await render_static_view(<Banner title={banner_title('onedrive', 'Snapshots')} />);
   if (snapshots.length === 0) {
     logger.info('No OneDrive snapshots found.');
     return;
@@ -90,7 +91,7 @@ export async function execute_onedrive_list_versions(
     options.file,
   );
 
-  await render_static_view(<Banner title="Atlas OneDrive File Versions" />);
+  await render_static_view(<Banner title={banner_title('onedrive', 'File Versions')} />);
   if (versions.length === 0) {
     logger.info('No versions found for this file.');
     return;

--- a/packages/cli/src/commands/onedrive-command.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-command.handlers.tsx
@@ -16,6 +16,7 @@ import {
   ONEDRIVE_VERIFICATION_USE_CASE_TOKEN,
   USER_IDENTITY_RESOLVER_TOKEN,
 } from '@wisecom/atlas-types';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { ErrorList } from '@/ui/components/error-list';
 import { KeyValueList } from '@/ui/components/key-value-list';
@@ -102,7 +103,7 @@ export async function execute_onedrive_backup(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas OneDrive Backup" />
+      <Banner title={banner_title('onedrive', 'Backup')} />
       <KeyValueList
         items={[
           {
@@ -177,7 +178,7 @@ export async function execute_onedrive_restore(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas OneDrive Restore" />
+      <Banner title={banner_title('onedrive', 'Restore')} />
       <KeyValueList
         items={[
           { label: 'Snapshot', value: result.snapshot_id },
@@ -212,7 +213,7 @@ export async function execute_onedrive_save(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas OneDrive Save" />
+      <Banner title={banner_title('onedrive', 'Save')} />
       <KeyValueList
         items={[
           { label: 'Snapshot', value: result.snapshot_id },
@@ -246,7 +247,7 @@ export async function execute_onedrive_verify(
     options.snapshot,
   );
 
-  await render_static_view(<Banner title="Atlas OneDrive Verify" />);
+  await render_static_view(<Banner title={banner_title('onedrive', 'Verify')} />);
   if (result.failed_file_ids.length === 0 && result.index_issues.length === 0) {
     logger.success(`All ${result.total_checked} entries passed verification`);
     return;

--- a/packages/cli/src/commands/onedrive-data-ops.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-data-ops.handlers.tsx
@@ -5,6 +5,7 @@ import {
   ONEDRIVE_DELETION_USE_CASE_TOKEN,
   ONEDRIVE_STATUS_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { KeyValueList } from '@/ui/components/key-value-list';
 import { render_static_view } from '@/ui/render';
@@ -63,7 +64,7 @@ export async function execute_onedrive_status(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas OneDrive Status" />
+      <Banner title={banner_title('onedrive', 'Status')} />
       <KeyValueList
         items={[
           { label: 'Tenant', value: tenant_id },

--- a/packages/cli/src/commands/onedrive.command.ts
+++ b/packages/cli/src/commands/onedrive.command.ts
@@ -1,4 +1,3 @@
-import { Option } from 'commander';
 import type { Command } from 'commander';
 import type { Container } from 'inversify';
 import {
@@ -27,14 +26,27 @@ import {
   type OneDriveDeleteOptions,
   type OneDriveStatusCommandOptions,
 } from '@/commands/onedrive-data-ops.handlers';
+import {
+  with_conflict,
+  with_file_filter,
+  with_object_lock,
+  with_output,
+  with_required_snapshot,
+  with_snapshot,
+  with_tenant,
+  with_yes,
+} from '@/commands/shared-options';
 
 type ContainerFactory = () => Container;
 
-/** Registers `atlas onedrive` command group with backup, list, and verify subcommands. */
+const OWNER_FLAG = '-o, --owner <id>';
+const OWNER_DESCRIPTION = 'user email or Entra object ID';
+
+/** Registers `atlas onedrive` command group. */
 export function register_onedrive_command(program: Command, get_container: ContainerFactory): void {
   const group = program
     .command('onedrive')
-    .description('OneDrive backup and verification commands');
+    .description('OneDrive backup, restore, save, verify, catalog, status, and deletion commands');
   register_onedrive_backup(group, get_container);
   register_onedrive_restore(group, get_container);
   register_onedrive_save(group, get_container);
@@ -47,133 +59,123 @@ export function register_onedrive_command(program: Command, get_container: Conta
 }
 
 function register_onedrive_backup(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('backup')
     .description('Back up changed OneDrive files for one user')
-    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
+    .requiredOption(OWNER_FLAG, OWNER_DESCRIPTION)
     .option('--full', 'force full crawl ignoring saved delta state')
     .option(
       '--folder <path>',
       'only back up this folder and its subfolders (e.g. /Projects); changing it forces a full crawl',
-    )
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .option(
-      '--retention-days <n>',
-      'apply Object Lock default retention for N days (persists on the bucket)',
-    )
-    .option('--lock-mode <mode>', 'Object Lock mode: governance|compliance')
-    .action((options: OneDriveBackupOptions) => execute_onedrive_backup(get_container(), options));
+    );
+  with_object_lock(
+    command,
+    'apply Object Lock default retention for N days (persists on the bucket)',
+  );
+  with_tenant(command).action((options: OneDriveBackupOptions) =>
+    execute_onedrive_backup(get_container(), options),
+  );
 }
 
 function register_onedrive_restore(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('restore')
     .description('Restore files from a OneDrive snapshot')
-    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
-    .requiredOption('-s, --snapshot <id>', 'snapshot identifier')
+    .requiredOption(OWNER_FLAG, OWNER_DESCRIPTION)
     .option('--target-owner <id>', 'target user email or Entra object ID (defaults to owner)')
-    .option('--file-filter <paths...>', 'only restore specific files (by ID or path)')
     .option(
       '--destination <path>',
       'restore under this folder instead of a generated Restore-<timestamp> root',
     )
     .option('--in-place', 'restore to the original paths, mixing files into live content')
-    .option('--name <filename>', 'rename the restored file; requires a single-file restore')
-    .addOption(
-      new Option('-c, --conflict <mode>', 'file conflict policy (default: rename)').choices([
-        'replace',
-        'rename',
-        'fail',
-      ]),
-    )
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: OneDriveRestoreCommandOptions) =>
-      execute_onedrive_restore(get_container(), options),
-    );
+    .option('--name <filename>', 'rename the restored file; requires a single-file restore');
+  with_required_snapshot(command, 'snapshot identifier');
+  with_file_filter(command, 'restore');
+  with_conflict(command);
+  with_tenant(command).action((options: OneDriveRestoreCommandOptions) =>
+    execute_onedrive_restore(get_container(), options),
+  );
 }
 
 function register_onedrive_save(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('save')
     .description('Save files from a OneDrive snapshot to a local zip archive')
-    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
-    .requiredOption('-s, --snapshot <id>', 'snapshot identifier')
-    .option('--file-filter <paths...>', 'only save specific files (by ID or path)')
-    .option('-O, --output <path>', 'output zip file path')
-    .option('--skip-verify', 'skip SHA-256 integrity checks')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: OneDriveSaveCommandOptions) =>
-      execute_onedrive_save(get_container(), options),
-    );
+    .requiredOption(OWNER_FLAG, OWNER_DESCRIPTION)
+    .option('--skip-verify', 'skip SHA-256 integrity checks');
+  with_required_snapshot(command, 'snapshot identifier');
+  with_file_filter(command, 'save');
+  with_output(command, 'output zip file path');
+  with_tenant(command).action((options: OneDriveSaveCommandOptions) =>
+    execute_onedrive_save(get_container(), options),
+  );
 }
 
 function register_onedrive_list_snapshots(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('list-snapshots')
     .description('List OneDrive snapshots for a user')
-    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: OneDriveListSnapshotsOptions) =>
-      execute_onedrive_list_snapshots(get_container(), options),
-    );
+    .requiredOption(OWNER_FLAG, OWNER_DESCRIPTION);
+  with_tenant(command).action((options: OneDriveListSnapshotsOptions) =>
+    execute_onedrive_list_snapshots(get_container(), options),
+  );
 }
 
 function register_onedrive_list_versions(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('list-versions')
     .description('List all backed-up versions for a specific file')
-    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
-    .requiredOption('-f, --file <ref>', 'file ID or path')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: OneDriveListVersionsOptions) =>
-      execute_onedrive_list_versions(get_container(), options),
-    );
+    .requiredOption(OWNER_FLAG, OWNER_DESCRIPTION)
+    .requiredOption('-f, --file <ref>', 'file ID or path');
+  with_tenant(command).action((options: OneDriveListVersionsOptions) =>
+    execute_onedrive_list_versions(get_container(), options),
+  );
 }
 
 function register_onedrive_restore_version(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('restore-version')
     .description('Restore stored file versions back into OneDrive')
-    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
+    .requiredOption(OWNER_FLAG, OWNER_DESCRIPTION)
     .option('-f, --file <ref>', 'file ID or path; required with --version')
     .option('--version <id>', 'exact stored version to restore')
     .option('--before <iso>', "restore each file's last version at or before this instant")
     .option('--path <prefix>', 'limit a bulk rollback to this folder and below')
-    .option('--in-place', 'upload over the original file instead of writing a copy beside it')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: OneDriveRestoreVersionOptions) =>
-      execute_onedrive_restore_version(get_container(), options),
-    );
+    .option('--in-place', 'upload over the original file instead of writing a copy beside it');
+  with_tenant(command).action((options: OneDriveRestoreVersionOptions) =>
+    execute_onedrive_restore_version(get_container(), options),
+  );
 }
 
 function register_onedrive_verify(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('verify')
     .description('Verify integrity of a OneDrive snapshot')
-    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
-    .requiredOption('-s, --snapshot <id>', 'snapshot identifier')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: OneDriveVerifyOptions) => execute_onedrive_verify(get_container(), options));
+    .requiredOption(OWNER_FLAG, OWNER_DESCRIPTION);
+  with_required_snapshot(command, 'snapshot identifier');
+  with_tenant(command).action((options: OneDriveVerifyOptions) =>
+    execute_onedrive_verify(get_container(), options),
+  );
 }
 
 function register_onedrive_status(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('status')
     .description('Check whether an owner OneDrive backup is up to date')
-    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: OneDriveStatusCommandOptions) =>
-      execute_onedrive_status(get_container(), options),
-    );
+    .requiredOption(OWNER_FLAG, OWNER_DESCRIPTION);
+  with_tenant(command).action((options: OneDriveStatusCommandOptions) =>
+    execute_onedrive_status(get_container(), options),
+  );
 }
 
 function register_onedrive_delete(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('delete')
     .description('Delete OneDrive backups for one owner, or a single snapshot')
-    .requiredOption('-o, --owner <id>', 'user email or Entra object ID')
-    .option('-s, --snapshot <id>', 'delete a single snapshot instead of every backup')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .option('-y, --yes', 'skip confirmation prompt')
-    .action((options: OneDriveDeleteOptions) => execute_onedrive_delete(get_container(), options));
+    .requiredOption(OWNER_FLAG, OWNER_DESCRIPTION);
+  with_snapshot(command, 'delete a single snapshot instead of every backup');
+  with_yes(command);
+  with_tenant(command).action((options: OneDriveDeleteOptions) =>
+    execute_onedrive_delete(get_container(), options),
+  );
 }

--- a/packages/cli/src/commands/outlook-backup.handler.tsx
+++ b/packages/cli/src/commands/outlook-backup.handler.tsx
@@ -10,6 +10,7 @@ import { build_object_lock_policy, build_object_lock_request } from '@/command-o
 import { format_bytes } from '@/command-formatters';
 import { report_run_outcome } from '@/command-run-outcome';
 import { logger } from '@wisecom/atlas-core';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { KeyValueList, type KeyValueItem } from '@/ui/components/key-value-list';
 import { render_static_view } from '@/ui/render';
@@ -64,7 +65,7 @@ export async function execute_outlook_backup(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Backup" />
+      <Banner title={banner_title('outlook', 'Backup')} />
       <KeyValueList items={items} />
     </Box>,
   );

--- a/packages/cli/src/commands/outlook-catalog.handler.tsx
+++ b/packages/cli/src/commands/outlook-catalog.handler.tsx
@@ -8,6 +8,7 @@ import type { Manifest, AttachmentEntry } from '@wisecom/atlas-types';
 import { format_bytes } from '@/command-formatters';
 import { logger } from '@wisecom/atlas-core';
 import { describe_scope_conflict, resolve_outlook_scope } from '@/commands/outlook-scope';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { KeyValueList, type KeyValueItem } from '@/ui/components/key-value-list';
@@ -39,7 +40,7 @@ export async function execute_outlook_list(
   const tenant_id = options.tenant ?? container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas List" />
+      <Banner title={banner_title('outlook', 'List')} />
       <KeyValueList items={[{ label: 'Tenant', value: tenant_id }]} />
     </Box>,
   );
@@ -90,7 +91,7 @@ export async function execute_outlook_read(
     return;
   }
 
-  await render_static_view(<Banner title="Atlas Read" />);
+  await render_static_view(<Banner title={banner_title('outlook', 'Read')} />);
 
   if (!result) {
     logger.error(`Message not found. Check the snapshot ID and message ID are correct.`);

--- a/packages/cli/src/commands/outlook-data-ops.handler.tsx
+++ b/packages/cli/src/commands/outlook-data-ops.handler.tsx
@@ -13,6 +13,7 @@ import {
   print_delete_result,
   render_delete_banner,
 } from '@/commands/deletion-presenter';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { ask_confirmation } from '@/ui/components/confirm-prompt';
 import { ErrorList } from '@/ui/components/error-list';
@@ -53,7 +54,7 @@ export async function execute_outlook_save(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Save" />
+      <Banner title={banner_title('outlook', 'Save')} />
       <KeyValueList items={[{ label: 'Tenant', value: tenant_id }]} />
     </Box>,
   );

--- a/packages/cli/src/commands/outlook-mgmt.handler.tsx
+++ b/packages/cli/src/commands/outlook-mgmt.handler.tsx
@@ -18,6 +18,7 @@ import {
 } from '@wisecom/atlas-types';
 import { format_bytes } from '@/command-formatters';
 import { logger } from '@wisecom/atlas-core';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { KeyValueList } from '@/ui/components/key-value-list';
@@ -51,7 +52,7 @@ export async function execute_outlook_verify(
   const tenant_id = resolve_tenant_id(container, options);
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Verify" />
+      <Banner title={banner_title('outlook', 'Verify')} />
       <KeyValueList items={[{ label: 'Mailbox', value: options.mailbox }]} />
     </Box>,
   );
@@ -78,7 +79,7 @@ export async function execute_outlook_status(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Status" />
+      <Banner title={banner_title('outlook', 'Status')} />
       <KeyValueList
         items={[
           { label: 'Tenant', value: tenant_id },
@@ -100,7 +101,7 @@ export async function execute_outlook_mailboxes(
   const tenant_id = resolve_tenant_id(container, options);
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Mailboxes" />
+      <Banner title={banner_title('outlook', 'Mailboxes')} />
       <KeyValueList items={[{ label: 'Tenant', value: tenant_id }]} />
     </Box>,
   );

--- a/packages/cli/src/commands/outlook-restore.handler.tsx
+++ b/packages/cli/src/commands/outlook-restore.handler.tsx
@@ -7,6 +7,7 @@ import { RESTORE_USE_CASE_TOKEN } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core';
 import { report_run_outcome } from '@/command-run-outcome';
 import { resolve_outlook_scope } from '@/commands/outlook-scope';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { ErrorList } from '@/ui/components/error-list';
 import { KeyValueList, type KeyValueItem } from '@/ui/components/key-value-list';
@@ -70,7 +71,7 @@ export async function execute_outlook_restore(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Restore" />
+      <Banner title={banner_title('outlook', 'Restore')} />
       <KeyValueList items={[{ label: 'Tenant', value: tenant_id }]} />
     </Box>,
   );

--- a/packages/cli/src/commands/outlook.command.ts
+++ b/packages/cli/src/commands/outlook.command.ts
@@ -28,6 +28,17 @@ import {
   type OutlookStatusOptions,
   type OutlookMailboxesOptions,
 } from '@/commands/outlook-mgmt.handler';
+import {
+  reject_retired_short,
+  with_folder,
+  with_object_lock,
+  with_output,
+  with_repeatable_folder,
+  with_required_snapshot,
+  with_snapshot,
+  with_tenant,
+  with_yes,
+} from '@/commands/shared-options';
 
 type ContainerFactory = () => Container;
 
@@ -35,7 +46,9 @@ type ContainerFactory = () => Container;
 export function register_outlook_command(program: Command, get_container: ContainerFactory): void {
   const group = program
     .command('outlook')
-    .description('Outlook mailbox backup, restore, and management commands');
+    .description(
+      'Outlook mailbox backup, restore, save, verify, catalog, status, and deletion commands',
+    );
   register_outlook_backup(group, get_container);
   register_outlook_verify(group, get_container);
   register_outlook_restore(group, get_container);
@@ -48,127 +61,138 @@ export function register_outlook_command(program: Command, get_container: Contai
 }
 
 function register_outlook_backup(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('backup')
     .description('Back up one mailbox from M365 tenant to object storage')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .requiredOption('-m, --mailbox <id>', 'mailbox to back up')
-    .option('-f, --folder <name...>', 'specific folder(s) to back up (e.g. -f Inbox "Sent Items")')
     .option('--full', 'force a full backup, ignoring saved delta state from prior runs')
     .option('--exclude-junk', 'skip the Junk Email folder (captured by default)')
     .option(
       '--include-recoverable-items',
       'also back up hard-deleted and hold-retained mail from Recoverable Items',
     )
-    .option('-P, --page-size <n>', 'Graph API page size per delta request (1-100)', '10')
-    .option('--retention-days <n>', 'apply object lock retention for N days')
-    .option('--lock-mode <mode>', 'Object Lock mode: governance|compliance')
-    .action((options: OutlookBackupOptions) => execute_outlook_backup(get_container(), options));
+    .option('-P, --page-size <n>', 'Graph API page size per delta request (1-100)', '10');
+  with_repeatable_folder(
+    command,
+    'folder to back up; repeat for more (e.g. -f Inbox -f "Sent Items")',
+  );
+  with_object_lock(command, 'apply object lock retention for N days');
+  with_tenant(command).action((options: OutlookBackupOptions) =>
+    execute_outlook_backup(get_container(), options),
+  );
 }
 
 function register_outlook_verify(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('verify')
     .description('Verify integrity of a backup snapshot')
-    .requiredOption('-s, --snapshot <id>', 'snapshot identifier to verify')
     .requiredOption('-m, --mailbox <email>', 'mailbox that owns the snapshot')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option(
       '--fast',
       'existence-only checks (no download/decrypt); catches missing objects cheaply',
-    )
-    .action((options: OutlookVerifyOptions) => execute_outlook_verify(get_container(), options));
+    );
+  with_required_snapshot(command, 'snapshot identifier to verify');
+  with_tenant(command).action((options: OutlookVerifyOptions) =>
+    execute_outlook_verify(get_container(), options),
+  );
 }
 
 function register_outlook_restore(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('restore')
     .description('Restore emails from a backup snapshot or full mailbox backup')
-    .option('-s, --snapshot <id>', 'restore from a specific snapshot')
     .option('-m, --mailbox <email>', 'restore from all snapshots for this mailbox')
     .option('-T, --target <email>', 'target mailbox (defaults to source mailbox)')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .option('-f, --folder <name>', 'restore only messages from this folder')
     .option('--message <ref>', 'restore a single message by # from atlas list, or full ID')
     .option('--start-date <YYYY-MM-DD>', 'include snapshots created on or after this date')
     .option('--end-date <YYYY-MM-DD>', 'include snapshots created on or before this date')
     .option(
       '--include-recoverable-items',
       'include hard-deleted and hold-retained mail captured from Recoverable Items',
-    )
-    .action((options: OutlookRestoreOptions) => execute_outlook_restore(get_container(), options));
+    );
+  with_snapshot(command, 'restore from a specific snapshot');
+  with_folder(command, 'restore only messages from this folder');
+  with_tenant(command).action((options: OutlookRestoreOptions) =>
+    execute_outlook_restore(get_container(), options),
+  );
 }
 
 function register_outlook_list(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('list')
     .description('Browse backed-up data (mailboxes, snapshots, messages)')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option('-m, --mailbox <email>', 'list snapshots for a specific mailbox')
-    .option('-s, --snapshot <id>', 'list messages inside a specific snapshot')
     .option('--all', 'show all messages (default caps at 50)')
-    .option('-S, --subjects', 'reveal email subjects (hidden by default for data protection)')
-    .action((options: OutlookListOptions) => execute_outlook_list(get_container(), options));
+    .option('-S, --subjects', 'reveal email subjects (hidden by default for data protection)');
+  with_snapshot(command, 'list messages inside a specific snapshot');
+  with_tenant(command).action((options: OutlookListOptions) =>
+    execute_outlook_list(get_container(), options),
+  );
 }
 
 function register_outlook_read(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('read')
     .description('Decrypt and display a single backed-up message')
-    .requiredOption('-s, --snapshot <id>', 'snapshot containing the message')
     .requiredOption('--message <ref>', 'message # from atlas list, or full message ID')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .option('--raw', 'output the full JSON blob instead of formatted view')
-    .action((options: OutlookReadOptions) => execute_outlook_read(get_container(), options));
+    .option('--raw', 'output the full JSON blob instead of formatted view');
+  with_required_snapshot(command, 'snapshot containing the message');
+  with_tenant(command).action((options: OutlookReadOptions) =>
+    execute_outlook_read(get_container(), options),
+  );
 }
 
 function register_outlook_save(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('save')
     .description('Save backed-up emails as EML files in a compressed zip archive')
-    .option('-s, --snapshot <id>', 'save from a specific snapshot')
     .option('-m, --mailbox <email>', 'save from all snapshots for this mailbox')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .option('-f, --folder <name>', 'save only messages from this folder')
     .option('--message <ref>', 'save a single message by # from atlas list, or full ID')
     .option('--start-date <YYYY-MM-DD>', 'include snapshots created on or after this date')
     .option('--end-date <YYYY-MM-DD>', 'include snapshots created on or before this date')
-    .option('-o, --output <path>', 'output zip file path (default: Restore-<timestamp>.zip)')
     .option('--skip-verify', 'skip SHA-256 integrity checks (faster on low-power systems)')
     .option(
       '--include-recoverable-items',
       'include hard-deleted and hold-retained mail captured from Recoverable Items',
-    )
-    .action((options: OutlookSaveOptions) => execute_outlook_save(get_container(), options));
+    );
+  with_snapshot(command, 'save from a specific snapshot');
+  with_folder(command, 'save only messages from this folder');
+  with_output(command, 'output zip file path (default: Restore-<timestamp>.zip)');
+  // `-o` was this command's own spelling of --output and is the owner everywhere else.
+  reject_retired_short(command, '-o', '--output');
+  with_tenant(command).action((options: OutlookSaveOptions) =>
+    execute_outlook_save(get_container(), options),
+  );
 }
 
 function register_outlook_delete(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('delete')
     .description('Delete backed-up mail data (one mailbox or one snapshot)')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .option('-m, --mailbox <email>', 'delete all data and manifests for a mailbox')
-    .option('-s, --snapshot <id>', 'delete a single snapshot manifest')
-    .option('-y, --yes', 'skip confirmation prompt')
-    .action((options: OutlookDeleteOptions) => execute_outlook_delete(get_container(), options));
+    .option('-m, --mailbox <email>', 'delete all data and manifests for a mailbox');
+  with_snapshot(command, 'delete a single snapshot manifest');
+  with_yes(command);
+  with_tenant(command).action((options: OutlookDeleteOptions) =>
+    execute_outlook_delete(get_container(), options),
+  );
 }
 
 function register_outlook_status(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('status')
     .description('Check if a mailbox backup is up to date (delta peek, no backup runs)')
-    .requiredOption('-m, --mailbox <email>', 'mailbox to check')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: OutlookStatusOptions) => execute_outlook_status(get_container(), options));
+    .requiredOption('-m, --mailbox <email>', 'mailbox to check');
+  with_tenant(command).action((options: OutlookStatusOptions) =>
+    execute_outlook_status(get_container(), options),
+  );
 }
 
 function register_outlook_mailboxes(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('mailboxes')
     .description('List tenant mailboxes from Microsoft Graph (live, not from backup catalog)')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .option('--licensed-only', 'only show mailboxes with an active Exchange Online license')
-    .action((options: OutlookMailboxesOptions) =>
-      execute_outlook_mailboxes(get_container(), options),
-    );
+    .option('--licensed-only', 'only show mailboxes with an active Exchange Online license');
+  with_tenant(command).action((options: OutlookMailboxesOptions) =>
+    execute_outlook_mailboxes(get_container(), options),
+  );
 }

--- a/packages/cli/src/commands/rehydrate.command.tsx
+++ b/packages/cli/src/commands/rehydrate.command.tsx
@@ -29,6 +29,8 @@ import { logger, GRAPH_IDENTITY_RESOLVER_TOKEN } from '@wisecom/atlas-core';
 import type { UserIdentityResolver } from '@wisecom/atlas-types';
 import { resolve_site_id } from '@/commands/sharepoint-command.handlers';
 import { resolve_secret_option } from '@/utils/secret-option';
+import { with_snapshot, with_tenant } from '@/commands/shared-options';
+import { banner_title } from '@/ui/banner-title';
 
 /**
  * Resolves an owner for recovery without touching primary storage.
@@ -71,21 +73,22 @@ export function register_rehydrate_command(
   program: Command,
   get_container: ContainerFactory,
 ): void {
-  program
+  const command = program
     .command('rehydrate')
     .description('Recover snapshots from a replica to primary (disaster recovery)')
-    .option('-s, --snapshot <id>', 'recover a specific snapshot')
     .option('-m, --mailbox <id>', 'recover all snapshots for a mailbox')
     .option('--site <url-or-id>', 'recover all snapshots for a SharePoint site')
     .option('-o, --owner <email-or-id>', 'recover all OneDrive snapshots for an owner')
     .option('--all', 'recover all mailboxes and snapshots (full tenant DR)')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option('--source-endpoint <url>', 'source replica S3 endpoint URL')
     .option('--source-access-key <key>', 'source replica S3 access key')
     .option('--source-secret-key <key>', 'source replica S3 secret key; "-" reads it from stdin')
     .option('--source-region <region>', 'source replica S3 region')
-    .option('--source-config <path>', 'path to JSON file with source S3 credentials')
-    .action((options: RehydrateOptions) => execute_rehydrate(get_container(), options));
+    .option('--source-config <path>', 'path to JSON file with source S3 credentials');
+  with_snapshot(command, 'recover a specific snapshot');
+  with_tenant(command).action((options: RehydrateOptions) =>
+    execute_rehydrate(get_container(), options),
+  );
 }
 
 function resolve_tenant_id(container: Container, options: RehydrateOptions): string {
@@ -123,7 +126,7 @@ async function execute_rehydrate(container: Container, options: RehydrateOptions
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Rehydrate" />
+      <Banner title={banner_title('tenant', 'Rehydrate')} />
       <KeyValueList items={header_items} />
     </Box>,
   );

--- a/packages/cli/src/commands/replicate.command.tsx
+++ b/packages/cli/src/commands/replicate.command.tsx
@@ -27,6 +27,8 @@ import { logger } from '@wisecom/atlas-core';
 import { resolve_owner } from '@/commands/onedrive-command.handlers';
 import { resolve_site_id } from '@/commands/sharepoint-command.handlers';
 import { resolve_secret_option } from '@/utils/secret-option';
+import { with_snapshot, with_tenant } from '@/commands/shared-options';
+import { banner_title } from '@/ui/banner-title';
 
 type ContainerFactory = () => Container;
 
@@ -41,32 +43,43 @@ interface ReplicateOptions {
   targetSecretKey?: string;
   targetRegion?: string;
   targetConfig?: string;
-  status?: boolean;
 }
 
-/** Registers the `atlas replicate` subcommand. */
+/** Adds the scope flags both `replicate` and `replicate status` select snapshots with. */
+function with_replication_scope(command: Command): Command {
+  const scoped = command
+    .option('-m, --mailbox <id>', 'all unreplicated snapshots for a mailbox')
+    .option('--site <url-or-id>', 'all unreplicated snapshots for a SharePoint site')
+    .option('-o, --owner <email-or-id>', 'all unreplicated snapshots for a OneDrive owner');
+  return with_tenant(with_snapshot(scoped, 'a specific snapshot'));
+}
+
+/** Registers the `atlas replicate` subcommand and its `status` reporting subcommand. */
 export function register_replicate_command(
   program: Command,
   get_container: ContainerFactory,
 ): void {
-  program
+  const group = program
     .command('replicate')
     .description('Replicate snapshots to a secondary S3 storage target')
-    .option('-s, --snapshot <id>', 'replicate a specific snapshot')
-    .option('-m, --mailbox <id>', 'replicate all unreplicated snapshots for a mailbox')
-    .option('--site <url-or-id>', 'replicate all unreplicated snapshots for a SharePoint site')
-    .option(
-      '-o, --owner <email-or-id>',
-      'replicate all unreplicated snapshots for a OneDrive owner',
-    )
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option('--target-endpoint <url>', 'target S3 endpoint URL')
     .option('--target-access-key <key>', 'target S3 access key')
     .option('--target-secret-key <key>', 'target S3 secret key; "-" reads it from stdin')
     .option('--target-region <region>', 'target S3 region')
-    .option('--target-config <path>', 'path to JSON file with target S3 credentials')
-    .option('--status', 'show replication status instead of replicating')
-    .action((options: ReplicateOptions) => execute_replicate(get_container(), options));
+    .option('--target-config <path>', 'path to JSON file with target S3 credentials');
+  with_replication_scope(group).action((options: ReplicateOptions) =>
+    execute_replicate(get_container(), options),
+  );
+
+  // Reporting is its own verb rather than a flag that silently changes what the command does. The
+  // scope flags are declared on both, so each `--help` is complete; commander binds a flag typed
+  // after the subcommand name to the parent, so the action reads the merged view.
+  const status = group
+    .command('status')
+    .description('Show replication status instead of replicating');
+  with_replication_scope(status).action((_options: ReplicateOptions, command: Command) =>
+    execute_replicate_status(get_container(), command.optsWithGlobals<ReplicateOptions>()),
+  );
 }
 
 function resolve_tenant_id(container: Container, options: ReplicateOptions): string {
@@ -74,26 +87,30 @@ function resolve_tenant_id(container: Container, options: ReplicateOptions): str
   return container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
 }
 
+async function execute_replicate_status(
+  container: Container,
+  options: ReplicateOptions,
+): Promise<void> {
+  const tenant_id = resolve_tenant_id(container, options);
+  const use_case = container.get<ReplicationUseCase>(REPLICATION_USE_CASE_TOKEN);
+  const owner_scope = options.owner
+    ? (await resolve_owner(container, tenant_id, options.owner)).object_id
+    : undefined;
+  const site_scope = options.site
+    ? await resolve_site_id(container, tenant_id, options.site)
+    : undefined;
+  const scope_id = options.mailbox ?? site_scope ?? owner_scope;
+  await show_status(use_case, tenant_id, options.snapshot, scope_id);
+}
+
 async function execute_replicate(container: Container, options: ReplicateOptions): Promise<void> {
   const tenant_id = resolve_tenant_id(container, options);
   const use_case = container.get<ReplicationUseCase>(REPLICATION_USE_CASE_TOKEN);
 
-  if (options.status) {
-    const owner_scope = options.owner
-      ? (await resolve_owner(container, tenant_id, options.owner)).object_id
-      : undefined;
-    const site_scope = options.site
-      ? await resolve_site_id(container, tenant_id, options.site)
-      : undefined;
-    const scope_id = options.mailbox ?? site_scope ?? owner_scope;
-    await show_status(use_case, tenant_id, options.snapshot, scope_id);
-    return;
-  }
-
   const target = build_target(container, options);
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Replicate" />
+      <Banner title={banner_title('tenant', 'Replicate')} />
       <KeyValueList
         items={[
           { label: 'Tenant', value: tenant_id },
@@ -115,7 +132,7 @@ async function execute_replicate(container: Container, options: ReplicateOptions
     await report_results(results);
   } else {
     logger.error(
-      'Either --snapshot, --mailbox, --owner, or --site is required (or --status to view status)',
+      'Either --snapshot, --mailbox, --owner, or --site is required (or "atlas replicate status")',
     );
     process.exitCode = 1;
   }
@@ -282,7 +299,7 @@ async function show_status(
   snapshot_id: string | undefined,
   scope_id: string | undefined,
 ): Promise<void> {
-  await render_static_view(<Banner title="Replication Status" />);
+  await render_static_view(<Banner title={banner_title('tenant', 'Replication Status')} />);
 
   let records: ReplicationStatusRecord[];
   if (snapshot_id) {

--- a/packages/cli/src/commands/shared-options.ts
+++ b/packages/cli/src/commands/shared-options.ts
@@ -1,0 +1,122 @@
+import { InvalidArgumentError, Option, type Command } from 'commander';
+
+/**
+ * Option groups shared by every command group, so one concept is spelled one way everywhere.
+ *
+ * Registration composes these instead of repeating `.option()` calls: a workload cannot drift into
+ * its own vocabulary, and a flag that belongs to a group (Object Lock retention and mode) cannot be
+ * half-registered, which is how `--lock-mode` ended up documenting its values in prose on four
+ * commands while accepting anything (issue #162).
+ */
+
+/** Object Lock modes S3 accepts; the same list validates the flag and documents it. */
+export const LOCK_MODES = ['governance', 'compliance'] as const;
+
+/** File conflict policies a drive restore can apply. */
+export const CONFLICT_MODES = ['replace', 'rename', 'fail'] as const;
+
+/** What `atlas stats --service` accepts, including the all-services default. */
+export const STATS_SERVICES = ['outlook', 'onedrive', 'sharepoint', 'all'] as const;
+
+/** `-t, --tenant`: every command reads the tenant from the flag or falls back to config. */
+export function with_tenant(command: Command): Command {
+  return command.option('-t, --tenant <id>', 'tenant identifier (defaults to config)');
+}
+
+/** `-s, --snapshot`: `-s` is the snapshot on every command that has one, and nothing else. */
+export function with_snapshot(command: Command, description: string): Command {
+  return command.option('-s, --snapshot <id>', description);
+}
+
+/** `-s, --snapshot`, required: same spelling as {@link with_snapshot} where the id is mandatory. */
+export function with_required_snapshot(command: Command, description: string): Command {
+  return command.requiredOption('-s, --snapshot <id>', description);
+}
+
+/**
+ * `--retention-days` plus `--lock-mode`, which are only meaningful together.
+ *
+ * The mode is validated by commander rather than by prose, so a typo fails before Atlas opens a
+ * Graph connection instead of applying no lock at all.
+ */
+export function with_object_lock(command: Command, retention_description: string): Command {
+  return command
+    .option('--retention-days <n>', retention_description)
+    .addOption(
+      new Option('--lock-mode <mode>', 'Object Lock mode; requires --retention-days').choices([
+        ...LOCK_MODES,
+      ]),
+    );
+}
+
+/**
+ * `--output`: an archive path, with no short flag on any command.
+ *
+ * `-o` is the owner everywhere it appears, so the output path gives up its short spelling rather
+ * than mean two things. `-O` was the drive spelling and is rejected outright.
+ */
+export function with_output(command: Command, description: string): Command {
+  return reject_retired_short(command.option('--output <path>', description), '-O', '--output');
+}
+
+/** `-c, --conflict`: the drive restore file conflict policy, defaulting to a non-destructive rename. */
+export function with_conflict(command: Command): Command {
+  return command.addOption(
+    new Option('-c, --conflict <mode>', 'file conflict policy')
+      .choices([...CONFLICT_MODES])
+      .default('rename'),
+  );
+}
+
+/** `--file-filter`: restrict a drive operation to specific files, by ID or path. */
+export function with_file_filter(command: Command, verb: string): Command {
+  return command.option('--file-filter <paths...>', `only ${verb} specific files (by ID or path)`);
+}
+
+/** `-f, --folder`: one folder name, the arity every Outlook command now shares. */
+export function with_folder(command: Command, description: string): Command {
+  return command.option('-f, --folder <name>', description);
+}
+
+/**
+ * `-f, --folder`, repeatable: `-f Inbox -f "Sent Items"`.
+ *
+ * Outlook backup used to take a variadic `<name...>` while restore and save took a single value, so
+ * the same flag had two arities within one command group and a variadic `-f` swallowed the next
+ * flag's argument. Repeating the flag keeps multiple folders reachable at one arity.
+ */
+export function with_repeatable_folder(command: Command, description: string): Command {
+  return command.option(
+    '-f, --folder <name>',
+    description,
+    (value: string, previous?: string[]) => [...(previous ?? []), value],
+  );
+}
+
+/** `-y, --yes`: skip the confirmation prompt on a destructive command. */
+export function with_yes(command: Command): Command {
+  return command.option('-y, --yes', 'skip confirmation prompt');
+}
+
+/**
+ * Fails a short flag that used to mean something else, naming what to pass instead.
+ *
+ * v5.0.0 reassigns `-s`, `-o`, and `-O`. A script that kept the old spelling must break loudly:
+ * silently resolving `atlas stats -s <site>` as a snapshot id would back up or report on the wrong
+ * thing, which is a data bug rather than a breaking change (issue #322).
+ */
+export function reject_retired_short(
+  command: Command,
+  short: string,
+  replacement: string,
+): Command {
+  // Short-only and hidden: it exists to be caught, so it gets no long spelling that could read
+  // like a supported flag, and `-o` next to `-O` stay separate options on one command.
+  return command.addOption(
+    new Option(`${short} <value>`, `retired: use ${replacement}`).hideHelp().argParser(() => {
+      throw new InvalidArgumentError(
+        `${short} no longer means ${replacement} in v5.0.0. Pass ${replacement} instead.`,
+      );
+    }),
+  );
+}

--- a/packages/cli/src/commands/sharepoint-catalog.command.tsx
+++ b/packages/cli/src/commands/sharepoint-catalog.command.tsx
@@ -8,6 +8,8 @@ import {
   SHAREPOINT_CATALOG_USE_CASE_TOKEN,
   SHAREPOINT_CONNECTOR_TOKEN,
 } from '@wisecom/atlas-types';
+import { with_tenant } from '@/commands/shared-options';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { render_static_view } from '@/ui/render';
@@ -32,14 +34,13 @@ export function register_sharepoint_list_snapshots(
   group: Command,
   get_container: ContainerFactory,
 ): void {
-  group
+  const command = group
     .command('list-snapshots')
     .description('List SharePoint snapshots for a site')
-    .requiredOption('--site <url-or-id>', 'SharePoint site URL or site ID')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: SharePointListSnapshotsOptions) =>
-      execute_sharepoint_list_snapshots(get_container(), options),
-    );
+    .requiredOption('--site <url-or-id>', 'SharePoint site URL or site ID');
+  with_tenant(command).action((options: SharePointListSnapshotsOptions) =>
+    execute_sharepoint_list_snapshots(get_container(), options),
+  );
 }
 
 /** Registers `atlas sharepoint list-versions` subcommand. */
@@ -47,15 +48,14 @@ export function register_sharepoint_list_versions(
   group: Command,
   get_container: ContainerFactory,
 ): void {
-  group
+  const command = group
     .command('list-versions')
     .description('List all backed-up versions for a specific file')
     .requiredOption('--site <url-or-id>', 'SharePoint site URL or site ID')
-    .requiredOption('-f, --file <ref>', 'file ID or path')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: SharePointListVersionsOptions) =>
-      execute_sharepoint_list_versions(get_container(), options),
-    );
+    .requiredOption('-f, --file <ref>', 'file ID or path');
+  with_tenant(command).action((options: SharePointListVersionsOptions) =>
+    execute_sharepoint_list_versions(get_container(), options),
+  );
 }
 
 function resolve_tenant_id(container: Container, options: SharePointTenantOptions): string {
@@ -107,7 +107,7 @@ async function execute_sharepoint_list_snapshots(
   const catalog = container.get<SharePointCatalogUseCase>(SHAREPOINT_CATALOG_USE_CASE_TOKEN);
   const snapshots = await catalog.list_sharepoint_snapshots(tenant_id, site.site_id);
 
-  await render_static_view(<Banner title="Atlas SharePoint Snapshots" />);
+  await render_static_view(<Banner title={banner_title('sharepoint', 'Snapshots')} />);
   if (snapshots.length === 0) {
     logger.info('No SharePoint snapshots found.');
     return;
@@ -134,7 +134,7 @@ async function execute_sharepoint_list_versions(
     options.file,
   );
 
-  await render_static_view(<Banner title="Atlas SharePoint File Versions" />);
+  await render_static_view(<Banner title={banner_title('sharepoint', 'File Versions')} />);
   if (versions.length === 0) {
     logger.info('No versions found for this file.');
     return;

--- a/packages/cli/src/commands/sharepoint-command.handlers.tsx
+++ b/packages/cli/src/commands/sharepoint-command.handlers.tsx
@@ -17,6 +17,7 @@ import {
   SHAREPOINT_SAVE_USE_CASE_TOKEN,
   SHAREPOINT_VERIFICATION_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { ErrorList } from '@/ui/components/error-list';
@@ -107,7 +108,7 @@ export async function execute_sharepoint_list_sites(
   const connector = container.get<SharePointSiteConnector>(SHAREPOINT_CONNECTOR_TOKEN);
   const sites = await connector.list_sites(tenant_id);
 
-  await render_static_view(<Banner title="Atlas SharePoint Sites" />);
+  await render_static_view(<Banner title={banner_title('sharepoint', 'Sites')} />);
   if (sites.length === 0) {
     logger.info('No SharePoint sites found.');
     return;
@@ -144,7 +145,7 @@ export async function execute_sharepoint_backup(
     object_lock_request,
   });
 
-  await render_static_view(<Banner title="Atlas SharePoint Backup" />);
+  await render_static_view(<Banner title={banner_title('sharepoint', 'Backup')} />);
   if (results.length > 1) {
     logger.info(`Backed up ${results.length} site(s) including subsites`);
   }
@@ -233,7 +234,7 @@ export async function execute_sharepoint_restore(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas SharePoint Restore" />
+      <Banner title={banner_title('sharepoint', 'Restore')} />
       <KeyValueList
         items={[
           { label: 'Snapshot', value: result.snapshot_id },
@@ -271,7 +272,7 @@ export async function execute_sharepoint_save(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas SharePoint Save" />
+      <Banner title={banner_title('sharepoint', 'Save')} />
       <KeyValueList
         items={[
           { label: 'Snapshot', value: result.snapshot_id },
@@ -310,7 +311,7 @@ export async function execute_sharepoint_verify(
     options.snapshot,
   );
 
-  await render_static_view(<Banner title="Atlas SharePoint Verify" />);
+  await render_static_view(<Banner title={banner_title('sharepoint', 'Verify')} />);
   if (result.failed_file_ids.length === 0 && result.index_issues.length === 0) {
     logger.success(`All ${result.total_checked} entries passed verification`);
     return;

--- a/packages/cli/src/commands/sharepoint-data-ops.handlers.tsx
+++ b/packages/cli/src/commands/sharepoint-data-ops.handlers.tsx
@@ -5,6 +5,7 @@ import {
   SHAREPOINT_DELETION_USE_CASE_TOKEN,
   SHAREPOINT_STATUS_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { KeyValueList } from '@/ui/components/key-value-list';
 import { render_static_view } from '@/ui/render';
@@ -63,7 +64,7 @@ export async function execute_sharepoint_status(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas SharePoint Status" />
+      <Banner title={banner_title('sharepoint', 'Status')} />
       <KeyValueList
         items={[
           { label: 'Tenant', value: tenant_id },

--- a/packages/cli/src/commands/sharepoint.command.ts
+++ b/packages/cli/src/commands/sharepoint.command.ts
@@ -1,4 +1,3 @@
-import { Option } from 'commander';
 import type { Command } from 'commander';
 import type { Container } from 'inversify';
 import {
@@ -27,17 +26,34 @@ import {
   type SharePointDeleteOptions,
   type SharePointStatusCommandOptions,
 } from '@/commands/sharepoint-data-ops.handlers';
+import {
+  with_conflict,
+  with_file_filter,
+  with_object_lock,
+  with_output,
+  with_required_snapshot,
+  with_snapshot,
+  with_tenant,
+  with_yes,
+} from '@/commands/shared-options';
 
 type ContainerFactory = () => Container;
 
-/** Registers `atlas sharepoint` command group with backup and verify subcommands. */
+// `--site` carries no short flag: `-s` is the snapshot on every command that has one, and a site
+// and a snapshot are the two values an operator is most likely to confuse (issue #162).
+const SITE_FLAG = '--site <url-or-id>';
+const SITE_DESCRIPTION = 'SharePoint site URL, hostname, or composite site ID';
+
+/** Registers `atlas sharepoint` command group. */
 export function register_sharepoint_command(
   program: Command,
   get_container: ContainerFactory,
 ): void {
   const group = program
     .command('sharepoint')
-    .description('SharePoint backup, restore, and verification commands');
+    .description(
+      'SharePoint backup, restore, save, verify, catalog, status, and deletion commands',
+    );
   register_sharepoint_list_sites(group, get_container);
   register_sharepoint_list_snapshots(group, get_container);
   register_sharepoint_list_versions(group, get_container);
@@ -54,126 +70,111 @@ function register_sharepoint_restore_version(
   group: Command,
   get_container: ContainerFactory,
 ): void {
-  group
+  const command = group
     .command('restore-version')
     .description('Restore stored file versions back into a SharePoint library')
-    .requiredOption('--site <url-or-id>', 'SharePoint site URL or site ID')
+    .requiredOption(SITE_FLAG, SITE_DESCRIPTION)
     .option('-f, --file <ref>', 'file ID or path; required with --version')
     .option('--version <id>', 'exact stored version to restore')
     .option('--before <iso>', "restore each file's last version at or before this instant")
     .option('--path <prefix>', 'limit a bulk rollback to this folder and below')
-    .option('--in-place', 'upload over the original file instead of writing a copy beside it')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: SharePointRestoreVersionOptions) =>
-      execute_sharepoint_restore_version(get_container(), options),
-    );
+    .option('--in-place', 'upload over the original file instead of writing a copy beside it');
+  with_tenant(command).action((options: SharePointRestoreVersionOptions) =>
+    execute_sharepoint_restore_version(get_container(), options),
+  );
 }
 
 function register_sharepoint_list_sites(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('list-sites')
-    .description('List all SharePoint sites in the tenant')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: SharePointTenantOptions) =>
-      execute_sharepoint_list_sites(get_container(), options),
-    );
+    .description('List all SharePoint sites in the tenant');
+  with_tenant(command).action((options: SharePointTenantOptions) =>
+    execute_sharepoint_list_sites(get_container(), options),
+  );
 }
 
 function register_sharepoint_backup(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('backup')
     .description('Back up changed files in a SharePoint site')
-    .requiredOption('--site <url-or-id>', 'SharePoint site URL or site ID')
+    .requiredOption(SITE_FLAG, SITE_DESCRIPTION)
     .option('--full', 'force full crawl ignoring saved delta state')
     .option(
       '--include-subsites',
       'also back up every subsite beneath the site (one snapshot per subsite)',
-    )
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .option(
-      '--retention-days <n>',
-      'apply Object Lock default retention for N days (persists on the bucket)',
-    )
-    .option('--lock-mode <mode>', 'Object Lock mode: governance|compliance')
-    .action((options: SharePointBackupOptions) =>
-      execute_sharepoint_backup(get_container(), options),
     );
+  with_object_lock(
+    command,
+    'apply Object Lock default retention for N days (persists on the bucket)',
+  );
+  with_tenant(command).action((options: SharePointBackupOptions) =>
+    execute_sharepoint_backup(get_container(), options),
+  );
 }
 
 function register_sharepoint_restore(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('restore')
     .description('Restore files from a SharePoint snapshot')
-    .requiredOption('--site <url-or-id>', 'SharePoint site URL or site ID')
-    .requiredOption('-s, --snapshot <id>', 'snapshot identifier')
+    .requiredOption(SITE_FLAG, SITE_DESCRIPTION)
     .option('--target-site <url-or-id>', 'target site to restore to (defaults to original site)')
-    .option('--file-filter <paths...>', 'only restore specific files (by ID or path)')
     .option(
       '--destination <path>',
       'restore under this folder instead of a generated Restore-<timestamp> root',
     )
     .option('--in-place', 'restore to the original paths, mixing files into live content')
-    .option('--name <filename>', 'rename the restored file; requires a single-file restore')
-    .addOption(
-      new Option('-c, --conflict <mode>', 'file conflict policy (default: rename)').choices([
-        'replace',
-        'rename',
-        'fail',
-      ]),
-    )
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: SharePointRestoreCommandOptions) =>
-      execute_sharepoint_restore(get_container(), options),
-    );
+    .option('--name <filename>', 'rename the restored file; requires a single-file restore');
+  with_required_snapshot(command, 'snapshot identifier');
+  with_file_filter(command, 'restore');
+  with_conflict(command);
+  with_tenant(command).action((options: SharePointRestoreCommandOptions) =>
+    execute_sharepoint_restore(get_container(), options),
+  );
 }
 
 function register_sharepoint_save(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('save')
     .description('Save files from a SharePoint snapshot to a local zip archive')
-    .requiredOption('--site <url-or-id>', 'SharePoint site URL or site ID')
-    .requiredOption('-s, --snapshot <id>', 'snapshot identifier')
-    .option('--file-filter <paths...>', 'only save specific files (by ID or path)')
-    .option('-O, --output <path>', 'output zip file path')
-    .option('--skip-verify', 'skip SHA-256 integrity checks')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: SharePointSaveCommandOptions) =>
-      execute_sharepoint_save(get_container(), options),
-    );
+    .requiredOption(SITE_FLAG, SITE_DESCRIPTION)
+    .option('--skip-verify', 'skip SHA-256 integrity checks');
+  with_required_snapshot(command, 'snapshot identifier');
+  with_file_filter(command, 'save');
+  with_output(command, 'output zip file path');
+  with_tenant(command).action((options: SharePointSaveCommandOptions) =>
+    execute_sharepoint_save(get_container(), options),
+  );
 }
 
 function register_sharepoint_verify(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('verify')
     .description('Verify integrity of a SharePoint snapshot')
-    .requiredOption('--site <url-or-id>', 'SharePoint site URL or site ID')
-    .requiredOption('-s, --snapshot <id>', 'snapshot identifier')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: SharePointVerifyOptions) =>
-      execute_sharepoint_verify(get_container(), options),
-    );
+    .requiredOption(SITE_FLAG, SITE_DESCRIPTION);
+  with_required_snapshot(command, 'snapshot identifier');
+  with_tenant(command).action((options: SharePointVerifyOptions) =>
+    execute_sharepoint_verify(get_container(), options),
+  );
 }
 
 function register_sharepoint_status(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('status')
     .description('Check whether a site SharePoint backup is up to date')
-    .requiredOption('--site <site>', 'site URL, hostname, or composite site ID')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .action((options: SharePointStatusCommandOptions) =>
-      execute_sharepoint_status(get_container(), options),
-    );
+    .requiredOption(SITE_FLAG, SITE_DESCRIPTION);
+  with_tenant(command).action((options: SharePointStatusCommandOptions) =>
+    execute_sharepoint_status(get_container(), options),
+  );
 }
 
 function register_sharepoint_delete(group: Command, get_container: ContainerFactory): void {
-  group
+  const command = group
     .command('delete')
     .description('Delete SharePoint backups for one site, or a single snapshot')
-    .requiredOption('--site <site>', 'site URL, hostname, or composite site ID')
-    .option('-s, --snapshot <id>', 'delete a single snapshot instead of every backup')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .option('-y, --yes', 'skip confirmation prompt')
-    .action((options: SharePointDeleteOptions) =>
-      execute_sharepoint_delete(get_container(), options),
-    );
+    .requiredOption(SITE_FLAG, SITE_DESCRIPTION);
+  with_snapshot(command, 'delete a single snapshot instead of every backup');
+  with_yes(command);
+  with_tenant(command).action((options: SharePointDeleteOptions) =>
+    execute_sharepoint_delete(get_container(), options),
+  );
 }

--- a/packages/cli/src/commands/stats-drive.view.tsx
+++ b/packages/cli/src/commands/stats-drive.view.tsx
@@ -1,6 +1,7 @@
 import type { DriveStats, DriveOwnerSummary, DriveMonthlyBreakdown } from '@wisecom/atlas-types';
 import { Box, Text } from 'ink';
 import type { ReactElement } from 'react';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { KeyValueList } from '@/ui/components/key-value-list';
 import type { KeyValueItem } from '@/ui/components/key-value-list';
@@ -10,8 +11,8 @@ import { render_static_view } from '@/ui/render';
 import { format_bytes, format_microseconds } from '@/command-formatters';
 
 const SERVICE_LABELS: Record<DriveStats['service'], { title: string; owners: string }> = {
-  onedrive: { title: 'Atlas OneDrive Statistics', owners: 'Owners' },
-  sharepoint: { title: 'Atlas SharePoint Statistics', owners: 'Sites' },
+  onedrive: { title: banner_title('onedrive', 'Statistics'), owners: 'Owners' },
+  sharepoint: { title: banner_title('sharepoint', 'Statistics'), owners: 'Sites' },
 };
 
 /** Renders OneDrive or SharePoint drive statistics as banner, overview, and tables. */

--- a/packages/cli/src/commands/stats-outlook.view.tsx
+++ b/packages/cli/src/commands/stats-outlook.view.tsx
@@ -6,6 +6,7 @@ import type {
 } from '@wisecom/atlas-types';
 import { Box, Text } from 'ink';
 import type { ReactElement } from 'react';
+import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { KeyValueList } from '@/ui/components/key-value-list';
 import type { KeyValueItem } from '@/ui/components/key-value-list';
@@ -18,7 +19,10 @@ import { format_bytes, format_microseconds } from '@/command-formatters';
 export async function print_bucket_stats(stats: BucketStats): Promise<void> {
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Bucket Statistics" subtitle={`Tenant: ${stats.tenant_id}`} />
+      <Banner
+        title={banner_title('tenant', 'Bucket Statistics')}
+        subtitle={`Tenant: ${stats.tenant_id}`}
+      />
       <Text bold>Overview</Text>
       <KeyValueList items={build_overview_items(stats)} />
       {stats.monthly_breakdown.length > 0 ? (
@@ -32,7 +36,10 @@ export async function print_bucket_stats(stats: BucketStats): Promise<void> {
 export async function print_mailbox_stats(stats: MailboxStats): Promise<void> {
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Mailbox Statistics" subtitle={`Mailbox: ${stats.owner_id}`} />
+      <Banner
+        title={banner_title('outlook', 'Statistics')}
+        subtitle={`Mailbox: ${stats.owner_id}`}
+      />
       <Text bold>Overview</Text>
       <KeyValueList items={build_overview_items(stats)} />
       {stats.folders.length > 0 ? <FolderTable folders={stats.folders} /> : undefined}

--- a/packages/cli/src/commands/stats.command.ts
+++ b/packages/cli/src/commands/stats.command.ts
@@ -1,3 +1,4 @@
+import { Option } from 'commander';
 import type { Command } from 'commander';
 import type { Container } from 'inversify';
 import type { AtlasConfig } from '@wisecom/atlas-core';
@@ -8,6 +9,7 @@ import type { BucketStats, MailboxStats, DriveStats } from '@wisecom/atlas-types
 import { resolve_owner } from '@/commands/onedrive-command.handlers';
 import { print_bucket_stats, print_mailbox_stats } from '@/commands/stats-outlook.view';
 import { print_drive_stats } from '@/commands/stats-drive.view';
+import { reject_retired_short, with_tenant, STATS_SERVICES } from '@/commands/shared-options';
 
 type ContainerFactory = () => Container;
 type StatsServiceName = 'outlook' | 'onedrive' | 'sharepoint';
@@ -24,28 +26,31 @@ interface StatsOptions {
 }
 
 const SERVICE_NAMES: StatsServiceName[] = ['outlook', 'onedrive', 'sharepoint'];
-const DEFAULT_TOP = 20;
+const DEFAULT_TOP = '20';
 
 /** Registers the `atlas stats` subcommand for storage statistics. */
 export function register_stats_command(program: Command, get_container: ContainerFactory): void {
-  program
+  const command = program
     .command('stats')
     .description('Show storage statistics for Outlook, OneDrive, and SharePoint backups')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
     .option('-m, --mailbox <email>', 'Outlook statistics for a specific mailbox')
     .option('-o, --owner <email|id>', 'OneDrive statistics for a specific owner')
-    .option('-s, --site <url|id>', 'SharePoint statistics for a specific site')
-    .option('--service <name>', 'limit output to one service: outlook, onedrive, sharepoint, all')
-    .option('--top <n>', `maximum owner/site rows in drive tables (default ${DEFAULT_TOP})`)
-    .option('--json', 'output raw JSON instead of formatted tables')
-    .action((options: StatsOptions) => execute_stats(get_container(), options));
+    .option('--site <url|id>', 'SharePoint statistics for a specific site')
+    .addOption(
+      new Option('--service <name>', 'limit output to one service').choices([...STATS_SERVICES]),
+    )
+    .option('--top <n>', 'maximum owner/site rows in drive tables', DEFAULT_TOP)
+    .option('--json', 'output raw JSON instead of formatted tables');
+  // `-s` was this command's own spelling of --site while it meant --snapshot everywhere else.
+  reject_retired_short(command, '-s', '--site');
+  with_tenant(command).action((options: StatsOptions) => execute_stats(get_container(), options));
 }
 
 /** Collects stats for every selected service, then prints tables or a single JSON payload. */
 async function execute_stats(container: Container, options: StatsOptions): Promise<void> {
   const tenant_id = resolve_tenant_id(container, options);
   const services = resolve_services(options);
-  const top = parse_top(options.top);
+  const top = parse_top(options.top ?? DEFAULT_TOP);
   const stats = container.get<StatsUseCase>(STATS_USE_CASE_TOKEN);
 
   const collected: [StatsServiceName, ServiceStats][] = [];
@@ -76,12 +81,8 @@ function resolve_services(options: StatsOptions): StatsServiceName[] {
     throw new Error('Use only one of --mailbox, --owner, or --site at a time');
   }
 
+  // Commander has already rejected anything outside STATS_SERVICES.
   const requested = options.service ?? 'all';
-  if (requested !== 'all' && !SERVICE_NAMES.includes(requested as StatsServiceName)) {
-    throw new Error(
-      `Unknown --service "${requested}"; expected outlook, onedrive, sharepoint, or all`,
-    );
-  }
   if (scoped.length === 1) {
     if (requested !== 'all' && requested !== scoped[0]) {
       throw new Error(`--service ${requested} conflicts with the ${scoped[0]} scope flag`);
@@ -128,9 +129,8 @@ function resolve_tenant_id(container: Container, options: StatsOptions): string 
   return container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
 }
 
-/** Parses and validates the --top row limit. */
-function parse_top(raw: string | undefined): number {
-  if (raw === undefined) return DEFAULT_TOP;
+/** Parses and validates the --top row limit, which commander always supplies. */
+function parse_top(raw: string): number {
   const value = Number.parseInt(raw, 10);
   if (!Number.isInteger(value) || value <= 0) {
     throw new Error('--top must be a positive integer');

--- a/packages/cli/src/commands/storage-check.command.tsx
+++ b/packages/cli/src/commands/storage-check.command.tsx
@@ -5,6 +5,8 @@ import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
 import type { ObjectLockMode } from '@wisecom/atlas-types/ports/backup/use-case.port';
 import type { StorageCheckResult, StorageCheckUseCase } from '@wisecom/atlas-types';
 import { STORAGE_CHECK_USE_CASE_TOKEN } from '@wisecom/atlas-types';
+import { with_object_lock, with_tenant } from '@/commands/shared-options';
+import { banner_title } from '@/ui/banner-title';
 import { Box } from 'ink';
 import { Banner } from '@/ui/components/banner';
 import { KeyValueList } from '@/ui/components/key-value-list';
@@ -26,13 +28,13 @@ export function register_storage_check_command(
   program: Command,
   get_container: ContainerFactory,
 ): void {
-  program
+  const command = program
     .command('storage-check')
-    .description('Check S3/MinIO Object Lock readiness for backup policies')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .option('--lock-mode <mode>', 'Object Lock mode: governance|compliance')
-    .option('--retention-days <n>', 'planned retention period in days')
-    .action((options: StorageCheckOptions) => execute_storage_check(get_container(), options));
+    .description('Check S3/MinIO Object Lock readiness for backup policies');
+  with_object_lock(command, 'planned retention period in days');
+  with_tenant(command).action((options: StorageCheckOptions) =>
+    execute_storage_check(get_container(), options),
+  );
 }
 
 async function execute_storage_check(
@@ -52,7 +54,7 @@ async function execute_storage_check(
 
   await render_static_view(
     <Box flexDirection="column">
-      <Banner title="Atlas Storage Check" />
+      <Banner title={banner_title('tenant', 'Storage Check')} />
       <KeyValueList items={build_result_items(result, ready)} />
     </Box>,
   );

--- a/packages/cli/src/commands/tenant-delete.command.tsx
+++ b/packages/cli/src/commands/tenant-delete.command.tsx
@@ -5,6 +5,7 @@ import { ATLAS_CONFIG_TOKEN, logger } from '@wisecom/atlas-core';
 import type { DeletionUseCase } from '@wisecom/atlas-types';
 import { DELETION_USE_CASE_TOKEN } from '@wisecom/atlas-types';
 import { print_delete_result, render_delete_banner } from '@/commands/deletion-presenter';
+import { with_tenant, with_yes } from '@/commands/shared-options';
 import { ask_exact_match } from '@/ui/components/confirm-prompt';
 
 type ContainerFactory = () => Container;
@@ -23,13 +24,14 @@ export function register_tenant_delete_command(
   program: Command,
   get_container: ContainerFactory,
 ): void {
-  program
+  const command = program
     .command('delete')
     .description('Delete tenant-wide data across every workload')
-    .option('-t, --tenant <id>', 'tenant identifier (defaults to config)')
-    .option('--purge', 'delete ALL data in the tenant bucket, every workload (irreversible)')
-    .option('-y, --yes', 'skip confirmation prompt')
-    .action((options: TenantDeleteOptions) => execute_tenant_delete(get_container(), options));
+    .option('--purge', 'delete ALL data in the tenant bucket, every workload (irreversible)');
+  with_yes(command);
+  with_tenant(command).action((options: TenantDeleteOptions) =>
+    execute_tenant_delete(get_container(), options),
+  );
 }
 
 /** Purges every object in the tenant bucket after confirmation. */

--- a/packages/cli/src/ui/banner-title.ts
+++ b/packages/cli/src/ui/banner-title.ts
@@ -1,0 +1,23 @@
+/**
+ * The one place a command banner title is built.
+ *
+ * Titles used to be written by hand at each render site, which produced `Atlas Backup` next to
+ * `Atlas OneDrive Backup` and `Replication Status` with no product name at all (issue #162). A
+ * workload-scoped command names its workload; a tenant-scoped one does not.
+ */
+
+/** Which surface a command acts on: a workload, or the tenant as a whole. */
+export type BannerScope = 'outlook' | 'onedrive' | 'sharepoint' | 'tenant';
+
+const SCOPE_LABELS: Record<BannerScope, string> = {
+  outlook: 'Outlook',
+  onedrive: 'OneDrive',
+  sharepoint: 'SharePoint',
+  tenant: '',
+};
+
+/** Builds a banner title: `Atlas · OneDrive Backup`, or `Atlas · Replicate` for tenant scope. */
+export function banner_title(scope: BannerScope, verb: string): string {
+  const label = SCOPE_LABELS[scope];
+  return label === '' ? `Atlas · ${verb}` : `Atlas · ${label} ${verb}`;
+}

--- a/packages/cli/tests/unit/cli-flag-consistency.test.ts
+++ b/packages/cli/tests/unit/cli-flag-consistency.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { BACKUP_USE_CASE_TOKEN, STATS_USE_CASE_TOKEN } from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
+import { register_onedrive_command } from '@/commands/onedrive.command';
+import { register_outlook_command } from '@/commands/outlook.command';
+import { register_stats_command } from '@/commands/stats.command';
+
+const mock_run_backup = vi.fn();
+
+vi.mock('@/adapters/backup-operation.adapter', () => ({
+  run_backup_with_cli_adapter: (...args: unknown[]): unknown => mock_run_backup(...args),
+}));
+
+function make_sync_result(): Record<string, unknown> {
+  return {
+    snapshot: { id: 'snap-1' },
+    manifest: { total_objects: 1, total_size_bytes: 10 },
+    summary: { folder_errors: [], warnings: [], excluded_folders: [], interrupted: false },
+  };
+}
+
+function make_container(): Container {
+  const container = new Container();
+  container.bind(BACKUP_USE_CASE_TOKEN).toConstantValue({ sync_mailbox: vi.fn() });
+  container.bind(STATS_USE_CASE_TOKEN).toConstantValue({ get_bucket_stats: vi.fn() });
+  container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({ tenant_id: 'tenant-from-config' });
+  return container;
+}
+
+function make_program(): Command {
+  const container = make_container();
+  const program = new Command();
+  program.exitOverride();
+  register_outlook_command(program, () => container);
+  register_onedrive_command(program, () => container);
+  register_stats_command(program, () => container);
+  return program;
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  mock_run_backup.mockReset();
+  mock_run_backup.mockResolvedValue(make_sync_result());
+});
+
+/**
+ * v5.0.0 reassigns three short flags. A script that kept the old spelling has to fail naming the
+ * replacement: resolving `stats -s <site>` as a snapshot id would report on the wrong scope, and
+ * `outlook save -o <path>` as an owner would put the archive somewhere else (issues #162, #322).
+ */
+describe('retired short flags', () => {
+  let program: Command;
+
+  beforeEach(() => {
+    program = make_program();
+  });
+
+  it('rejects `stats -s`, naming --site', async () => {
+    await expect(
+      program.parseAsync(['stats', '-s', 'https://contoso.sharepoint.com/sites/x'], {
+        from: 'user',
+      }),
+    ).rejects.toThrow(/-s no longer means --site/);
+  });
+
+  it('rejects `outlook save -o`, naming --output', async () => {
+    await expect(
+      program.parseAsync(['outlook', 'save', '-s', 'snap-1', '-o', 'export.zip'], { from: 'user' }),
+    ).rejects.toThrow(/-o no longer means --output/);
+  });
+
+  it('rejects `onedrive save -O`, naming --output', async () => {
+    await expect(
+      program.parseAsync(
+        ['onedrive', 'save', '-o', 'user@example.com', '-s', 'snap-1', '-O', 'export.zip'],
+        { from: 'user' },
+      ),
+    ).rejects.toThrow(/-O no longer means --output/);
+  });
+
+  it('still reads -o as the owner on a drive command', () => {
+    const save = program.commands
+      .find((command) => command.name() === 'onedrive')!
+      .commands.find((command) => command.name() === 'save')!;
+
+    expect(save.options.find((option) => option.short === '-o')?.long).toBe('--owner');
+  });
+});
+
+describe('outlook --folder arity', () => {
+  let program: Command;
+
+  beforeEach(() => {
+    program = make_program();
+  });
+
+  // The flag was variadic on backup and single-valued on restore and save, so one group carried
+  // two arities and a variadic `-f` swallowed the next flag's argument.
+  it('collects a repeated -f into every named folder', async () => {
+    await program.parseAsync(
+      ['outlook', 'backup', '-m', 'user@test.com', '-f', 'Inbox', '-f', 'Sent Items'],
+      { from: 'user' },
+    );
+
+    expect(mock_run_backup.mock.calls[0]![3].folder_filter).toEqual(['Inbox', 'Sent Items']);
+  });
+
+  it('does not consume the following flag as another folder', async () => {
+    await program.parseAsync(['outlook', 'backup', '-f', 'Inbox', '-m', 'user@test.com'], {
+      from: 'user',
+    });
+
+    expect(mock_run_backup.mock.calls[0]![3].folder_filter).toEqual(['Inbox']);
+    expect(mock_run_backup.mock.calls[0]![2]).toBe('user@test.com');
+  });
+});

--- a/packages/cli/tests/unit/config-command.test.ts
+++ b/packages/cli/tests/unit/config-command.test.ts
@@ -84,7 +84,7 @@ describe('atlas config set', () => {
   it('reads the value from stdin when given "-", keeping it out of shell history', async () => {
     fs_mocks.readFileSync.mockReturnValue('  FAKE-secret-from-stdin  \n');
 
-    await run(['client.secret', '-']);
+    await run(['set', 'client.secret', '-']);
 
     // Read from fd 0, not from the argument vector.
     expect(fs_mocks.readFileSync).toHaveBeenCalledWith(0, 'utf-8');
@@ -94,13 +94,15 @@ describe('atlas config set', () => {
   });
 
   it('rejects an invalid value and writes nothing', async () => {
-    await expect(run(['tenant.id', 'not-a-guid'])).rejects.toThrow(/Invalid value for tenant.id/);
+    await expect(run(['set', 'tenant.id', 'not-a-guid'])).rejects.toThrow(
+      /Invalid value for tenant.id/,
+    );
 
     expect(mocks.write_secure_config).not.toHaveBeenCalled();
   });
 
   it('rejects a passphrase below the minimum length', async () => {
-    await expect(run(['encryption.passphrase', 'short'])).rejects.toThrow(/at least 12/);
+    await expect(run(['set', 'encryption.passphrase', 'short'])).rejects.toThrow(/at least 12/);
 
     expect(mocks.write_secure_config).not.toHaveBeenCalled();
   });
@@ -108,7 +110,7 @@ describe('atlas config set', () => {
   it('keeps existing keys when storing a new one', async () => {
     mocks.read_secure_config.mockReturnValue({ tenant_id: 'existing-tenant' });
 
-    await run(['s3.region', 'eu-north-1']);
+    await run(['set', 's3.region', 'eu-north-1']);
 
     expect(mocks.write_secure_config).toHaveBeenCalledWith({
       tenant_id: 'existing-tenant',
@@ -119,7 +121,7 @@ describe('atlas config set', () => {
   it('warns that an ATLAS_* variable overrides the value just stored', async () => {
     mocks.read_env_overrides.mockReturnValue({ s3_region: 'us-west-2' });
 
-    await run(['s3.region', 'eu-north-1']);
+    await run(['set', 's3.region', 'eu-north-1']);
 
     expect(output.join('\n')).toMatch(/environment variable currently overrides s3\.region/);
   });
@@ -127,13 +129,13 @@ describe('atlas config set', () => {
   it('does not warn when the environment agrees with the stored value', async () => {
     mocks.read_env_overrides.mockReturnValue({ s3_region: 'eu-north-1' });
 
-    await run(['s3.region', 'eu-north-1']);
+    await run(['set', 's3.region', 'eu-north-1']);
 
     expect(output.join('\n')).not.toMatch(/environment variable currently overrides/);
   });
 
   it('skips the live probe while the credential group is incomplete', async () => {
-    await run(['client.id', '00000000-0000-0000-0000-000000000002']);
+    await run(['set', 'client.id', '00000000-0000-0000-0000-000000000002']);
 
     expect(output.join('\n')).toMatch(/Graph credentials incomplete/);
     expect(azure_mocks.get_token).not.toHaveBeenCalled();
@@ -142,13 +144,15 @@ describe('atlas config set', () => {
   it('probes Graph once the last credential in the group is stored', async () => {
     mocks.read_secure_config.mockReturnValue(COMPLETE_GRAPH);
 
-    await run(['client.secret', 'FAKE-client-secret']);
+    await run(['set', 'client.secret', 'FAKE-client-secret']);
 
     expect(azure_mocks.get_token).toHaveBeenCalledTimes(1);
   });
 
   it('rejects an unknown key', async () => {
-    await expect(run(['nope.key', 'value'])).rejects.toThrow(/Unknown config key "nope.key"/);
+    await expect(run(['set', 'nope.key', 'value'])).rejects.toThrow(
+      /Unknown config key "nope.key"/,
+    );
 
     expect(mocks.write_secure_config).not.toHaveBeenCalled();
   });
@@ -156,7 +160,7 @@ describe('atlas config set', () => {
 
 describe('atlas config get', () => {
   it('warns and prints nothing when the key is unset', async () => {
-    await run(['tenant.id']);
+    await run(['get', 'tenant.id']);
 
     expect(output.join('\n')).toMatch(/tenant\.id is not set/);
     expect(console.log).not.toHaveBeenCalled();
@@ -192,8 +196,8 @@ describe('atlas config list', () => {
 });
 
 describe('atlas config unset', () => {
-  it('errors with usage when no key is given', async () => {
-    await expect(run(['unset'])).rejects.toThrow(/Usage: atlas config unset/);
+  it('refuses to run without a key rather than guessing one', async () => {
+    await expect(run(['unset'])).rejects.toThrow(/missing required argument/);
 
     expect(mocks.write_secure_config).not.toHaveBeenCalled();
   });

--- a/packages/cli/tests/unit/config-secret-masking.test.ts
+++ b/packages/cli/tests/unit/config-secret-masking.test.ts
@@ -87,7 +87,7 @@ describe('atlas config never prints a secret in full', () => {
   });
 
   it.each(secret_keys.map((spec) => spec.key))('config get masks %s', async (key) => {
-    await run([key]);
+    await run(['get', key]);
 
     const full_value = FAKE_VALUES[key]!;
     expect(output.join('\n')).not.toContain(full_value);
@@ -97,7 +97,7 @@ describe('atlas config never prints a secret in full', () => {
   });
 
   it.each(plain_keys.map((spec) => spec.key))('config get prints %s in full', async (key) => {
-    await run([key]);
+    await run(['get', key]);
 
     // Distinguishes masking from blanket redaction: a non-secret must survive.
     expect(output.join('\n')).toContain(FAKE_VALUES[key]!);

--- a/packages/cli/tests/unit/object-lock-flags.test.ts
+++ b/packages/cli/tests/unit/object-lock-flags.test.ts
@@ -111,12 +111,12 @@ describe('drive backups reject bad Object Lock flags before reaching Graph (issu
     expect(h.backup_onedrive).not.toHaveBeenCalled();
   });
 
-  it('fails a SharePoint backup without resolving the site', async () => {
+  it('rejects an unknown --lock-mode at the flag boundary, before resolving the site', async () => {
     await expect(
       h.program.parseAsync(['sharepoint', 'backup', '--site', SITE_URL, '--lock-mode', 'bogus'], {
         from: 'user',
       }),
-    ).rejects.toThrow(INVALID_MODE_ERROR);
+    ).rejects.toThrow(/Allowed choices are governance, compliance/);
 
     expect(h.resolve_site).not.toHaveBeenCalled();
     expect(h.backup_site_tree).not.toHaveBeenCalled();

--- a/packages/cli/tests/unit/replication-owner-scope.test.ts
+++ b/packages/cli/tests/unit/replication-owner-scope.test.ts
@@ -156,8 +156,8 @@ describe('replicate/rehydrate --owner OneDrive scope', () => {
     );
   });
 
-  it('scopes --status -o to the resolved owner object ID', async () => {
-    await program.parseAsync(['replicate', '--status', '-o', OWNER_EMAIL], { from: 'user' });
+  it('scopes `replicate status -o` to the resolved owner object ID', async () => {
+    await program.parseAsync(['replicate', 'status', '-o', OWNER_EMAIL], { from: 'user' });
 
     expect(outlook.get_replication_status_by_owner).toHaveBeenCalledWith(
       'test-tenant',

--- a/packages/cli/tests/unit/replication-site-scope.test.ts
+++ b/packages/cli/tests/unit/replication-site-scope.test.ts
@@ -157,11 +157,11 @@ describe('replicate/rehydrate --site SharePoint scope', () => {
     );
   });
 
-  it('scopes --status by the resolved site id, not the raw URL', async () => {
+  it('scopes `replicate status` by the resolved site id, not the raw URL', async () => {
     const use_case = container.get<{ get_replication_status_by_owner: Mock }>(
       REPLICATION_USE_CASE_TOKEN,
     );
-    await program.parseAsync(['replicate', '--status', '--site', SITE_URL], { from: 'user' });
+    await program.parseAsync(['replicate', 'status', '--site', SITE_URL], { from: 'user' });
 
     expect(use_case.get_replication_status_by_owner).toHaveBeenCalledWith('test-tenant', SITE_ID);
   });

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -146,7 +146,7 @@ export function merge_and_validate(partial: Partial<AtlasConfig>): AtlasConfig {
   if (missing.length > 0) {
     throw new Error(
       `Missing required config fields: ${missing.join(', ')}. ` +
-        'Set them via "atlas config <key> <value>", atlas.config.json, or ATLAS_* environment variables.',
+        'Set them via "atlas config set <key> <value>", atlas.config.json, or ATLAS_* environment variables.',
     );
   }
 


### PR DESCRIPTION
## Summary

Every command group had grown its own spelling, so knowing `atlas outlook` taught you the wrong flags for `atlas onedrive`. Registration now composes shared option builders instead of repeating `.option()` calls, `-s` means `--snapshot` everywhere, `-o` means `--owner` everywhere, `--output` has no short flag at all, and reporting verbs are subcommands rather than flags that change what a command does.

A retired short flag is rejected and names its replacement, per the decision recorded on #322. `atlas stats -s <site>` now fails with `-s no longer means --site in v5.0.0. Pass --site instead.` rather than resolving the site as a snapshot id, which would report on the wrong scope.

Two items in the issue are not here, because both reach past the CLI: `--fast` for drive verification needs the verification services to gain an existence-only path, and the `--json` rollout is #94. I kept the per-workload subject names (`-m, --mailbox`, `-o, --owner`, `--site`): a mailbox, a drive owner, and a site are different identifiers, and the SDK names them the same way.

Closes #162

## Changes

- Add `packages/cli/src/commands/shared-options.ts`: tenant, snapshot, object lock, output, conflict, file filter, folder, and confirmation builders, plus the retired-short-flag guard.
- Add `packages/cli/src/ui/banner-title.ts` and build every banner title from it, so `Atlas · Outlook Backup` and `Atlas · OneDrive Backup` are formed the same way.
- Make `-s` the snapshot everywhere: `stats` takes `--site` with no short flag and rejects `-s`.
- Drop the short flag from `--output` on all three save commands and reject the old `-o` and `-O` spellings.
- Give Outlook's `--folder` one arity: a single value on backup, restore, and save, repeatable on backup (`-f Inbox -f "Sent Items"`), so a variadic `-f` can no longer swallow the next flag's argument.
- Validate `--lock-mode` and `--service` with `.choices()` and express every default as a commander default, so `--help` states it once and `--top` no longer carries its default in prose.
- Replace `replicate --status` with `replicate status` and the positional `config [key] [value]` with `config get|set|list|unset|validate`.
- Correct the group descriptions that had drifted from the verbs they register.
- Update `docs/reference/cli.md` (including a short-flag section), plus the configuration, getting-started, OneDrive, SharePoint, replication, and Entra pages.

## Evidence

Retired flags and the new verbs, from the built CLI:

```console
$ atlas stats -s https://contoso.sharepoint.com/sites/x
error: option '-s <value>' argument 'https://contoso.sharepoint.com/sites/x' is invalid. -s no longer means --site in v5.0.0. Pass --site instead.

$ atlas onedrive save -o user@example.com -s snap-1 -O out.zip
error: option '-O <value>' argument 'out.zip' is invalid. -O no longer means --output in v5.0.0. Pass --output instead.

$ atlas config --help
Commands:
  list               Print every key with its masked value and the source it resolves from
  get <key>          Print the effective value of one key
  set <key> <value>  Store a value in the encrypted local store
  unset <key>        Remove a key from the encrypted local store
  validate           Live-validate Graph and S3 connectivity with the effective config
```

Commander binds a flag typed after a subcommand name to the parent when the parent declares it too, so `replicate status` reads the merged option view; without that, `atlas replicate status -o <owner>` silently reported on the whole tenant.

The old-to-new flag table for `docs/migration/v5.md` is posted on #322, which owns that page.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run format:check` passes
- [x] `pnpm run test` passes with no regressions
- [x] `pnpm run typecheck` passes
- [x] `pnpm run docs:build` passes
- [x] New and changed behavior has regression coverage
- [x] No file exceeds 300 effective lines
- [x] No relative imports were added
- [x] Secrets and credentials are not committed
- [x] Targets `dev`
- [x] No package version was changed
- [x] Labelled for release notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reorganized `atlas config` with explicit `list`, `get`, `set`, `unset`, and `validate` subcommands.
  - Changed replication status checks to use `atlas replicate status`.
  - Standardized CLI options and validation across Outlook, OneDrive, SharePoint, statistics, and tenant commands.
  - Added clearer provider-specific command banners.

- **Documentation**
  - Updated CLI examples and reference material for current configuration commands, output options, status syntax, and flag behavior.

- **Bug Fixes**
  - Invalid option values now produce clearer command-line errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->