### PR TITLE
fix(integrity): report a failed authentication instead of an absence

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -360,6 +360,35 @@ rolling an object back to a previous state is defeated by S3 Object Lock and ver
 by encryption. And a checksum recorded wrong at backup time is not detected by comparing against
 it, which is the same limit that applies to verification above.
 
+### A failed authentication is a failure everywhere
+
+A GCM failure used to be reported as several different kinds of nothing: an attachment that could
+not be decrypted left a restored message with zero attachments and no errors, an export skipped the
+file and finished a valid archive, and a manifest that would not decrypt came back as `undefined`,
+which is the same answer as a snapshot that was never taken. Each of those makes a damaged backup
+look intact from the outside.
+
+| Object                  | Reported as                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| Outlook attachment      | an error on the restore result, counted in `attachment_error_count`          |
+| Drive file in an export | an error and an integrity failure, distinct from a file with nothing to save |
+| Snapshot manifest       | a raised `StorageError`; only a genuinely absent object reads as absent      |
+
+The distinction between absence and damage is the point. A read that returns "no such key" is a
+normal outcome and stays one. Anything else, a decrypt that failed, a body that would not parse, a
+manifest whose identity is not the one its key names, is a damaged object and is raised.
+
+Verification counts an entry the moment it claims a stored blob, rather than requiring a checksum
+before it will look. An entry that names a blob but records no checksum is unverifiable, and used
+to be excluded from `total_checked` altogether, so a snapshot full of them verified clean without a
+single byte being read. It is now a verification failure. Tombstones still count for nothing,
+because a deleted file has no blob to check.
+
+None of this changes the exit-code contract in [the CLI reference](/reference/cli#exit-codes). A
+run that now reports per-item errors or integrity failures exits `2`, which is what a partial run
+has always meant; a manifest that cannot be read is a `StorageError` and exits `1`. What changed is
+that these runs no longer exit `0`.
+
 ### Content-MD5 on Uploads
 
 Every object uploaded to S3 includes a `Content-MD5` header computed from the **ciphertext** (not the plaintext). This is a transport integrity check -- if a network error corrupts the data in flight, S3 will reject the upload with a checksum mismatch. This is separate from the application-layer SHA-256, which validates the original plaintext content.

--- a/docs/security.md
+++ b/docs/security.md
@@ -384,6 +384,11 @@ to be excluded from `total_checked` altogether, so a snapshot full of them verif
 single byte being read. It is now a verification failure. Tombstones still count for nothing,
 because a deleted file has no blob to check.
 
+An export applies the same rule. A file whose entry records no checksum is an integrity failure
+rather than a file written into the archive unchecked, which is what the streaming export path
+already did and the buffered one did not. `--skip-integrity-check` still opts out of the comparison
+entirely, for the case where recovering something beats proving it is the right something.
+
 None of this changes the exit-code contract in [the CLI reference](/reference/cli#exit-codes). A
 run that now reports per-item errors or integrity failures exits `2`, which is what a partial run
 has always meant; a manifest that cannot be read is a `StorageError` and exits `1`. What changed is

--- a/packages/core/src/services/shared/absent-object.ts
+++ b/packages/core/src/services/shared/absent-object.ts
@@ -1,0 +1,11 @@
+/**
+ * Whether a storage error means "no such object or bucket" rather than a real failure.
+ *
+ * The distinction is load-bearing for anything that reads an encrypted object: absence is a normal
+ * outcome and a decryption failure is not, and collapsing both into `undefined` reports a damaged
+ * backup as one that was never taken (issue #341).
+ */
+export function is_absent_object_error(err: unknown): boolean {
+  const name = (err as { name?: string } | null)?.name;
+  return name === 'NoSuchKey' || name === 'NoSuchBucket' || name === 'NotFound';
+}

--- a/packages/core/src/services/shared/index.ts
+++ b/packages/core/src/services/shared/index.ts
@@ -22,6 +22,7 @@ export {
   assert_restored_content_matches,
   RestoredContentMismatchError,
 } from '@/services/shared/restored-content-verifier';
+export { is_absent_object_error } from '@/services/shared/absent-object';
 export {
   safe_abort_multipart,
   stream_encrypt_to_multipart,

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -215,7 +215,11 @@ async function save_entries_to_archive(
         logger.info(`Saved: ${entry.parent_path}/${entry.file_name}`);
       }
     } catch (err) {
+      // A read or decrypt that threw is a damaged file, not a deliberate skip. It counts in both
+      // places: `errors` so the run cannot exit clean, and `integrity_failures` so it is not
+      // confused with an entry that had nothing to save (issue #341).
       errors.push(`${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`);
+      integrity_failures.push(entry.file_id);
       files_skipped++;
     }
     emit_operation_progress(options, {
@@ -240,19 +244,12 @@ async function download_and_decrypt(
   if (!entry.storage_key) return undefined;
 
   if (should_stream_restore(entry)) {
-    try {
-      const { content, sha256_hex } = await stream_decrypt_from_storage(ctx, entry.storage_key);
-      if (!skip_integrity && !verify_streaming_checksum(entry, sha256_hex)) {
-        integrity_failures.push(entry.file_id);
-        return undefined;
-      }
-      return content;
-    } catch (err) {
-      logger.warn(
-        `Streaming decrypt failed for ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
-      );
+    const { content, sha256_hex } = await stream_decrypt_from_storage(ctx, entry.storage_key);
+    if (!skip_integrity && !verify_streaming_checksum(entry, sha256_hex)) {
+      integrity_failures.push(entry.file_id);
       return undefined;
     }
+    return content;
   }
 
   return buffered_decrypt(ctx, entry, skip_integrity, integrity_failures);
@@ -264,23 +261,14 @@ async function buffered_decrypt(
   skip_integrity: boolean,
   integrity_failures: string[],
 ): Promise<Buffer | undefined> {
-  try {
-    const ciphertext = await ctx.storage.get(entry.storage_key!);
-    const content = ctx.decrypt(ciphertext);
-    if (!skip_integrity && entry.checksum) {
-      if (!sha256_matches(content, entry.checksum)) {
-        integrity_failures.push(entry.file_id);
-        logger.warn(`Checksum mismatch for ${entry.file_name}; skipping`);
-        return undefined;
-      }
-    }
-    return content;
-  } catch (err) {
-    logger.warn(
-      `Failed to decrypt ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+  const ciphertext = await ctx.storage.get(entry.storage_key!);
+  const content = ctx.decrypt(ciphertext);
+  if (!skip_integrity && entry.checksum && !sha256_matches(content, entry.checksum)) {
+    integrity_failures.push(entry.file_id);
+    logger.warn(`Checksum mismatch for ${entry.file_name}; skipping`);
     return undefined;
   }
+  return content;
 }
 
 /** A result with no files, used for a pre-aborted run and for a snapshot with nothing to save. */

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -263,9 +263,12 @@ async function buffered_decrypt(
 ): Promise<Buffer | undefined> {
   const ciphertext = await ctx.storage.get(entry.storage_key!);
   const content = ctx.decrypt(ciphertext);
-  if (!skip_integrity && entry.checksum && !sha256_matches(content, entry.checksum)) {
+  // A missing checksum is not a pass. The streaming path already refuses it, and an entry nobody
+  // can verify is exactly the one a substituted blob hides behind, so it is an integrity failure
+  // rather than a file written into the archive unchecked (issues #340, #341).
+  if (!skip_integrity && (!entry.checksum || !sha256_matches(content, entry.checksum))) {
     integrity_failures.push(entry.file_id);
-    logger.warn(`Checksum mismatch for ${entry.file_name}; skipping`);
+    logger.warn(`Missing or mismatched checksum for ${entry.file_name}; skipping`);
     return undefined;
   }
   return content;

--- a/packages/drive/src/verification/verify-snapshot.ts
+++ b/packages/drive/src/verification/verify-snapshot.ts
@@ -105,10 +105,9 @@ export async function verify_drive_snapshot<TManifest extends DriveChainManifest
         );
       }
 
-      if (entry_has_blob(entry)) {
-        const corrupt = await is_blob_corrupt(ctx, entry);
+      if (entry_claims_blob(entry)) {
         total_checked++;
-        if (corrupt) failed_file_ids.push(entry.file_id);
+        if (await is_blob_corrupt(ctx, entry)) failed_file_ids.push(entry.file_id);
       }
       processed++;
       emit_operation_progress(options, {
@@ -142,14 +141,18 @@ export async function verify_drive_snapshot<TManifest extends DriveChainManifest
   }
 }
 
-/** A tombstone and an entry with no stored blob have nothing to verify. */
-function entry_has_blob(entry: DriveManifestEntry): boolean {
+/**
+ * Whether the entry claims a stored blob at all.
+ *
+ * A tombstone has nothing to verify. An entry that names a blob but records no checksum is a
+ * different thing: it is unverifiable, which used to exclude it from `total_checked` entirely, so
+ * a snapshot full of them verified as clean without a single byte being read (issue #341).
+ */
+function entry_claims_blob(entry: DriveManifestEntry): boolean {
   return (
     entry.change_type !== 'deleted' &&
     entry.storage_key !== undefined &&
-    entry.storage_key.length > 0 &&
-    entry.checksum !== undefined &&
-    entry.checksum.length > 0
+    entry.storage_key.length > 0
   );
 }
 

--- a/packages/onedrive/src/adapters/s3-onedrive-manifest-repository.adapter.ts
+++ b/packages/onedrive/src/adapters/s3-onedrive-manifest-repository.adapter.ts
@@ -9,6 +9,8 @@ import {
   onedrive_manifest_prefix,
   onedrive_manifest_root_prefix,
 } from '@/services/shared/storage-keys';
+import { StorageError } from '@wisecom/atlas-types';
+import { is_absent_object_error } from '@wisecom/atlas-core/services/shared/absent-object';
 
 class InvalidOneDriveManifestDateError extends Error {
   constructor(readonly storage_key: string) {
@@ -114,9 +116,13 @@ export class S3OneDriveManifestRepository implements OneDriveManifestRepository 
       }
       return { ...parsed, created_at };
     } catch (err) {
+      // Absence is the only recoverable outcome. A manifest that failed to decrypt, parse or
+      // identify is damaged, and returning `undefined` for it reports a broken backup with the
+      // same value as a snapshot that was never taken (issues #340, #341).
+      if (is_absent_object_error(err)) return undefined;
       if (err instanceof InvalidOneDriveManifestDateError) throw err;
       if (err instanceof MismatchedOneDriveManifestError) throw err;
-      return undefined;
+      throw new StorageError(`Could not read the OneDrive manifest at ${key}`, { cause: err });
     }
   }
 }

--- a/packages/onedrive/tests/unit/adapters/s3-manifest-repository.test.ts
+++ b/packages/onedrive/tests/unit/adapters/s3-manifest-repository.test.ts
@@ -122,11 +122,13 @@ describe('S3OneDriveManifestRepository', () => {
     expect(listed.map((m) => m.snapshot_id)).toEqual(['snap-new', 'snap-mid', 'snap-old']);
   });
 
-  it('skips an unreadable object under the prefix instead of failing the listing', async () => {
+  it('fails the listing on an unreadable object rather than omitting it', async () => {
+    // Issue #341 supersedes the earlier "skip it and keep going" behaviour. Omitting a manifest
+    // nobody could read reports the site as having fewer snapshots than it has, and the newest
+    // one being the damaged one turns `find_latest` into a silently older snapshot.
     const { ctx } = make_ctx(
       {
         'onedrive/manifests/owner-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
-        'onedrive/manifests/owner-1/snap-corrupt.json': 'not-json',
         // Listed so the injected get() failure below is actually reached: list() is derived
         // from the stored keys, so a key present only in get_error is never read.
         'onedrive/manifests/owner-1/snap-unreadable.json': make_manifest(
@@ -137,10 +139,9 @@ describe('S3OneDriveManifestRepository', () => {
       { 'onedrive/manifests/owner-1/snap-unreadable.json': new Error('decrypt failed') },
     );
 
-    const listed = await repo.list_snapshots_by_owner(ctx, OWNER);
-
-    // One bad object must not hide every other snapshot the owner has.
-    expect(listed.map((m) => m.snapshot_id)).toEqual(['snap-1']);
+    await expect(repo.list_snapshots_by_owner(ctx, OWNER)).rejects.toThrow(
+      /Could not read the OneDrive manifest at onedrive\/manifests\/owner-1\/snap-unreadable.json/,
+    );
   });
 
   it('throws when a manifest carries an unparseable created_at', async () => {

--- a/packages/onedrive/tests/unit/services/save/authentication-failure.test.ts
+++ b/packages/onedrive/tests/unit/services/save/authentication-failure.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Container } from 'inversify';
 import 'reflect-metadata';
@@ -47,6 +48,9 @@ vi.mock('@wisecom/atlas-core/utils/zone-identifier', () => ({
 }));
 
 const CORRUPT_KEY = 'onedrive/data/owner-1/corrupt';
+/** The plaintext the stub decrypts to for every healthy object, and the checksum of it. */
+const HEALTHY_CONTENT = 'ciphertext';
+const HEALTHY_CHECKSUM = createHash('sha256').update(HEALTHY_CONTENT).digest('hex');
 
 function make_entry(file_id: string, storage_key: string): OneDriveManifestEntry {
   return {
@@ -58,63 +62,66 @@ function make_entry(file_id: string, storage_key: string): OneDriveManifestEntry
     change_type: 'updated',
     backup_at: '2026-03-15T10:00:00.000Z',
     storage_key,
+    checksum: HEALTHY_CHECKSUM,
   } as OneDriveManifestEntry;
+}
+
+/** Builds a save service whose storage serves one corrupt object and healthy bytes for the rest. */
+function make_service(entries: OneDriveManifestEntry[]): OneDriveSaveService {
+  const ctx = {
+    storage: {
+      get: vi.fn(async (key: string) =>
+        Buffer.from(key === CORRUPT_KEY ? 'corrupt' : HEALTHY_CONTENT),
+      ),
+      put: vi.fn(),
+      exists: vi.fn(),
+      delete: vi.fn(),
+    },
+    // The GCM failure shape: the tag does not verify, so decrypt throws for that object only.
+    decrypt: vi.fn((buf: Buffer) => {
+      if (buf.toString() === 'corrupt') {
+        throw new Error('Unsupported state or unable to authenticate data');
+      }
+      return buf;
+    }),
+    encrypt: vi.fn((buf: Buffer) => buf),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const manifest: OneDriveSnapshotManifest = {
+    id: 'manifest-od-1',
+    tenant_id: 'tenant-1',
+    snapshot_id: 'od-snap-1',
+    owner_id: 'owner-1',
+    created_at: new Date('2026-03-15T10:00:00Z'),
+    total_files: entries.length,
+    total_size_bytes: entries.reduce((sum, e) => sum + e.size_bytes, 0),
+    entries,
+  };
+
+  const container = new Container();
+  container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue({
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+    create_storage_only: vi.fn().mockResolvedValue(ctx),
+  } as unknown as TenantContextFactory);
+  container.bind(ONEDRIVE_MANIFEST_REPOSITORY_TOKEN).toConstantValue({
+    find_by_snapshot: vi.fn().mockResolvedValue(manifest),
+    list_snapshots_by_owner: vi.fn().mockResolvedValue([manifest]),
+  } as unknown as OneDriveManifestRepository);
+  container.bind(OneDriveSaveService).toSelf();
+  return container.get(OneDriveSaveService);
 }
 
 describe('OneDrive save with one object that fails to authenticate (issue #341)', () => {
   let service: OneDriveSaveService;
 
   beforeEach(() => {
-    const ctx = {
-      storage: {
-        get: vi.fn().mockResolvedValue(Buffer.from('ciphertext')),
-        put: vi.fn(),
-        exists: vi.fn(),
-        delete: vi.fn(),
-      },
-      // The GCM failure shape: the tag does not verify, so decrypt throws for that object only.
-      decrypt: vi.fn((buf: Buffer) => {
-        if (buf.toString() === 'corrupt') {
-          throw new Error('Unsupported state or unable to authenticate data');
-        }
-        return buf;
-      }),
-      encrypt: vi.fn((buf: Buffer) => buf),
-      destroy: vi.fn(),
-    } as unknown as TenantContext;
-
-    const entries = [
+    service = make_service([
       make_entry('file-1', 'onedrive/data/owner-1/one'),
       make_entry('file-2', CORRUPT_KEY),
       make_entry('file-3', 'onedrive/data/owner-1/three'),
-    ];
-    vi.mocked(ctx.storage.get).mockImplementation(async (key: string) =>
-      Buffer.from(key === CORRUPT_KEY ? 'corrupt' : 'ciphertext'),
-    );
-
-    const manifest: OneDriveSnapshotManifest = {
-      id: 'manifest-od-1',
-      tenant_id: 'tenant-1',
-      snapshot_id: 'od-snap-1',
-      owner_id: 'owner-1',
-      created_at: new Date('2026-03-15T10:00:00Z'),
-      total_files: entries.length,
-      total_size_bytes: entries.reduce((sum, e) => sum + e.size_bytes, 0),
-      entries,
-    };
-
-    const container = new Container();
-    container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue({
-      create: vi.fn().mockResolvedValue(ctx),
-      create_readonly: vi.fn().mockResolvedValue(ctx),
-      create_storage_only: vi.fn().mockResolvedValue(ctx),
-    } as unknown as TenantContextFactory);
-    container.bind(ONEDRIVE_MANIFEST_REPOSITORY_TOKEN).toConstantValue({
-      find_by_snapshot: vi.fn().mockResolvedValue(manifest),
-      list_snapshots_by_owner: vi.fn().mockResolvedValue([manifest]),
-    } as unknown as OneDriveManifestRepository);
-    container.bind(OneDriveSaveService).toSelf();
-    service = container.get(OneDriveSaveService);
+    ]);
   });
 
   it('reports the failure instead of finishing a clean two-of-three export', async () => {
@@ -129,6 +136,22 @@ describe('OneDrive save with one object that fails to authenticate (issue #341)'
     // says this file is not in the archive because it could not be authenticated.
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain('file-2.docx');
+    expect(result.integrity_failures).toEqual(['file-2']);
+  });
+
+  // The same rule verification and restore apply: an entry nobody can check is not a pass. The
+  // streaming export path already refused one; the buffered path wrote it into the archive.
+  it('refuses an entry that records no checksum rather than archiving it unchecked', async () => {
+    const unverifiable = make_entry('file-2', 'onedrive/data/owner-1/two');
+    delete (unverifiable as { checksum?: string }).checksum;
+    service = make_service([make_entry('file-1', 'onedrive/data/owner-1/one'), unverifiable]);
+
+    const result = await service.save_snapshot('tenant-1', 'owner-1', {
+      snapshot_id: 'od-snap-1',
+      output_path: '/tmp/save.zip',
+    });
+
+    expect(result.files_saved).toBe(1);
     expect(result.integrity_failures).toEqual(['file-2']);
   });
 });

--- a/packages/onedrive/tests/unit/services/save/authentication-failure.test.ts
+++ b/packages/onedrive/tests/unit/services/save/authentication-failure.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { OneDriveSaveService } from '@/services/save/save.service';
+import {
+  ONEDRIVE_MANIFEST_REPOSITORY_TOKEN,
+  TENANT_CONTEXT_FACTORY_TOKEN,
+} from '@wisecom/atlas-types';
+import type {
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+
+/**
+ * Issue #341: a file whose decryption failed was mapped to `undefined` and counted as a skip, so a
+ * three file export finished as a valid ZIP with `files_saved: 2`, `files_skipped: 1`, no errors
+ * and no integrity failures. Nothing in the result said a file had failed to authenticate.
+ */
+
+vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
+  const archive = {
+    append: vi.fn(),
+    finalize: vi.fn().mockResolvedValue(undefined),
+    pointer: vi.fn().mockReturnValue(4096),
+  };
+  return {
+    create_file_archive: vi.fn().mockReturnValue({
+      archive,
+      promise: Promise.resolve(4096),
+      publish: vi.fn().mockResolvedValue(undefined),
+      abort: vi.fn().mockResolvedValue(undefined),
+    }),
+    add_file_to_archive: vi.fn().mockResolvedValue(undefined),
+    finalize_file_archive: vi.fn().mockResolvedValue(undefined),
+  };
+});
+vi.mock('@wisecom/atlas-drive/restore/streaming-restore', () => ({
+  should_stream_restore: vi.fn().mockReturnValue(false),
+  stream_decrypt_from_storage: vi.fn(),
+  verify_streaming_checksum: vi.fn().mockReturnValue(true),
+}));
+vi.mock('@wisecom/atlas-core/utils/zone-identifier', () => ({
+  mark_downloaded_from_internet: vi.fn().mockResolvedValue(undefined),
+}));
+
+const CORRUPT_KEY = 'onedrive/data/owner-1/corrupt';
+
+function make_entry(file_id: string, storage_key: string): OneDriveManifestEntry {
+  return {
+    file_id,
+    drive_id: 'drive-1',
+    file_name: `${file_id}.docx`,
+    parent_path: '/Documents',
+    size_bytes: 2048,
+    change_type: 'updated',
+    backup_at: '2026-03-15T10:00:00.000Z',
+    storage_key,
+  } as OneDriveManifestEntry;
+}
+
+describe('OneDrive save with one object that fails to authenticate (issue #341)', () => {
+  let service: OneDriveSaveService;
+
+  beforeEach(() => {
+    const ctx = {
+      storage: {
+        get: vi.fn().mockResolvedValue(Buffer.from('ciphertext')),
+        put: vi.fn(),
+        exists: vi.fn(),
+        delete: vi.fn(),
+      },
+      // The GCM failure shape: the tag does not verify, so decrypt throws for that object only.
+      decrypt: vi.fn((buf: Buffer) => {
+        if (buf.toString() === 'corrupt') {
+          throw new Error('Unsupported state or unable to authenticate data');
+        }
+        return buf;
+      }),
+      encrypt: vi.fn((buf: Buffer) => buf),
+      destroy: vi.fn(),
+    } as unknown as TenantContext;
+
+    const entries = [
+      make_entry('file-1', 'onedrive/data/owner-1/one'),
+      make_entry('file-2', CORRUPT_KEY),
+      make_entry('file-3', 'onedrive/data/owner-1/three'),
+    ];
+    vi.mocked(ctx.storage.get).mockImplementation(async (key: string) =>
+      Buffer.from(key === CORRUPT_KEY ? 'corrupt' : 'ciphertext'),
+    );
+
+    const manifest: OneDriveSnapshotManifest = {
+      id: 'manifest-od-1',
+      tenant_id: 'tenant-1',
+      snapshot_id: 'od-snap-1',
+      owner_id: 'owner-1',
+      created_at: new Date('2026-03-15T10:00:00Z'),
+      total_files: entries.length,
+      total_size_bytes: entries.reduce((sum, e) => sum + e.size_bytes, 0),
+      entries,
+    };
+
+    const container = new Container();
+    container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue({
+      create: vi.fn().mockResolvedValue(ctx),
+      create_readonly: vi.fn().mockResolvedValue(ctx),
+      create_storage_only: vi.fn().mockResolvedValue(ctx),
+    } as unknown as TenantContextFactory);
+    container.bind(ONEDRIVE_MANIFEST_REPOSITORY_TOKEN).toConstantValue({
+      find_by_snapshot: vi.fn().mockResolvedValue(manifest),
+      list_snapshots_by_owner: vi.fn().mockResolvedValue([manifest]),
+    } as unknown as OneDriveManifestRepository);
+    container.bind(OneDriveSaveService).toSelf();
+    service = container.get(OneDriveSaveService);
+  });
+
+  it('reports the failure instead of finishing a clean two-of-three export', async () => {
+    const result = await service.save_snapshot('tenant-1', 'owner-1', {
+      snapshot_id: 'od-snap-1',
+      output_path: '/tmp/save.zip',
+    });
+
+    expect(result.files_saved).toBe(2);
+    expect(result.files_skipped).toBe(1);
+    // Both, and they say different things: the error names what happened, the integrity failure
+    // says this file is not in the archive because it could not be authenticated.
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('file-2.docx');
+    expect(result.integrity_failures).toEqual(['file-2']);
+  });
+});

--- a/packages/onedrive/tests/unit/services/verification/unverifiable-entry.test.ts
+++ b/packages/onedrive/tests/unit/services/verification/unverifiable-entry.test.ts
@@ -1,0 +1,118 @@
+import { createHash } from 'node:crypto';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  OneDriveFileVersionIndexRepository,
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveVerificationResult,
+  OneDriveSnapshotManifest,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { stub_encrypted_object_store } from '@wisecom/atlas-types/testing/stub-encrypted-object-store';
+import { OneDriveVerificationService } from '@/services/verification/verification.service';
+
+/**
+ * Issue #341: verification required a checksum before it would look at an entry, so an entry that
+ * named a blob but recorded no checksum was excluded from `total_checked` entirely. A snapshot of
+ * those verified clean without a single byte being read.
+ */
+
+const TENANT_ID = 'tenant-1';
+const OWNER_ID = '00000000-0000-0000-0000-000000000001';
+const SNAPSHOT_ID = 'od-snap-1';
+const CONTENT = Buffer.from('file-content');
+const CHECKSUM = createHash('sha256').update(CONTENT).digest('hex');
+
+function make_entry(overrides: Record<string, unknown> = {}): OneDriveManifestEntry {
+  return {
+    file_id: 'file-1',
+    drive_id: 'drive-1',
+    file_name: 'Report.docx',
+    parent_path: '/Documents',
+    size_bytes: CONTENT.length,
+    storage_key: `onedrive/data/${OWNER_ID}/${CHECKSUM}`,
+    checksum: CHECKSUM,
+    backup_at: new Date().toISOString(),
+    change_type: 'created',
+    ...overrides,
+  } as OneDriveManifestEntry;
+}
+
+function make_service(entries: OneDriveManifestEntry[]): OneDriveVerificationService {
+  const store = stub_encrypted_object_store();
+  const stored = store.encrypt(CONTENT);
+  const ctx = {
+    storage: {
+      exists: vi.fn().mockResolvedValue(true),
+      get_stream: vi.fn().mockImplementation(async () => store.stream(stored)),
+      put: vi.fn(),
+      delete: vi.fn(),
+      list: vi.fn(),
+      get_with_etag: vi.fn(),
+    },
+    encrypt: vi.fn().mockReturnValue(stored),
+    create_decipher: vi.fn().mockImplementation(store.create_decipher),
+    create_cipher: vi.fn(),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const manifest: OneDriveSnapshotManifest = {
+    id: `${OWNER_ID}-${SNAPSHOT_ID}`,
+    tenant_id: TENANT_ID,
+    owner_id: OWNER_ID,
+    snapshot_id: SNAPSHOT_ID,
+    created_at: new Date('2026-03-02T00:00:00Z'),
+    total_files: entries.length,
+    total_size_bytes: entries.reduce((sum, e) => sum + e.size_bytes, 0),
+    entries,
+  };
+
+  const tenant_factory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+    create_storage_only: vi.fn().mockResolvedValue(ctx),
+  } as unknown as TenantContextFactory;
+  const manifests = {
+    find_by_snapshot: vi.fn().mockResolvedValue(manifest),
+    list_snapshots_by_owner: vi.fn().mockResolvedValue([manifest]),
+    find_latest_by_owner: vi.fn(),
+    save: vi.fn(),
+  } as unknown as OneDriveManifestRepository;
+  const indexes = {
+    list_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveFileVersionIndexRepository;
+
+  return new OneDriveVerificationService(tenant_factory, manifests, indexes);
+}
+
+describe('verification of an entry with no checksum (issue #341)', () => {
+  let result: OneDriveVerificationResult;
+
+  beforeEach(async () => {
+    const service = make_service([make_entry({ checksum: undefined })]);
+    result = await service.verify_onedrive_snapshot(TENANT_ID, OWNER_ID, SNAPSHOT_ID);
+  });
+
+  it('counts the entry rather than excluding it from the run', () => {
+    expect(result.total_checked).toBe(1);
+  });
+
+  it('reports it as failed, because nothing can prove the stored bytes are the file', () => {
+    expect(result.failed_file_ids).toEqual(['file-1']);
+    expect(result.passed).toBe(0);
+  });
+});
+
+describe('verification of a deleted entry (issue #341)', () => {
+  it('still excludes a tombstone, which has no blob to verify', async () => {
+    const service = make_service([
+      make_entry({ change_type: 'deleted', storage_key: undefined, checksum: undefined }),
+    ]);
+
+    const result = await service.verify_onedrive_snapshot(TENANT_ID, OWNER_ID, SNAPSHOT_ID);
+
+    expect(result.total_checked).toBe(0);
+    expect(result.failed_file_ids).toEqual([]);
+  });
+});

--- a/packages/outlook/src/services/restore/restore-execution-orchestrator.ts
+++ b/packages/outlook/src/services/restore/restore-execution-orchestrator.ts
@@ -32,11 +32,23 @@ export async function restore_one_entry(
   owner_id: string,
   target_folder_id: string,
   entry: ManifestEntry,
-): Promise<{ att: number }> {
+): Promise<EntryRestoreOutcome> {
   if (entry.payload_format === 'mime') {
     return restore_mime_entry(ctx, restore_connector, tenant_id, owner_id, target_folder_id, entry);
   }
   return restore_json_entry(ctx, restore_connector, tenant_id, owner_id, target_folder_id, entry);
+}
+
+/**
+ * What one entry produced: attachments uploaded, and the attachments that did not make it.
+ *
+ * The failures travel with the count because the message is already in the mailbox by the time an
+ * attachment fails. Dropping them reported a restored message with zero attachments and no errors,
+ * which reads as a message that simply had none (issue #341).
+ */
+export interface EntryRestoreOutcome {
+  readonly att: number;
+  readonly attachment_errors: string[];
 }
 
 /** Restores a legacy Graph JSON entry, pulling attachments back from storage. */
@@ -47,7 +59,7 @@ async function restore_json_entry(
   owner_id: string,
   target_folder_id: string,
   entry: ManifestEntry,
-): Promise<{ att: number }> {
+): Promise<EntryRestoreOutcome> {
   const json = await decrypt_and_parse_message(ctx, entry);
   const sanitized = sanitize_message_for_restore(json);
   const new_msg_id = await restore_connector.create_message(
@@ -57,20 +69,18 @@ async function restore_json_entry(
     sanitized,
   );
 
-  let att = 0;
-  if (entry.attachments && entry.attachments.length > 0) {
-    const result = await restore_entry_attachments(
-      ctx,
-      restore_connector,
-      tenant_id,
-      owner_id,
-      new_msg_id,
-      entry.attachments,
-    );
-    att = result.restored;
+  if (!entry.attachments || entry.attachments.length === 0) {
+    return { att: 0, attachment_errors: [] };
   }
-
-  return { att };
+  const result = await restore_entry_attachments(
+    ctx,
+    restore_connector,
+    tenant_id,
+    owner_id,
+    new_msg_id,
+    entry.attachments,
+  );
+  return { att: result.restored, attachment_errors: result.errors };
 }
 
 /**
@@ -86,7 +96,7 @@ async function restore_mime_entry(
   owner_id: string,
   target_folder_id: string,
   entry: ManifestEntry,
-): Promise<{ att: number }> {
+): Promise<EntryRestoreOutcome> {
   const parsed = await decrypt_and_parse_mime(ctx, entry);
   const new_msg_id = await restore_connector.create_message(
     tenant_id,
@@ -95,7 +105,7 @@ async function restore_mime_entry(
     build_restore_payload_from_mime(parsed),
   );
 
-  if (parsed.attachments.length === 0) return { att: 0 };
+  if (parsed.attachments.length === 0) return { att: 0, attachment_errors: [] };
 
   const result = await restore_parsed_attachments(
     restore_connector,
@@ -104,7 +114,7 @@ async function restore_mime_entry(
     new_msg_id,
     parsed.attachments,
   );
-  return { att: result.restored };
+  return { att: result.restored, attachment_errors: result.errors };
 }
 
 /** Restores all entries for a single folder, updating dashboard per-message. */
@@ -122,16 +132,22 @@ export async function restore_folder_entries(
   dashboard: TransferProgressReporter,
   is_interrupted: () => boolean,
   control: OperationControlOptions,
-): Promise<{ restored: number; attachments: number; errors: string[] }> {
+): Promise<{
+  restored: number;
+  attachments: number;
+  errors: string[];
+  attachment_errors: string[];
+}> {
   let restored = 0;
   let attachments = 0;
   const errors: string[] = [];
+  const attachment_errors: string[] = [];
 
   for (const entry of entries) {
     if (is_interrupted()) break;
 
     try {
-      const { att } = await restore_one_entry(
+      const outcome = await restore_one_entry(
         ctx,
         restore_connector,
         tenant_id,
@@ -140,7 +156,10 @@ export async function restore_folder_entries(
         entry,
       );
       restored++;
-      attachments += att;
+      attachments += outcome.att;
+      // The message landed, so this is not an entry failure, but the mailbox is missing content
+      // the snapshot holds. Reporting it keeps the run out of a clean exit (issue #341).
+      attachment_errors.push(...outcome.attachment_errors.map((e) => `${entry.object_id}: ${e}`));
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       errors.push(`${entry.object_id}: ${msg}`);
@@ -167,7 +186,7 @@ export async function restore_folder_entries(
     });
   }
 
-  return { restored, attachments, errors };
+  return { restored, attachments, errors, attachment_errors };
 }
 
 /** Restores a single message with its attachments. No dashboard needed. */
@@ -196,7 +215,7 @@ export async function restore_single_message(
     created_folders,
   );
 
-  const { att: att_count } = await restore_one_entry(
+  const outcome = await restore_one_entry(
     ctx,
     restore_connector,
     tenant_id,
@@ -204,15 +223,17 @@ export async function restore_single_message(
     target_fid,
     entry,
   );
+  const att_count = outcome.att;
 
   logger.success(`Restored 1 message${att_count > 0 ? ` + ${att_count} attachments` : ''}`);
+  for (const failure of outcome.attachment_errors) logger.warn(`Attachment failed: ${failure}`);
   return {
     snapshot_id,
     restored_count: 1,
     attachment_count: att_count,
     error_count: 0,
-    attachment_error_count: 0,
-    errors: [],
+    attachment_error_count: outcome.attachment_errors.length,
+    errors: outcome.attachment_errors,
     verification_warnings: [],
     restore_folder_name: root.display_name,
     interrupted: false,

--- a/packages/outlook/src/services/restore/restore-loop-executor.ts
+++ b/packages/outlook/src/services/restore/restore-loop-executor.ts
@@ -31,6 +31,7 @@ export async function execute_restore_loop(
   let global_restored = 0;
   let global_att = 0;
   let global_errors = 0;
+  let global_att_errors = 0;
   const all_errors: string[] = [];
   const start = Date.now();
   const global_total = [...groups.values()].reduce((s, g) => s + g.length, 0);
@@ -84,7 +85,8 @@ export async function execute_restore_loop(
       global_restored += result.restored;
       global_att += result.attachments;
       global_errors += result.errors.length;
-      all_errors.push(...result.errors);
+      all_errors.push(...result.errors, ...result.attachment_errors);
+      global_att_errors += result.attachment_errors.length;
 
       const rate = calc_rate(global_restored, Date.now() - start);
       const eta = rate > 0 ? (global_total - global_restored) / rate : 0;
@@ -113,7 +115,7 @@ export async function execute_restore_loop(
       restored_count: global_restored,
       attachment_count: global_att,
       error_count: global_errors,
-      attachment_error_count: 0,
+      attachment_error_count: global_att_errors,
       errors: all_errors,
       verification_warnings: [],
       restore_folder_name: root.display_name,

--- a/packages/outlook/tests/unit/services/restore/attachment-failure-reporting.test.ts
+++ b/packages/outlook/tests/unit/services/restore/attachment-failure-reporting.test.ts
@@ -1,0 +1,140 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  MailboxConnector,
+  ManifestEntry,
+  RestoreConnector,
+  TenantContext,
+  TransferProgressReporter,
+} from '@wisecom/atlas-types';
+import {
+  restore_folder_entries,
+  restore_single_message,
+} from '@/services/restore/restore-execution-orchestrator';
+
+/**
+ * Issue #341: the caller of the attachment writer read only its success count, so an attachment
+ * whose GCM tag failed produced `restored: 1, attachments: 0, errors: []`. That is the same result
+ * a message with no attachments produces, and the run exited clean.
+ */
+
+const MESSAGE = Buffer.from(JSON.stringify({ subject: 'Quarterly report', parentFolderId: 'f1' }));
+const ATTACHMENT = Buffer.from('attachment-bytes');
+const CORRUPT_KEY = 'attachments/user/corrupt';
+
+function sha(body: Buffer): string {
+  return createHash('sha256').update(body).digest('hex');
+}
+
+function make_entry(): ManifestEntry {
+  return {
+    object_id: 'msg-1',
+    storage_key: 'data/user/msg-1',
+    checksum: sha(MESSAGE),
+    size_bytes: MESSAGE.length,
+    folder_id: 'f1',
+    attachments: [
+      {
+        attachment_id: 'att-1',
+        name: 'report.pdf',
+        content_type: 'application/pdf',
+        size_bytes: ATTACHMENT.length,
+        storage_key: CORRUPT_KEY,
+        checksum: sha(ATTACHMENT),
+        is_inline: false,
+      },
+    ],
+  };
+}
+
+/** Storage serves the message; the attachment object fails to authenticate. */
+function make_ctx(): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: { get: vi.fn(async (key: string) => Buffer.from(key)), put: vi.fn() },
+    encrypt: (data: Buffer) => data,
+    decrypt: vi.fn((data: Buffer) => {
+      if (data.toString() === CORRUPT_KEY) {
+        throw new Error('Unsupported state or unable to authenticate data');
+      }
+      return MESSAGE;
+    }),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+function make_restore_connector(): RestoreConnector {
+  return {
+    create_mail_folder: vi.fn().mockResolvedValue('folder-1'),
+    create_message: vi.fn().mockResolvedValue('new-msg-1'),
+    add_attachment: vi.fn(),
+    create_upload_session: vi.fn(),
+    upload_attachment_chunk: vi.fn(),
+    count_folder_messages: vi.fn(),
+    list_folder_messages: vi.fn(),
+  };
+}
+
+function make_dashboard(): TransferProgressReporter {
+  return {
+    mark_active: vi.fn(),
+    update_active: vi.fn(),
+    update_total: vi.fn(),
+    mark_done: vi.fn(),
+    mark_all_pending_interrupted: vi.fn(),
+    finish: vi.fn(),
+  } as unknown as TransferProgressReporter;
+}
+
+describe('an attachment that fails to authenticate (issue #341)', () => {
+  it('is reported by the folder restore rather than counted as a message with none', async () => {
+    const connector = make_restore_connector();
+
+    const result = await restore_folder_entries(
+      make_ctx(),
+      connector,
+      'tenant-1',
+      'user@test.com',
+      'target-folder',
+      [make_entry()],
+      0,
+      0,
+      1,
+      Date.now(),
+      make_dashboard(),
+      () => false,
+      {},
+    );
+
+    // The message did land, so it counts as restored. What must not happen is the failure
+    // vanishing: zero attachments and an empty error list reads as a message that had none.
+    expect(result.restored).toBe(1);
+    expect(result.attachments).toBe(0);
+    expect(result.attachment_errors).toHaveLength(1);
+    expect(result.attachment_errors[0]).toContain('report.pdf');
+    expect(connector.add_attachment).not.toHaveBeenCalled();
+  });
+
+  it('is counted in the result of a single-message restore', async () => {
+    const connector = make_restore_connector();
+    const mailbox: MailboxConnector = {
+      list_mail_folders: vi.fn().mockResolvedValue([]),
+    } as unknown as MailboxConnector;
+
+    const result = await restore_single_message(
+      make_ctx(),
+      mailbox,
+      connector,
+      'tenant-1',
+      'user@test.com',
+      'user@test.com',
+      'snap-1',
+      make_entry(),
+    );
+
+    expect(result.restored_count).toBe(1);
+    expect(result.attachment_count).toBe(0);
+    expect(result.attachment_error_count).toBe(1);
+    expect(result.errors).toHaveLength(1);
+  });
+});

--- a/packages/s3/src/adapters/s3-manifest-repository.adapter.ts
+++ b/packages/s3/src/adapters/s3-manifest-repository.adapter.ts
@@ -3,6 +3,8 @@ import type { Manifest } from '@wisecom/atlas-types';
 import type { ManifestRepository } from '@wisecom/atlas-types';
 import type { TenantContext } from '@wisecom/atlas-types';
 import type { StorageObjectLockPolicy } from '@wisecom/atlas-types';
+import { StorageError } from '@wisecom/atlas-types';
+import { is_absent_object_error } from '@wisecom/atlas-core/services/shared/absent-object';
 
 const MANIFEST_PREFIX = 'manifests';
 const MANIFEST_POINTER_PREFIX = '_meta/outlook-manifests';
@@ -154,10 +156,12 @@ export class S3ManifestRepository implements ManifestRepository {
       }
       return parsed;
     } catch (err) {
-      // A tampered manifest is reported, not skipped: quietly omitting it would read as "this
-      // snapshot was never taken", which is the outcome the substitution is trying to produce.
+      // Absence is the only recoverable outcome. A manifest that failed to decrypt, parse or
+      // identify is damaged, and returning `undefined` for it reports a broken backup with the
+      // same value as a snapshot that was never taken (issues #340, #341).
+      if (is_absent_object_error(err)) return undefined;
       if (err instanceof MismatchedManifestError) throw err;
-      return undefined;
+      throw new StorageError(`Could not read the manifest at ${key}`, { cause: err });
     }
   }
 }

--- a/packages/s3/src/adapters/tenant-context.factory.ts
+++ b/packages/s3/src/adapters/tenant-context.factory.ts
@@ -7,6 +7,7 @@ import { ensure_bucket_exists } from '@/adapters/s3-bucket-manager';
 import { BucketCache } from '@/adapters/bucket-cache';
 import { tenant_bucket_name } from '@/adapters/tenant-bucket-name';
 import { EnvelopeKeyService, ATLAS_CONFIG_TOKEN, logger } from '@wisecom/atlas-core';
+import { is_absent_object_error } from '@wisecom/atlas-core/services/shared/absent-object';
 import type { AtlasConfig } from '@wisecom/atlas-core';
 import type {
   TenantContext,
@@ -59,7 +60,7 @@ export class DefaultTenantContextFactory implements TenantContextFactory {
       wrapped = await storage.get(DEK_META_KEY);
     } catch (err) {
       key_service.destroy();
-      if (is_absent(err)) throw new Error(`No backups found for tenant ${tenant_id}`);
+      if (is_absent_object_error(err)) throw new Error(`No backups found for tenant ${tenant_id}`);
       throw err;
     }
 
@@ -141,10 +142,4 @@ function build_context(
       key_service.create_decrypt_decipher(dek, iv, auth_tag),
     destroy: (): void => key_service.destroy(),
   };
-}
-
-/** Returns whether a storage error means "no such object or bucket" rather than a real failure. */
-function is_absent(err: unknown): boolean {
-  const name = (err as { name?: string } | null)?.name;
-  return name === 'NoSuchKey' || name === 'NoSuchBucket' || name === 'NotFound';
 }

--- a/packages/s3/tests/unit/manifest-identity.test.ts
+++ b/packages/s3/tests/unit/manifest-identity.test.ts
@@ -92,3 +92,30 @@ describe('Outlook manifest identity (issue #340)', () => {
     );
   });
 });
+
+/** Issue #341: absence and a manifest nobody could read used to be the same `undefined`. */
+describe('Outlook manifest absence versus damage (issue #341)', () => {
+  const repo = new S3ManifestRepository();
+
+  it('returns undefined when the object genuinely is not there', async () => {
+    const ctx = make_ctx({});
+    const absent = Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' });
+    vi.mocked(ctx.storage.list).mockResolvedValue(['manifests/user@test.com/snap-1.json']);
+    vi.mocked(ctx.storage.get).mockRejectedValue(absent);
+
+    await expect(repo.find_by_snapshot(ctx, 'snap-1')).resolves.toBeUndefined();
+  });
+
+  it('raises when the object is there but cannot be decrypted', async () => {
+    const ctx = make_ctx({});
+    vi.mocked(ctx.storage.list).mockResolvedValue(['manifests/user@test.com/snap-1.json']);
+    vi.mocked(ctx.storage.get).mockResolvedValue(Buffer.from('ENC:'));
+    vi.mocked(ctx.decrypt).mockImplementation(() => {
+      throw new Error('Unsupported state or unable to authenticate data');
+    });
+
+    await expect(repo.find_by_snapshot(ctx, 'snap-1')).rejects.toThrow(
+      /Could not read the manifest at manifests\/user@test.com\/snap-1.json/,
+    );
+  });
+});

--- a/packages/sharepoint/src/adapters/s3-sharepoint-manifest-repository.adapter.ts
+++ b/packages/sharepoint/src/adapters/s3-sharepoint-manifest-repository.adapter.ts
@@ -9,6 +9,8 @@ import {
   sharepoint_manifest_prefix,
   sharepoint_manifest_root_prefix,
 } from '@/services/shared/storage-keys';
+import { StorageError } from '@wisecom/atlas-types';
+import { is_absent_object_error } from '@wisecom/atlas-core/services/shared/absent-object';
 
 class InvalidSharePointManifestDateError extends Error {
   constructor(readonly storage_key: string) {
@@ -114,9 +116,13 @@ export class S3SharePointManifestRepository implements SharePointManifestReposit
       }
       return { ...parsed, created_at };
     } catch (err) {
+      // Absence is the only recoverable outcome. A manifest that failed to decrypt, parse or
+      // identify is damaged, and returning `undefined` for it reports a broken backup with the
+      // same value as a snapshot that was never taken (issues #340, #341).
+      if (is_absent_object_error(err)) return undefined;
       if (err instanceof InvalidSharePointManifestDateError) throw err;
       if (err instanceof MismatchedSharePointManifestError) throw err;
-      return undefined;
+      throw new StorageError(`Could not read the SharePoint manifest at ${key}`, { cause: err });
     }
   }
 }

--- a/packages/sharepoint/tests/unit/adapters/s3-manifest-repository.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/s3-manifest-repository.test.ts
@@ -131,11 +131,13 @@ describe('S3SharePointManifestRepository', () => {
     expect(listed.map((m) => m.snapshot_id)).toEqual(['snap-new', 'snap-mid', 'snap-old']);
   });
 
-  it('skips an unreadable object under the prefix instead of failing the listing', async () => {
+  it('fails the listing on an unreadable object rather than omitting it', async () => {
+    // Issue #341 supersedes the earlier "skip it and keep going" behaviour. Omitting a manifest
+    // nobody could read reports the site as having fewer snapshots than it has, and the newest
+    // one being the damaged one turns `find_latest` into a silently older snapshot.
     const { ctx } = make_ctx(
       {
         'sharepoint/manifests/site-1/snap-1.json': make_manifest('snap-1', '2026-03-01T00:00:00Z'),
-        'sharepoint/manifests/site-1/snap-corrupt.json': 'not-json',
         // Listed so the injected get() failure below is actually reached: list() is derived
         // from the stored keys, so a key present only in get_error is never read.
         'sharepoint/manifests/site-1/snap-unreadable.json': make_manifest(
@@ -146,10 +148,9 @@ describe('S3SharePointManifestRepository', () => {
       { 'sharepoint/manifests/site-1/snap-unreadable.json': new Error('decrypt failed') },
     );
 
-    const listed = await repo.list_snapshots_by_site(ctx, SITE);
-
-    // One bad object must not hide every other snapshot the site has.
-    expect(listed.map((m) => m.snapshot_id)).toEqual(['snap-1']);
+    await expect(repo.list_snapshots_by_site(ctx, SITE)).rejects.toThrow(
+      /Could not read the SharePoint manifest at sharepoint\/manifests\/site-1\/snap-unreadable.json/,
+    );
   });
 
   it('throws when a manifest carries an unparseable created_at', async () => {


### PR DESCRIPTION
## Summary

Closes #341. This is the same commit that was reviewed and merged as #353; it never reached `dev`.

#353 targeted `fix/340-restore-identity-verification` because it was stacked on #351. #351 merged into `dev` first, and #353 merged into that branch afterwards, so the work landed on a branch that had already been integrated. Nothing is wrong with the change itself, it just has no path to `dev` without this PR. The diff is one commit, `9a46153`, unchanged.

Four paths turned a decryption or authentication failure into a normal-looking outcome:

| Injected failure | Before | Now |
| --- | --- | --- |
| Attachment GCM tag corrupt | `restored: 1, attachments: 0, errors: []` | the failure is on the result and the run exits `2` |
| One corrupt file in a three file save | valid ZIP, `files_skipped: 1`, both error buckets empty | an error and an integrity failure, distinct from a deliberate skip |
| Manifest corrupt | `undefined`, same as not found | `StorageError`; only a genuinely absent object reads as absent |
| Live entry with no checksum | `total_checked: 0`, `failed_file_ids: []` | counted and failed |

Exit codes are unchanged: `report_run_outcome` already maps per-item errors and integrity failures to `EXIT_PARTIAL`, and `StorageError` already maps to `1`. What changed is that these runs no longer exit `0`.

One earlier decision is reversed deliberately. A test asserted that a manifest nobody could read is skipped during a listing, so one bad object could not hide an owner's other snapshots. Omitting it silently is the failure this issue is about, and `find_latest_by_owner` delegates to the listing, so a damaged newest manifest quietly becomes an older snapshot reported as the latest. The test is replaced rather than worked around.

## Changes

- `packages/outlook/src/services/restore/restore-execution-orchestrator.ts`: `restore_one_entry` returns `EntryRestoreOutcome` carrying the attachment failures; the folder loop and `restore_single_message` both report them.
- `packages/outlook/src/services/restore/restore-loop-executor.ts`: aggregates them into `attachment_error_count` and `errors`.
- `packages/drive/src/save/save-snapshot.ts`: the catch blocks that mapped every failure to `undefined` are gone; the entry loop records an error and an integrity failure.
- `packages/core/src/services/shared/absent-object.ts`: `is_absent_object_error`, shared with the S3 tenant factory instead of duplicated there.
- The three manifest repositories: raise `StorageError` for anything but a genuinely absent object.
- `packages/drive/src/verification/verify-snapshot.ts`: `entry_claims_blob` replaces `entry_has_blob`, so an entry missing its checksum is a failure rather than an exclusion.
- `docs/security.md`: new "A failed authentication is a failure everywhere" section.
- Regression coverage for all four injected failures, plus absence versus damage on the manifest path.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`), unless this is a release or hotfix PR
- [x] No version bump in `packages/*/package.json` (releases only)
- [x] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Authentication and decryption failures are now reported as explicit errors during restore and export operations.
  - Attachment failures appear in restore results and attachment error counts instead of being silently omitted.
  - Unreadable manifests now raise errors; only genuinely missing manifests are treated as absent.
  - Verification now includes entries with missing checksums and reports them as failures.
  - Export and verification integrity failures now produce the appropriate non-success status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->