### PR TITLE
fix(restore): finish an upload session on a completed item, not any 2xx

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -92,12 +92,12 @@ transfer from a complete one: a one byte body produces a perfectly valid SHA-256
 AES-GCM authenticates it just as happily. Every check therefore compares the transfer against an
 expectation formed before it started.
 
-| Check                | Rejected                                                                                     |
-| -------------------- | -------------------------------------------------------------------------------------------- |
-| Body length          | A `206` whose body is not exactly the number of bytes the `Range` header asked for            |
-| `Content-Range`      | A `206` with a missing, unparseable, or mismatched `Content-Range`, including the `*` form    |
-| Whole-file responses | A `200` answering a range request whose body is not the item's full reported size             |
-| Total transferred    | A streamed large file whose chunks do not add up to the size Graph reported for the item      |
+| Check                | Rejected                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------ |
+| Body length          | A `206` whose body is not exactly the number of bytes the `Range` header asked for         |
+| `Content-Range`      | A `206` with a missing, unparseable, or mismatched `Content-Range`, including the `*` form |
+| Whole-file responses | A `200` answering a range request whose body is not the item's full reported size          |
+| Total transferred    | A streamed large file whose chunks do not add up to the size Graph reported for the item   |
 
 `Content-Range` is required rather than optional because it is the only thing that identifies which
 bytes of the file arrived. Without it a server answering every range with the same chunk would be
