### PR TITLE
fix(restore): verify what was decrypted is what the manifest recorded

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -327,6 +327,39 @@ When you run `atlas outlook verify`, Atlas performs a full integrity check for a
 
 `atlas outlook verify` checks the **message entries** listed in the manifest. For a MIME entry that covers the attachments too, because they are part of the message bytes being hashed. For a legacy JSON entry the separate attachment objects are not hashed against the manifest; they are protected by GCM authentication during any decrypt operation (backup, restore, save), which detects tampering but not a checksum recorded wrong at backup time.
 
+### What the GCM tag does not tell you
+
+The authentication tag proves the bytes were produced under the tenant DEK. It does not say which
+object they belong to. Content is encrypted with one key per tenant and nothing in the ciphertext
+names the object, so any object in the tenant authenticates in any other object's place. Moving one
+blob over another needs write access to the bucket, not the key or the passphrase, and the swapped
+object still decrypts cleanly.
+
+The manifest checksum is what distinguishes them, so it is compared before anything acts on the
+bytes, not after:
+
+| Path                       | Checked before                                                |
+| -------------------------- | ------------------------------------------------------------- |
+| Outlook message restore    | `POST /messages`, for both MIME and legacy JSON entries       |
+| Outlook attachment restore | the attachment upload, per attachment                         |
+| Drive file restore         | the upload, buffered and streamed alike                       |
+| Snapshot manifests         | the manifest is used, by rebuilding its key from its own body |
+
+An entry that records no checksum is refused rather than restored unverified: an unverifiable
+restore is exactly what the substitution is trying to produce.
+
+A manifest is checked differently because it has no checksum of its own. Its identity is in its
+body, so Atlas rebuilds the storage key from the decrypted `owner_id`/`site_id` and `snapshot_id`
+and compares it to the key it read. A manifest planted under another snapshot's key is reported as
+corrupt rather than skipped, because quietly omitting it reads as "this snapshot was never taken",
+which is the outcome the substitution wants.
+
+Two limits are worth stating plainly. Neither check prevents **replay of an older ciphertext for
+the same object**: an earlier version of that exact object still matches its own checksum, so
+rolling an object back to a previous state is defeated by S3 Object Lock and versioning rather than
+by encryption. And a checksum recorded wrong at backup time is not detected by comparing against
+it, which is the same limit that applies to verification above.
+
 ### Content-MD5 on Uploads
 
 Every object uploaded to S3 includes a `Content-MD5` header computed from the **ciphertext** (not the plaintext). This is a transport integrity check -- if a network error corrupts the data in flight, S3 will reject the upload with a checksum mismatch. This is separate from the application-layer SHA-256, which validates the original plaintext content.

--- a/packages/core/src/services/shared/index.ts
+++ b/packages/core/src/services/shared/index.ts
@@ -19,6 +19,10 @@ export type { DriveChainEntry, DriveChainManifest } from '@/services/shared/driv
 export { stream_decrypt_from_storage } from '@/services/shared/stream-decrypt';
 export type { StreamDecryptResult } from '@/services/shared/stream-decrypt';
 export {
+  assert_restored_content_matches,
+  RestoredContentMismatchError,
+} from '@/services/shared/restored-content-verifier';
+export {
   safe_abort_multipart,
   stream_encrypt_to_multipart,
   stream_to_content_addressed_storage,

--- a/packages/core/src/services/shared/restored-content-verifier.ts
+++ b/packages/core/src/services/shared/restored-content-verifier.ts
@@ -1,0 +1,48 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Raised when decrypted bytes are not the bytes the manifest recorded for that entry.
+ *
+ * Separate from a decryption failure on purpose: the bytes authenticated, so the key material and
+ * the object are intact. What failed is the claim that this object is the one the manifest points
+ * at.
+ */
+export class RestoredContentMismatchError extends Error {
+  constructor(
+    readonly label: string,
+    readonly expected_checksum: string,
+    readonly actual_checksum: string,
+  ) {
+    super(
+      `Restored content for ${label} does not match its manifest checksum ` +
+        `(expected ${expected_checksum}, got ${actual_checksum}); refusing to restore it`,
+    );
+    this.name = 'RestoredContentMismatchError';
+  }
+}
+
+/**
+ * Fails a restore when the decrypted bytes are not what the manifest recorded.
+ *
+ * Content is encrypted with one tenant key and nothing in the ciphertext says which object it is,
+ * so any object in the tenant authenticates in any other object's place. Anyone who can write to
+ * the bucket, without the key, can swap two blobs and have a restore put one message's contents
+ * where another belongs. The manifest checksum is the only thing that distinguishes them, so it is
+ * checked before any side effect rather than after (issue #340).
+ *
+ * An entry with no recorded checksum cannot be verified and is refused for the same reason: an
+ * unverifiable restore is exactly the case the substitution produces.
+ */
+export function assert_restored_content_matches(
+  label: string,
+  content: Buffer,
+  expected_checksum: string | undefined,
+): void {
+  const actual = createHash('sha256').update(content).digest('hex');
+  if (!expected_checksum) {
+    throw new RestoredContentMismatchError(label, '<none recorded>', actual);
+  }
+  if (actual !== expected_checksum) {
+    throw new RestoredContentMismatchError(label, expected_checksum, actual);
+  }
+}

--- a/packages/onedrive/src/adapters/s3-onedrive-manifest-repository.adapter.ts
+++ b/packages/onedrive/src/adapters/s3-onedrive-manifest-repository.adapter.ts
@@ -17,6 +17,20 @@ class InvalidOneDriveManifestDateError extends Error {
   }
 }
 
