### PR TITLE
docs(migration): cover the v5 CLI flag and verb changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ It is infrastructure rather than a desktop backup app: a CLI and a typed SDK, bu
 
 Recovery is only useful if it still works when the production environment cannot be trusted. That shapes the architecture:
 
-| Property | How it works | Why it matters |
-| --- | --- | --- |
-| **Per-tenant encryption** | AES-256-GCM envelope encryption; a scrypt-derived key wraps a per-tenant data key that never leaves memory unwrapped | Storage compromise alone does not expose mail or files |
-| **Customer-controlled storage** | Any S3-compatible backend: AWS, MinIO, or on-premise | You decide where backup data lives and who holds the credentials |
-| **Content-addressed storage** | Messages, attachments, and files keyed by SHA-256 of the plaintext | Identical content is stored once; re-runs do not re-upload |
-| **Storage-level immutability** | S3 Object Lock with time-based retention | Retention is enforced by the storage layer, not by application logic |
-| **Delta synchronisation** | Graph delta cursors per folder, drive, and library | Incremental runs; a single failed item does not replay the whole backlog |
-| **Snapshot replication** | Ciphertext copied as-is to a secondary S3 target | A second, independent copy for disaster recovery |
-| **Open implementation** | Apache-2.0, no proprietary archive format | The recovery path can be audited rather than assumed |
+| Property                        | How it works                                                                                                         | Why it matters                                                           |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **Per-tenant encryption**       | AES-256-GCM envelope encryption; a scrypt-derived key wraps a per-tenant data key that never leaves memory unwrapped | Storage compromise alone does not expose mail or files                   |
+| **Customer-controlled storage** | Any S3-compatible backend: AWS, MinIO, or on-premise                                                                 | You decide where backup data lives and who holds the credentials         |
+| **Content-addressed storage**   | Messages, attachments, and files keyed by SHA-256 of the plaintext                                                   | Identical content is stored once; re-runs do not re-upload               |
+| **Storage-level immutability**  | S3 Object Lock with time-based retention                                                                             | Retention is enforced by the storage layer, not by application logic     |
+| **Delta synchronisation**       | Graph delta cursors per folder, drive, and library                                                                   | Incremental runs; a single failed item does not replay the whole backlog |
+| **Snapshot replication**        | Ciphertext copied as-is to a secondary S3 target                                                                     | A second, independent copy for disaster recovery                         |
+| **Open implementation**         | Apache-2.0, no proprietary archive format                                                                            | The recovery path can be audited rather than assumed                     |
 
 Large files stream without touching disk: transfers at or above 64 MiB are downloaded, encrypted, and assembled into multipart uploads in bounded memory.
 
@@ -63,19 +63,20 @@ SharePoint coverage is document libraries only. Generic lists and site pages are
 
 ## Documentation
 
