### PR TITLE
fix(backup): reject a drive transfer that is not the bytes it asked for

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -85,6 +85,35 @@ Implementation thresholds from `@wisecom/atlas-onedrive`:
 
 Chunked downloads retry each **4 MiB** range independently (5 attempts with backoff in the adapter), so a transient failure replays a single chunk instead of the whole file. Each range request is also aborted if the chunk has not transferred at roughly 256 KB/s, with a floor of 30 seconds. That budget is sized from the chunk being fetched, not the file, so a dead connection costs about 30 seconds and then a retry regardless of whether the file is 5 MB or 5 GB.
 
+#### What a chunk has to prove before it is stored
+
+The checksum Atlas records is computed over the bytes that arrived, so it cannot tell a truncated
+transfer from a complete one: a one byte body produces a perfectly valid SHA-256 for one byte, and
+AES-GCM authenticates it just as happily. Every check therefore compares the transfer against an
+expectation formed before it started.
+
+| Check                | Rejected                                                                                     |
+| -------------------- | -------------------------------------------------------------------------------------------- |
+| Body length          | A `206` whose body is not exactly the number of bytes the `Range` header asked for            |
+| `Content-Range`      | A `206` with a missing, unparseable, or mismatched `Content-Range`, including the `*` form    |
+| Whole-file responses | A `200` answering a range request whose body is not the item's full reported size             |
+| Total transferred    | A streamed large file whose chunks do not add up to the size Graph reported for the item      |
+
+`Content-Range` is required rather than optional because it is the only thing that identifies which
+bytes of the file arrived. Without it a server answering every range with the same chunk would be
+indistinguishable from a correct one, and the result would be a validly encrypted backup of the
+wrong content.
+
+One more case is a restart rather than a truncation. If the CDN honours the first range requests
+and then answers a later one with the whole file, the whole-file fallback would start again at byte
+zero while the chunks already consumed are inside the cipher, producing an object holding a prefix
+followed by the entire file. Atlas fails the item instead. The next run retries it and takes the
+streamed path from the first chunk. A CDN that ignores `Range` from the very first request is
+unaffected, since nothing has been consumed yet.
+
+A failed check fails that item, not the run. The file is recorded in the failed-item ledger, no
+manifest entry is written for it, and the next backup retries it.
+
 ### Unicode Path Handling
 
 OneDrive paths and file names from Graph are normalized to **Unicode NFC** in the connector and catalog (`String.prototype.normalize('NFC')`). That aligns macOS (often NFD) with Windows and Linux naming, so the same logical path does not produce duplicate index entries after sync.

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -92,6 +92,15 @@ SharePoint's direct download URLs (pre-authenticated CDN links via `@microsoft.g
 - **Exponential backoff** when `Retry-After` is absent or carries no usable wait (base 1s, max 32s, with jitter). A `Retry-After` in the past is treated as absent, since honouring it as "retry now" would remove the jitter that stops concurrent workers retrying in lockstep. A value further out than an hour is capped at an hour and treated as a server bug rather than an instruction.
 - **Graph content fallback.** If the pre-authenticated URL fails after retries, Atlas falls back to `GET /drives/{drive_id}/items/{item_id}/content`, which routes through the Graph gateway rather than the CDN.
 - **Stall timeout per chunk.** Each range request is aborted if the chunk has not transferred at roughly 256 KB/s, with a floor of 30 seconds. The budget is sized from the chunk being fetched, not the file, so a dead connection costs about 30 seconds and then a retry regardless of whether the file is 5 MB or 5 GB. If the CDN ignores the `Range` header and answers `200` with the whole file, the budget is re-sized to that body before it is read.