+class MismatchedOneDriveManifestError extends Error {
+  constructor(
+    readonly storage_key: string,
+    owner_id: string,
+    snapshot_id: string,
+  ) {
+    super(
+      `OneDrive manifest at ${storage_key} decrypts to ${owner_id}/${snapshot_id}; ` +
+        `refusing to use a manifest that is not the one the key names`,
+    );
+    this.name = 'MismatchedOneDriveManifestError';
+  }
+}
+
 /** Persists OneDrive snapshot manifests as encrypted JSON in S3. */
 @injectable()
 export class S3OneDriveManifestRepository implements OneDriveManifestRepository {
@@ -74,7 +88,15 @@ export class S3OneDriveManifestRepository implements OneDriveManifestRepository 
     return manifests.sort((a, b) => b.created_at.getTime() - a.created_at.getTime());
   }
 
-  /** Decrypts and parses a manifest object from storage, or undefined on recoverable failure. */
+  /**
+   * Downloads one manifest, rejecting a body that is not the identity the key names.
+   *
+   * A manifest is encrypted with the tenant key and nothing in the ciphertext says which manifest
+   * it is, so any manifest in the tenant authenticates at any other manifest's key. Rebuilding the
+   * key from the decrypted body and comparing it to the key that was read is what distinguishes
+   * them, and it covers every lookup here rather than only the one that had an id to check
+   * (issue #340).
+   */
   private async download_manifest(
     ctx: TenantContext,
     key: string,
@@ -83,6 +105,9 @@ export class S3OneDriveManifestRepository implements OneDriveManifestRepository 
       const payload = await ctx.storage.get(key);
       const json = ctx.decrypt(payload).toString('utf-8');
       const parsed = JSON.parse(json) as OneDriveSnapshotManifest;
+      if (onedrive_manifest_key(parsed.owner_id, parsed.snapshot_id) !== key) {
+        throw new MismatchedOneDriveManifestError(key, parsed.owner_id, parsed.snapshot_id);
+      }
       const created_at = new Date(parsed.created_at);
       if (Number.isNaN(created_at.getTime())) {
         throw new InvalidOneDriveManifestDateError(key);
@@ -90,6 +115,7 @@ export class S3OneDriveManifestRepository implements OneDriveManifestRepository 
       return { ...parsed, created_at };
     } catch (err) {
       if (err instanceof InvalidOneDriveManifestDateError) throw err;
+      if (err instanceof MismatchedOneDriveManifestError) throw err;
       return undefined;
     }
   }

--- a/packages/onedrive/tests/unit/adapters/manifest-identity.test.ts
+++ b/packages/onedrive/tests/unit/adapters/manifest-identity.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { OneDriveSnapshotManifest, TenantContext } from '@wisecom/atlas-types';
+import { S3OneDriveManifestRepository } from '@/adapters/s3-onedrive-manifest-repository.adapter';
+
+/**
+ * Issue #340, mirrored from the SharePoint suite. A manifest is encrypted with the tenant key and
+ * nothing in the ciphertext says which manifest it is, so any manifest in the tenant authenticates
+ * at any other manifest's key.
+ */
+
+function make_manifest(owner_id: string, snapshot_id: string): OneDriveSnapshotManifest {
+  return {
+    id: `${owner_id}-${snapshot_id}`,
+    tenant_id: 'tenant-1',
+    owner_id,
+    snapshot_id,
+    created_at: new Date('2026-03-01T00:00:00Z'),
+    total_files: 1,
+    total_size_bytes: 10,
+    entries: [],
+  };
+}
+
+function make_ctx(objects: Record<string, unknown>): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: {
+      list: vi.fn(async (prefix: string) =>
+        Object.keys(objects).filter((key) => key.startsWith(prefix)),
+      ),
+      get: vi.fn(async (key: string) => Buffer.from(JSON.stringify(objects[key]), 'utf-8')),
+      put: vi.fn(),
+    },
+    encrypt: (data: Buffer) => data,
+    decrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+describe('OneDrive manifest identity (issue #340)', () => {
+  const repo = new S3OneDriveManifestRepository();
+
+  it('returns the manifest when the body is the identity its key names', async () => {
+    const ctx = make_ctx({
+      'onedrive/manifests/owner-a/snap-a.json': make_manifest('owner-a', 'snap-a'),
+    });
+
+    const found = await repo.find_by_snapshot(ctx, 'owner-a', 'snap-a');
+
+    expect(found?.snapshot_id).toBe('snap-a');
+  });
+
+  it('refuses a manifest whose body names another owner and snapshot', async () => {
+    const ctx = make_ctx({
+      'onedrive/manifests/owner-a/snap-a.json': make_manifest('owner-b', 'snap-b'),
+    });
+
+    await expect(repo.find_by_snapshot(ctx, 'owner-a', 'snap-a')).rejects.toThrow(
+      /decrypts to owner-b\/snap-b/,
+    );
+  });
+
+  it('refuses the planted manifest through the listing path as well', async () => {
+    const ctx = make_ctx({
+      'onedrive/manifests/owner-a/snap-a.json': make_manifest('owner-b', 'snap-b'),
+    });
+
+    await expect(repo.list_snapshots_by_owner(ctx, 'owner-a')).rejects.toThrow(
+      /refusing to use a manifest that is not the one the key names/,
+    );
+  });
+});

