### PR TITLE
fix(s3): promote an object over 5 GB with ranged UploadPartCopy

### DIFF
--- a/docs/self-hosting/storage.md
+++ b/docs/self-hosting/storage.md
@@ -211,3 +211,26 @@ Content blobs stay one object per file, addressed by SHA-256 (`onedrive/data/<ow
 | Scaleway                                                     | None documented                           | Recommends objects larger than 1 MB for Glacier tiers ([FAQ](https://www.scaleway.com/en/docs/object-storage/faq/))                      |
 | Backblaze B2                                                 | None documented                           | B2's own cost guide warns some services round up to 128 KB ([cost comparison](https://www.backblaze.com/cloud-storage/pricing))          |
 | MinIO self-hosted                                            | None                                      | Filesystem block size still applies                                                                                                      |
+
+## Per-Object Size Ceiling
+
+A large file is uploaded as a multipart stream to a staging key, then promoted to its
+content-addressed key with a server-side copy. Two S3 limits bound that:
+
+| Limit                      | Value  | How Atlas stays inside it                                                    |
+| -------------------------- | ------ | ---------------------------------------------------------------------------- |
+| Single `CopyObject` source | 5 GB   | A source above it is promoted with ranged `UploadPartCopy` instead           |
+| Object size                | 5 TB   | Not enforced by Atlas; a file larger than this cannot be stored in S3 at all |
+| Parts per multipart upload | 10,000 | Copy parts are 1 GiB, which reaches 10 TiB and so never runs out             |
+
+The 5 GB threshold is a constant in Atlas, not something read from the backend. MinIO does not
+enforce the AWS limit, so deciding from the backend's behaviour would mean the request that fails
+on AWS is the one never exercised locally. Both take the same branch for the same object size.
+
+The promotion is server-side either way: no byte travels back through Atlas, and the ciphertext,
+its checksum, its metadata and any Object Lock retention are identical whichever request is used.
+Retention on a ranged copy is declared when the multipart upload is created, which is where it
+takes effect for a multipart destination.
+
+The practical ceiling is therefore S3's own 5 TB per object, which is far above what Microsoft 365
+will serve: OneDrive and SharePoint cap a single file at 250 GB.

--- a/packages/s3/src/adapters/s3-large-copy.ts
+++ b/packages/s3/src/adapters/s3-large-copy.ts
@@ -1,0 +1,176 @@
+import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CopyObjectCommand,
+  CreateMultipartUploadCommand,
+  HeadObjectCommand,
+  UploadPartCopyCommand,
+  type S3Client,
+} from '@aws-sdk/client-s3';
+import type { StorageObjectLockPolicy } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import { build_s3_copy_source } from '@/adapters/s3-error-classifier';
+
+/**
+ * Largest source a single `CopyObject` may have.
+ *
+ * AWS refuses a larger one and requires multipart `UploadPartCopy` instead. The threshold is a
+ * constant rather than something read from the backend, so MinIO and AWS take the same branch and
+ * the local suites exercise the path AWS would (issue #346).
+ *
+ * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
+ */
+export const MAX_SINGLE_COPY_BYTES = 5 * 1024 * 1024 * 1024;
+
+/**
+ * Bytes per `UploadPartCopy` range.
+ *
+ * 1 GiB against the 10,000 part ceiling reaches 10 TiB, comfortably past S3's 5 TiB per-object
+ * limit, so no object the upload path can produce runs out of parts.
+ */
+const COPY_PART_BYTES = 1024 * 1024 * 1024;
+
+export interface ServerSideCopyRequest {
+  readonly bucket: string;
+  readonly source_key: string;
+  readonly dest_key: string;
+  readonly metadata?: Record<string, string> | undefined;
+  readonly object_lock_policy?: StorageObjectLockPolicy | undefined;
+}
+
+/**
+ * Copies an object within a bucket, choosing the request the source size allows.
+ *
+ * A single `CopyObject` is limited to a 5 GB source, which is smaller than the objects the
+ * multipart upload path accepts, so promoting a large file used to fail after its bytes were
+ * already uploaded. The size comes from a `HeadObject` on the source rather than from the backend's
+ * own opinion, so MinIO and AWS take the same branch (issue #346).
+ */
+export async function copy_object_server_side(
+  client: S3Client,
+  request: ServerSideCopyRequest,
+): Promise<void> {
+  const copy_source = build_s3_copy_source(request.bucket, request.source_key);
+  const head = await client.send(
+    new HeadObjectCommand({ Bucket: request.bucket, Key: request.source_key }),
+  );
+  const source_bytes = head.ContentLength ?? 0;
+
+  if (source_bytes > MAX_SINGLE_COPY_BYTES) {
+    await copy_object_in_parts(client, { ...request, copy_source, source_bytes });
+    return;
+  }
+
+  await client.send(
+    new CopyObjectCommand({
+      Bucket: request.bucket,
+      Key: request.dest_key,
+      CopySource: copy_source,
+      Metadata: request.metadata,
+      MetadataDirective: request.metadata ? 'REPLACE' : undefined,
+      ObjectLockMode: request.object_lock_policy?.mode,
+      ObjectLockRetainUntilDate: request.object_lock_policy?.retain_until
+        ? new Date(request.object_lock_policy.retain_until)
+        : undefined,
+    }),
+  );
+}
+
+interface LargeCopyRequest extends ServerSideCopyRequest {
+  readonly copy_source: string;
+  readonly source_bytes: number;
+}
+
+/**
+ * Promotes an object larger than {@link MAX_SINGLE_COPY_BYTES} with ranged `UploadPartCopy`.
+ *
+ * Server-side throughout: no byte travels through Atlas, so the ciphertext, its checksum and the
+ * metadata are the source object's own. Retention and Object Lock are declared on
+ * `CreateMultipartUpload`, which is where they take effect for a multipart destination, so the
+ * promoted object carries the same policy the single-request copy would have given it.
+ */
+async function copy_object_in_parts(client: S3Client, request: LargeCopyRequest): Promise<void> {
+  const created = await client.send(
+    new CreateMultipartUploadCommand({
+      Bucket: request.bucket,
+      Key: request.dest_key,
+      Metadata: request.metadata,
+      ObjectLockMode: request.object_lock_policy?.mode,
+      ObjectLockRetainUntilDate: request.object_lock_policy?.retain_until
+        ? new Date(request.object_lock_policy.retain_until)
+        : undefined,
+    }),
+  );
+  const upload_id = created.UploadId;
+  if (!upload_id) throw new Error('CreateMultipartUpload returned no UploadId for a ranged copy');
+
+  try {
+    const parts = await copy_every_part(client, request, upload_id);
+    await client.send(
+      new CompleteMultipartUploadCommand({
+        Bucket: request.bucket,
+        Key: request.dest_key,
+        UploadId: upload_id,
+        MultipartUpload: { Parts: parts },
+      }),
+    );
+  } catch (err) {
+    // An abandoned multipart upload keeps billing for its parts until a lifecycle rule sweeps it.
+    await abort_quietly(client, request, upload_id);
+    throw err;
+  }
+}
+
+/** Copies each 1 GiB range in turn, returning the completed part list in order. */
+async function copy_every_part(
+  client: S3Client,
+  request: LargeCopyRequest,
+  upload_id: string,
+): Promise<{ ETag: string; PartNumber: number }[]> {
+  const parts: { ETag: string; PartNumber: number }[] = [];
+  let part_number = 1;
+
+  for (let offset = 0; offset < request.source_bytes; offset += COPY_PART_BYTES) {
+    const end = Math.min(offset + COPY_PART_BYTES, request.source_bytes) - 1;
+    const response = await client.send(
+      new UploadPartCopyCommand({
+        Bucket: request.bucket,
+        Key: request.dest_key,
+        UploadId: upload_id,
+        CopySource: request.copy_source,
+        CopySourceRange: `bytes=${offset}-${end}`,
+        PartNumber: part_number,
+      }),
+    );
+    const etag = response.CopyPartResult?.ETag;
+    if (!etag) {
+      throw new Error(`UploadPartCopy returned no ETag for bytes=${offset}-${end}`);
+    }
+    parts.push({ ETag: etag, PartNumber: part_number });
+    part_number++;
+  }
+
+  return parts;
+}
+
+async function abort_quietly(
+  client: S3Client,
+  request: LargeCopyRequest,
+  upload_id: string,
+): Promise<void> {
+  try {
+    await client.send(
+      new AbortMultipartUploadCommand({
+        Bucket: request.bucket,
+        Key: request.dest_key,
+        UploadId: upload_id,
+      }),
+    );
+  } catch (err) {
+    logger.warn(
+      `Could not abort the ranged copy of ${request.dest_key}: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `Its parts bill until a lifecycle rule sweeps them.`,
+    );
+  }
+}