+- **Transfer validation.** A `206` is rejected unless its body is exactly the requested length and
+  its `Content-Range` names the range that was asked for, a `200` answering a range request is
+  rejected unless it carries the item's full reported size, and a streamed large file is rejected
+  unless its chunks add up to that size. A recorded checksum is computed over whatever arrived, so
+  without these an interrupted transfer becomes a validly encrypted backup of the wrong bytes. If
+  the CDN starts ignoring `Range` partway through a file, the item fails rather than having the
+  whole-file body appended to the chunks already consumed. See
+  [What a chunk has to prove before it is stored](/onedrive-backup#what-a-chunk-has-to-prove-before-it-is-stored)
+  for the full table; the two providers behave identically here.
 
 ## Failed Items and Delta Progress
 

--- a/packages/drive/src/backup/download-integrity.ts
+++ b/packages/drive/src/backup/download-integrity.ts
@@ -1,0 +1,77 @@
+/**
+ * Length checks for downloaded drive content.
+ *
+ * A backup that hashes whatever arrived cannot detect a truncated transfer: the SHA-256 is computed
+ * over the received bytes, so a one byte body produces a perfectly valid checksum for one byte, and
+ * AES-GCM authenticates that byte just as happily. The only defence is an expectation formed before
+ * the transfer, from the range that was requested and the size Graph reported (issue #338).
+ */
+
+/** Raised when a transfer delivered something other than the bytes that were asked for. */
+export class DownloadIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DownloadIntegrityError';
+  }
+}
+
+/**
+ * Fails a `206` that does not deliver exactly the requested range.
+ *
+ * RFC 9110 requires `Content-Range` on a partial response, so a missing header is itself a reason
+ * to distrust the body: without it there is nothing to say which bytes of the file arrived, and a
+ * server answering every range with the same chunk would be indistinguishable from a correct one.
+ */
+export function assert_range_chunk(
+  item_id: string,
+  range_start: number,
+  range_end: number,
+  content_range: string | null,
+  body_length: number,
+): void {
+  const expected_length = range_end - range_start + 1;
+  if (body_length !== expected_length) {
+    throw new DownloadIntegrityError(
+      `Range bytes=${range_start}-${range_end} of ${item_id} returned ${body_length} bytes, ` +
+        `expected ${expected_length}`,
+    );
+  }
+
+  const satisfied = parse_content_range(content_range);
+  if (!satisfied) {
+    throw new DownloadIntegrityError(
+      `Range bytes=${range_start}-${range_end} of ${item_id} came back without a usable ` +
+        `Content-Range header (got ${content_range ?? 'none'})`,
+    );
+  }
+  if (satisfied.start !== range_start || satisfied.end !== range_end) {
+    throw new DownloadIntegrityError(
+      `Range bytes=${range_start}-${range_end} of ${item_id} was answered with ` +
+        `bytes ${satisfied.start}-${satisfied.end}`,
+    );
+  }
+}
+
+/**
+ * Fails a transfer whose byte count does not match the size Graph reported for the item.
+ *
+ * A reported size of zero means the delta page carried no `size` field, so there is no expectation
+ * to check against and the transfer is accepted as-is.
+ */
+export function assert_transferred_size(
+  item_id: string,
+  transferred_bytes: number,
+  expected_bytes: number,
+): void {
+  if (expected_bytes <= 0 || transferred_bytes === expected_bytes) return;
+  throw new DownloadIntegrityError(
+    `Download of ${item_id} produced ${transferred_bytes} bytes, expected ${expected_bytes}`,
+  );
+}
+
+/** Parses the `bytes <start>-<end>/<size>` form; anything else, including `*`, is unusable. */
+function parse_content_range(header: string | null): { start: number; end: number } | undefined {
+  const match = /^bytes (\d+)-(\d+)\/(?:\d+|\*)$/.exec(header?.trim() ?? '');
+  if (!match) return undefined;
+  return { start: Number(match[1]), end: Number(match[2]) };
+}

--- a/packages/drive/src/backup/large-file-pipeline.ts
+++ b/packages/drive/src/backup/large-file-pipeline.ts
@@ -2,6 +2,7 @@ import { logger } from '@wisecom/atlas-core/utils/logger';
 import { stream_to_content_addressed_storage } from '@wisecom/atlas-core/services/shared/stream-encrypt-upload';
 import type { StorageObjectLockPolicy, TenantContext } from '@wisecom/atlas-types';
 import type { DriveDeltaItem } from '@/drive-ports';
+import { assert_transferred_size } from '@/backup/download-integrity';
 import { format_bytes } from '@/shared/format-bytes';
 import type { DriveStorageKeys } from '@/shared/storage-keys';
 