--- a/packages/outlook/src/services/restore/restore-attachment-writer.ts
+++ b/packages/outlook/src/services/restore/restore-attachment-writer.ts
@@ -3,6 +3,7 @@ import type { RestoreConnector } from '@wisecom/atlas-types';
 import type { AttachmentEntry } from '@wisecom/atlas-types';
 import type { MimeAttachment } from '@/services/shared/mime-message-parser';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { assert_restored_content_matches } from '@wisecom/atlas-core/services/shared/restored-content-verifier';
 
 export interface AttachmentRestoreResult {
   readonly restored: number;
@@ -35,7 +36,7 @@ export async function restore_entry_attachments(
     }
 
     try {
-      const content = await decrypt_attachment(ctx, att.storage_key);
+      const content = await decrypt_attachment(ctx, att);
 
       await restore_connector.add_attachment(tenant_id, owner_id, new_message_id, {
         name: att.name,
@@ -88,8 +89,15 @@ export async function restore_parsed_attachments(
   return { restored, skipped: 0, errors };
 }
 
-/** Fetches and decrypts a single attachment binary from object storage. */
-async function decrypt_attachment(ctx: TenantContext, storage_key: string): Promise<Buffer> {
-  const ciphertext = await ctx.storage.get(storage_key);
-  return ctx.decrypt(ciphertext);
+/**
+ * Fetches and decrypts a single attachment binary from object storage.
+ *
+ * Verified against the manifest checksum before it is returned, so a substituted blob fails the
+ * entry rather than being uploaded under another attachment's name (issue #340).
+ */
+async function decrypt_attachment(ctx: TenantContext, att: AttachmentEntry): Promise<Buffer> {
+  const ciphertext = await ctx.storage.get(att.storage_key);
+  const content = ctx.decrypt(ciphertext);
+  assert_restored_content_matches(`attachment "${att.name}"`, content, att.checksum);
+  return content;
 }

--- a/packages/outlook/src/services/restore/restore-message-transformer.ts
+++ b/packages/outlook/src/services/restore/restore-message-transformer.ts
@@ -1,5 +1,6 @@
 import type { TenantContext } from '@wisecom/atlas-types';
 import type { ManifestEntry } from '@wisecom/atlas-types';
+import { assert_restored_content_matches } from '@wisecom/atlas-core/services/shared/restored-content-verifier';
 import { parse_mime_message } from '@/services/shared/mime-message-parser';
 import type { MimeAddress, ParsedMimeMessage } from '@/services/shared/mime-message-parser';
 
@@ -51,14 +52,15 @@ const WRITABLE_FIELDS = new Set([
 
 /**
  * Decrypts a manifest entry from storage and parses the JSON payload.
- * Returns the raw Graph message object as stored during backup.
+ *
+ * The checksum is compared before the bytes are parsed, so a substituted object fails here rather
+ * than reaching `create_message` (issue #340).
  */
 export async function decrypt_and_parse_message(
   ctx: TenantContext,
   entry: ManifestEntry,
 ): Promise<Record<string, unknown>> {
-  const ciphertext = await ctx.storage.get(entry.storage_key);
-  const plaintext = ctx.decrypt(ciphertext);
+  const plaintext = await decrypt_verified_entry(ctx, entry);
   return JSON.parse(plaintext.toString('utf-8')) as Record<string, unknown>;
 }
 
@@ -70,8 +72,15 @@ export async function decrypt_and_parse_mime(
   ctx: TenantContext,
   entry: ManifestEntry,
 ): Promise<ParsedMimeMessage> {
+  return parse_mime_message(await decrypt_verified_entry(ctx, entry));
+}
+
+/** Fetches, decrypts and checksum-verifies one entry's stored payload. */
+async function decrypt_verified_entry(ctx: TenantContext, entry: ManifestEntry): Promise<Buffer> {
   const ciphertext = await ctx.storage.get(entry.storage_key);
-  return parse_mime_message(ctx.decrypt(ciphertext));
+  const plaintext = ctx.decrypt(ciphertext);
+  assert_restored_content_matches(`message ${entry.object_id}`, plaintext, entry.checksum);
+  return plaintext;
 }
 
 /**

--- a/packages/outlook/tests/unit/services/restore/ciphertext-substitution.test.ts
+++ b/packages/outlook/tests/unit/services/restore/ciphertext-substitution.test.ts
@@ -1,0 +1,141 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  AttachmentEntry,
+  ManifestEntry,
+  RestoreConnector,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { restore_one_entry } from '@/services/restore/restore-execution-orchestrator';
+import { restore_entry_attachments } from '@/services/restore/restore-attachment-writer';
+
+/**
+ * Issue #340: content is encrypted with one tenant key and nothing in the ciphertext says which
+ * object it belongs to, so any object in the tenant authenticates in any other object's place.
+ * Swapping two blobs needs write access to the bucket, not the key. The manifest checksum is the
+ * only thing that distinguishes them, and it has to be checked before the Graph call, not after.
+ */
+
+const MESSAGE_A = Buffer.from(JSON.stringify({ subject: 'Message A', parentFolderId: 'f1' }));
+const MESSAGE_B = Buffer.from(JSON.stringify({ subject: 'Message B', parentFolderId: 'f1' }));
+const ATTACHMENT_A = Buffer.from('attachment-a-bytes');
+const ATTACHMENT_B = Buffer.from('attachment-b-bytes');
+
+function sha(body: Buffer): string {
+  return createHash('sha256').update(body).digest('hex');
+}
+
+/** Stores plaintext directly; `decrypt` is the identity, so every stored blob authenticates. */
+function make_ctx(objects: Record<string, Buffer>): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: {
+      get: vi.fn(async (key: string) => objects[key] ?? Buffer.alloc(0)),
+      put: vi.fn(),
+    },
+    encrypt: (data: Buffer) => data,
+    decrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+function make_restore_connector(): RestoreConnector {
+  return {
+    create_mail_folder: vi.fn(),
+    create_message: vi.fn().mockResolvedValue('new-msg-1'),
+    add_attachment: vi.fn(),
+    create_upload_session: vi.fn(),
+    upload_attachment_chunk: vi.fn(),
+    count_folder_messages: vi.fn(),
+    list_folder_messages: vi.fn(),
+  };
+}
+
+function make_entry(checksum: string): ManifestEntry {
+  return {
+    object_id: 'msg-a',
+    storage_key: 'data/user/msg-a',
+    checksum,
+    size_bytes: MESSAGE_A.length,
+    folder_id: 'f1',
+  };
+}
+
+function make_attachment(checksum: string): AttachmentEntry {
+  return {
+    attachment_id: 'att-a',
+    name: 'report.pdf',
+    content_type: 'application/pdf',
+    size_bytes: ATTACHMENT_A.length,
+    storage_key: 'attachments/user/att-a',
+    checksum,
+    is_inline: false,
+  };
+}
+
+describe('Outlook restore under ciphertext substitution (issue #340)', () => {
+  it('restores the message when the stored bytes are the ones the manifest recorded', async () => {
+    const ctx = make_ctx({ 'data/user/msg-a': MESSAGE_A });
+    const connector = make_restore_connector();
+
+    await restore_one_entry(
+      ctx,
+      connector,
+      'tenant-1',
+      'user@test.com',
+      'f1',
+      make_entry(sha(MESSAGE_A)),
+    );
+
+    expect(connector.create_message).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates no message when another message was written over the blob', async () => {
+    // Message B's ciphertext under message A's key: it decrypts and authenticates, and before the
+    // fix it reached create_message as message A.
+    const ctx = make_ctx({ 'data/user/msg-a': MESSAGE_B });
+    const connector = make_restore_connector();
+
+    await expect(
+      restore_one_entry(
+        ctx,
+        connector,
+        'tenant-1',
+        'user@test.com',
+        'f1',
+        make_entry(sha(MESSAGE_A)),
+      ),
+    ).rejects.toThrow(/does not match its manifest checksum/);
+
+    expect(connector.create_message).not.toHaveBeenCalled();
+  });
+
+  it('refuses an entry that records no checksum, since nothing can distinguish it', async () => {
+    const ctx = make_ctx({ 'data/user/msg-a': MESSAGE_B });
+    const connector = make_restore_connector();
+
+    await expect(
+      restore_one_entry(ctx, connector, 'tenant-1', 'user@test.com', 'f1', make_entry('')),
+    ).rejects.toThrow(/does not match its manifest checksum/);
+
+    expect(connector.create_message).not.toHaveBeenCalled();
+  });
+
+  it('uploads no attachment when another attachment was written over the blob', async () => {
+    const ctx = make_ctx({ 'attachments/user/att-a': ATTACHMENT_B });
+    const connector = make_restore_connector();
+
+    const result = await restore_entry_attachments(
+      ctx,
+      connector,
+      'tenant-1',
+      'user@test.com',
+      'new-msg-1',
+      [make_attachment(sha(ATTACHMENT_A))],
+    );
+
+    expect(connector.add_attachment).not.toHaveBeenCalled();
+    expect(result.restored).toBe(0);
+    expect(result.errors[0]).toMatch(/does not match its manifest checksum/);
+  });
+});

--- a/packages/outlook/tests/unit/services/restore/folder-id-backfill.test.ts
+++ b/packages/outlook/tests/unit/services/restore/folder-id-backfill.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import type { ManifestEntry, TenantContext } from '@wisecom/atlas-types';
 import { backfill_missing_folder_ids } from '@/services/restore/restore-execution-orchestrator';
@@ -10,12 +11,19 @@ import { filter_entries_by_folder_name } from '@/services/restore/folder-restore
  * died before touching a single message.
  */
 const INBOX_ID = 'AAMkAG-inbox';
+const JSON_BODY = JSON.stringify({ parentFolderId: INBOX_ID });
+const BROKEN_BODY = 'not json at all';
+
+/** Restore refuses bytes that do not match the entry's checksum (issue #340), so fixtures digest. */
+function sha(body: string): string {
+  return createHash('sha256').update(body).digest('hex');
+}
 
 function entry(overrides: Partial<ManifestEntry> = {}): ManifestEntry {
   return {
     object_id: 'msg-1',
     storage_key: 'outlook/data/owner/abc',
-    checksum: 'sha',
+    checksum: sha(''),
     size_bytes: 10,
     ...overrides,
   } as ManifestEntry;
@@ -40,7 +48,12 @@ const MIME_BODY = 'From: john.doe@example.com\r\nSubject: Example subject\r\n\r\
 
 describe('backfill_missing_folder_ids', () => {
   it('does not throw on a legacy MIME entry without folder_id', async () => {
-    const mime = entry({ object_id: 'mime-1', storage_key: 'k-mime', payload_format: 'mime' });
+    const mime = entry({
+      object_id: 'mime-1',
+      storage_key: 'k-mime',
+      payload_format: 'mime',
+      checksum: sha(MIME_BODY),
+    });
     const ctx = make_ctx({ 'k-mime': MIME_BODY });
 
     await expect(backfill_missing_folder_ids(ctx, [mime])).resolves.toBeUndefined();
@@ -48,8 +61,8 @@ describe('backfill_missing_folder_ids', () => {
   });
 
   it('still backfills a legacy JSON entry from its decrypted payload', async () => {
-    const json = entry({ object_id: 'json-1', storage_key: 'k-json' });
-    const ctx = make_ctx({ 'k-json': JSON.stringify({ parentFolderId: INBOX_ID }) });
+    const json = entry({ object_id: 'json-1', storage_key: 'k-json', checksum: sha(JSON_BODY) });
+    const ctx = make_ctx({ 'k-json': JSON_BODY });
 
     await backfill_missing_folder_ids(ctx, [json]);
 
@@ -57,11 +70,16 @@ describe('backfill_missing_folder_ids', () => {
   });
 
   it('backfills the JSON entries alongside a MIME entry that cannot be resolved', async () => {
-    const mime = entry({ object_id: 'mime-1', storage_key: 'k-mime', payload_format: 'mime' });
-    const json = entry({ object_id: 'json-1', storage_key: 'k-json' });
+    const mime = entry({
+      object_id: 'mime-1',
+      storage_key: 'k-mime',
+      payload_format: 'mime',
+      checksum: sha(MIME_BODY),
+    });
+    const json = entry({ object_id: 'json-1', storage_key: 'k-json', checksum: sha(JSON_BODY) });
     const ctx = make_ctx({
       'k-mime': MIME_BODY,
-      'k-json': JSON.stringify({ parentFolderId: INBOX_ID }),
+      'k-json': JSON_BODY,
     });
 
     await backfill_missing_folder_ids(ctx, [mime, json]);
@@ -72,12 +90,17 @@ describe('backfill_missing_folder_ids', () => {
 
   it('selects the folder-matching entries and skips the unresolved MIME one', async () => {
     // The end-to-end shape of a `-f Inbox` run: backfill, then filter.
-    const mime = entry({ object_id: 'mime-1', storage_key: 'k-mime', payload_format: 'mime' });
-    const json = entry({ object_id: 'json-1', storage_key: 'k-json' });
+    const mime = entry({
+      object_id: 'mime-1',
+      storage_key: 'k-mime',
+      payload_format: 'mime',
+      checksum: sha(MIME_BODY),
+    });
+    const json = entry({ object_id: 'json-1', storage_key: 'k-json', checksum: sha(JSON_BODY) });
     const stamped = entry({ object_id: 'json-2', folder_id: INBOX_ID });
     const ctx = make_ctx({
       'k-mime': MIME_BODY,
-      'k-json': JSON.stringify({ parentFolderId: INBOX_ID }),
+      'k-json': JSON_BODY,
     });
     const folder_map = new Map<string, string>([[INBOX_ID, 'Inbox']]);
 
@@ -99,11 +122,15 @@ describe('backfill_missing_folder_ids', () => {
 
   it('keeps going when one JSON payload is unreadable', async () => {
     // A corrupt entry is the same failure shape as the MIME one: it must not take the run with it.
-    const broken = entry({ object_id: 'json-broken', storage_key: 'k-broken' });
-    const good = entry({ object_id: 'json-good', storage_key: 'k-good' });
+    const broken = entry({
+      object_id: 'json-broken',
+      storage_key: 'k-broken',
+      checksum: sha(BROKEN_BODY),
+    });
+    const good = entry({ object_id: 'json-good', storage_key: 'k-good', checksum: sha(JSON_BODY) });
     const ctx = make_ctx({
-      'k-broken': 'not json at all',
-      'k-good': JSON.stringify({ parentFolderId: INBOX_ID }),
+      'k-broken': BROKEN_BODY,
+      'k-good': JSON_BODY,
     });
 
     await expect(backfill_missing_folder_ids(ctx, [broken, good])).resolves.toBeUndefined();

--- a/packages/outlook/tests/unit/services/restore/mime-entry.test.ts
+++ b/packages/outlook/tests/unit/services/restore/mime-entry.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   restore_one_entry,
@@ -63,10 +64,15 @@ function build_stored_json(): Buffer {
   );
 }
 
+/** Restore refuses bytes that do not match the entry's checksum (issue #340). */
+function sha(body: Buffer): string {
+  return createHash('sha256').update(body).digest('hex');
+}
+
 const MIME_ENTRY: ManifestEntry = {
   object_id: 'msg-mime',
   storage_key: 'data/user/mime-blob',
-  checksum: 'chk-mime',
+  checksum: sha(build_stored_mime()),
   size_bytes: 2048,
   subject: 'Q1 reconciliation figures',
   folder_id: 'f1',
@@ -77,7 +83,7 @@ const MIME_ENTRY: ManifestEntry = {
 const JSON_ENTRY: ManifestEntry = {
   object_id: 'msg-json',
   storage_key: 'data/user/json-blob',
-  checksum: 'chk-json',
+  checksum: sha(build_stored_json()),
   size_bytes: 512,
   subject: 'Legacy JSON message',
   folder_id: 'f1',
@@ -86,7 +92,7 @@ const JSON_ENTRY: ManifestEntry = {
       attachment_id: 'att-1',
       name: 'legacy.txt',
       content_type: 'text/plain',
-      checksum: 'chk-att-1',
+      checksum: sha(JSON_ATTACHMENT_BYTES),
       size_bytes: JSON_ATTACHMENT_BYTES.length,
       is_inline: false,
       storage_key: 'data/user/att-blob',

--- a/packages/outlook/tests/unit/services/restore/restore-attachment-writer.test.ts
+++ b/packages/outlook/tests/unit/services/restore/restore-attachment-writer.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { restore_entry_attachments } from '@/services/restore/restore-attachment-writer';
 import type { TenantContext } from '@wisecom/atlas-types';
@@ -5,6 +6,10 @@ import type { RestoreConnector } from '@wisecom/atlas-types';
 import type { AttachmentEntry } from '@wisecom/atlas-types';
 import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
 import { stub_tenant_create_decipher } from '@wisecom/atlas-types/testing/stub-tenant-create-decipher';
+
+/** What the stubbed storage decrypts to, and the digest restore now checks it against (#340). */
+const STORED_CONTENT = 'content';
+const STORED_CHECKSUM = createHash('sha256').update(STORED_CONTENT).digest('hex');
 
 function make_ctx(): TenantContext {
   return {
@@ -56,7 +61,7 @@ function make_attachment(overrides: Partial<AttachmentEntry> = {}): AttachmentEn
     content_type: 'application/pdf',
     size_bytes: 1024,
     storage_key: 'attachments/user/sha256hash',
-    checksum: 'sha256hash',
+    checksum: STORED_CHECKSUM,
     is_inline: false,
     ...overrides,
   };

--- a/packages/outlook/tests/unit/services/restore/restore-message-transformer.test.ts
+++ b/packages/outlook/tests/unit/services/restore/restore-message-transformer.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, it, expect, vi } from 'vitest';
 import {
   sanitize_message_for_restore,
@@ -161,7 +162,7 @@ describe('decrypt_and_parse_message', () => {
     const entry: ManifestEntry = {
       object_id: 'msg-1',
       storage_key: 'data/user/abc123',
-      checksum: 'abc',
+      checksum: createHash('sha256').update(json_buf).digest('hex'),
       size_bytes: 100,
     };
 

--- a/packages/outlook/tests/unit/services/restore/restore.service.fixtures.ts
+++ b/packages/outlook/tests/unit/services/restore/restore.service.fixtures.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type { Manifest, ManifestEntry } from '@wisecom/atlas-types';
 
 /** Builds a minimal Outlook manifest entry for restore service tests. */
@@ -5,7 +6,7 @@ export function make_restore_entry(id: string, folder_id: string): ManifestEntry
   return {
     object_id: id,
     storage_key: `data/user/${id}`,
-    checksum: id,
+    checksum: STORED_PAYLOAD_CHECKSUM,
     size_bytes: 100,
     subject: `Subject ${id}`,
     folder_id,
@@ -38,3 +39,14 @@ export function make_stored_message(folder_id: string): Buffer {
   });
   return Buffer.concat([Buffer.from('E'), Buffer.from(json)]);
 }
+
+/**
+ * SHA-256 of the plaintext the stubbed storage hands back for every key.
+ *
+ * Restore verifies decrypted bytes against the entry's checksum before it calls Graph (issue
+ * #340), so a fixture entry has to carry the digest of what the stub actually stores rather than
+ * an arbitrary string.
+ */
+export const STORED_PAYLOAD_CHECKSUM = createHash('sha256')
+  .update(make_stored_message('f1').subarray(1))
+  .digest('hex');

--- a/packages/outlook/tests/unit/services/restore/restore.service.test.ts
+++ b/packages/outlook/tests/unit/services/restore/restore.service.test.ts
@@ -19,6 +19,7 @@ import {
   make_restore_entry as make_entry,
   make_restore_manifest as make_manifest,
   make_stored_message,
+  STORED_PAYLOAD_CHECKSUM,
 } from './restore.service.fixtures';
 
 describe('RestoreService', () => {
@@ -220,7 +221,7 @@ describe('RestoreService', () => {
           content_type: 'application/pdf',
           size_bytes: 512,
           storage_key: 'attachments/user/hash1',
-          checksum: 'hash1',
+          checksum: STORED_PAYLOAD_CHECKSUM,
           is_inline: false,
         },
       ],

--- a/packages/s3/src/adapters/s3-manifest-repository.adapter.ts
+++ b/packages/s3/src/adapters/s3-manifest-repository.adapter.ts
@@ -25,6 +25,20 @@ function snapshot_pointer_key(snapshot_id: string): string {
   return `${MANIFEST_POINTER_PREFIX}/snapshots/${snapshot_id}.json`;
 }
 
+class MismatchedManifestError extends Error {
+  constructor(
+    readonly storage_key: string,
+    owner_id: string,
+    snapshot_id: string,
+  ) {
+    super(
+      `Outlook manifest at ${storage_key} decrypts to ${owner_id}/${snapshot_id}; ` +
+        `refusing to use a manifest that is not the one the key names`,
+    );
+    this.name = 'MismatchedManifestError';
+  }
+}
+
 /**
  * Stores manifests as encrypted JSON in the tenant's S3 bucket.
  * Key layout: manifests/{owner_id}/{snapshot_id}.json
@@ -119,7 +133,14 @@ export class S3ManifestRepository implements ManifestRepository {
     return results.filter((manifest): manifest is Manifest => manifest !== undefined);
   }
 
-  /** Downloads an encrypted manifest blob, decrypts it, and parses the JSON. */
+  /**
+   * Downloads an encrypted manifest blob, decrypts it, and rejects a body the key does not name.
+   *
+   * A manifest is encrypted with the tenant key and nothing in the ciphertext says which manifest
+   * it is, so any manifest in the tenant authenticates at any other manifest's key. Rebuilding the
+   * key from the decrypted body is what distinguishes them, and doing it here covers the legacy
+   * scan and the listing paths as well as the pointer lookups (issue #340).
+   */
   private async download_and_decrypt(
     ctx: TenantContext,
     key: string,
@@ -127,8 +148,15 @@ export class S3ManifestRepository implements ManifestRepository {
     try {
       const encrypted = await ctx.storage.get(key);
       const json = ctx.decrypt(encrypted);
-      return JSON.parse(json.toString('utf-8')) as Manifest;
-    } catch {
+      const parsed = JSON.parse(json.toString('utf-8')) as Manifest;
+      if (manifest_key(parsed.owner_id, parsed.snapshot_id) !== key) {
+        throw new MismatchedManifestError(key, parsed.owner_id, parsed.snapshot_id);
+      }
+      return parsed;
+    } catch (err) {
+      // A tampered manifest is reported, not skipped: quietly omitting it would read as "this
+      // snapshot was never taken", which is the outcome the substitution is trying to produce.
+      if (err instanceof MismatchedManifestError) throw err;
       return undefined;
     }
   }

--- a/packages/s3/tests/unit/manifest-identity.test.ts
+++ b/packages/s3/tests/unit/manifest-identity.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { S3ManifestRepository } from '@/adapters/s3-manifest-repository.adapter';
+import type { Manifest, TenantContext } from '@wisecom/atlas-types';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+import { stub_tenant_create_decipher } from '@wisecom/atlas-types/testing/stub-tenant-create-decipher';
+
+/**
+ * Issue #340: a manifest is encrypted with the tenant key and nothing in the ciphertext says which
+ * manifest it is, so any manifest in the tenant authenticates at any other manifest's key. The
+ * pointer lookups already compared the id they had; the legacy scan and the listings did not.
+ */
+
+function make_manifest(owner_id: string, snapshot_id: string): Manifest {
+  return {
+    id: `${owner_id}-${snapshot_id}`,
+    tenant_id: 'test-tenant',
+    owner_id,
+    snapshot_id,
+    created_at: new Date('2026-01-15T10:00:00Z'),
+    total_objects: 0,
+    total_size_bytes: 0,
+    delta_links: {},
+    entries: [],
+  };
+}
+
+function make_ctx(objects: Record<string, Manifest>): TenantContext {
+  return {
+    tenant_id: 'test-tenant',
+    storage: {
+      put: vi.fn(),
+      get: vi.fn(async (key: string) => {
+        const value = objects[key];
+        if (!value) throw new Error(`missing ${key}`);
+        return Buffer.concat([Buffer.from('ENC:'), Buffer.from(JSON.stringify(value))]);
+      }),
+      list: vi.fn(async (prefix: string) =>
+        Object.keys(objects).filter((key) => key.startsWith(prefix)),
+      ),
+      delete: vi.fn(),
+      delete_version: vi.fn(),
+      exists: vi.fn(),
+      list_versions: vi.fn().mockResolvedValue([]),
+      begin_multipart_upload: vi.fn(),
+      copy: vi.fn(),
+      get_with_etag: vi.fn(),
+      get_stream: vi.fn(),
+      apply_default_retention: vi.fn(),
+      abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+      probe_immutability: vi.fn(),
+    },
+    encrypt: vi.fn((data: Buffer) => Buffer.concat([Buffer.from('ENC:'), data])),
+    decrypt: vi.fn((data: Buffer) => data.subarray(4)),
+    create_cipher: stub_tenant_create_cipher,
+    create_decipher: stub_tenant_create_decipher,
+    destroy: vi.fn(),
+  };
+}
+
+describe('Outlook manifest identity (issue #340)', () => {
+  const repo = new S3ManifestRepository();
+
+  it('returns the manifest when the body is the identity its key names', async () => {
+    const ctx = make_ctx({
+      'manifests/user@test.com/snap-1.json': make_manifest('user@test.com', 'snap-1'),
+    });
+
+    const found = await repo.find_by_snapshot(ctx, 'snap-1');
+
+    expect(found?.snapshot_id).toBe('snap-1');
+  });
+
+  it('refuses a manifest whose body names another owner and snapshot', async () => {
+    // Valid ciphertext for this tenant, planted at another snapshot's key. No pointer object
+    // exists, so this is the legacy scan path that had no identity check at all.
+    const ctx = make_ctx({
+      'manifests/user@test.com/snap-1.json': make_manifest('other@test.com', 'snap-2'),
+    });
+
+    await expect(repo.find_by_snapshot(ctx, 'snap-1')).rejects.toThrow(
+      /decrypts to other@test.com\/snap-2/,
+    );
+  });
+
+  it('refuses the planted manifest through the listing path as well', async () => {
+    const ctx = make_ctx({
+      'manifests/user@test.com/snap-1.json': make_manifest('other@test.com', 'snap-2'),
+    });
+
+    await expect(repo.list_all_manifests(ctx)).rejects.toThrow(
+      /refusing to use a manifest that is not the one the key names/,
+    );
+  });
+});

--- a/packages/sharepoint/src/adapters/s3-sharepoint-manifest-repository.adapter.ts
+++ b/packages/sharepoint/src/adapters/s3-sharepoint-manifest-repository.adapter.ts
@@ -17,6 +17,20 @@ class InvalidSharePointManifestDateError extends Error {
   }
 }
 
+class MismatchedSharePointManifestError extends Error {
+  constructor(
+    readonly storage_key: string,
+    site_id: string,
+    snapshot_id: string,
+  ) {
+    super(
+      `SharePoint manifest at ${storage_key} decrypts to ${site_id}/${snapshot_id}; ` +
+        `refusing to use a manifest that is not the one the key names`,
+    );
+    this.name = 'MismatchedSharePointManifestError';
+  }
+}
+
 /** Persists SharePoint snapshot manifests as encrypted JSON in S3. */
 @injectable()
 export class S3SharePointManifestRepository implements SharePointManifestRepository {
@@ -74,6 +88,15 @@ export class S3SharePointManifestRepository implements SharePointManifestReposit
     return manifests.sort((a, b) => b.created_at.getTime() - a.created_at.getTime());
   }
 
+  /**
+   * Downloads one manifest, rejecting a body that is not the identity the key names.
+   *
+   * A manifest is encrypted with the tenant key and nothing in the ciphertext says which manifest
+   * it is, so any manifest in the tenant authenticates at any other manifest's key. Rebuilding the
+   * key from the decrypted body and comparing it to the key that was read is what distinguishes
+   * them, and it covers every lookup here rather than only the one that had an id to check
+   * (issue #340).
+   */
   private async download_manifest(
     ctx: TenantContext,
     key: string,
@@ -82,6 +105,9 @@ export class S3SharePointManifestRepository implements SharePointManifestReposit
       const payload = await ctx.storage.get(key);
       const json = ctx.decrypt(payload).toString('utf-8');
       const parsed = JSON.parse(json) as SharePointSnapshotManifest;
+      if (sharepoint_manifest_key(parsed.site_id, parsed.snapshot_id) !== key) {
+        throw new MismatchedSharePointManifestError(key, parsed.site_id, parsed.snapshot_id);
+      }
       const created_at = new Date(parsed.created_at);
       if (Number.isNaN(created_at.getTime())) {
         throw new InvalidSharePointManifestDateError(key);
@@ -89,6 +115,7 @@ export class S3SharePointManifestRepository implements SharePointManifestReposit
       return { ...parsed, created_at };
     } catch (err) {
       if (err instanceof InvalidSharePointManifestDateError) throw err;
+      if (err instanceof MismatchedSharePointManifestError) throw err;
       return undefined;
     }
   }

--- a/packages/sharepoint/tests/unit/adapters/manifest-identity.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/manifest-identity.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SharePointSnapshotManifest, TenantContext } from '@wisecom/atlas-types';
+import { S3SharePointManifestRepository } from '@/adapters/s3-sharepoint-manifest-repository.adapter';
+
+/**
+ * Issue #340: a manifest is encrypted with the tenant key and nothing in the ciphertext says which
+ * manifest it is, so any manifest in the tenant authenticates at any other manifest's key. Someone
+ * with write access to the bucket and no key can move one under another's name.
+ */
+
+function make_manifest(site_id: string, snapshot_id: string): SharePointSnapshotManifest {
+  return {
+    id: `${site_id}-${snapshot_id}`,
+    tenant_id: 'tenant-1',
+    site_id,
+    snapshot_id,
+    created_at: new Date('2026-03-01T00:00:00Z'),
+    total_files: 1,
+    total_size_bytes: 10,
+    entries: [],
+  };
+}
+
+function make_ctx(objects: Record<string, unknown>): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: {
+      list: vi.fn(async (prefix: string) =>
+        Object.keys(objects).filter((key) => key.startsWith(prefix)),
+      ),
+      get: vi.fn(async (key: string) => Buffer.from(JSON.stringify(objects[key]), 'utf-8')),
+      put: vi.fn(),
+    },
+    encrypt: (data: Buffer) => data,
+    decrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+describe('SharePoint manifest identity (issue #340)', () => {
+  const repo = new S3SharePointManifestRepository();
+
+  it('returns the manifest when the body is the identity its key names', async () => {
+    const ctx = make_ctx({
+      'sharepoint/manifests/site-a/snap-a.json': make_manifest('site-a', 'snap-a'),
+    });
+
+    const found = await repo.find_by_snapshot(ctx, 'site-a', 'snap-a');
+
+    expect(found?.snapshot_id).toBe('snap-a');
+  });
+
+  it('refuses a manifest whose body names another site and snapshot', async () => {
+    // Valid ciphertext for this tenant, planted at another snapshot's key.
+    const ctx = make_ctx({
+      'sharepoint/manifests/site-a/snap-a.json': make_manifest('site-b', 'snap-b'),
+    });
+
+    await expect(repo.find_by_snapshot(ctx, 'site-a', 'snap-a')).rejects.toThrow(
+      /decrypts to site-b\/snap-b/,
+    );
+  });
+
+  it('refuses the planted manifest through the listing path as well', async () => {
+    const ctx = make_ctx({
+      'sharepoint/manifests/site-a/snap-a.json': make_manifest('site-b', 'snap-b'),
+    });
+
+    // A silent skip here would leave `find_latest_by_site` reporting the site as never backed up.
+    await expect(repo.list_snapshots_by_site(ctx, 'site-a')).rejects.toThrow(
+      /refusing to use a manifest that is not the one the key names/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Part of #340. Content is encrypted with one DEK per tenant and nothing in the ciphertext says which object it belongs to, so any object in the tenant authenticates in any other object's place. Overwriting one blob with another needs write access to the bucket, not the key or the passphrase, and the swapped object decrypts cleanly. Drive restore compensated by comparing the manifest checksum. Outlook restore did not, and the manifest repositories did not check that a decrypted manifest was the identity that had been requested.

I reproduced both halves before changing anything, and both reproductions are in the diff as tests. Message B's bytes under message A's key reached `create_message` as message A. A manifest naming `site-b`/`snap-b` planted at `site-a`/`snap-a`'s key was returned for `site-a`/`snap-a`.

**Restore now checks before it acts, not after.** Outlook message and attachment restore compare the SHA-256 of the decrypted bytes against the manifest checksum before the Graph call, for MIME and legacy JSON entries alike. An entry that records no checksum is refused rather than restored unverified, since an unverifiable restore is exactly what the substitution produces. The check lives in one place, `assert_restored_content_matches` in `packages/core`, so the message path and the attachment path cannot drift apart.

**A manifest is checked by rebuilding its key.** It carries no checksum of its own, but its identity is in its body, so the repositories rebuild the storage key from the decrypted `owner_id`/`site_id` and `snapshot_id` and compare it to the key they read. Doing it in the shared download helper covers the listing and legacy-scan paths, which had no check at all, rather than only the pointer lookups that already compared the id they happened to hold. A planted manifest is reported rather than skipped, because quietly omitting it reads as "this snapshot was never taken", which is the outcome the attack wants.

**Not in this PR, by decision:** the fourth acceptance criterion, binding object purpose and identity into the envelope as AAD, is #350. It changes the on-disk format for every object Atlas writes and wants its own review. #340 stays open until that lands. What is here defeats the substitution in the reproduction; the AAD binding is prevention where this is detection, and it also covers objects with no manifest entry to check against.

## Changes

- `packages/core/src/services/shared/restored-content-verifier.ts`: new `assert_restored_content_matches` and `RestoredContentMismatchError`, exported from the shared barrel.
- `packages/outlook/src/services/restore/restore-message-transformer.ts`: both decrypt helpers route through one verified read, so JSON and MIME entries are checked identically.
- `packages/outlook/src/services/restore/restore-attachment-writer.ts`: attachment bytes are verified against the entry checksum before upload; a mismatch fails that attachment and is collected as an entry error rather than taking the message with it.
- `packages/s3`, `packages/onedrive`, `packages/sharepoint` manifest repositories: reject a decrypted manifest whose rebuilt key is not the key it was read from.
- `docs/security.md`: new "What the GCM tag does not tell you" section under Integrity Validation, covering what is checked where, and stating that neither check prevents replay of an older ciphertext for the same object, which stays Object Lock's and versioning's job.
- Regression coverage: cross-object substitution for messages and attachments in `packages/outlook`, and a planted manifest for all three workloads through both the direct lookup and the listing path.
- Restore fixtures now digest what the stub actually stores. They carried strings like `'chk-mime'`, which modelled a world where the bytes were never checked.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`), unless this is a release or hotfix PR
- [x] No version bump in `packages/*/package.json` (releases only)
- [x] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Restore operations now verify decrypted content against recorded SHA-256 checksums before creating messages or uploading attachments.
  * Missing or mismatched checksums are rejected to help prevent blob-substitution attacks.
  * Manifest identities are validated against their storage locations across supported providers.
  * Tampered or incorrectly placed manifests are reported instead of being silently ignored.
* **Documentation**
  * Added documentation describing checksum-based protections and remaining security limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->