### PR TITLE
test(sharepoint): stop the whole-file budget case copying 2.5 GiB

### DIFF
--- a/packages/sharepoint/tests/unit/adapters/chunk-download-timeout.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/chunk-download-timeout.test.ts
@@ -134,13 +134,17 @@ describe('chunk download abort timeout', () => {
     // the entire file, so draining it needs the file's budget, not a chunk's.
     // Arming that per response instead of per chunk is what keeps the common
     // path fast without regressing this one.
-    const total = 100 * 1024 * 1024;
-    const whole_file = Buffer.alloc(total, 7);
+    // Three chunks, not twenty-five, and one body buffer rather than one per chunk. The size only
+    // has to put the whole-file budget above the 30 second floor, which starts at 7.33 MiB; at
+    // 100 MiB the mock re-copied the body on every chunk and the case spent 2.5 GiB of memcpy to
+    // assert two numbers, which is what made it time out on a loaded runner.
+    const total = 12 * 1024 * 1024;
+    const whole_file = Buffer.alloc(total, 7).buffer;
 
     fetch_mock.mockResolvedValue({
       status: 200,
       headers: { get: (): string | null => null },
-      arrayBuffer: () => Promise.resolve(whole_file.buffer.slice(0, whole_file.length)),
+      arrayBuffer: () => Promise.resolve(whole_file),
     } as unknown as Response);
 
     const delays = capture_armed_delays();


### PR DESCRIPTION
## Summary

`chunk download abort timeout > still grants the whole-file budget when the CDN ignores Range and returns 200` fails intermittently in CI. It failed a docs-only PR (#349) on the first run and passed on a re-run, so nothing in that diff caused it.

The cause is in the test, not the code under test. It hands a 100 MiB body to `download_file_chunked`, and the SharePoint adapter downloader has no Range-ignored fallback, so it issues one request per chunk: twenty-five calls, each answered by `whole_file.buffer.slice(0, whole_file.length)`, which allocates and copies a fresh 100 MiB ArrayBuffer every time. That is roughly 2.5 GiB of memcpy plus the garbage it leaves, to assert two numbers. About 480 ms on my machine, and past vitest's 5 second limit on a loaded runner under coverage instrumentation.

The size is arbitrary. The only thing it has to do is put the whole-file budget above the 30 second floor so the two values are distinguishable, and `compute_chunk_timeout_ms` crosses that at 7.33 MiB. At 12 MiB the run is three chunks instead of twenty-five, and the body buffer is allocated once rather than per response. Same two assertions, 10 ms instead of 480 ms.

I checked the sibling cases and the OneDrive twin for the same shape. They allocate one 4 MiB chunk per response, which is the size the code is actually being asked about, so they stay as they are.

## Changes

- `packages/sharepoint/tests/unit/adapters/chunk-download-timeout.test.ts`: the whole-file budget case uses a 12 MiB body and allocates it once, with a comment naming the floor the size has to clear so nobody shrinks it below 7.33 MiB and quietly makes the assertion vacuous.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`), unless this is a release or hotfix PR
- [x] No version bump in `packages/*/package.json` (releases only)
- [x] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)