--- a/packages/s3/src/adapters/s3-object-storage.adapter.ts
+++ b/packages/s3/src/adapters/s3-object-storage.adapter.ts
@@ -7,7 +7,6 @@ import {
   HeadObjectCommand,
   ListObjectsV2Command,
   CreateMultipartUploadCommand,
-  CopyObjectCommand,
   ListMultipartUploadsCommand,
   AbortMultipartUploadCommand,
   type S3Client,
@@ -36,11 +35,8 @@ import {
   ObjectLockVersioningDisabledError,
   PreconditionFailedError,
 } from '@/adapters/object-lock.errors';
-import {
-  build_s3_copy_source,
-  is_backend_mode_rejection,
-  is_precondition_failed,
-} from '@/adapters/s3-error-classifier';
+import { is_backend_mode_rejection, is_precondition_failed } from '@/adapters/s3-error-classifier';
+import { copy_object_server_side } from '@/adapters/s3-large-copy';
 
 /**
  * S3-backed ObjectStorage scoped to a single bucket.
@@ -285,7 +281,14 @@ export class S3ObjectStorage implements ObjectStorage {
     }
   }
 
-  /** Copies an object server-side within this bucket. */
+  /**
+   * Copies an object server-side within this bucket.
+   *
+   * A single `CopyObject` is limited to a 5 GB source, which is smaller than the objects the
+   * multipart upload path accepts, so promotion used to fail on a large file after its bytes were
+   * already uploaded. The source size decides the request: anything above the limit is copied as
+   * ranged `UploadPartCopy` parts instead (issue #346).
+   */
   async copy(
     source_key: string,
     dest_key: string,
@@ -293,21 +296,14 @@ export class S3ObjectStorage implements ObjectStorage {
     object_lock_policy?: StorageObjectLockPolicy,
   ): Promise<void> {
     await this.validate_immutability_policy(object_lock_policy);
-    const copy_source = build_s3_copy_source(this._bucket, source_key);
     try {
-      await this._client.send(
-        new CopyObjectCommand({
-          Bucket: this._bucket,
-          Key: dest_key,
-          CopySource: copy_source,
-          Metadata: metadata,
-          MetadataDirective: metadata ? 'REPLACE' : undefined,
-          ObjectLockMode: object_lock_policy?.mode,
-          ObjectLockRetainUntilDate: object_lock_policy?.retain_until
-            ? new Date(object_lock_policy.retain_until)
-            : undefined,
-        }),
-      );
+      await copy_object_server_side(this._client, {
+        bucket: this._bucket,
+        source_key,
+        dest_key,
+        metadata,
+        object_lock_policy,
+      });
     } catch (err) {
       if (is_backend_mode_rejection(err, object_lock_policy?.mode)) {
         throw new ObjectLockModeRejectedError(

--- a/packages/s3/tests/unit/s3-large-copy.test.ts
+++ b/packages/s3/tests/unit/s3-large-copy.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BucketCache } from '@/adapters/bucket-cache';
+import { S3ObjectStorage } from '@/adapters/s3-object-storage.adapter';
+import { MAX_SINGLE_COPY_BYTES } from '@/adapters/s3-large-copy';
+
+/**
+ * Issue #346: promotion always issued a single `CopyObject`, which AWS refuses for a source over
+ * 5 GB. The multipart upload path accepts objects well past that, so a large backup failed at
+ * promotion after every byte was already uploaded. MinIO does not enforce the limit, which is why
+ * the local suites never saw it, so the branch is decided by the source size rather than by the
+ * backend and both take the same one.
+ */
+
+const BUCKET = 'test-bucket';
+const GIB = 1024 * 1024 * 1024;
+
+function command_names(send: ReturnType<typeof vi.fn>): string[] {
+  return send.mock.calls.map(
+    (call) => (call[0] as { constructor: { name: string } }).constructor.name,
+  );
+}
+
+function inputs_of(send: ReturnType<typeof vi.fn>, name: string): Record<string, unknown>[] {
+  return send.mock.calls
+    .map((call) => call[0] as { constructor: { name: string }; input: Record<string, unknown> })
+    .filter((cmd) => cmd.constructor.name === name)
+    .map((cmd) => cmd.input);
+}
+
+describe('server-side promotion either side of the single-copy limit (issue #346)', () => {
+  let send: ReturnType<typeof vi.fn>;
+  let storage: S3ObjectStorage;
+
+  beforeEach(() => {
+    send = vi.fn();
+    storage = new S3ObjectStorage({ send } as never, BUCKET, new BucketCache());
+  });
+
+  /** Answers HeadObject with a size, and every other command with a plausible success. */
+  function answer(bytes: number): (command: { constructor: { name: string } }) => Promise<unknown> {
+    let part = 0;
+    return async (command) => {
+      switch (command.constructor.name) {
+        case 'HeadObjectCommand':
+          return { ContentLength: bytes };
+        case 'CreateMultipartUploadCommand':
+          return { UploadId: 'upload-1' };
+        case 'UploadPartCopyCommand':
+          return { CopyPartResult: { ETag: `"etag-${++part}"` } };
+        // A retention policy is validated against the bucket before any copy is attempted.
+        case 'GetBucketVersioningCommand':
+          return { Status: 'Enabled' };
+        case 'GetObjectLockConfigurationCommand':
+          return { ObjectLockConfiguration: { ObjectLockEnabled: 'Enabled' } };
+        default:
+          return {};
+      }
+    };
+  }
+
+  function given_source_size(bytes: number): void {
+    send.mockImplementation(answer(bytes));
+  }
+
+  it('uses a single CopyObject exactly at the limit', async () => {
+    given_source_size(MAX_SINGLE_COPY_BYTES);
+
+    await storage.copy('staging/big', 'data/big');
+
+    expect(command_names(send)).toEqual(['HeadObjectCommand', 'CopyObjectCommand']);
+    expect(inputs_of(send, 'CopyObjectCommand')[0]).toMatchObject({
+      Bucket: BUCKET,
+      Key: 'data/big',
+      CopySource: `${BUCKET}/staging/big`,
+    });
+  });
+
+  it('switches to ranged UploadPartCopy one byte past the limit', async () => {
+    given_source_size(MAX_SINGLE_COPY_BYTES + 1);
+
+    await storage.copy('staging/big', 'data/big');
+
+    expect(command_names(send)).not.toContain('CopyObjectCommand');
+    // Six 1 GiB parts for 5 GiB + 1 byte: five full ranges and a one byte tail.
+    const parts = inputs_of(send, 'UploadPartCopyCommand');
+    expect(parts).toHaveLength(6);
+    expect(parts[0]?.['CopySourceRange']).toBe(`bytes=0-${GIB - 1}`);
+    expect(parts[5]?.['CopySourceRange']).toBe(
+      `bytes=${MAX_SINGLE_COPY_BYTES}-${MAX_SINGLE_COPY_BYTES}`,
+    );
+    expect(command_names(send).at(-1)).toBe('CompleteMultipartUploadCommand');
+  });
+
+  it('carries metadata and Object Lock onto the ranged copy, as the single copy does', async () => {
+    given_source_size(6 * GIB);
+
+    await storage.copy(
+      'staging/big',
+      'data/big',
+      { custom: 'meta' },
+      { mode: 'COMPLIANCE', retain_until: '2030-01-01T00:00:00.000Z' },
+    );
+
+    // Declared on CreateMultipartUpload, which is where they take effect for a multipart target.
+    expect(inputs_of(send, 'CreateMultipartUploadCommand')[0]).toMatchObject({
+      Metadata: { custom: 'meta' },
+      ObjectLockMode: 'COMPLIANCE',
+      ObjectLockRetainUntilDate: new Date('2030-01-01T00:00:00.000Z'),
+    });
+  });
+
+  it('aborts the multipart upload when a part copy fails, then rethrows', async () => {
+    const respond = answer(6 * GIB);
+    send.mockImplementation(async (command: { constructor: { name: string } }) => {
+      if (command.constructor.name === 'UploadPartCopyCommand') throw new Error('copy refused');
+      return respond(command);
+    });
+
+    await expect(storage.copy('staging/big', 'data/big')).rejects.toThrow('copy refused');
+
+    expect(command_names(send)).toContain('AbortMultipartUploadCommand');
+    expect(command_names(send)).not.toContain('CompleteMultipartUploadCommand');
+  });
+
+  it('fails rather than completing when a part copy returns no ETag', async () => {
+    const respond = answer(6 * GIB);
+    send.mockImplementation(async (command: { constructor: { name: string } }) => {
+      if (command.constructor.name === 'UploadPartCopyCommand') return {};
+      return respond(command);
+    });
+
+    await expect(storage.copy('staging/big', 'data/big')).rejects.toThrow(/no ETag/);
+
+    expect(command_names(send)).not.toContain('CompleteMultipartUploadCommand');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #346.

The multipart upload path stages a large object under `.../staging/...` and then promotes it to its content-addressed key with a server-side copy. That promotion always issued a single `CopyObject`, which AWS caps at a 5 GB source and refuses above it, requiring multipart `UploadPartCopy` instead. So the promotion step could not handle every object the upload path accepts: a file past 5 GB failed at the very last step, after all of its bytes had already been transferred and paid for. MinIO does not enforce the limit, which is exactly why the local suites never saw it.

The source size now decides the request. A `HeadObject` on the source gives the size, and anything above the limit is copied as 1 GiB `UploadPartCopy` ranges into a multipart upload on the destination.

**The threshold is a constant, not something read from the backend.** That is the fourth acceptance criterion and it matters: if the branch were chosen from what the backend tolerates, the request that fails on AWS would be the one never exercised locally, which is how this bug survived in the first place. Both backends take the same branch for the same object size, and the regression drives it either side of the boundary with a stubbed `HeadObject`.

Nothing else changes. Both paths are server-side, so no byte travels back through Atlas and the ciphertext, its checksum and its metadata stay the source object's own. Retention and Object Lock are declared on `CreateMultipartUpload`, which is where they take effect for a multipart destination, and there is a test asserting they land there. A part copy that fails aborts the upload rather than leaving parts billing until a lifecycle rule sweeps them, and an abort that itself fails is logged.

Part sizing: 1 GiB against the 10,000 part ceiling reaches 10 TiB, comfortably past S3's own 5 TB per-object limit, so no object the upload path can produce runs out of parts.

The copy logic moved into its own module because `s3-object-storage.adapter.ts` was already at the 300 effective line limit and adding the branch inline pushed it to 308. The adapter keeps the permission validation and the Object Lock error mapping.

## Changes

- `packages/s3/src/adapters/s3-large-copy.ts`: new `copy_object_server_side`, which heads the source and picks between `CopyObject` and ranged `UploadPartCopy`, plus `MAX_SINGLE_COPY_BYTES`.
- `packages/s3/src/adapters/s3-object-storage.adapter.ts`: `copy()` delegates to it, keeping the immutability validation and the `ObjectLockModeRejectedError` mapping.
- `packages/s3/tests/unit/s3-large-copy.test.ts`: exactly at the limit uses one `CopyObject`; one byte past it uses six ranged parts with the tail range asserted; metadata and Object Lock reach `CreateMultipartUpload`; a failed part copy aborts and rethrows; a part copy with no ETag fails rather than completing a truncated object.
- `docs/self-hosting/storage.md`: new "Per-Object Size Ceiling" section with the three S3 limits, why the threshold is a constant, and the note that the practical ceiling is S3's 5 TB, well above the 250 GB Microsoft 365 will serve.

## Verification note

This is confirmed against the documented AWS limit and the SDK's command surface, not against a live AWS bucket, which matches how the issue was reported. The regression asserts which commands Atlas sends and with what ranges; it cannot assert that AWS accepts them.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`), unless this is a release or hotfix PR
- [x] No version bump in `packages/*/package.json` (releases only)
- [x] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)
