### PR TITLE
test(e2e): drive the v5 CLI interface

### DIFF
--- a/e2e/tests/test_10_outlook.py
+++ b/e2e/tests/test_10_outlook.py
@@ -69,7 +69,7 @@ def test_04_verify_passes_on_a_fresh_snapshot(cli: Cli, settings: Settings) -> N
 def test_05_save_exports_an_eml_archive(cli: Cli, exports: Path, run_marker: str) -> None:
     """`outlook save` produces a zip containing the message as `.eml`."""
     archive = exports / f"{run_marker}.zip"
-    cli.ok("outlook", "save", "-s", STATE["snapshot"], "-o", str(archive))
+    cli.ok("outlook", "save", "-s", STATE["snapshot"], "--output", str(archive))
 
     assert archive.exists(), f"{archive} was not written"
     with zipfile.ZipFile(archive) as zf:

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -140,8 +140,8 @@ def test_05_save_exports_the_file(
 ) -> None:
     """`onedrive save` writes a zip that mirrors the drive hierarchy.
 
-    Note the capital `-O` for output: `onedrive save` differs from `outlook save` here, and `-o` is
-    the owner.
+    `--output` carries no short flag on any workload since v5.0.0, so `-o` is unambiguously the
+    owner here (issue #162).
     """
     archive = exports / f"{run_marker}-onedrive.zip"
     cli.ok(
@@ -151,7 +151,7 @@ def test_05_save_exports_the_file(
         settings.onedrive_owner,
         "-s",
         STATE["snapshot"],
-        "-O",
+        "--output",
         str(archive),
         timeout=WHOLE_DRIVE_TIMEOUT,
     )

--- a/e2e/tests/test_30_sharepoint.py
+++ b/e2e/tests/test_30_sharepoint.py
@@ -105,7 +105,7 @@ def test_06_save_exports_the_file(
         settings.sharepoint_site,
         "-s",
         STATE["snapshot"],
-        "-O",
+        "--output",
         str(archive),
     )
 

--- a/e2e/tests/test_35_regressions.py
+++ b/e2e/tests/test_35_regressions.py
@@ -147,6 +147,29 @@ def test_03_sdk_lists_the_snapshots_the_cli_wrote(settings: Settings, s3: Any) -
     )
 
 
+def test_04_retired_v4_invocations_fail_against_the_shipped_bundle(cli: Cli) -> None:
+    """Every v4 spelling v5.0.0 dropped is rejected rather than reinterpreted (#162, #322).
+
+    Exit code and message only: parsing fails before any Graph or S3 call, so the values below are
+    placeholders. The point is that a scheduled `atlas stats -s <site>` breaks loudly instead of
+    resolving the site as a snapshot id and reporting on the wrong scope. Here rather than in a
+    unit test because the failure has to hold for the bundle an operator's cron actually runs.
+    """
+    for argv, expected in (
+        (("stats", "-s", "contoso.sharepoint.com"), "Pass --site instead"),
+        (("outlook", "save", "-s", "snap-1", "-o", "export.zip"), "Pass --output instead"),
+        (
+            ("onedrive", "save", "-o", "owner", "-s", "snap-1", "-O", "export.zip"),
+            "Pass --output instead",
+        ),
+        (("replicate", "--status", "-m", "user@example.com"), "unknown option '--status'"),
+        (("config", "tenant.id", UNKNOWN_TENANT), "unknown command 'tenant.id'"),
+    ):
+        result = cli.run(*argv)
+        assert result.code != 0, result.describe()
+        assert expected in result.out, result.describe()
+
+
 def _sole_owner(s3: Any, settings: Settings) -> str:
     """The one Outlook owner segment in the bucket, read from the manifest keys."""
     owners = {key.split("/")[1] for key in storage.list_keys(s3, settings.bucket, "manifests/")}