@@ -57,7 +58,7 @@ export async function process_large_drive_file(
 
   const result = await stream_to_content_addressed_storage(
     ctx,
-    deps.fetch_chunks(download_url, item.size_bytes, item.item_id),
+    counted_chunks(deps.fetch_chunks(download_url, item.size_bytes, item.item_id), item),
     {
       staging_key,
       staging_prefix: deps.keys.staging_prefix_for(owner_id),
@@ -73,6 +74,26 @@ export async function process_large_drive_file(
   }
 
   return result;
+}
+
+/**
+ * Passes chunks straight through, then fails the item if they did not add up to its reported size.
+ *
+ * The last point where a truncated, duplicated or restarted transfer can still be caught: past it
+ * the bytes have a checksum and an auth tag of their own, and nothing downstream knows how many
+ * there should have been (issue #338). Throwing here aborts the staged multipart upload, so no
+ * canonical object is promoted and no manifest entry is written.
+ */
+async function* counted_chunks(
+  chunks: AsyncIterable<Buffer>,
+  item: DriveDeltaItem,
+): AsyncGenerator<Buffer> {
+  let transferred = 0;
+  for await (const chunk of chunks) {
+    transferred += chunk.length;
+    yield chunk;
+  }
+  assert_transferred_size(item.item_id, transferred, item.size_bytes);
 }
 
 /** Removes leftover staging objects and incomplete multipart uploads. */

--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -24,6 +24,11 @@ export {
 export { format_bytes } from '@/shared/format-bytes';
 export { LARGE_FILE_THRESHOLD } from '@/backup/large-file-threshold';
 export {
+  assert_range_chunk,
+  assert_transferred_size,
+  DownloadIntegrityError,
+} from '@/backup/download-integrity';
+export {
   stream_whole_file_in_chunks,
   type WholeFileStreamOptions,
 } from '@/backup/whole-file-stream';

--- a/packages/drive/tests/unit/backup/download-integrity.test.ts
+++ b/packages/drive/tests/unit/backup/download-integrity.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { assert_range_chunk, assert_transferred_size } from '@/backup/download-integrity';
+
+// Issue #338: the checksum is computed over whatever arrived, so a truncated, duplicated or
+// restarted transfer produces a validly encrypted object with a matching checksum. The only
+// defence is the expectation formed before the transfer.
+
+describe('assert_range_chunk (issue #338)', () => {
+  it('rejects a 206 body shorter than the range that was requested', () => {
+    expect(() => assert_range_chunk('item-1', 0, 4_194_303, 'bytes 0-0/8388608', 1)).toThrow(
+      /returned 1 bytes, expected 4194304/,
+    );
+  });
+
+  it('rejects a 206 that answered a range other than the one asked for', () => {
+    expect(() =>
+      assert_range_chunk('item-1', 4_194_304, 8_388_607, 'bytes 0-4194303/8388608', 4_194_304),
+    ).toThrow(/was answered with bytes 0-4194303/);
+  });
+
+  it('rejects a 206 with no usable Content-Range, so a repeated chunk cannot pass unnoticed', () => {
+    expect(() => assert_range_chunk('item-1', 0, 3, null, 4)).toThrow(/without a usable/);
+    expect(() => assert_range_chunk('item-1', 0, 3, 'bytes */8388608', 4)).toThrow(
+      /without a usable/,
+    );
+  });
+
+  it('accepts the range it asked for', () => {
+    expect(() => assert_range_chunk('item-1', 0, 3, 'bytes 0-3/8', 4)).not.toThrow();
+  });
+});
+
+describe('assert_transferred_size (issue #338)', () => {
+  it('accepts a transfer with no reported size to check against', () => {
+    expect(() => assert_transferred_size('item-1', 12, 0)).not.toThrow();
+  });
+
+  it('rejects a short and an over-long transfer alike', () => {
+    expect(() => assert_transferred_size('item-1', 5, 8)).toThrow(/produced 5 bytes, expected 8/);
+    expect(() => assert_transferred_size('item-1', 12, 8)).toThrow(/produced 12 bytes, expected 8/);
+  });
+});

--- a/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
@@ -1,5 +1,6 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import { stream_whole_file_in_chunks } from '@wisecom/atlas-drive/backup/whole-file-stream';
+import { assert_range_chunk } from '@wisecom/atlas-drive/backup/download-integrity';
 import {
   is_retryable_error,
   is_transient_error,
@@ -45,14 +46,16 @@ export async function* fetch_file_chunks(
   item_id: string,
 ): AsyncGenerator<Buffer> {
   const chunk_count = Math.ceil(total_bytes / CHUNK_SIZE_BYTES);
+  let yielded_chunks = 0;
 
   for (let i = 0; i < chunk_count; i++) {
     const range_start = i * CHUNK_SIZE_BYTES;
     const range_end = Math.min(range_start + CHUNK_SIZE_BYTES - 1, total_bytes - 1);
     const expected_length = range_end - range_start + 1;
 
+    let chunk: Buffer;
     try {
-      yield await download_chunk_with_retry(
+      chunk = await download_chunk_with_retry(
         download_url,
         range_start,
         range_end,
@@ -65,9 +68,19 @@ export async function* fetch_file_chunks(
       );
     } catch (err) {
       if (!(err instanceof RangeIgnoredError)) throw err;
+      // The streamed pass restarts at byte zero, so it can only replace the chunks already handed
+      // to the consumer, never continue them. Once one has been yielded the consumer has fed it
+      // into a cipher and appending a second copy of the file would produce a validly encrypted
+      // object holding a prefix plus the whole file (issue #338). Fail the item instead; the next
+      // run retries it and takes the streamed path from the first chunk.
+      if (yielded_chunks > 0) {
+        throw new Error(
+          `Range requests stopped being honoured for ${item_id} after ${yielded_chunks} chunk(s); ` +
+            `the partial transfer cannot be continued by a whole-file download`,
+        );
+      }
       // Every remaining chunk would fetch and discard the same whole file: a 1 GiB item costs
-      // 256 GiB transferred to produce 1 GiB. One streamed pass delivers the rest, and the
-      // chunks already yielded are re-read from the start, which is the price of finding out.
+      // 256 GiB transferred to produce 1 GiB. One streamed pass delivers the whole file instead.
       logger.warn(
         `Range requests are ignored for ${item_id} (HTTP 200 with the full body); ` +
           `falling back to one streamed download`,
@@ -80,6 +93,8 @@ export async function* fetch_file_chunks(
       });
       return;
     }
+    yielded_chunks++;
+    yield chunk;
   }
 }
 
@@ -211,16 +226,24 @@ async function download_single_chunk(
     const buf = Buffer.from(await response.arrayBuffer());
 
     if (response.status === 200) {
-      // A single-chunk item legitimately comes back whole, so the slice is a no-op there.
-      if (buf.length < range_end + 1) {
+      // A single-chunk item legitimately comes back whole, so the slice is a no-op there. Anything
+      // other than the whole file means the body is not what the slice offsets assume (issue #338).
+      if (buf.length !== total_bytes) {
         throw new CdnHttpError(
-          `CDN returned 200 with ${buf.length} bytes but range_end is ${range_end} for ${item_id}`,
+          `CDN returned 200 with ${buf.length} bytes for ${item_id}, expected ${total_bytes}`,
           200,
         );
       }
       return buf.subarray(range_start, range_end + 1);
     }
 
+    assert_range_chunk(
+      item_id,
+      range_start,
+      range_end,
+      response.headers.get('Content-Range'),
+      buf.length,
+    );
     return buf;
   } finally {
     clearTimeout(timer);

--- a/packages/onedrive/tests/unit/adapters/chunk-download-timeout.test.ts
+++ b/packages/onedrive/tests/unit/adapters/chunk-download-timeout.test.ts
@@ -29,9 +29,13 @@ describe('chunk download abort timeout', () => {
       .mockImplementation((_url: string, init: { headers: { Range: string } }) => {
         const [, start, end] = /bytes=(\d+)-(\d+)/.exec(init.headers.Range)!;
         const body = Buffer.alloc(Number(end) - Number(start) + 1, 1);
+        const content_range = `bytes ${start}-${end}/*`;
         return Promise.resolve({
           status: 206,
-          headers: { get: (): string | null => null },
+          headers: {
+            get: (name: string): string | null =>
+              name.toLowerCase() === 'content-range' ? content_range : null,
+          },
           arrayBuffer: () => Promise.resolve(body.buffer.slice(0, body.length)),
         } as unknown as Response);
       });

--- a/packages/onedrive/tests/unit/adapters/chunked-download-integrity.test.ts
+++ b/packages/onedrive/tests/unit/adapters/chunked-download-integrity.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CHUNK_SIZE_BYTES, fetch_file_chunks } from '@/adapters/graph-onedrive-chunked-download';
+
+// Issue #338: a Range response was accepted without checking its length or its Content-Range, so a
+// short, duplicated or restarted body was encrypted and hashed into a backup that verifies against
+// itself. Each case below produced `stored: true` before the fix.
+
+const TOTAL_BYTES = 2 * CHUNK_SIZE_BYTES;
+
+function to_array_buffer(body: Buffer): ArrayBuffer {
+  const copy = new ArrayBuffer(body.byteLength);
+  new Uint8Array(copy).set(body);
+  return copy;
+}
+
+function response(status: number, body: Buffer, content_range?: string): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: (name: string): string | null =>
+        name.toLowerCase() === 'content-range' ? (content_range ?? null) : null,
+    },
+    arrayBuffer: (): Promise<ArrayBuffer> => Promise.resolve(to_array_buffer(body)),
+    body: {
+      cancel: (): Promise<void> => Promise.resolve(),
+      async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+        yield new Uint8Array(body);
+      },
+    },
+  } as unknown as Response;
+}
+
+interface RangeInit {
+  readonly headers: Record<string, string>;
+}
+
+function requested_range(init: RangeInit): { start: number; end: number } {
+  const [, start, end] = /bytes=(\d+)-(\d+)/.exec(init.headers['Range'] ?? '')!;
+  return { start: Number(start), end: Number(end) };
+}
+
+/** A well-behaved CDN: exactly the requested bytes, with the matching Content-Range. */
+function honest_range(init: RangeInit): Response {
+  const { start, end } = requested_range(init);
+  return response(206, Buffer.alloc(end - start + 1, 1), `bytes ${start}-${end}/${TOTAL_BYTES}`);
+}
+
+async function collect(): Promise<Buffer> {
+  const parts: Buffer[] = [];
+  for await (const chunk of fetch_file_chunks('https://cdn.test/file', TOTAL_BYTES, 'item-1')) {
+    parts.push(chunk);
+  }
+  return Buffer.concat(parts);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('chunked download integrity (issue #338)', () => {
+  it('yields the whole file when every range is answered honestly', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init: RangeInit) => Promise.resolve(honest_range(init))),
+    );
+
+    expect((await collect()).length).toBe(TOTAL_BYTES);
+  });
+
+  it('fails a 206 whose body is shorter than the range it claims to answer', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init: RangeInit) => {
+        const { start, end } = requested_range(init);
+        return Promise.resolve(
+          response(206, Buffer.alloc(1, 1), `bytes ${start}-${end}/${TOTAL_BYTES}`),
+        );
+      }),
+    );
+
+    await expect(collect()).rejects.toThrow(/returned 1 bytes, expected 4194304/);
+  });
+
+  it('fails a 206 that answers a different range than the one requested', async () => {
+    // The shape a duplicated or reordered chunk takes on the wire: a full-length body carrying
+    // bytes the caller did not ask for. Without the header check it concatenates silently.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          response(
+            206,
+            Buffer.alloc(CHUNK_SIZE_BYTES, 1),
+            `bytes 0-${CHUNK_SIZE_BYTES - 1}/${TOTAL_BYTES}`,
+          ),
+        ),
+      ),
+    );
+
+    await expect(collect()).rejects.toThrow(/was answered with bytes 0-4194303/);
+  });
+
+  it('fails rather than appending when Range stops being honoured mid-file', async () => {
+    // The fallback restarts at byte zero, so continuing it after a chunk has been consumed would
+    // encrypt a prefix followed by the whole file.
+    let call = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init: RangeInit) =>
+        Promise.resolve(
+          call++ === 0 ? honest_range(init) : response(200, Buffer.alloc(TOTAL_BYTES, 1)),
+        ),
+      ),
+    );
+
+    await expect(collect()).rejects.toThrow(/stopped being honoured .* after 1 chunk/);
+  });
+
+  it('still takes the streamed fallback when the first range is already ignored', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(response(200, Buffer.alloc(TOTAL_BYTES, 1)))),
+    );
+
+    expect((await collect()).length).toBe(TOTAL_BYTES);
+  });
+});