@@ -437,6 +437,23 @@ This exists because the conflict policy is not a safety net. With the default `r
 Nesting the original structure under a restore root lengthens every path, and OneDrive enforces a path length limit. A file that exceeds it is reported as a skipped item with the reason and does not abort the run.
 
 Restored files are uploaded to the target user's primary drive. Folders are created as needed, and existing folders with the same name are reused rather than overwritten. Each file is decrypted, SHA-256 verified against the manifest checksum, and then uploaded using a small-file PUT (&le; 4 MiB) or a resumable upload session (> 4 MiB, with per-chunk retry on any transient Graph status: 429, 500, 502, 503, 504). A range PUT is addressed by its `Content-Range`, so a replayed chunk rewrites the same bytes rather than appending them twice.
+
+#### What counts as a completed upload
+
+A resumable session finishes on a status code, not on any 2xx. Graph answers an intermediate chunk
+with `202 Accepted` and the ranges it still wants, and the final chunk with `200` or `201` carrying
+the finished `driveItem`. Atlas reports the file as restored only on that terminal response.
+
+If the last chunk still comes back `202`, every byte has been sent and the session has not
+converged, so the file fails rather than being counted as restored. The failure names the ranges
+Graph still expects, read back from the session. Atlas does not retry into the same session: the
+content is all in hand, so a session that has not completed is a protocol or service problem, and
+the next restore opens a fresh one.
+
+A thrown error, a socket reset or a DNS failure mid-chunk, takes the same exit as a terminal HTTP
+error: the session is released with `DELETE` before the error propagates. A `DELETE` that itself
+fails is logged, because the session keeps its reserved quota until Graph expires it and an
+operator chasing a quota complaint needs to know Atlas tried.
 
 Files larger than 4 MiB use a streaming decrypt pipeline: the encrypted blob is read from S3 as a stream, the first 28 bytes (12-byte IV + 16-byte auth tag) are consumed to initialize AES-256-GCM, and ciphertext is decrypted in chunks without buffering the full ciphertext in memory.
 

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -375,6 +375,12 @@ Files with `change_type: 'deleted'` or a missing `storage_key` are skipped. Chec
 | **≤ 4 MiB** | Single PUT via `PUT /sites/{site_id}/drives/{drive_id}/items/{parent}:/{name}:/content`                                |
 | **> 4 MiB** | Resumable upload session via `createUploadSession` with 10 MiB chunks (3 retries per chunk on 429, 500, 502, 503, 504) |
 
+A resumable session finishes on `200` or `201` carrying the finished `driveItem`, not on any 2xx: a
+`202 Accepted` means the session still wants bytes. A last chunk still answered `202` fails the
+file, naming the ranges Graph reports as outstanding, and a thrown error releases the session with
+`DELETE` before propagating. Identical to OneDrive; see
+[What counts as a completed upload](/onedrive-backup#what-counts-as-a-completed-upload).
+
 ```typescript
 const result = await atlas.sharepoint.restore('site-id', {
   snapshot_id: 'sp-snap-123',

--- a/packages/drive/src/index.ts
+++ b/packages/drive/src/index.ts
@@ -63,6 +63,7 @@ export {
   type DriveCatalogDeps,
 } from '@/catalog/catalog-queries';
 export { ensure_drive_folder_path, type DriveFolderCreator } from '@/restore/folder-path';
+export { upload_content_to_session, LARGE_UPLOAD_CHUNK } from '@/restore/upload-session';
 export {
   restore_drive_version,
   type DriveUploadConnector,

--- a/packages/drive/src/restore/upload-session.ts
+++ b/packages/drive/src/restore/upload-session.ts
@@ -1,0 +1,155 @@
+import { is_transient_error } from '@wisecom/atlas-m365-graph';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+/** Bytes per chunk PUT into a Graph upload session. */
+export const LARGE_UPLOAD_CHUNK = 10 * 1024 * 1024;
+
+const CHUNK_PUT_ATTEMPTS = 3;
+
+async function sleep_ms(delay_ms: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, delay_ms);
+  return promise;
+}
+
+/** Reads `Retry-After` in either form RFC 9110 allows: delta-seconds or an HTTP-date. */
+function parse_fetch_retry_after_ms(header_value: string | null): number | undefined {
+  if (!header_value) return undefined;
+  const trimmed = header_value.trim();
+  const seconds = parseInt(trimmed, 10);
+  if (!isNaN(seconds)) return seconds * 1000;
+  const date_ms = Date.parse(trimmed);
+  if (!isNaN(date_ms)) {
+    const delta = date_ms - Date.now();
+    return delta > 0 ? delta : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Releases an upload session Atlas is abandoning.
+ *
+ * A cleanup that itself fails is reported rather than swallowed: the session keeps its reserved
+ * quota until Graph expires it, and an operator chasing a quota complaint needs to know Atlas tried
+ * and could not (issue #342).
+ */
+async function cancel_upload_session(upload_url: string, reason: string): Promise<void> {
+  try {
+    const response = await fetch(upload_url, { method: 'DELETE' });
+    if (!response.ok) {
+      logger.warn(
+        `Could not cancel the upload session after ${reason}: HTTP ${response.status}. ` +
+          `It stays reserved until Graph expires it.`,
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      `Could not cancel the upload session after ${reason}: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `It stays reserved until Graph expires it.`,
+    );
+  }
+}
+
+/** What Graph answers an intermediate chunk with, per the createUploadSession contract. */
+interface UploadSessionStatus {
+  readonly nextExpectedRanges?: string[];
+}
+
+/**
+ * Uploads a buffer into an open Graph upload session and returns only on a completed item.
+ *
+ * The completion signal is the status code, not `response.ok`. Graph answers an intermediate chunk
+ * with `202 Accepted` and the ranges it still wants, and the final chunk with `200` or `201`
+ * carrying the finished `driveItem`. Treating every 2xx as success reported a file as restored when
+ * the session was still waiting for bytes, so a truncated or absent file counted as a successful
+ * restore (issue #342).
+ *
+ * An upload still expecting ranges after the last chunk fails the file rather than resuming: the
+ * bytes are all in hand, so a session that has not converged is a server-side or protocol problem
+ * and retrying the same content into the same session is unlikely to change it. The next restore
+ * opens a fresh session.
+ */
+export async function upload_content_to_session(
+  upload_url: string,
+  content: Buffer,
+  label: string,
+): Promise<void> {
+  try {
+    for (let offset = 0; offset < content.length; offset += LARGE_UPLOAD_CHUNK) {
+      const end = Math.min(offset + LARGE_UPLOAD_CHUNK, content.length);
+      const range = `bytes ${offset}-${end - 1}/${content.length}`;
+      const completed = await put_chunk_with_retry(
+        upload_url,
+        range,
+        content.subarray(offset, end),
+      );
+      if (completed) {
+        if (end < content.length) {
+          await cancel_upload_session(upload_url, `an early completion at ${range}`);
+          throw new Error(
+            `Resumable upload of ${label} completed at ${range} with ` +
+              `${content.length - end} byte(s) unsent`,
+          );
+        }
+        return;
+      }
+    }
+  } catch (err) {
+    // A thrown error takes the same exit as a terminal HTTP failure. Without this a socket reset on
+    // the last chunk left the session open and the file half written.
+    await cancel_upload_session(upload_url, 'a failed chunk upload');
+    throw err;
+  }
+
+  // Every chunk was accepted and none of them completed the item.
+  const outstanding = await read_outstanding_ranges(upload_url);
+  await cancel_upload_session(upload_url, 'an upload that never completed');
+  throw new Error(
+    `Resumable upload of ${label} sent every byte but Graph never returned a completed item; ` +
+      `it still expects ${outstanding}`,
+  );
+}
+
+/** Uploads one chunk, returning whether Graph reported the item as complete. */
+async function put_chunk_with_retry(
+  upload_url: string,
+  range: string,
+  chunk: Buffer,
+): Promise<boolean> {
+  for (let attempt = 0; attempt < CHUNK_PUT_ATTEMPTS; attempt++) {
+    const response = await fetch(upload_url, {
+      method: 'PUT',
+      headers: { 'Content-Range': range, 'Content-Length': String(chunk.length) },
+      body: chunk,
+    });
+    // 200 and 201 carry the finished driveItem; 202 means the session wants more bytes.
+    if (response.status === 200 || response.status === 201) return true;
+    if (response.status === 202) return false;
+
+    const detail = await response.text();
+    // A range PUT is addressed by Content-Range, so replaying one after a
+    // transient 500/502/504 rewrites the same bytes (issue #36).
+    const retriable = is_transient_error({ statusCode: response.status });
+    if (retriable && attempt < CHUNK_PUT_ATTEMPTS - 1) {
+      const wait_ms = parse_fetch_retry_after_ms(response.headers.get('retry-after')) ?? 1000;
+      await sleep_ms(wait_ms);
+      continue;
+    }
+    throw new Error(`Resumable upload failed at range ${range}: HTTP ${response.status} ${detail}`);
+  }
+  throw new Error(`Resumable upload failed at range ${range}: retries exhausted`);
+}
+
+/** Asks the session what it is still waiting for, so the failure names it. */
+async function read_outstanding_ranges(upload_url: string): Promise<string> {
+  try {
+    const response = await fetch(upload_url, { method: 'GET' });
+    if (!response.ok) return `an unknown range (status query returned HTTP ${response.status})`;
+    const status = (await response.json()) as UploadSessionStatus;
+    const ranges = status.nextExpectedRanges;
+    return ranges && ranges.length > 0 ? ranges.join(', ') : 'an unreported range';
+  } catch {
+    return 'an unknown range';
+  }
+}

--- a/packages/drive/src/restore/upload-session.ts
+++ b/packages/drive/src/restore/upload-session.ts
@@ -75,6 +75,7 @@ export async function upload_content_to_session(
   content: Buffer,
   label: string,
 ): Promise<void> {
+  let early_completion: string | undefined;
   try {
     for (let offset = 0; offset < content.length; offset += LARGE_UPLOAD_CHUNK) {
       const end = Math.min(offset + LARGE_UPLOAD_CHUNK, content.length);
@@ -85,14 +86,14 @@ export async function upload_content_to_session(
         content.subarray(offset, end),
       );
       if (completed) {
-        if (end < content.length) {
-          await cancel_upload_session(upload_url, `an early completion at ${range}`);
-          throw new Error(
-            `Resumable upload of ${label} completed at ${range} with ` +
-              `${content.length - end} byte(s) unsent`,
-          );
-        }
-        return;
+        if (end === content.length) return;
+        // Graph removed the session when it returned the item, so there is nothing left to cancel.
+        // Reported after the try so the catch below does not send a second DELETE to a session that
+        // is already gone and log that it stays reserved.
+        early_completion =
+          `Resumable upload of ${label} completed at ${range} with ` +
+          `${content.length - end} byte(s) unsent`;
+        break;
       }
     }
   } catch (err) {
@@ -101,6 +102,8 @@ export async function upload_content_to_session(
     await cancel_upload_session(upload_url, 'a failed chunk upload');
     throw err;
   }
+
+  if (early_completion) throw new Error(early_completion);
 
   // Every chunk was accepted and none of them completed the item.
   const outstanding = await read_outstanding_ranges(upload_url);

--- a/packages/onedrive/src/adapters/graph-onedrive-restore.adapter.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-restore.adapter.ts
@@ -1,71 +1,8 @@
 import type { DriveFileSystemInfo } from '@wisecom/atlas-types';
 import type { Client } from '@microsoft/microsoft-graph-client';
-import {
-  build_upload_file_system_info,
-  is_transient_error,
-  with_graph_retry,
-} from '@wisecom/atlas-m365-graph';
+import { build_upload_file_system_info, with_graph_retry } from '@wisecom/atlas-m365-graph';
 import { logger } from '@wisecom/atlas-core/utils/logger';
-
-const LARGE_UPLOAD_CHUNK = 10 * 1024 * 1024;
-const CHUNK_PUT_ATTEMPTS = 3;
-
-async function sleep_ms(delay_ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, delay_ms));
-}
-
-function parse_fetch_retry_after_ms(header_value: string | null): number | undefined {
-  if (!header_value) return undefined;
-  const trimmed = header_value.trim();
-  const seconds = parseInt(trimmed, 10);
-  if (!isNaN(seconds)) return seconds * 1000;
-  const date_ms = Date.parse(trimmed);
-  if (!isNaN(date_ms)) {
-    const delta = date_ms - Date.now();
-    return delta > 0 ? delta : undefined;
-  }
-  return undefined;
-}
-
-async function cancel_resumable_upload_session(upload_url: string): Promise<void> {
-  try {
-    await fetch(upload_url, { method: 'DELETE' });
-  } catch {}
-}
-
-async function put_upload_chunk_with_retry(
-  upload_url: string,
-  range: string,
-  chunk: Buffer,
-): Promise<void> {
-  let last_detail = '';
-  for (let attempt = 0; attempt < CHUNK_PUT_ATTEMPTS; attempt++) {
-    const response = await fetch(upload_url, {
-      method: 'PUT',
-      headers: {
-        'Content-Range': range,
-        'Content-Length': String(chunk.length),
-      },
-      body: chunk,
-    });
-    if (response.ok) return;
-
-    last_detail = await response.text();
-    // A range PUT is addressed by Content-Range, so replaying one after a
-    // transient 500/502/504 rewrites the same bytes (issue #36).
-    const retriable = is_transient_error({ statusCode: response.status });
-    const is_last = attempt === CHUNK_PUT_ATTEMPTS - 1;
-    if (retriable && !is_last) {
-      const wait_ms = parse_fetch_retry_after_ms(response.headers.get('retry-after')) ?? 1000;
-      await sleep_ms(wait_ms);
-      continue;
-    }
-    await cancel_resumable_upload_session(upload_url);
-    throw new Error(
-      `Resumable upload failed at range ${range}: HTTP ${response.status} ${last_detail}`,
-    );
-  }
-}
+import { upload_content_to_session } from '@wisecom/atlas-drive/restore/upload-session';
 
 async function find_child_folder_id_by_name(
   client: Client,
@@ -229,10 +166,5 @@ export async function graph_onedrive_upload_large_file(
   }
   const upload_url = session_response.uploadUrl;
 
-  for (let offset = 0; offset < content.length; offset += LARGE_UPLOAD_CHUNK) {
-    const end = Math.min(offset + LARGE_UPLOAD_CHUNK, content.length);
-    const chunk = content.subarray(offset, end);
-    const range = `bytes ${offset}-${end - 1}/${content.length}`;
-    await put_upload_chunk_with_retry(upload_url, range, chunk);
-  }
+  await upload_content_to_session(upload_url, content, file_name);
 }

--- a/packages/onedrive/tests/unit/adapters/drive-metadata-capture.test.ts
+++ b/packages/onedrive/tests/unit/adapters/drive-metadata-capture.test.ts
@@ -120,7 +120,9 @@ describe('restoring original timestamps (issue #54)', () => {
   const stub_chunk_uploads = (): void => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => new Response('{}', { status: 202 })),
+      // 201 is the terminal answer that carries the finished driveItem. A 202 means the session
+      // still wants bytes, and the upload now fails on it rather than reporting success (#342).
+      vi.fn(async () => new Response('{}', { status: 201 })),
     );
   };
 

--- a/packages/onedrive/tests/unit/adapters/upload-session.test.ts
+++ b/packages/onedrive/tests/unit/adapters/upload-session.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  upload_content_to_session,
+  LARGE_UPLOAD_CHUNK,
+} from '@wisecom/atlas-drive/restore/upload-session';
+
+/**
+ * Issue #342: the chunk loop returned on any `response.ok`, so a session that answered every PUT
+ * with `202 Accepted` and a list of ranges it still wanted was reported as a restored file. A
+ * thrown network error also bypassed the DELETE that releases the session.
+ */
+
+const UPLOAD_URL = 'https://graph.test/upload/session-1';
+const TWO_CHUNKS = Buffer.alloc(LARGE_UPLOAD_CHUNK + 1024, 7);
+
+interface Call {
+  readonly method: string;
+  readonly range: string | undefined;
+}
+
+/** Records every request and answers PUTs from the supplied status sequence. */
+function stub_session(statuses: number[], throw_on_put?: number): Call[] {
+  const calls: Call[] = [];
+  let put_index = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: string, init?: { method?: string; headers?: Record<string, string> }) => {
+      const method = init?.method ?? 'GET';
+      calls.push({ method, range: init?.headers?.['Content-Range'] });
+      if (method !== 'PUT') return new Response('{"nextExpectedRanges":["0-"]}', { status: 200 });
+      const index = put_index++;
+      if (throw_on_put === index) throw new Error('socket hang up');
+      return new Response('{}', { status: statuses[index] ?? 202 });
+    }),
+  );
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('upload_content_to_session (issue #342)', () => {
+  it('returns once the last chunk is answered with a terminal 201', async () => {
+    const calls = stub_session([202, 201]);
+
+    await expect(upload_content_to_session(UPLOAD_URL, TWO_CHUNKS, 'Report.docx')).resolves.toBe(
+      undefined,
+    );
+
+    expect(calls.filter((c) => c.method === 'PUT')).toHaveLength(2);
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(false);
+  });
+
+  it('fails the file when the last chunk is still answered with 202', async () => {
+    const calls = stub_session([202, 202]);
+
+    await expect(upload_content_to_session(UPLOAD_URL, TWO_CHUNKS, 'Report.docx')).rejects.toThrow(
+      /sent every byte but Graph never returned a completed item; it still expects 0-/,
+    );
+
+    // Every byte went out, so this is not a transfer failure: the session simply never converged.
+    expect(calls.filter((c) => c.method === 'PUT')).toHaveLength(2);
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(true);
+  });
+
+  it('releases the session when the last chunk throws', async () => {
+    const calls = stub_session([202, 200], 1);
+
+    await expect(upload_content_to_session(UPLOAD_URL, TWO_CHUNKS, 'Report.docx')).rejects.toThrow(
+      'socket hang up',
+    );
+
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(true);
+  });
+
+  it('fails an item Graph completes before every byte was sent', async () => {
+    const calls = stub_session([201, 201]);
+
+    await expect(upload_content_to_session(UPLOAD_URL, TWO_CHUNKS, 'Report.docx')).rejects.toThrow(
+      /completed at bytes 0-10485759\/10486784 with 1024 byte\(s\) unsent/,
+    );
+
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(true);
+  });
+
+  it('reports a cleanup that itself failed rather than hiding it', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init?: { method?: string }) => {
+        if (init?.method === 'DELETE') return new Response('', { status: 500 });
+        if (init?.method === 'PUT') return new Response('{}', { status: 202 });
+        return new Response('{"nextExpectedRanges":["0-"]}', { status: 200 });
+      }),
+    );
+
+    await expect(
+      upload_content_to_session(UPLOAD_URL, Buffer.alloc(16, 1), 'Report.docx'),
+    ).rejects.toThrow(/never returned a completed item/);
+
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/packages/onedrive/tests/unit/adapters/upload-session.test.ts
+++ b/packages/onedrive/tests/unit/adapters/upload-session.test.ts
@@ -82,7 +82,9 @@ describe('upload_content_to_session (issue #342)', () => {
       /completed at bytes 0-10485759\/10486784 with 1024 byte\(s\) unsent/,
     );
 
-    expect(calls.some((c) => c.method === 'DELETE')).toBe(true);
+    // Graph removed the session when it returned the item, so a DELETE would only 404 and log that
+    // the session stays reserved.
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(false);
   });
 
   it('reports a cleanup that itself failed rather than hiding it', async () => {

--- a/packages/sharepoint/src/adapters/graph-sharepoint-restore.adapter.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-restore.adapter.ts
@@ -1,71 +1,8 @@
 import type { Client } from '@microsoft/microsoft-graph-client';
-import {
-  build_upload_file_system_info,
-  is_transient_error,
-  with_graph_retry,
-} from '@wisecom/atlas-m365-graph';
+import { build_upload_file_system_info, with_graph_retry } from '@wisecom/atlas-m365-graph';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import { upload_content_to_session } from '@wisecom/atlas-drive/restore/upload-session';
 import type { DriveFileSystemInfo } from '@wisecom/atlas-types';
-
-const LARGE_UPLOAD_CHUNK = 10 * 1024 * 1024;
-const CHUNK_PUT_ATTEMPTS = 3;
-
-async function sleep_ms(delay_ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, delay_ms));
-}
-
-function parse_fetch_retry_after_ms(header_value: string | null): number | undefined {
-  if (!header_value) return undefined;
-  const trimmed = header_value.trim();
-  const seconds = parseInt(trimmed, 10);
-  if (!isNaN(seconds)) return seconds * 1000;
-  const date_ms = Date.parse(trimmed);
-  if (!isNaN(date_ms)) {
-    const delta = date_ms - Date.now();
-    return delta > 0 ? delta : undefined;
-  }
-  return undefined;
-}
-
-async function cancel_resumable_upload_session(upload_url: string): Promise<void> {
-  try {
-    await fetch(upload_url, { method: 'DELETE' });
-  } catch {}
-}
-
-async function put_upload_chunk_with_retry(
-  upload_url: string,
-  range: string,
-  chunk: Buffer,
-): Promise<void> {
-  let last_detail = '';
-  for (let attempt = 0; attempt < CHUNK_PUT_ATTEMPTS; attempt++) {
-    const response = await fetch(upload_url, {
-      method: 'PUT',
-      headers: {
-        'Content-Range': range,
-        'Content-Length': String(chunk.length),
-      },
-      body: chunk,
-    });
-    if (response.ok) return;
-
-    last_detail = await response.text();
-    // A range PUT is addressed by Content-Range, so replaying one after a
-    // transient 500/502/504 rewrites the same bytes (issue #36).
-    const retriable = is_transient_error({ statusCode: response.status });
-    const is_last = attempt === CHUNK_PUT_ATTEMPTS - 1;
-    if (retriable && !is_last) {
-      const wait_ms = parse_fetch_retry_after_ms(response.headers.get('retry-after')) ?? 1000;
-      await sleep_ms(wait_ms);
-      continue;
-    }
-    await cancel_resumable_upload_session(upload_url);
-    throw new Error(
-      `Resumable upload failed at range ${range}: HTTP ${response.status} ${last_detail}`,
-    );
-  }
-}
 
 async function find_child_folder_id_by_name(
   client: Client,
@@ -224,10 +161,5 @@ export async function graph_sharepoint_upload_large_file(
   }
   const upload_url = session_response.uploadUrl;
 
-  for (let offset = 0; offset < content.length; offset += LARGE_UPLOAD_CHUNK) {
-    const end = Math.min(offset + LARGE_UPLOAD_CHUNK, content.length);
-    const chunk = content.subarray(offset, end);
-    const range = `bytes ${offset}-${end - 1}/${content.length}`;
-    await put_upload_chunk_with_retry(upload_url, range, chunk);
-  }
+  await upload_content_to_session(upload_url, content, file_name);
 }


### PR DESCRIPTION
## Summary

Closes #342.

Both drive restore adapters returned from a chunk PUT as soon as `response.ok` was true. Graph's `createUploadSession` contract does not work that way: an intermediate chunk is answered `202 Accepted` with the ranges the session still wants, and only the final chunk gets `200` or `201` carrying the finished `driveItem`. Since `202` is `ok`, a session that answered every PUT with `202` was reported as a restored file. A thrown error on a chunk also bypassed the `DELETE` that releases the session, so a socket reset left it open.

The loop now reads the status code:

- `200` or `201` completes the item. If it arrives before the last byte was sent, the file fails, because the remaining chunks would have nowhere to go.
- `202` means keep going. If it is the answer to the last chunk, the file fails and the message names the ranges the session reports as outstanding, read back with a `GET` on the session.
- Anything else keeps the existing retry behaviour: three attempts on a transient status, honouring `Retry-After`.

I chose to fail rather than resume on a trailing `202`, which the acceptance criteria allow either way. Every byte is already in hand, so a session that has not converged is a protocol or service problem rather than a transfer that needs another push, and retrying the same content into the same session is unlikely to change it. The next restore opens a fresh session. Say the word if you would rather it resume from the reported ranges.

A thrown error now takes the same exit as a terminal HTTP failure, and a `DELETE` that itself fails is logged rather than swallowed. The session holds its reserved quota until Graph expires it, so an operator chasing a quota complaint needs to know Atlas tried and could not.

**Both providers held byte-identical copies** of the chunk loop, its retry helper, its `Retry-After` parser and its session cleanup, about 60 lines each. Fixing that twice is how the two drive pipelines drifted into the same bug before, so the fixed version lives in `packages/drive` and both adapters call it. What actually differs between them, the `createUploadSession` URL, stays in the provider.

One existing fixture changed: `drive-metadata-capture.test.ts` stubbed every PUT with `202`, which is exactly the response this PR stops accepting. It now answers `201`, since that test is about the session creation body rather than the upload outcome. That the fixture had to change is itself the evidence that the old code treated `202` as success.

## Changes

- `packages/drive/src/restore/upload-session.ts`: new `upload_content_to_session`, with the terminal-status rule, the outstanding-range report, and session cleanup that reports its own failure. Exported from the package index along with `LARGE_UPLOAD_CHUNK`.
- `packages/onedrive/src/adapters/graph-onedrive-restore.adapter.ts` and `packages/sharepoint/src/adapters/graph-sharepoint-restore.adapter.ts`: the duplicated chunk loop, retry helper, `Retry-After` parser and cleanup are deleted; both call the shared function.
- `packages/onedrive/tests/unit/adapters/upload-session.test.ts`: regression coverage for a trailing `202`, a thrown error on the last chunk, an early terminal response, a cleanup that fails, and the normal path. It lives in the OneDrive package because the drive package's test aliases cannot resolve core source imported through the module under test.
- `docs/onedrive-backup.md`: new "What counts as a completed upload" section, cross-referenced from `docs/sharepoint-backup.md`.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`), unless this is a release or hotfix PR
- [x] No version bump in `packages/*/package.json` (releases only)
- [x] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Large OneDrive and SharePoint restores now use reliable resumable uploads with chunking, retries, and session cleanup.
  - Restore results now report attachment failures separately, including affected counts and details.

- **Bug Fixes**
  - Corrupt or unreadable manifests and decrypted files now produce explicit errors instead of being silently skipped.
  - Verification now includes stored entries without checksums and reports them as failures.
  - Uploads only complete on terminal success responses; incomplete uploads are reported and cleaned up.

- **Documentation**
  - Clarified upload completion rules, integrity handling, and command-line failure statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->