--- a/e2e/tests/test_40_replication.py
+++ b/e2e/tests/test_40_replication.py
@@ -74,8 +74,8 @@ def test_02_replicate_copies_every_workload_and_the_key(
 
 
 def test_03_status_records_the_replication(cli: Cli, settings: Settings, s3: Any) -> None:
-    """`replicate --status` reads the sidecar records replication wrote on primary."""
-    cli.ok("replicate", "--status", "-m", settings.mailbox)
+    """`replicate status` reads the sidecar records replication wrote on primary."""
+    cli.ok("replicate", "status", "-m", settings.mailbox)
     assert storage.list_keys(s3, settings.bucket, "_meta/replication/"), (
         "no replication record written"
     )


### PR DESCRIPTION
## Summary

Stacked on #332, which reassigns the CLI's short flags and turns two flags into subcommands. The E2E suite drives the shipped bundle, so it was still typing the v4 spellings: `outlook save -o <path>`, `onedrive save -O <path>`, `sharepoint save -O <path>` and `replicate --status`. Every one of those now fails at parse time, which would have taken the nightly run down at the first export.

Merge #332 first, or merge this into it; the base branch is `feat/162-cli-flag-consistency`, not `dev`.

No assertion on Atlas output needed changing. The suite reads Graph state, S3 keys and exit codes, and the strings it does match on (`Resuming incremental sync`, `lock-capable`, `Status:          ready`, a snapshot id in `status` output) are unaffected by the banner-title change.

Along the way the missing-config error still told operators to run `atlas config <key> <value>`, so that string moved to `config set` on the base branch.

## Changes

- `test_10_outlook.py`: `outlook save -o` becomes `--output`.
- `test_20_onedrive.py`, `test_30_sharepoint.py`: `save -O` becomes `--output`, and the note explaining why OneDrive differed from Outlook is replaced by the rule that now holds everywhere.
- `test_40_replication.py`: `replicate --status` becomes `replicate status`.
- `test_35_regressions.py`: new case pinning every retired v4 spelling against the bundle, so a reintroduced alias fails the nightly run rather than silently changing what a cron job backs up.

## Evidence

The new regression case, run against `packages/cli/dist/cli.mjs` with no tenant (parsing fails first):

```console
argv=[stats -s contoso.sharepoint.com] exit=1
error: option '-s <value>' argument 'contoso.sharepoint.com' is invalid. -s no longer means --site in v5.0.0. Pass --site instead.
argv=[outlook save -s snap-1 -o export.zip] exit=1
error: option '-o <value>' argument 'export.zip' is invalid. -o no longer means --output in v5.0.0. Pass --output instead.
argv=[onedrive save -o owner -s snap-1 -O export.zip] exit=1
error: option '-O <value>' argument 'export.zip' is invalid. -O no longer means --output in v5.0.0. Pass --output instead.
argv=[replicate --status -m user@example.com] exit=1
error: unknown option '--status'
argv=[config tenant.id 00000000-0000-0000-0000-00000000e2e0] exit=1
error: unknown command 'tenant.id'
```

The four migrated invocations were run the same way and reach configuration resolution rather than a flag error, which is as far as they can get without credentials:

```console
$ atlas sharepoint save --site contoso.sharepoint.com -s snap-1 --output /tmp/e2e-out.zip
[x] Cannot load Atlas configuration.
[x]   Cause: Missing required config fields: ...
```

Also run: `uvx ruff check .`, `uvx ruff format --check .`, `uv run --frozen mypy .`, and `uv run python -m atlas_e2e.self_check` (10 safety checks pass).

Not verified: a full suite run. That needs the E2E tenant and MinIO, so the nightly `e2e.yml` run is the first end-to-end proof.

## Checklist

- [x] `uvx ruff check .` passes
- [x] `uvx ruff format --check .` passes
- [x] `uv run --frozen mypy .` passes
- [x] `atlas_e2e.self_check` passes
- [x] Every changed invocation exercised against the shipped bundle
- [x] Secrets and tenant data are not committed
- [x] Targets the stacked base branch, not `dev`
- [x] No package version was changed
- [x] Labelled for release notes