--- a/packages/onedrive/tests/unit/adapters/graph-chunked-download.test.ts
+++ b/packages/onedrive/tests/unit/adapters/graph-chunked-download.test.ts
@@ -11,11 +11,18 @@ function to_array_buffer(body: Buffer): ArrayBuffer {
   return copy;
 }
 
-function range_response(status: number, body = Buffer.alloc(0)): Response {
+function range_response(
+  status: number,
+  body = Buffer.alloc(0),
+  content_range = `bytes 0-${Math.max(body.length - 1, 0)}/${body.length}`,
+): Response {
   return {
     status,
     ok: status >= 200 && status < 300,
-    headers: { get: (): string | null => null },
+    headers: {
+      get: (name: string): string | null =>
+        name.toLowerCase() === 'content-range' && status === 206 ? content_range : null,
+    },
     arrayBuffer: (): Promise<ArrayBuffer> => Promise.resolve(to_array_buffer(body)),
     text: (): Promise<string> => Promise.resolve(''),
     // The Range-ignored path cancels the body unread, and the streamed fallback iterates it.

--- a/packages/onedrive/tests/unit/services/backup/large-file-pipeline.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/large-file-pipeline.test.ts
@@ -15,6 +15,9 @@ const { cleanup_stale_staging, process_large_file } =
 
 const KEY = randomBytes(32);
 const OWNER = 'owner-1';
+// The chunk source is mocked, so the item's reported size is whatever the mock yields: the
+// pipeline now fails an item whose chunks do not add up to it (issue #338).
+const ITEM_BYTES = 1024;
 
 interface Recorded {
   readonly ctx: TenantContext;
@@ -68,7 +71,7 @@ function make_item(overrides: Partial<OneDriveDeltaItem> = {}): OneDriveDeltaIte
     kind: 'file',
     file_name: 'movie.mp4',
     parent_path: '/Videos',
-    size_bytes: 400 * 1024 * 1024,
+    size_bytes: ITEM_BYTES,
     deleted: false,
     ...overrides,
   } as OneDriveDeltaItem;
@@ -83,7 +86,7 @@ function make_connector(url?: string): OneDriveConnector {
 beforeEach(() => {
   vi.clearAllMocks();
   chunk_mocks.fetch_file_chunks.mockImplementation(async function* () {
-    yield Buffer.alloc(1024, 7);
+    yield Buffer.alloc(ITEM_BYTES, 7);
   });
 });
 
@@ -103,7 +106,7 @@ describe('process_large_file', () => {
     expect(connector.resolve_download_url).not.toHaveBeenCalled();
     expect(chunk_mocks.fetch_file_chunks).toHaveBeenCalledWith(
       'https://cdn.example/abc',
-      400 * 1024 * 1024,
+      ITEM_BYTES,
       'item-1',
     );
   });
@@ -195,6 +198,45 @@ describe('process_large_file', () => {
     expect(begin).toContain('staging');
     expect(begin).toContain('item-1');
     expect(recorded.copy_args[0]?.from).toBe(begin.slice('begin:'.length));
+  });
+
+  // Issue #338: the checksum is taken over whatever arrived, so a transfer that ended early or
+  // restarted mid-stream produces a validly encrypted object with a matching checksum. The
+  // reported item size is the only expectation that can catch it.
+  it('fails an item whose chunks ended before its reported size, promoting nothing', async () => {
+    const recorded = make_ctx();
+    chunk_mocks.fetch_file_chunks.mockImplementation(async function* () {
+      yield Buffer.alloc(ITEM_BYTES / 2, 7);
+    });
+
+    await expect(
+      process_large_file(
+        make_connector('https://cdn.example/abc'),
+        make_item(),
+        OWNER,
+        recorded.ctx,
+      ),
+    ).rejects.toThrow(/produced 512 bytes, expected 1024/);
+    expect(recorded.ops).not.toContain('complete');
+    expect(recorded.ops).not.toContain('copy');
+  });
+
+  it('fails an item whose chunks overran its reported size, promoting nothing', async () => {
+    const recorded = make_ctx();
+    chunk_mocks.fetch_file_chunks.mockImplementation(async function* () {
+      yield Buffer.alloc(ITEM_BYTES / 2, 7);
+      yield Buffer.alloc(ITEM_BYTES, 7);
+    });
+
+    await expect(
+      process_large_file(
+        make_connector('https://cdn.example/abc'),
+        make_item(),
+        OWNER,
+        recorded.ctx,
+      ),
+    ).rejects.toThrow(/produced 1536 bytes, expected 1024/);
+    expect(recorded.ops).not.toContain('copy');
   });
 });
 

--- a/packages/sharepoint/src/adapters/graph-sharepoint-chunked-download.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-chunked-download.ts
@@ -4,6 +4,7 @@ import {
   is_transient_error,
   parse_retry_after_ms,
 } from '@wisecom/atlas-m365-graph';
+import { assert_range_chunk } from '@wisecom/atlas-drive/backup/download-integrity';
 
 export const CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
 export const CHUNK_DOWNLOAD_THRESHOLD = 4 * 1024 * 1024;
@@ -163,15 +164,24 @@ async function download_single_chunk(
         `CDN returned HTTP 200 instead of 206 for Range request on ${item_id} — ` +
           `server ignored Range header, slicing ${buf.length} bytes to expected range`,
       );
-      if (buf.length < range_end + 1) {
+      // A single-chunk item legitimately comes back whole, so the slice is a no-op there. Anything
+      // other than the whole file means the body is not what the slice offsets assume (issue #338).
+      if (buf.length !== total_bytes) {
         throw new CdnHttpError(
-          `CDN returned 200 with ${buf.length} bytes but range_end is ${range_end} for ${item_id}`,
+          `CDN returned 200 with ${buf.length} bytes for ${item_id}, expected ${total_bytes}`,
           200,
         );
       }
       return buf.subarray(range_start, range_end + 1);
     }
 
+    assert_range_chunk(
+      item_id,
+      range_start,
+      range_end,
+      response.headers.get('Content-Range'),
+      buf.length,
+    );
     return buf;
   } finally {
     clearTimeout(timer);

--- a/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
+++ b/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
@@ -1,5 +1,6 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import { stream_whole_file_in_chunks } from '@wisecom/atlas-drive/backup/whole-file-stream';
+import { assert_range_chunk } from '@wisecom/atlas-drive/backup/download-integrity';
 
 const CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
 const MAX_CHUNK_RETRIES = 5;
@@ -32,14 +33,16 @@ export async function* fetch_file_chunks(
   item_id: string,
 ): AsyncGenerator<Buffer> {
   const chunk_count = Math.ceil(total_bytes / CHUNK_SIZE_BYTES);
+  let yielded_chunks = 0;
 
   for (let i = 0; i < chunk_count; i++) {
     const range_start = i * CHUNK_SIZE_BYTES;
     const range_end = Math.min(range_start + CHUNK_SIZE_BYTES - 1, total_bytes - 1);
     const expected_length = range_end - range_start + 1;
 
+    let chunk: Buffer;
     try {
-      yield await download_chunk_with_retry(
+      chunk = await download_chunk_with_retry(
         download_url,
         range_start,
         range_end,
@@ -47,13 +50,24 @@ export async function* fetch_file_chunks(
         item_id,
         i + 1,
         chunk_count,
+        total_bytes,
         chunk_count > 1,
       );
     } catch (err) {
       if (!(err instanceof RangeIgnoredError)) throw err;
+      // The streamed pass restarts at byte zero, so it can only replace the chunks already handed
+      // to the consumer, never continue them. Once one has been yielded the consumer has fed it
+      // into a cipher and appending a second copy of the file would produce a validly encrypted
+      // object holding a prefix plus the whole file (issue #338). Fail the item instead; the next
+      // run retries it and takes the streamed path from the first chunk.
+      if (yielded_chunks > 0) {
+        throw new Error(
+          `Range requests stopped being honoured for ${item_id} after ${yielded_chunks} chunk(s); ` +
+            `the partial transfer cannot be continued by a whole-file download`,
+        );
+      }
       // Every remaining chunk would fetch and discard the same whole file: a 1 GiB item costs
-      // 256 GiB transferred to produce 1 GiB. One streamed pass delivers the rest, and the
-      // chunks already yielded are re-read from the start, which is the price of finding out.
+      // 256 GiB transferred to produce 1 GiB. One streamed pass delivers the whole file instead.
       logger.warn(
         `Range requests are ignored for ${item_id} (HTTP 200 with the full body); ` +
           `falling back to one streamed download`,
@@ -66,6 +80,8 @@ export async function* fetch_file_chunks(
       });
       return;
     }
+    yielded_chunks++;
+    yield chunk;
   }
 }
 
@@ -77,6 +93,7 @@ async function download_chunk_with_retry(
   item_id: string,
   chunk_index: number,
   total_chunks: number,
+  total_bytes: number,
   report_ignored_range: boolean,
 ): Promise<Buffer> {
   for (let attempt = 0; attempt <= MAX_CHUNK_RETRIES; attempt++) {
@@ -87,6 +104,7 @@ async function download_chunk_with_retry(
         range_end,
         expected_length,
         item_id,
+        total_bytes,
         report_ignored_range,
       );
     } catch (err) {
@@ -117,6 +135,7 @@ async function download_single_chunk(
   range_end: number,
   expected_length: number,
   item_id: string,
+  total_bytes: number,
   report_ignored_range: boolean,
 ): Promise<Buffer> {
   const timeout_ms = Math.max(30_000, Math.ceil(expected_length / MIN_THROUGHPUT_BYTES_PER_MS));
@@ -150,15 +169,23 @@ async function download_single_chunk(
     const buf = Buffer.from(await response.arrayBuffer());
 
     if (response.status === 200) {
-      // A single-chunk item legitimately comes back whole, so the slice is a no-op there.
-      if (buf.length < range_end + 1) {
+      // A single-chunk item legitimately comes back whole, so the slice is a no-op there. Anything
+      // other than the whole file means the body is not what the slice offsets assume (issue #338).
+      if (buf.length !== total_bytes) {
         throw new Error(
-          `CDN returned 200 with ${buf.length} bytes but range_end is ${range_end} for ${item_id}`,
+          `CDN returned 200 with ${buf.length} bytes for ${item_id}, expected ${total_bytes}`,
         );
       }
       return buf.subarray(range_start, range_end + 1);
     }
 
+    assert_range_chunk(
+      item_id,
+      range_start,
+      range_end,
+      response.headers.get('Content-Range'),
+      buf.length,
+    );
     return buf;
   } finally {
     clearTimeout(timer);

--- a/packages/sharepoint/tests/unit/adapters/chunk-download-timeout.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/chunk-download-timeout.test.ts
@@ -45,9 +45,13 @@ describe('chunk download abort timeout', () => {
   /** A 206 answering exactly the requested range. */
   function range_response(range_start: number, range_end: number): Response {
     const body = Buffer.alloc(range_end - range_start + 1, 1);
+    const content_range = `bytes ${range_start}-${range_end}/*`;
     return {
       status: 206,
-      headers: { get: (): string | null => null },
+      headers: {
+        get: (name: string): string | null =>
+          name.toLowerCase() === 'content-range' ? content_range : null,
+      },
       arrayBuffer: () => Promise.resolve(body.buffer.slice(0, body.length)),
     } as unknown as Response;
   }

--- a/packages/sharepoint/tests/unit/services/backup/chunked-download-integrity.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/chunked-download-integrity.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetch_file_chunks } from '@/services/backup/large-file-chunk-download';
+
+// Issue #338, mirrored from the OneDrive suite. The two drive downloaders are copies, and
+// divergent coverage between them is what let the replication gate divergence through (#190).
+
+const CHUNK_SIZE = 4 * 1024 * 1024;
+const TOTAL_BYTES = 2 * CHUNK_SIZE;
+
+interface RangeInit {
+  readonly headers: Record<string, string>;
+}
+
+function to_array_buffer(body: Buffer): ArrayBuffer {
+  const copy = new ArrayBuffer(body.byteLength);
+  new Uint8Array(copy).set(body);
+  return copy;
+}
+
+function response(status: number, body: Buffer, content_range?: string): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: (name: string): string | null =>
+        name.toLowerCase() === 'content-range' ? (content_range ?? null) : null,
+    },
+    arrayBuffer: (): Promise<ArrayBuffer> => Promise.resolve(to_array_buffer(body)),
+    body: {
+      cancel: (): Promise<void> => Promise.resolve(),
+      async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+        yield new Uint8Array(body);
+      },
+    },
+  } as unknown as Response;
+}
+
+function requested_range(init: RangeInit): { start: number; end: number } {
+  const [, start, end] = /bytes=(\d+)-(\d+)/.exec(init.headers['Range'] ?? '')!;
+  return { start: Number(start), end: Number(end) };
+}
+
+/** A well-behaved CDN: exactly the requested bytes, with the matching Content-Range. */
+function honest_range(init: RangeInit): Response {
+  const { start, end } = requested_range(init);
+  return response(206, Buffer.alloc(end - start + 1, 1), `bytes ${start}-${end}/${TOTAL_BYTES}`);
+}
+
+async function collect(): Promise<Buffer> {
+  const parts: Buffer[] = [];
+  for await (const chunk of fetch_file_chunks('https://cdn.test/file', TOTAL_BYTES, 'item-1')) {
+    parts.push(chunk);
+  }
+  return Buffer.concat(parts);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('SharePoint chunked download integrity (issue #338)', () => {
+  it('yields the whole file when every range is answered honestly', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init: RangeInit) => Promise.resolve(honest_range(init))),
+    );
+
+    expect((await collect()).length).toBe(TOTAL_BYTES);
+  });
+
+  it('fails a 206 whose body is shorter than the range it claims to answer', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init: RangeInit) => {
+        const { start, end } = requested_range(init);
+        return Promise.resolve(
+          response(206, Buffer.alloc(1, 1), `bytes ${start}-${end}/${TOTAL_BYTES}`),
+        );
+      }),
+    );
+
+    await expect(collect()).rejects.toThrow(/returned 1 bytes, expected 4194304/);
+  });
+
+  it('fails a 206 that answers a different range than the one requested', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          response(206, Buffer.alloc(CHUNK_SIZE, 1), `bytes 0-${CHUNK_SIZE - 1}/${TOTAL_BYTES}`),
+        ),
+      ),
+    );
+
+    await expect(collect()).rejects.toThrow(/was answered with bytes 0-4194303/);
+  });
+
+  it('fails rather than appending when Range stops being honoured mid-file', async () => {
+    let call = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init: RangeInit) =>
+        Promise.resolve(
+          call++ === 0 ? honest_range(init) : response(200, Buffer.alloc(TOTAL_BYTES, 1)),
+        ),
+      ),
+    );
+
+    await expect(collect()).rejects.toThrow(/stopped being honoured .* after 1 chunk/);
+  });
+
+  it('still takes the streamed fallback when the first range is already ignored', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(response(200, Buffer.alloc(TOTAL_BYTES, 1)))),
+    );
+
+    expect((await collect()).length).toBe(TOTAL_BYTES);
+  });
+});

