### PR TITLE
feat(cli): two configuration sources, store first

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,44 +1,44 @@
 # Configuration
 
-The Atlas CLI merges configuration from four sources, in this order. Later sources win.
+The Atlas CLI reads configuration from two sources. Later wins.
 
-1. **Config file**: `atlas.config.json` or `.atlas/config.json`, searched in cwd, then `~/.atlas/`
-2. **Encrypted secure store**: `~/.atlas/config.enc`, managed with `atlas config`
-3. **`.env` file**: loaded via dotenv, and does not overwrite existing environment variables
-4. **Environment variables**: always take precedence
+1. **Encrypted secure store**: `~/.atlas/config.enc`, written with `atlas config set`. The recommended source, and the only one that does not leave credentials readable on disk.
+2. **Environment variables**: `ATLAS_*`, either exported or read from a `.env` file in the directory Atlas runs in.
 
-This lets you keep defaults in a config file, credentials in the encrypted store on operator workstations, and environment variables for CI/CD or container orchestration where secrets are injected at runtime.
+Use the store on a workstation or a long-lived host, and environment variables where a platform injects secrets at runtime: containers, CI, a scheduled job with a unit-file environment.
 
-The SDK does not use this discovery chain. Pass credentials and tenant configuration explicitly to `createAtlasInstance`; v5 rejects missing or blank required fields, passphrases shorter than 14 UTF-8 bytes, and malformed HTTP(S) S3 endpoints before creating clients. The optional `atlas.validate()` probes an existing tenant bucket and Graph token acquisition without provisioning storage. See [SDK configuration validation](/reference/sdk#configuration-validation) for endpoint constraints and typed failures.
+Earlier versions also read a plaintext `atlas.config.json`. v5.0.0 does not read it at all; see [Migrating to v5](/migration/v5#configuration-sources) for the commands that replace it.
+
+The SDK uses neither source. Pass credentials and tenant configuration explicitly to `createAtlasInstance`; v5 rejects missing or blank required fields, passphrases shorter than 14 UTF-8 bytes, and malformed HTTP(S) S3 endpoints before creating clients. The optional `atlas.validate()` probes an existing tenant bucket and Graph token acquisition without provisioning storage. See [SDK configuration validation](/reference/sdk#configuration-validation) for endpoint constraints and typed failures.
 
 ## Variables
 
-Every setting has three equivalent forms: an environment variable, a config file field, and an `atlas config` key for the encrypted store.
+Every setting has two equivalent forms: an `atlas config` key for the encrypted store, and an environment variable.
 
 ### Microsoft 365 credentials
 
-| Variable              | Config field    | `atlas config` key | Required | Description                    |
-| --------------------- | --------------- | ------------------ | -------- | ------------------------------ |
-| `ATLAS_TENANT_ID`     | `tenant_id`     | `tenant.id`        | yes      | Azure AD tenant ID             |
-| `ATLAS_CLIENT_ID`     | `client_id`     | `client.id`        | yes      | App registration client ID     |
-| `ATLAS_CLIENT_SECRET` | `client_secret` | `client.secret`    | yes      | App registration client secret |
+| Variable              | `atlas config` key | Required | Description                    |
+| --------------------- | ------------------ | -------- | ------------------------------ |
+| `ATLAS_TENANT_ID`     | `tenant.id`        | yes      | Azure AD tenant ID             |
+| `ATLAS_CLIENT_ID`     | `client.id`        | yes      | App registration client ID     |
+| `ATLAS_CLIENT_SECRET` | `client.secret`    | yes      | App registration client secret |
 
 ### S3 storage
 
-| Variable              | Config field    | `atlas config` key | Required | Description                                    |
-| --------------------- | --------------- | ------------------ | -------- | ---------------------------------------------- |
-| `ATLAS_S3_ENDPOINT`   | `s3_endpoint`   | `s3.endpoint`      | yes      | S3 endpoint URL (e.g. `http://localhost:9000`) |
-| `ATLAS_S3_ACCESS_KEY` | `s3_access_key` | `s3.access-key`    | yes      | S3 access key                                  |
-| `ATLAS_S3_SECRET_KEY` | `s3_secret_key` | `s3.secret-key`    | yes      | S3 secret key                                  |
-| `ATLAS_S3_REGION`     | `s3_region`     | `s3.region`        | no       | S3 region (default: `us-east-1`)               |
+| Variable              | `atlas config` key | Required | Description                                    |
+| --------------------- | ------------------ | -------- | ---------------------------------------------- |
+| `ATLAS_S3_ENDPOINT`   | `s3.endpoint`      | yes      | S3 endpoint URL (e.g. `http://localhost:9000`) |
+| `ATLAS_S3_ACCESS_KEY` | `s3.access-key`    | yes      | S3 access key                                  |
+| `ATLAS_S3_SECRET_KEY` | `s3.secret-key`    | yes      | S3 secret key                                  |
+| `ATLAS_S3_REGION`     | `s3.region`        | no       | S3 region (default: `us-east-1`)               |
 
 ### Encryption
 
-| Variable                      | Config field            | `atlas config` key      | Required | Description                               |
-| ----------------------------- | ----------------------- | ----------------------- | -------- | ----------------------------------------- |
-| `ATLAS_ENCRYPTION_PASSPHRASE` | `encryption_passphrase` | `encryption.passphrase` | yes      | Master passphrase for envelope encryption |
+| Variable                      | `atlas config` key      | Required | Description                               |
+| ----------------------------- | ----------------------- | -------- | ----------------------------------------- |
+| `ATLAS_ENCRYPTION_PASSPHRASE` | `encryption.passphrase` | yes      | Master passphrase for envelope encryption |
 
-## The Encrypted Secure Store (`atlas config`)
+## The Encrypted Secure Store (`atlas config`), Recommended
 
 ```bash
 atlas config set tenant.id 4fa2a706-b26a-4bbe-9b1c-1e671b586b8f
@@ -58,46 +58,33 @@ Values are validated on save: format checks per key (GUID, URL, minimum passphra
 
 Because environment variables still win, `atlas config` warns when a saved value is currently shadowed by an `ATLAS_*` variable.
 
-## Config File Example
+## Environment Variables and `.env`
 
-```json
-{
-  "tenant_id": "your-azure-tenant-id",
-  "client_id": "app-client-id",
-  "client_secret": "app-client-secret",
-  "s3_endpoint": "http://localhost:9000",
-  "s3_access_key": "minioadmin",
-  "s3_secret_key": "minioadmin",
-  "encryption_passphrase": "my-secret-passphrase"
-}
+```bash
+export ATLAS_TENANT_ID=4fa2a706-b26a-4bbe-9b1c-1e671b586b8f
+atlas outlook backup -m john.doe@example.com
 ```
 
-Atlas loads the first config file it finds, searching in this order:
+A `.env` file in the working directory is loaded for the same variables, and does not overwrite one that is already exported. This is the source to use where the platform owns the secrets: a container's environment, a CI job's masked variables, a systemd unit's `EnvironmentFile`.
 
-1. `./atlas.config.json`
-2. `./.atlas/config.json`
-3. `~/.atlas/config.json`
-
-Values from the config file can be overridden by `.env` entries and environment variables.
+It is also the weaker source. A `.env` file is plaintext, and any process running as the same user can read both it and the environment of a running Atlas process. Prefer `atlas config set` wherever a person, rather than a platform, is supplying the value.
 
 ## Invalid Configuration
 
-If a required field is missing or invalid, Atlas exits immediately with an error listing every missing field. It will not start a backup with partial configuration. This fail-fast behavior prevents silent failures where a run appears successful but is missing critical settings like the encryption passphrase.
+If a required field is missing or invalid, Atlas exits immediately with an error listing every missing field and naming both sources. It will not start a backup with partial configuration. This fail-fast behavior prevents silent failures where a run appears successful but is missing critical settings like the encryption passphrase.
 
 ## S3 Path Style
 
 Atlas uses `forcePathStyle: true` when constructing the S3 client. This is **required** for MinIO and most self-hosted S3-compatible endpoints, which use path-style URLs (`http://host:9000/bucket-name`) rather than virtual-hosted-style (`http://bucket-name.host:9000`). AWS S3 supports both styles, so the setting is compatible there too.
 
-::: danger Secure Your Configuration Files
-The config file and `.env` file contain sensitive credentials: Azure client secrets, S3 access keys, and the encryption passphrase. On Linux, restrict file permissions immediately:
+::: danger Secure your `.env` file
+A `.env` file holds sensitive credentials in plaintext: Azure client secrets, S3 access keys, and the encryption passphrase. On Linux, restrict its permissions immediately:
 
 ```bash
-chmod 600 .env atlas.config.json
+chmod 600 .env
 ```
 
-Atlas enforces this at runtime. On Unix systems, if a config file has group- or world-readable bits set (`mode & 0o077 !== 0`), a warning is logged recommending `chmod 600`. It is a warning rather than a hard error to avoid breaking existing deployments, but address it promptly.
-
-Never commit these files to version control. The included `.gitignore` already excludes `.env`, but verify that your config file is also excluded. In multi-user environments, ensure only the service account running Atlas can read these files.
+Never commit it. The included `.gitignore` already excludes `.env`. In multi-user environments, ensure only the service account running Atlas can read it, and prefer `atlas config set`, which stores the same values encrypted with the key held in the OS keyring.
 :::
 
 ## Replication Target Config
@@ -125,5 +112,5 @@ Never commit these files to version control. The included `.gitignore` already e
 The encryption passphrase is **not** included in this file. Atlas uses a shared encryption model, so the passphrase from the main configuration applies to all targets.
 
 ::: danger Secure Target Config Files
-Target config files contain S3 credentials. Apply the same file permission restrictions as the main config file (`chmod 600`). Never commit them to version control.
+Target config files contain S3 credentials, so restrict them to the owner (`chmod 600`). Never commit them to version control. They are the one JSON file Atlas still reads: a peer target has no encrypted-store or environment equivalent.
 :::

--- a/docs/migration/v5.md
+++ b/docs/migration/v5.md
@@ -116,6 +116,40 @@ await atlas.outlook.save(snapshotId, { output: res });
 
 Passing both `output` and `outputPath` throws `ConfigError`. For a stream export the result reports `outputPath: ''`, and a failed run destroys the stream rather than ending it. See [Exporting to a Stream](/reference/sdk#exporting-to-a-stream), which closes [issue #44](https://github.com/wisecom-oy/atlas/issues/44).
 
+## Configuration sources
+
+The CLI read four sources: a plaintext `atlas.config.json`, the encrypted store, `.env`, and the environment. It now reads two, with the environment winning:
+
+1. the encrypted store at `~/.atlas/config.enc`, written with `atlas config set`
+2. `ATLAS_*` variables, exported or read from `.env` in the working directory
+
+`atlas.config.json`, `.atlas/config.json` and `~/.atlas/config.json` are no longer read. An upgrader who kept one and configured nothing else sees the same failure as an upgrader with no configuration at all:
+
+```console
+$ atlas outlook list
+[x] Cannot load Atlas configuration.
+[x]   Cause: Missing required config fields: tenant_id, client_id, ... Set them via "atlas config set <key> <value>", or ATLAS_* environment variables (exported, or in a .env file in the current directory).
+```
+
+Move each field to the store, which is the recommended source because the values are encrypted at rest with the key in the OS keyring:
+
+| Field in `atlas.config.json` | Replacement                                      |
+| ---------------------------- | ------------------------------------------------ |
+| `tenant_id`                  | `atlas config set tenant.id <value>`             |
+| `client_id`                  | `atlas config set client.id <value>`             |
+| `client_secret`              | `atlas config set client.secret -`               |
+| `s3_endpoint`                | `atlas config set s3.endpoint <value>`           |
+| `s3_access_key`              | `atlas config set s3.access-key <value>`         |
+| `s3_secret_key`              | `atlas config set s3.secret-key -`               |
+| `s3_region`                  | `atlas config set s3.region <value>`             |
+| `encryption_passphrase`      | `atlas config set encryption.passphrase -`       |
+
+`-` reads the value from stdin, so a secret never reaches shell history. Where a platform already injects secrets, keep using `ATLAS_*` variables: containers, CI and systemd units need no change. Delete the JSON file once its values are moved, and check `atlas config list`, which now reports `env` or `secure store` as each value's source.
+
+`--target-config` and `--source-config` on `replicate` and `rehydrate` are unaffected. Those name a peer target's S3 credentials, which have no store or environment equivalent.
+
+This closes [issue #334](https://github.com/wisecom-oy/atlas/issues/334).
+
 ## Next
 
 The CLI flag changes land in the same release and are documented here as they merge.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -971,7 +971,7 @@ atlas config validate                                             # live Graph +
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `config set <key> <value>` | Validate and save a value to the encrypted store; `-` reads the value from stdin                                  |
 | `config get <key>`         | Print the current effective value (secrets masked)                                                                |
-| `config list`              | Print every key with its value and source (`env`, `secure store`, `config file`)                                  |
+| `config list`              | Print every key with its value and source (`env` or `secure store`)                                               |
 | `config unset <key>`       | Remove a key from the encrypted store                                                                             |
 | `config validate`          | Probe Microsoft Graph (token request) and S3 (`ListBuckets`) with the effective config; exits non-zero on failure |
 

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -4,7 +4,7 @@ Atlas ships as two npm packages:
 
 | Package                  | Install                             | Use when                                                                                                                                     |
 | ------------------------ | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`@wisecom/atlas-cli`** | `npm install -g @wisecom/atlas-cli` | Day-to-day operations from a shell: cron jobs, one-off backups, operator workflows. Reads `.env` and config files.                           |
+| **`@wisecom/atlas-cli`** | `npm install -g @wisecom/atlas-cli` | Day-to-day operations from a shell: cron jobs, one-off backups, operator workflows. Reads the encrypted store and `ATLAS_*` variables.       |
 | **`@wisecom/atlas-sdk`** | `npm add @wisecom/atlas-sdk`        | Embedding Atlas in your own Node.js app: multi-tenant SaaS, custom schedulers, portals, or automation that needs typed programmatic control. |
 
 This page documents **`@wisecom/atlas-sdk`**. For shell commands and flags, see [CLI Commands](/reference/cli).
@@ -33,7 +33,7 @@ const atlas = createAtlasInstance({
 });
 ```
 
-All credentials and tenant configuration are explicit. The SDK does not discover them in environment variables, `.env`, or config files, so a stale file or another tenant's inherited configuration cannot select credentials. The environment-loading container factory is not exported. Standard runtime controls such as TLS certificate validation still apply.
+All credentials and tenant configuration are explicit. The SDK does not discover them in environment variables or `.env`, so a stale file or another tenant's inherited configuration cannot select credentials. The environment-loading container factory is not exported. Standard runtime controls such as TLS certificate validation still apply.
 
 The tenant is bound at creation time, so every method operates within that tenant scope. Methods are async and return Promises.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -405,19 +405,11 @@ Read-only commands load the tenant context without provisioning: the bucket is n
 
 Grant a monitoring or audit principal the read-only row only. If it holds `s3:CreateBucket`, that is a leftover from Atlas versions before 2.1.0-beta and can be revoked.
 
-## Configuration File Security
+## Configuration Security
 
-### Filesystem Permission Check
+Configuration comes from two places: the encrypted store, and `ATLAS_*` variables read from the environment or a `.env` file in the working directory. A plaintext `atlas.config.json` was a third source until v5.0.0; it held `encryption_passphrase` and `client_secret` in the clear, and Atlas compensated with a load-time permission warning. Removing it removed the need for the warning.
 
-`atlas.config.json` may contain `encryption_passphrase` and `client_secret` in plaintext. On Unix systems, Atlas checks the file's permissions at load time and logs a warning if the file is group- or world-readable (i.e., any bits in `0o077` are set):
-
-```
-WARN Config file /home/user/atlas.config.json has overly permissive permissions (mode 0644). Recommended: chmod 600 /home/user/atlas.config.json
-```
-
-This check is skipped on Windows where Unix permission bits do not apply. The check is advisory (warning, not error) to avoid breaking existing deployments, but operators are strongly encouraged to restrict config files to owner-only access (`chmod 600`).
-
-Environment variables (`ATLAS_*`) and `.env` files avoid the JSON file but remain readable from the process environment and from plaintext dotfiles — the exact locations credential-stealing malware sweeps first.
+Environment variables and `.env` files remain readable from the process environment and from a plaintext dotfile, which is where credential-stealing malware looks first. They are the right source where a platform owns the secret, and the wrong one where a person does.
 
 ### Encrypted Secure Store
 

--- a/e2e/atlas_e2e/atlas.py
+++ b/e2e/atlas_e2e/atlas.py
@@ -100,7 +100,7 @@ class Cli:
             capture_output=True,
             text=True,
             timeout=timeout,
-            cwd=self._home,  # no repo-root atlas.config.json in scope
+            cwd=self._home,  # away from the repo root, so only the env vars below configure it
             env=env,
         )
         result = Result(

--- a/packages/cli/src/commands/config.command.ts
+++ b/packages/cli/src/commands/config.command.ts
@@ -12,13 +12,11 @@ import {
   read_env_overrides,
   read_secure_config,
   secure_config_dir,
-  try_load_config_file,
   write_secure_config,
 } from '@wisecom/atlas-core';
 import { create_s3_client } from '@wisecom/atlas-s3';
 
 type ConfigSources = {
-  readonly file: Partial<AtlasConfig>;
   readonly secure: Partial<AtlasConfig>;
   readonly env: Partial<AtlasConfig>;
   readonly merged: Partial<AtlasConfig>;
@@ -229,17 +227,14 @@ async function probe_s3(config: Partial<AtlasConfig>): Promise<boolean> {
   }
 }
 
-/** Reads all three config sources plus their merge (env wins). */
+/** Reads both config sources plus their merge (env wins). */
 function read_sources(): ConfigSources {
-  const file = try_load_config_file();
   const secure = read_secure_config();
   const env = read_env_overrides();
-  return { file, secure, env, merged: { ...file, ...secure, ...env } };
+  return { secure, env, merged: { ...secure, ...env } };
 }
 
-/** Names the highest-precedence source that provides a field. */
+/** Names the higher-precedence source that provides a field. */
 function resolve_source(sources: ConfigSources, field: keyof AtlasConfig): string {
-  if (sources.env[field] !== undefined) return 'env';
-  if (sources.secure[field] !== undefined) return 'secure store';
-  return 'config file';
+  return sources.env[field] === undefined ? 'secure store' : 'env';
 }

--- a/packages/cli/tests/unit/config-command.test.ts
+++ b/packages/cli/tests/unit/config-command.test.ts
@@ -27,7 +27,6 @@ const mocks = vi.hoisted(() => ({
   read_secure_config: vi.fn(),
   write_secure_config: vi.fn(),
   read_env_overrides: vi.fn(),
-  try_load_config_file: vi.fn(),
   secure_config_dir: vi.fn(() => '/tmp/fake-atlas'),
 }));
 vi.mock('@wisecom/atlas-core', async (import_original) => {
@@ -67,7 +66,6 @@ beforeEach(() => {
   vi.spyOn(console, 'warn').mockImplementation(capture);
   vi.spyOn(console, 'error').mockImplementation(capture);
 
-  mocks.try_load_config_file.mockReturnValue({});
   mocks.read_env_overrides.mockReturnValue({});
   mocks.read_secure_config.mockReturnValue({});
   azure_mocks.get_token.mockResolvedValue({ token: 'fake' });
@@ -175,7 +173,6 @@ describe('atlas config list', () => {
   });
 
   it('names the source a value resolves from, environment winning', async () => {
-    mocks.try_load_config_file.mockReturnValue({ s3_region: 'from-file' });
     mocks.read_secure_config.mockReturnValue({ s3_region: 'from-store' });
     mocks.read_env_overrides.mockReturnValue({ s3_region: 'from-env' });
 

--- a/packages/cli/tests/unit/config-secret-masking.test.ts
+++ b/packages/cli/tests/unit/config-secret-masking.test.ts
@@ -16,7 +16,6 @@ const mocks = vi.hoisted(() => ({
   read_secure_config: vi.fn(),
   write_secure_config: vi.fn(),
   read_env_overrides: vi.fn(),
-  try_load_config_file: vi.fn(),
   secure_config_dir: vi.fn(() => '/tmp/fake-atlas'),
 }));
 
@@ -66,7 +65,6 @@ beforeEach(() => {
   vi.spyOn(console, 'warn').mockImplementation(capture);
   vi.spyOn(console, 'error').mockImplementation(capture);
 
-  mocks.try_load_config_file.mockReturnValue({});
   mocks.read_env_overrides.mockReturnValue({});
   mocks.read_secure_config.mockReturnValue(full_config());
 });

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -1,8 +1,4 @@
-import { readFileSync, existsSync, statSync } from 'node:fs';
-import { resolve, join } from 'node:path';
-import { homedir, platform } from 'node:os';
 import { config as load_dotenv } from 'dotenv';
-import { logger } from '@/utils/logger';
 import { read_secure_config } from '@/utils/secure-config-store';
 
 export interface GraphConfig {
@@ -26,8 +22,6 @@ export type AtlasConfig = GraphConfig & S3Config & CryptoConfig;
 
 export const ATLAS_CONFIG_TOKEN = Symbol.for('AtlasConfig');
 
-const CONFIG_FILE_NAMES = ['atlas.config.json', join('.atlas', 'config.json')];
-
 const ENV_MAP: Record<string, keyof AtlasConfig> = {
   ATLAS_TENANT_ID: 'tenant_id',
   ATLAS_CLIENT_ID: 'client_id',
@@ -40,73 +34,20 @@ const ENV_MAP: Record<string, keyof AtlasConfig> = {
 };
 
 /**
- * Loads Atlas configuration by merging sources in this order
- * (later sources override earlier ones):
- *   1. atlas.config.json file
- *   2. Encrypted secure store (~/.atlas/config.enc, managed via "atlas config")
- *   3. .env file (loaded into process.env via dotenv, does NOT overwrite existing vars)
- *   4. Real environment variables (always win)
- * Throws if any required field is missing after merging.
+ * Loads Atlas configuration from the two sources v5.0.0 supports, environment winning:
+ *   1. the encrypted store at `~/.atlas/config.enc`, written by `atlas config set`
+ *   2. `ATLAS_*` environment variables, exported or read from `.env` in the working directory
+ *
+ * A plaintext `atlas.config.json` used to be a third source, searched in the working directory
+ * and then in `$HOME`. It held `client_secret` and `encryption_passphrase` in the clear, needed a
+ * permission warning to compensate, and let a stale file in `$HOME` supply credentials to a run
+ * somewhere else (issue #334). Throws if any required field is missing after merging.
  */
 export function load_config(): AtlasConfig {
   // quiet: dotenv's load banner goes to stdout, which corrupts pipeable output
   // such as `atlas outlook read --raw > message.eml`.
   load_dotenv({ quiet: true });
-  const file_config = try_load_config_file();
-  const secure_config = read_secure_config();
-  const env_overrides = read_env_overrides();
-  return merge_and_validate({ ...file_config, ...secure_config, ...env_overrides });
-}
-
-/**
- * Searches for a config file in the current directory and the user's
- * home directory. Returns the parsed contents, or an empty object if
- * no file is found.
- */
-export function try_load_config_file(): Partial<AtlasConfig> {
-  const search_dirs = [process.cwd(), homedir()];
-
-  for (const dir of search_dirs) {
-    for (const name of CONFIG_FILE_NAMES) {
-      const file_path = resolve(dir, name);
-      if (existsSync(file_path)) {
-        return parse_config_file(file_path);
-      }
-    }
-  }
-
-  return {};
-}
-
-/** Reads and JSON-parses a single config file. */
-function parse_config_file(file_path: string): Partial<AtlasConfig> {
-  warn_if_world_readable(file_path);
-  const raw = readFileSync(file_path, 'utf-8');
-  const parsed: unknown = JSON.parse(raw);
-
-  if (typeof parsed !== 'object' || parsed === null) {
-    throw new Error(`Config file ${file_path} must contain a JSON object`);
-  }
-
-  return parsed as Partial<AtlasConfig>;
-}
-
-/** Warns if a config file has group- or world-readable permissions (Unix only). */
-function warn_if_world_readable(file_path: string): void {
-  if (platform() === 'win32') return;
-  try {
-    const stat = statSync(file_path);
-    const other_bits = stat.mode & 0o077;
-    if (other_bits !== 0) {
-      const mode_str = `0${(stat.mode & 0o777).toString(8)}`;
-      logger.warn(
-        `Config file ${file_path} has overly permissive permissions (mode ${mode_str}). ` +
-          `Recommended: chmod 600 ${file_path}`,
-      );
-    }
-  } catch {
-    /* stat failure is non-fatal — config will fail at read anyway */
-  }
+  return merge_and_validate({ ...read_secure_config(), ...read_env_overrides() });
 }
 
 /**
@@ -146,7 +87,8 @@ export function merge_and_validate(partial: Partial<AtlasConfig>): AtlasConfig {
   if (missing.length > 0) {
     throw new Error(
       `Missing required config fields: ${missing.join(', ')}. ` +
-        'Set them via "atlas config set <key> <value>", atlas.config.json, or ATLAS_* environment variables.',
+        'Set them via "atlas config set <key> <value>", or ATLAS_* environment variables ' +
+        '(exported, or in a .env file in the current directory).',
     );
   }
 

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,11 +1,6 @@
 export { logger } from './logger';
 export type { AtlasConfig, GraphConfig, S3Config, CryptoConfig } from './config';
-export {
-  load_config,
-  try_load_config_file,
-  read_env_overrides,
-  ATLAS_CONFIG_TOKEN,
-} from './config';
+export { load_config, read_env_overrides, ATLAS_CONFIG_TOKEN } from './config';
 export {
   read_secure_config,
   write_secure_config,

--- a/packages/core/tests/unit/utils/config.test.ts
+++ b/packages/core/tests/unit/utils/config.test.ts
@@ -1,16 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  load_config,
-  try_load_config_file,
-  read_env_overrides,
-  merge_and_validate,
-} from '@/utils/config';
+import { load_config, read_env_overrides, merge_and_validate } from '@/utils/config';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
+import { read_secure_config } from '@/utils/secure-config-store';
 
 vi.mock('node:fs');
-vi.mock('node:os');
 vi.mock('dotenv', () => ({ config: vi.fn() }));
+vi.mock('@/utils/secure-config-store', () => ({ read_secure_config: vi.fn(() => ({})) }));
 
 const ALL_ENV_KEYS = [
   'ATLAS_TENANT_ID',
@@ -110,54 +105,43 @@ describe('config', () => {
     });
   });
 
-  describe('try_load_config_file', () => {
-    it('returns parsed contents when atlas.config.json exists in cwd', () => {
-      vi.mocked(os.homedir).mockReturnValue('/home/testuser');
-      vi.mocked(fs.existsSync).mockImplementation((p) => {
-        return String(p).includes('atlas.config.json') && !String(p).includes('.atlas');
-      });
-      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(FULL_CONFIG));
-
-      const result = try_load_config_file();
-      expect(result).toEqual(FULL_CONFIG);
-    });
-
-    it('returns empty object when no config file is found', () => {
-      vi.mocked(os.homedir).mockReturnValue('/home/testuser');
-      vi.mocked(fs.existsSync).mockReturnValue(false);
-      expect(try_load_config_file()).toEqual({});
-    });
-  });
-
   describe('load_config', () => {
-    it('merges file and env with env taking precedence', () => {
-      vi.mocked(os.homedir).mockReturnValue('/home/testuser');
-      vi.mocked(fs.existsSync).mockImplementation((p) => {
-        return String(p).includes('atlas.config.json') && !String(p).includes('.atlas');
-      });
-      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(FULL_CONFIG));
-
+    it('merges the secure store and the environment, environment winning', () => {
+      vi.mocked(read_secure_config).mockReturnValue(FULL_CONFIG);
       process.env['ATLAS_CLIENT_SECRET'] = 'env-override';
 
       const result = load_config();
+
       expect(result.tenant_id).toBe('tid');
       expect(result.client_secret).toBe('env-override');
     });
 
-    it('works with env vars only (no config file)', () => {
-      vi.mocked(os.homedir).mockReturnValue('/home/testuser');
-      vi.mocked(fs.existsSync).mockReturnValue(false);
+    it('works from environment variables alone', () => {
+      vi.mocked(read_secure_config).mockReturnValue({});
       set_all_env();
 
       const result = load_config();
+
       expect(result.tenant_id).toBe('tid');
       expect(result.s3_endpoint).toBe('http://localhost:9000');
     });
 
-    it('throws when config is incomplete', () => {
-      vi.mocked(os.homedir).mockReturnValue('/home/testuser');
-      vi.mocked(fs.existsSync).mockReturnValue(false);
+    // #334: a plaintext atlas.config.json used to be a third source, found in the working
+    // directory or in $HOME. It is not read at all now, so a run that still has one and nothing
+    // else fails naming the two supported sources rather than picking up stale credentials.
+    it('ignores a JSON config file in the working directory', () => {
+      vi.mocked(read_secure_config).mockReturnValue({});
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(FULL_CONFIG));
+
       expect(() => load_config()).toThrow('Missing required config fields');
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it('throws when configuration is incomplete', () => {
+      vi.mocked(read_secure_config).mockReturnValue({});
+
+      expect(() => load_config()).toThrow('atlas config set');
     });
   });
 });

--- a/tools/diagnostics.sh
+++ b/tools/diagnostics.sh
@@ -85,13 +85,11 @@ echo "Git commit: $(git_commit) ($(git_state))"
 # "Docker version 29.4.0, build 9d7ad9f" -> "29.4.0"
 echo "Docker: $(version_of docker --version | sed -E 's/^Docker version ([^,]+).*/\1/')"
 
-# Atlas merges configuration from four sources, later winning over earlier, so
-# "which sources exist" is usually the first question a config bug raises.
+# Atlas reads configuration from the encrypted store and from ATLAS_* variables, environment
+# winning, so "which sources exist" is usually the first question a config bug raises.
 echo ""
 echo "Config sources"
 echo "--------------"
-echo "atlas.config.json: $(present atlas.config.json)"
-echo "~/.atlas/config.json: $(present "$HOME/.atlas/config.json")"
 echo "~/.atlas/config.enc: $(present "$HOME/.atlas/config.enc")"
 echo ".env: $(present .env)"
 


### PR DESCRIPTION
## Summary

Configuration had four sources, and the plaintext one was the problem: `atlas.config.json` held `client_secret` and `encryption_passphrase` in the clear, was searched in three locations with first-match-wins, and needed its own permission-warning machinery to compensate. A stale file in `$HOME` could supply credentials to a run in another directory.

It is gone. Configuration now resolves from the encrypted store written by `atlas config set`, then from `ATLAS_*` variables, exported or read from `.env` in the working directory. The docs lead with the store, because it is the only source that does not leave credentials readable on disk.

Stacked on #332, which restructured `atlas config` into subcommands and rewrote the pages this touches. The base branch is `feat/162-cli-flag-consistency`, not `dev`.

Closes #334

## Changes

- Delete `try_load_config_file`, `parse_config_file`, `warn_if_world_readable` and `CONFIG_FILE_NAMES` from `packages/core/src/utils/config.ts`, and drop the export.
- `load_config` is dotenv, then the secure store, then the environment. The missing-field error names both surviving sources.
- `atlas config list` reports `env` or `secure store`; the `config file` label is gone, along with the third source in `read_sources`.
- Rewrite `docs/configuration.md` around two sources, leading with `atlas config` as recommended, and drop the config-file example, its search order and its permission section.
- `docs/security.md` replaces the config-file permission check with what the two sources actually defend against; `docs/migration/v5.md` gains a field-by-field replacement table; `tools/diagnostics.sh` stops probing for the JSON files.
- Regression coverage: a JSON config file in the working directory is not read, and the resulting failure names `atlas config set`.

`--target-config` and `--source-config` on `replicate` and `rehydrate` are untouched. Those name a peer target's S3 credentials, which have no store or environment equivalent, and the migration page says so.

## Evidence

Run against the built bundle in a temporary directory holding a complete `atlas.config.json` and nothing else:

```console
$ atlas outlook list
[x]   Cause: Missing required config fields: tenant_id, client_id, client_secret, s3_endpoint, s3_access_key, s3_secret_key, encryption_passphrase. Set them via "atlas config set <key> <value>", or ATLAS_* environment variables (exported, or in a .env file in the current directory).
```

Adding a `.env` to the same directory gets the command past configuration loading, and the source labels are the two that remain:

```console
$ atlas config list
[*] tenant.id                00000000-0000-0000-0000-000000000000  (env)
[*] client.secret            ****tenv  (env)
[*] s3.region                <unset>
[*] Secure store: /tmp/.../.atlas/config.enc
```

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run format:check` passes
- [x] `pnpm run test` passes with no regressions
- [x] `pnpm run typecheck` passes
- [x] `pnpm run docs:build` passes
- [x] `uvx ruff check .` and `uvx ruff format --check .` pass in `e2e`
- [x] Behaviour verified against the shipped bundle, not only in unit tests
- [x] No file exceeds 300 effective lines
- [x] No relative imports were added
- [x] Secrets and credentials are not committed
- [x] Targets the stacked base branch, not `dev`
- [x] No package version was changed
- [x] Labelled for release notes