-| Topic | |
-| --- | --- |
-| Getting Started | [docs](https://wisecom-oy.github.io/atlas/getting-started) |
-| Configuration | [docs](https://wisecom-oy.github.io/atlas/configuration) |
-| Azure AD Setup | [docs](https://wisecom-oy.github.io/atlas/azure-ad-setup) |
-| Security Model | [docs](https://wisecom-oy.github.io/atlas/security) |
-| Self-Hosting | [docs](https://wisecom-oy.github.io/atlas/self-hosting) |
-| OneDrive Backup | [docs](https://wisecom-oy.github.io/atlas/onedrive-backup) |
-| SharePoint Backup | [docs](https://wisecom-oy.github.io/atlas/sharepoint-backup) |
-| Storage Layout | [docs](https://wisecom-oy.github.io/atlas/operations/storage-layout) |
-| Troubleshooting | [docs](https://wisecom-oy.github.io/atlas/troubleshooting) |
-| CLI Reference | [docs](https://wisecom-oy.github.io/atlas/reference/cli) |
-| SDK Reference | [docs](https://wisecom-oy.github.io/atlas/reference/sdk) |
+| Topic             |                                                                      |
+| ----------------- | -------------------------------------------------------------------- |
+| Getting Started   | [docs](https://wisecom-oy.github.io/atlas/getting-started)           |
+| Configuration     | [docs](https://wisecom-oy.github.io/atlas/configuration)             |
+| Azure AD Setup    | [docs](https://wisecom-oy.github.io/atlas/azure-ad-setup)            |
+| Security Model    | [docs](https://wisecom-oy.github.io/atlas/security)                  |
+| Self-Hosting      | [docs](https://wisecom-oy.github.io/atlas/self-hosting)              |
+| OneDrive Backup   | [docs](https://wisecom-oy.github.io/atlas/onedrive-backup)           |
+| SharePoint Backup | [docs](https://wisecom-oy.github.io/atlas/sharepoint-backup)         |
+| Storage Layout    | [docs](https://wisecom-oy.github.io/atlas/operations/storage-layout) |
+| Troubleshooting   | [docs](https://wisecom-oy.github.io/atlas/troubleshooting)           |
+| CLI Reference     | [docs](https://wisecom-oy.github.io/atlas/reference/cli)             |
+| SDK Reference     | [docs](https://wisecom-oy.github.io/atlas/reference/sdk)             |
+| Migrating to v5   | [docs](https://wisecom-oy.github.io/atlas/migration/v5)              |
 
 **Packages:** [`@wisecom/atlas-cli`](https://www.npmjs.com/package/@wisecom/atlas-cli) for the command line, [`@wisecom/atlas-sdk`](https://www.npmjs.com/package/@wisecom/atlas-sdk) for the programmatic Node.js API.
 

--- a/docs/migration/v5.md
+++ b/docs/migration/v5.md
@@ -89,21 +89,79 @@ Together with the camelCase surface and enumerated exports in PR #323, this comp
 
 v4 returned `1` for every fatal exception. v5 uses the typed error categories introduced in v4.4.0, with the original Graph, AWS or Node failure reported separately on stderr.
 
-| Failure | v4 | v5 |
-| ------- | -- | -- |
-| Throttle exhaustion or recognized network/transient HTTP failure | `1` | `3` |
-| Authentication, permission or mailbox-license failure | `1` | `4` |
-| Wrong encryption passphrase | `1` | `5` |
-| Typed configuration failure or failure to load CLI configuration | `1` | `6` |
-| Missing resource | `1` | `7` |
-| Typed Object Lock retention refusal | `1` | `8` |
+| Failure                                                                                             | v4  | v5  |
+| --------------------------------------------------------------------------------------------------- | --- | --- |
+| Throttle exhaustion or recognized network/transient HTTP failure                                    | `1` | `3` |
+| Authentication, permission or mailbox-license failure                                               | `1` | `4` |
+| Wrong encryption passphrase                                                                         | `1` | `5` |
+| Typed configuration failure or failure to load CLI configuration                                    | `1` | `6` |
+| Missing resource                                                                                    | `1` | `7` |
+| Typed Object Lock retention refusal                                                                 | `1` | `8` |
 | Unexpected or unclassified failure, usage error, command-reported failure without a typed exception | `1` | `1` |
-| Complete operation | `0` | `0` |
-| Partial operation or soft interrupt | `2` | `2` |
+| Complete operation                                                                                  | `0` | `0` |
+| Partial operation or soft interrupt                                                                 | `2` | `2` |
 
 Replace checks that only recognize `1` as failure. A script using `if [ "$status" -eq 1 ]` would miss the new failure categories; test for nonzero first, then branch on the documented category when deciding whether to retry. Codes `4` through `8` require operator action rather than an unchanged retry. Code `3` permits scheduling a later attempt, but a timed-out write may already have committed.
 
 `Atlas code:` now identifies the Atlas category; `Transport code:`, `HTTP status:`, `Error name:` and `Body:` describe its underlying cause. Fatal details that previously went to stdout now go to stderr. Update log collectors accordingly, and use exit codes rather than parsing message wording. The [CLI reference](/reference/cli#exit-codes) lists the full mapping, precedence and command-reported exceptions.
+
+## CLI: one vocabulary for flags and verbs
+
+`-s` is the snapshot on every command that has one, and `-o` is the owner on every command that has one. Two commands spelled those letters differently, so the flags they collided with give up their short form rather than keep a second meaning: `--site` and `--output` now have no short spelling anywhere, and nothing can shadow `-s` or `-o` again.
+
+### Short flags whose meaning changed
+
+A retired short flag is rejected rather than reinterpreted. Silently resolving `atlas stats -s <site>` as a snapshot id would report on the wrong scope, and `atlas outlook save -o <path>` as an owner would put the archive somewhere else. That is a data bug wearing a breaking change's clothes, so the old spelling fails and names its replacement.
+
+| v4                                | v5                                      | Using the old form          |
+| --------------------------------- | --------------------------------------- | --------------------------- |
+| `atlas stats -s <site>`           | `atlas stats --site <site>`             | error naming `-s`, exit `1` |
+| `atlas outlook save -o <path>`    | `atlas outlook save --output <path>`    | error naming `-o`, exit `1` |
+| `atlas onedrive save -O <path>`   | `atlas onedrive save --output <path>`   | error naming `-O`, exit `1` |
+| `atlas sharepoint save -O <path>` | `atlas sharepoint save --output <path>` | error naming `-O`, exit `1` |
+
+```console
+$ atlas stats -s https://contoso.sharepoint.com/sites/finance
+error: option '-s <value>' argument 'https://contoso.sharepoint.com/sites/finance' is invalid. -s no longer means --site in v5.0.0. Pass --site instead.
+```
+
+The retired spellings are hidden from `--help`, because they are not flags you can use. They exist only so a script that still passes one stops instead of doing the wrong thing.
+
+### `-f` takes one folder and repeats
+
+`atlas outlook backup` took a variadic `-f <name...>` while restore and save took a single value, so one command group carried two arities and a variadic `-f` swallowed the next flag's argument. Every Outlook command now takes one folder per flag, repeated:
+
+| v4                                           | v5                                              |
+| -------------------------------------------- | ----------------------------------------------- |
+| `atlas outlook backup -f Inbox "Sent Items"` | `atlas outlook backup -f Inbox -f "Sent Items"` |
+
+A single-folder invocation is unchanged. The old multi-folder form fails with `error: too many arguments for 'backup'. Expected 0 arguments but got 1: Sent Items.` and exit `1`; the first folder is still read from `-f`, so the command does not quietly back up less than you asked for.
+
+### Verbs that replaced flags and positionals
+
+A flag that changes what a command does is a verb wearing the wrong clothes, and a positional that accepts either a key or the word `list` cannot document itself in `--help`.
+
+| v4                                       | v5                               | Using the old form                 |
+| ---------------------------------------- | -------------------------------- | ---------------------------------- |
+| `atlas replicate --status`               | `atlas replicate status`         | `error: unknown option '--status'` |
+| `atlas config <key> <value>`             | `atlas config set <key> <value>` | `error: unknown command '<key>'`   |
+| `atlas config <key>`                     | `atlas config get <key>`         | `error: unknown command '<key>'`   |
+| `atlas config list \| unset \| validate` | unchanged                        | still works                        |
+
+`list`, `unset` and `validate` were already spelled as words, and are now real subcommands rather than magic values in a positional, so `atlas config list --help` documents itself. The replication scope flags are declared on both `replicate` and `replicate status`, so each `--help` is complete.
+
+### Validation moved to the flag boundary
+
+`--lock-mode` and `--service` are validated by the argument parser instead of by hand, so a typo fails before Atlas opens a Graph or S3 connection rather than after:
+
+```console
+$ atlas sharepoint backup --site <site> --lock-mode bogus
+error: option '--lock-mode <mode>' argument 'bogus' is invalid. Allowed choices are governance, compliance.
+```
+
+A script that matched the old wording needs the new strings. The v4 messages were `Invalid object lock mode "bogus". Expected "governance" or "compliance".` from the policy layer and `Unknown --service "x"; expected outlook, onedrive, sharepoint, or all` from the stats command.
+
+Defaults are declared to the parser too, so `--help` shows `--top` as `(default: "20")` and `--conflict` as `(default: "rename")` instead of repeating the value in prose. The values themselves are unchanged.
 
 ## SDK: exports can stream
 
@@ -118,4 +176,4 @@ Passing both `output` and `outputPath` throws `ConfigError`. For a stream export
 
 ## Next
 
-The CLI flag changes land in the same release and are documented here as they merge.
+Two v5.0.0 items are still in flight and are documented here as they merge: `--fast` for drive verification, and the `--json` rollout across the remaining commands ([issue #94](https://github.com/wisecom-oy/atlas/issues/94)).


### PR DESCRIPTION
## Summary

Closes #322.

`docs/migration/v5.md` already covered the SDK renames, the enumerated exports, the `create_container` removal, eager configuration validation and the exit codes. It ended with a placeholder saying the CLI flag changes would be documented as they merge. That placeholder is the whole gap: v5.0.0 breaks outright with no aliases and no deprecation period, so the migration page is the only bridge an upgrader gets, and a flag change that is not on it is a broken script with nothing to look up.

This adds the CLI section: the three reassigned short flags, the Outlook folder arity, the verbs that replaced `replicate --status` and the `config` positional, and the validation that moved to the flag boundary. Each entry gives the old form, the new form, and what the old form now does.

I did not write these from the source. I built the CLI on the `feat/162-cli-flag-consistency` branch in a scratch worktree and ran each case, so every quoted message is the real output:

```console
$ atlas stats -s https://contoso.sharepoint.com/sites/finance
error: option '-s <value>' argument 'https://contoso.sharepoint.com/sites/finance' is invalid. -s no longer means --site in v5.0.0. Pass --site instead.
```

Same for `-o` and `-O` on the save commands, `error: too many arguments for 'backup'` on the old variadic `-f`, `error: unknown option '--status'`, `error: unknown command 'tenant.id'`, and both choice-validation messages. The exit code is `1`, confirmed by running it. I also confirmed the retired spellings are hidden from `--help`, that `--site` and `--output` carry no short flag on any command, and that `--help` renders `--top` as `(default: "20")` and `--conflict` as `(default: "rename")`.

The second acceptance criterion, that no short flag silently changes meaning, is already satisfied in code: `reject_retired_short` in `packages/cli/src/commands/shared-options.ts` fails the old spelling and names the replacement, with coverage in `packages/cli/tests/unit/cli-flag-consistency.test.ts`. Nothing to add there, so this PR is documentation only.

**Merge order.** The CLI behaviour lands in #332 and the configuration-source section in #335. This page describes both once they are on `dev`, so it should merge after #332. The issue anticipated that: the decisions were made first and the page merges last. I did not duplicate the configuration-source section, since #335 already adds it.

## Changes

- `docs/migration/v5.md`: new "CLI: one vocabulary for flags and verbs" section covering retired short flags, `-f` arity, the `replicate status` and `config get`/`config set` verbs, and parser-level validation of `--lock-mode` and `--service`.
- `docs/migration/v5.md`: the "Next" trailer now names what is genuinely still in flight, `--fast` for drive verification and the `--json` rollout, instead of the CLI changes this PR documents.
- `README.md`: the documentation table links the migration guide, which it was missing.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`), unless this is a release or hotfix PR
- [x] No version bump in `packages/*/package.json` (releases only)
- [x] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a README link to the v5 migration guide.
  * Expanded the v5 migration guide with CLI exit-code categories, stderr diagnostics, nonzero-status handling, command and flag changes, validation behavior, and displayed defaults.
  * Documented planned work for `--fast` and expanded `--json` support.
  * Reformatted the README architecture table for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->