--- a/packages/sharepoint/tests/unit/services/backup/large-file-chunk-download.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/large-file-chunk-download.test.ts
@@ -14,11 +14,15 @@ function to_array_buffer(body: Buffer): ArrayBuffer {
   return copy;
 }
 
-function range_response(status: number, body = Buffer.alloc(0)): Response {
+function range_response(status: number, body = Buffer.alloc(0), range_start = 0): Response {
+  const content_range = `bytes ${range_start}-${range_start + Math.max(body.length - 1, 0)}/*`;
   return {
     status,
     ok: status >= 200 && status < 300,
-    headers: { get: (): string | null => null },
+    headers: {
+      get: (name: string): string | null =>
+        name.toLowerCase() === 'content-range' && status === 206 ? content_range : null,
+    },
     arrayBuffer: (): Promise<ArrayBuffer> => Promise.resolve(to_array_buffer(body)),
     text: (): Promise<string> => Promise.resolve(''),
     // The Range-ignored path cancels the body unread, and the streamed fallback iterates it.
@@ -54,7 +58,7 @@ describe('fetch_file_chunks', () => {
     const fetch_mock = vi
       .fn()
       .mockResolvedValueOnce(range_response(206, first))
-      .mockResolvedValueOnce(range_response(206, second));
+      .mockResolvedValueOnce(range_response(206, second, CHUNK_SIZE));
     vi.stubGlobal('fetch', fetch_mock);
 
     const body = await collect('https://cdn.test/file', CHUNK_SIZE + 1024);

--- a/packages/sharepoint/tests/unit/services/backup/large-file-pipeline.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/large-file-pipeline.test.ts
@@ -15,6 +15,9 @@ const { cleanup_stale_staging, process_large_file } =
 
 const KEY = randomBytes(32);
 const SITE = 'site-1';
+// The chunk source is mocked, so the item's reported size is whatever the mock yields: the
+// pipeline now fails an item whose chunks do not add up to it (issue #338).
+const ITEM_BYTES = 1024;
 
 interface Recorded {
   readonly ctx: TenantContext;
@@ -68,7 +71,7 @@ function make_item(overrides: Partial<SharePointDeltaItem> = {}): SharePointDelt
     kind: 'file',
     file_name: 'movie.mp4',
     parent_path: '/Videos',
-    size_bytes: 400 * 1024 * 1024,
+    size_bytes: ITEM_BYTES,
     deleted: false,
     ...overrides,
   } as SharePointDeltaItem;
@@ -83,7 +86,7 @@ function make_connector(url?: string): SharePointSiteConnector {
 beforeEach(() => {
   vi.clearAllMocks();
   chunk_mocks.fetch_file_chunks.mockImplementation(async function* () {
-    yield Buffer.alloc(1024, 7);
+    yield Buffer.alloc(ITEM_BYTES, 7);
   });
 });
 
@@ -103,7 +106,7 @@ describe('process_large_file', () => {
     expect(connector.resolve_download_url).not.toHaveBeenCalled();
     expect(chunk_mocks.fetch_file_chunks).toHaveBeenCalledWith(
       'https://cdn.example/abc',
-      400 * 1024 * 1024,
+      ITEM_BYTES,
       'item-1',
     );
   });


### PR DESCRIPTION
## Summary

Closes #338.

The chunked download helpers accepted a `206` without checking its body length or its `Content-Range`, and nothing compared the bytes the pipeline consumed against the size Graph reported for the item. Since the recorded checksum is computed over the bytes that arrived, a one byte answer to a 4 MiB range produces a perfectly valid SHA-256 for one byte, and AES-GCM authenticates it just as happily. There was no expectation formed before the transfer for any of it to fail against.

I confirmed the four inputs from the issue against the real generator before changing anything: a short `206`, a `206` answering a range that was not requested, a late `200` restarting the file after chunks had already been consumed, and a streamed fallback that ends early. The first three still fail against the pre-fix adapter with the new tests in place, and pass after.

All three copies of the downloader had the same defect, so the checks live in `packages/drive` and each copy calls them:

- A `206` must be exactly the requested length, and must carry a `Content-Range` naming the range that was asked for. The header is required rather than optional because it is the only thing identifying which bytes arrived, and it is what makes a duplicated or reordered chunk detectable at all.
- A `200` answering a range request must carry the item's full reported size, since the slice offsets assume the whole file.
- The large-file pipeline counts the bytes it forwards and fails the item before anything is promoted out of staging. That covers the streamed fallback ending early or delivering the file twice, whichever provider supplied the chunks.
- When `Range` stops being honoured after a chunk has been consumed, the item fails instead of having the whole-file body appended to the prefix already inside the cipher. A CDN that ignores `Range` from the first request is unaffected, so the transfer amplification fix from #301 still applies.

A failed check fails that item, not the run: it goes into the failed-item ledger, no manifest entry is written for it, and the next backup retries it. Items whose delta page carried no `size` have no expectation to check against and are accepted as before.

## Changes

- `packages/drive/src/backup/download-integrity.ts`: new `assert_range_chunk` and `assert_transferred_size`, exported from the package index.
- `packages/drive/src/backup/large-file-pipeline.ts`: the chunk source is wrapped in a counting generator that fails the item when the chunks do not add up to its reported size.
- `packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts`, `packages/sharepoint/src/services/backup/large-file-chunk-download.ts`, `packages/sharepoint/src/adapters/graph-sharepoint-chunked-download.ts`: validate each `206`, require a `200` to be the whole file, and refuse to continue a partly consumed transfer with a whole-file download.
- Regression coverage: unit tests for both assertions in `packages/drive`, byte-accounting cases in the OneDrive large-file pipeline suite, and a generator-level suite mirrored across both providers for the four injected inputs.
- Updated the chunk fixtures that modelled servers the code now rejects: they previously returned no `Content-Range` at all, and the pipeline fixtures declared an item size their mocked chunks never matched.
- `docs/onedrive-backup.md`: new section on what a chunk has to prove before it is stored, with `docs/sharepoint-backup.md` cross-referencing it under Download Resilience.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`), unless this is a release or hotfix PR
- [x] No version bump in `packages/*/package.json` (releases only)
- [x] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)
