### PR TITLE
fix(restore): stream a large restore instead of buffering the whole file

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -457,6 +457,24 @@ operator chasing a quota complaint needs to know Atlas tried.
 
 Files larger than 4 MiB use a streaming decrypt pipeline: the encrypted blob is read from S3 as a stream, the first 28 bytes (12-byte IV + 16-byte auth tag) are consumed to initialize AES-256-GCM, and ciphertext is decrypted in chunks without buffering the full ciphertext in memory.
 
+#### Memory during a large restore
+
+The plaintext is not buffered either. Each decrypted chunk goes into the upload session as it is
+produced, so a restore holds two 10 MiB upload chunks and one download chunk regardless of whether
+the file is 5 MiB or 50 GiB. Peak memory therefore follows how many files a run restores at once,
+not the size of the largest file in the backup.
+
+Streaming a file that has not been verified yet is safe because the item does not exist until the
+session is committed. AES-256-GCM only authenticates at the end of the object, and the SHA-256 can
+only be compared once the last byte is out, so Atlas holds the committing chunk back until the
+decrypt stream has ended cleanly. A failed authentication tag or a checksum that does not match the
+manifest therefore abandons the session with `DELETE`, and Graph never creates the file. The bytes
+Graph already accepted belong to a session nobody can read, and they expire with it.
+
+A file that fails this way is reported as a restore error and the run exits non-zero. It is not a
+silent skip: a manifest entry whose stored object no longer matches is the case an operator most
+needs to hear about.
+
 **Conflict behavior** controls what happens when a file already exists at the target path:
 
 | Mode               | Behavior                                                                                  |
@@ -468,6 +486,13 @@ Files larger than 4 MiB use a streaming decrypt pipeline: the encrypted blob is 
 ### Saving to a local archive
 
 `atlas onedrive save` writes a zip archive instead of uploading to Graph. The archive preserves the OneDrive folder hierarchy, and files larger than 4 MiB use streaming decryption to avoid holding the full ciphertext in memory.
+
+The archive is written one entry at a time, and the next file is not decrypted until the
+destination has taken the previous one. With `--output` the destination is a local file and this is
+invisible. It matters when the SDK streams the archive somewhere slower, an HTTP response or an
+upload: the export now runs at the consumer's pace instead of compressing everything it can and
+holding the result in the archive's buffer. One file is held whole while it is compressed, so an
+export's peak follows the largest file in the snapshot rather than the snapshot.
 
 ```bash
 atlas onedrive save -o user@company.com -s od-snap-123

--- a/docs/security.md
+++ b/docs/security.md
@@ -394,6 +394,24 @@ run that now reports per-item errors or integrity failures exits `2`, which is w
 has always meant; a manifest that cannot be read is a `StorageError` and exits `1`. What changed is
 that these runs no longer exit `0`.
 
+### Nothing is released before it authenticates
+
+Restoring a large file streams the plaintext into a Graph upload session as it is decrypted, which
+means bytes leave Atlas before AES-256-GCM has authenticated the object and before the SHA-256 can
+be compared to the manifest. Neither check can happen earlier: the tag covers the whole object and
+arrives last, and a digest is only a digest once the final byte is in it.
+
+What makes that safe is where the release actually happens. An upload session accumulates chunks
+the caller cannot read, and the item only exists once the session is committed by the chunk
+carrying the last byte. Atlas holds that chunk back until the decrypt stream has ended without
+error, so a failed tag or a checksum that does not match abandons the session with `DELETE` and no
+file is created. What Graph already accepted stays inside a session nobody can read and expires
+with it.
+
+The property to keep when this code is touched: an unverified byte may travel, but nothing may
+make it visible. A destination that publishes as it receives, a filesystem path or a stream handed
+to a caller, needs the buffered path and its up-front verification instead.
+
 ### Content-MD5 on Uploads
 
 Every object uploaded to S3 includes a `Content-MD5` header computed from the **ciphertext** (not the plaintext). This is a transport integrity check -- if a network error corrupts the data in flight, S3 will reject the upload with a checksum mismatch. This is separate from the application-layer SHA-256, which validates the original plaintext content.

--- a/docs/security.md
+++ b/docs/security.md
@@ -408,6 +408,13 @@ error, so a failed tag or a checksum that does not match abandons the session wi
 file is created. What Graph already accepted stays inside a session nobody can read and expires
 with it.
 
+Holding a chunk back is necessary but not sufficient, because a session commits as soon as the
+ranges it has received cover the total it was opened for, and that total is the size the manifest
+recorded rather than anything measured during the restore. An object longer than its recorded size
+would fill the declared range mid-stream and commit there. Atlas therefore refuses any chunk that
+would reach the declared end while the source is still producing: the file fails, the session is
+released, and the recorded size and the stored object are reported as disagreeing.
+
 The property to keep when this code is touched: an unverified byte may travel, but nothing may
 make it visible. A destination that publishes as it receives, a filesystem path or a stream handed
 to a caller, needs the buffered path and its up-front verification instead.

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -381,6 +381,12 @@ file, naming the ranges Graph reports as outstanding, and a thrown error release
 `DELETE` before propagating. Identical to OneDrive; see
 [What counts as a completed upload](/onedrive-backup#what-counts-as-a-completed-upload).
 
+Plaintext is streamed into the session as it is decrypted rather than buffered, so a restore holds
+two upload chunks instead of the whole file, and the committing chunk is held back until the
+decrypt stream has ended. A failed tag or a checksum that does not match the manifest abandons the
+session, so the file is never created. Identical to OneDrive; see
+[Memory during a large restore](/onedrive-backup#memory-during-a-large-restore).
+
 ```typescript
 const result = await atlas.sharepoint.restore('site-id', {
   snapshot_id: 'sp-snap-123',
@@ -406,6 +412,10 @@ Library names were not recorded in older manifests, so rule 1 cannot apply to th
 ### Saving to a local archive
 
 `atlas sharepoint save` writes a zip archive instead of uploading to Graph. The archive preserves the SharePoint folder hierarchy from document libraries, and files larger than 4 MiB use streaming decryption to avoid holding the full ciphertext in memory.
+
+The archive is written one entry at a time and waits for the destination to take each one, so
+streaming an export to a slow consumer runs at the consumer's pace instead of queueing every entry
+it could decrypt.
 
 ```bash
 atlas sharepoint save --site https://contoso.sharepoint.com/sites/Engineering -s sp-snap-123

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -368,7 +368,9 @@ Before 4.0.0 a restore wrote every file back over its original path. With the de
 
 Restore decrypts stored file blobs, verifies SHA-256 checksums, and uploads them back to a site's document libraries via the Graph API. Restoring in place uses each manifest entry's own `drive_id`, so files return to the library they came from. Restoring to another site with `--target-site` re-points every upload at a library of that site, described in [Where a cross-site restore lands](#where-a-cross-site-restore-lands).
 
-Files with `change_type: 'deleted'` or a missing `storage_key` are skipped. Checksum verification runs before upload, and corrupted blobs are skipped with a warning.
+Files with `change_type: 'deleted'` or a missing `storage_key` are skipped. A blob whose checksum
+does not match the manifest is a restore error rather than a warning: the file is not created, it
+is named in the run's errors, and the run exits non-zero.
 
 | Size        | Strategy                                                                                                               |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------- |

--- a/packages/core/src/services/shared/byte-queue.ts
+++ b/packages/core/src/services/shared/byte-queue.ts
@@ -1,0 +1,50 @@
+/**
+ * A FIFO of buffers that hands out fixed-size blocks.
+ *
+ * Chunk sources and block consumers disagree on size: a ranged download arrives in 4 MiB pieces, a
+ * Graph response stream in whatever the socket produced, and both S3 multipart parts and Graph
+ * upload-session chunks have to go out at one fixed size. Concatenating the pending bytes on every
+ * flush copies the remainder again for each block, so copy volume grew with the input chunk size
+ * rather than with the payload (issue #343). Only the bytes actually handed out are copied here;
+ * everything still pending stays in the buffers it arrived in.
+ */
+export class ByteQueue {
+  private readonly _chunks: Buffer[] = [];
+  private _bytes = 0;
+
+  /** Bytes currently queued. */
+  get bytes(): number {
+    return this._bytes;
+  }
+
+  /** Appends a chunk. Empty chunks are dropped rather than queued. */
+  push(chunk: Buffer): void {
+    if (chunk.length === 0) return;
+    this._chunks.push(chunk);
+    this._bytes += chunk.length;
+  }
+
+  /** Removes and returns exactly `size` bytes. Throws when fewer are queued. */
+  take(size: number): Buffer {
+    if (size > this._bytes) {
+      throw new Error(`ByteQueue: asked for ${size} bytes, only ${this._bytes} queued`);
+    }
+    const block = Buffer.allocUnsafe(size);
+    let filled = 0;
+    while (filled < size) {
+      const head = this._chunks[0]!;
+      const wanted = size - filled;
+      if (head.length <= wanted) {
+        head.copy(block, filled);
+        filled += head.length;
+        this._chunks.shift();
+        continue;
+      }
+      head.copy(block, filled, 0, wanted);
+      this._chunks[0] = head.subarray(wanted);
+      filled += wanted;
+    }
+    this._bytes -= size;
+    return block;
+  }
+}

--- a/packages/core/src/services/shared/byte-queue.ts
+++ b/packages/core/src/services/shared/byte-queue.ts
@@ -17,7 +17,13 @@ export class ByteQueue {
     return this._bytes;
   }
 
-  /** Appends a chunk. Empty chunks are dropped rather than queued. */
+  /**
+   * Appends a chunk. Empty chunks are dropped rather than queued.
+   *
+   * The queue takes ownership: what is not handed out stays as a view into this buffer, so a caller
+   * reusing a scratch buffer would change bytes already queued. Every caller today pushes a fresh
+   * buffer, which is what `cipher.update` and a stream chunk both are.
+   */
   push(chunk: Buffer): void {
     if (chunk.length === 0) return;
     this._chunks.push(chunk);

--- a/packages/core/src/services/shared/file-save-zip-writer.ts
+++ b/packages/core/src/services/shared/file-save-zip-writer.ts
@@ -168,10 +168,17 @@ export async function append_archive_entry(
   content: Buffer,
 ): Promise<void> {
   const failed = archive_failure(file_archive);
-  const written = once(file_archive.archive, 'entry');
+  // A save keeps going after a per-entry failure, so an abandoned waiter would add a listener pair
+  // to the archiver for every entry left in the run.
+  const cancel_wait = new AbortController();
+  const written = once(file_archive.archive, 'entry', { signal: cancel_wait.signal });
   file_archive.archive.append(content, { name: entry_path });
-  await Promise.race([written, failed]);
-  await Promise.race([file_archive.drain(), failed]);
+  try {
+    await Promise.race([written, failed]);
+    await Promise.race([file_archive.drain(), failed]);
+  } finally {
+    cancel_wait.abort();
+  }
 }
 
 /** Rejects with whatever failed the archive, and never resolves, so it can only lose a race. */

--- a/packages/core/src/services/shared/file-save-zip-writer.ts
+++ b/packages/core/src/services/shared/file-save-zip-writer.ts
@@ -150,8 +150,13 @@ async function abort_archive(
  * destination as the source allowed: an export to a stalled consumer compressed every entry it
  * could decrypt and the result sat in the archive's readable buffer (issue #343). Waiting for the
  * archiver's `entry` event bounds the queue and {@link FileArchive.drain} bounds the buffer.
- * `once` rejects on `error`, so a destination that failed mid-entry surfaces here rather than
- * resolving as a saved file.
+ *
+ * A destination that fails is raised here rather than waited on. Its error lands on the byte-count
+ * promise, not on the archiver, and an archive that lost its destination stops emitting `entry`
+ * altogether: a disk filling up mid-export would otherwise park the producer forever.
+ *
+ * One entry at a time. The `entry` event names no correlation, so a caller appending two entries
+ * concurrently would pair each wait with whichever finished first.
  *
  * Callers own the entry path, because what makes one safe differs by workload: a drive export
  * carries a folder path the provider already validated, and a mail export builds one from a
@@ -162,10 +167,21 @@ export async function append_archive_entry(
   entry_path: string,
   content: Buffer,
 ): Promise<void> {
+  const failed = archive_failure(file_archive);
   const written = once(file_archive.archive, 'entry');
   file_archive.archive.append(content, { name: entry_path });
-  await written;
-  await file_archive.drain();
+  await Promise.race([written, failed]);
+  await Promise.race([file_archive.drain(), failed]);
+}
+
+/** Rejects with whatever failed the archive, and never resolves, so it can only lose a race. */
+function archive_failure(file_archive: FileArchive): Promise<never> {
+  return file_archive.promise.then(
+    () => new Promise<never>(() => undefined),
+    (err: unknown) => {
+      throw err instanceof Error ? err : new Error(String(err));
+    },
+  );
 }
 
 /** Adds a file to the archive under the given folder path. */

--- a/packages/core/src/services/shared/file-save-zip-writer.ts
+++ b/packages/core/src/services/shared/file-save-zip-writer.ts
@@ -78,6 +78,14 @@ export function create_file_archive(
     // Errors on the destination are not forwarded through pipe(), so without this a failed write
     // resolves on `close` and the caller reports a successful save.
     output.on('error', reject);
+    // `destroy()` with no error emits `close` and nothing else, so a consumer that walks away
+    // leaves a caller's stream with no `finish` to resolve on. Resolution has already happened by
+    // then on the success path, where `finish` precedes `close`.
+    if (staging_path === undefined) {
+      output.on('close', () =>
+        reject(new Error('The archive destination closed before the archive was finished')),
+      );
+    }
   });
   // Attach a handler now, so an error raised while entries are still being written is not an
   // unhandled rejection. Awaiting `promise` later still sees the rejection.
@@ -96,14 +104,18 @@ export function create_file_archive(
 }
 
 /**
- * Waits until the destination is ready for more, or until it is gone.
+ * Waits until the destination is ready for more, and fails when it is gone.
  *
- * A destination that is destroyed mid-export never emits `drain`, and a producer parked on that
- * event would wait forever instead of failing; the actual failure is delivered through the
- * archive's byte-count promise.
+ * A destination that is destroyed mid-export never emits `drain`, so a producer parked on that
+ * event waits forever. A `close` while entries are still being written is always premature, for a
+ * staged file as much as for a caller's stream, so it fails the entry that was waiting rather than
+ * letting the run report it as saved.
  */
 async function wait_for_drain(output: Writable): Promise<void> {
-  if (!output.writableNeedDrain || output.destroyed || output.writableEnded) return;
+  if (output.destroyed || output.writableEnded) {
+    throw new Error('The archive destination is closed');
+  }
+  if (!output.writableNeedDrain) return;
   const { promise, resolve, reject } = Promise.withResolvers<void>();
   const settle = (err?: Error): void => {
     output.off('drain', on_drain);
@@ -113,7 +125,7 @@ async function wait_for_drain(output: Writable): Promise<void> {
     else reject(err);
   };
   const on_drain = (): void => settle();
-  const on_close = (): void => settle();
+  const on_close = (): void => settle(new Error('The archive destination closed mid-entry'));
   const on_error = (err: Error): void => settle(err);
   output.once('drain', on_drain);
   output.once('close', on_close);

--- a/packages/core/src/services/shared/file-save-zip-writer.ts
+++ b/packages/core/src/services/shared/file-save-zip-writer.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import { once } from 'node:events';
 import { createWriteStream } from 'node:fs';
 import { rename, rm } from 'node:fs/promises';
 import type { Writable } from 'node:stream';
@@ -20,6 +21,14 @@ export type ArchiveTarget = string | Writable;
 export interface FileArchive {
   readonly archive: FileArchiveWriter;
   readonly promise: Promise<number>;
+  /**
+   * Resolves once the destination has taken what the archive has produced so far.
+   *
+   * The archiver keeps compressing whatever it is handed, so without this a producer runs as far
+   * ahead of a slow consumer as its source allows and the difference sits in the archive's readable
+   * buffer (issue #343).
+   */
+  drain(): Promise<void>;
   /**
    * Makes the completed archive available to its consumer. For a path target this moves the
    * finished archive onto the output path, which is untouched until then. For a stream target the
@@ -78,11 +87,38 @@ export function create_file_archive(
   return {
     archive,
     promise,
+    drain: () => wait_for_drain(output),
     publish: async () => {
       if (staging_path !== undefined) await rename(staging_path, target as string);
     },
     abort: () => abort_archive(archive, output, staging_path),
   };
+}
+
+/**
+ * Waits until the destination is ready for more, or until it is gone.
+ *
+ * A destination that is destroyed mid-export never emits `drain`, and a producer parked on that
+ * event would wait forever instead of failing; the actual failure is delivered through the
+ * archive's byte-count promise.
+ */
+async function wait_for_drain(output: Writable): Promise<void> {
+  if (!output.writableNeedDrain || output.destroyed || output.writableEnded) return;
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const settle = (err?: Error): void => {
+    output.off('drain', on_drain);
+    output.off('close', on_close);
+    output.off('error', on_error);
+    if (err === undefined) resolve();
+    else reject(err);
+  };
+  const on_drain = (): void => settle();
+  const on_close = (): void => settle();
+  const on_error = (err: Error): void => settle(err);
+  output.once('drain', on_drain);
+  output.once('close', on_close);
+  output.once('error', on_error);
+  await promise;
 }
 
 async function abort_archive(
@@ -106,17 +142,46 @@ async function abort_archive(
   }
 }
 
+/**
+ * Appends one entry at the given path in the archive, resolving once it has been compressed and
+ * the destination has taken what that produced.
+ *
+ * `append()` only queues, so awaiting it alone let a producer run as far ahead of a slow
+ * destination as the source allowed: an export to a stalled consumer compressed every entry it
+ * could decrypt and the result sat in the archive's readable buffer (issue #343). Waiting for the
+ * archiver's `entry` event bounds the queue and {@link FileArchive.drain} bounds the buffer.
+ * `once` rejects on `error`, so a destination that failed mid-entry surfaces here rather than
+ * resolving as a saved file.
+ *
+ * Callers own the entry path, because what makes one safe differs by workload: a drive export
+ * carries a folder path the provider already validated, and a mail export builds one from a
+ * subject the sender chose.
+ */
+export async function append_archive_entry(
+  file_archive: FileArchive,
+  entry_path: string,
+  content: Buffer,
+): Promise<void> {
+  const written = once(file_archive.archive, 'entry');
+  file_archive.archive.append(content, { name: entry_path });
+  await written;
+  await file_archive.drain();
+}
+
 /** Adds a file to the archive under the given folder path. */
 export async function add_file_to_archive(
-  archive: FileArchiveWriter,
+  file_archive: FileArchive,
   folder_path: string,
   file_name: string,
   content: Buffer,
 ): Promise<void> {
   const normalized =
     folder_path === '/' || folder_path === '' ? '' : folder_path.replace(/^\//, '');
-  const entry_path = normalized ? `${normalized}/${file_name}` : file_name;
-  archive.append(content, { name: entry_path });
+  await append_archive_entry(
+    file_archive,
+    normalized ? `${normalized}/${file_name}` : file_name,
+    content,
+  );
 }
 
 /** Finalizes the archive (must be called after all files are added). */

--- a/packages/core/src/services/shared/stream-decrypt.ts
+++ b/packages/core/src/services/shared/stream-decrypt.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import { Readable } from 'node:stream';
 import type { TenantContext } from '@wisecom/atlas-types';
 
@@ -63,11 +63,15 @@ export async function stream_sha256_from_storage(
  * wants {@link stream_decrypt_from_storage} and its buffered verification instead (issue #343).
  *
  * The generator must be drained or its `return()` called, which a `for await` loop does either way.
+ *
+ * `label` names the object in the failure. The storage key is not used for that: it carries the
+ * owner identifier, and this message reaches operator logs and run summaries.
  */
 export async function* stream_verified_plaintext(
   ctx: TenantContext,
   storage_key: string,
   expected_sha256_hex: string,
+  label: string,
 ): AsyncGenerator<Buffer> {
   const sha256 = createHash('sha256');
   for await (const chunk of decrypt_plaintext_chunks(ctx, storage_key)) {
@@ -75,9 +79,14 @@ export async function* stream_verified_plaintext(
     yield chunk;
   }
   const actual = sha256.digest('hex');
-  if (actual !== expected_sha256_hex) {
+  // ponytail: seventh copy of this two-line comparison in the repo; one shared helper in
+  // services/shared would be better, and touches five files this change has no business in.
+  const matches =
+    actual.length === expected_sha256_hex.length &&
+    timingSafeEqual(Buffer.from(actual, 'utf8'), Buffer.from(expected_sha256_hex, 'utf8'));
+  if (!matches) {
     throw new Error(
-      `Checksum mismatch for ${storage_key}: manifest recorded ${expected_sha256_hex}, decrypted ${actual}`,
+      `Checksum mismatch for ${label}: manifest recorded ${expected_sha256_hex}, decrypted ${actual}`,
     );
   }
 }

--- a/packages/core/src/services/shared/stream-decrypt.ts
+++ b/packages/core/src/services/shared/stream-decrypt.ts
@@ -52,6 +52,37 @@ export async function stream_sha256_from_storage(
 }
 
 /**
+ * Yields the plaintext of an encrypted object and fails the iteration unless the digest matches
+ * `expected_sha256_hex`.
+ *
+ * Nothing about a chunk is trustworthy while it is being yielded: AES-GCM only authenticates at
+ * `final()`, and the manifest checksum is only comparable once every byte has passed through. A
+ * consumer therefore MUST NOT make the bytes visible to anyone until the iteration has completed
+ * normally. A Graph upload session satisfies that by holding its last chunk back, so the item is
+ * only created after this generator returns; a caller that cannot delay its side effect that way
+ * wants {@link stream_decrypt_from_storage} and its buffered verification instead (issue #343).
+ *
+ * The generator must be drained or its `return()` called, which a `for await` loop does either way.
+ */
+export async function* stream_verified_plaintext(
+  ctx: TenantContext,
+  storage_key: string,
+  expected_sha256_hex: string,
+): AsyncGenerator<Buffer> {
+  const sha256 = createHash('sha256');
+  for await (const chunk of decrypt_plaintext_chunks(ctx, storage_key)) {
+    sha256.update(chunk);
+    yield chunk;
+  }
+  const actual = sha256.digest('hex');
+  if (actual !== expected_sha256_hex) {
+    throw new Error(
+      `Checksum mismatch for ${storage_key}: manifest recorded ${expected_sha256_hex}, decrypted ${actual}`,
+    );
+  }
+}
+
+/**
  * Yields decrypted plaintext chunks in one pass over the stored object.
  *
  * The IV and auth tag occupy the first {@link HEADER_LENGTH} bytes, which may

--- a/packages/core/src/services/shared/stream-encrypt-upload.ts
+++ b/packages/core/src/services/shared/stream-encrypt-upload.ts
@@ -4,6 +4,7 @@ import type {
   StorageObjectLockPolicy,
   TenantContext,
 } from '@wisecom/atlas-types';
+import { ByteQueue } from '@/services/shared/byte-queue';
 import { logger } from '@/utils/logger';
 
 /**
@@ -88,8 +89,7 @@ export async function stream_to_content_addressed_storage(
 }
 
 interface PendingPartState {
-  pending: Buffer[];
-  pending_bytes: number;
+  pending: ByteQueue;
   first_part_data: Buffer | null;
   part_number: number;
   completed_parts: CompletedPart[];
@@ -127,8 +127,7 @@ export async function stream_encrypt_to_multipart(
 
   try {
     const state: PendingPartState = {
-      pending: [],
-      pending_bytes: 0,
+      pending: new ByteQueue(),
       first_part_data: null,
       part_number: 2,
       completed_parts: [],
@@ -136,31 +135,21 @@ export async function stream_encrypt_to_multipart(
 
     for await (const chunk of chunks) {
       hash.update(chunk);
-      const encrypted = cipher.update(chunk);
-      if (encrypted.length === 0) continue;
+      state.pending.push(cipher.update(chunk));
 
-      state.pending.push(encrypted);
-      state.pending_bytes += encrypted.length;
-
-      while (state.pending_bytes >= PART_SIZE) {
+      while (state.pending.bytes >= PART_SIZE) {
         await flush_pending_parts(handle, state);
       }
     }
 
-    const final_block = cipher.final();
-    if (final_block.length > 0) {
-      state.pending.push(final_block);
-      state.pending_bytes += final_block.length;
-    }
+    state.pending.push(cipher.final());
 
     if (!state.first_part_data) {
-      state.first_part_data = Buffer.concat(state.pending);
-      state.pending.length = 0;
-      state.pending_bytes = 0;
+      state.first_part_data = state.pending.take(state.pending.bytes);
     }
 
-    if (state.pending_bytes > 0) {
-      const last_part = Buffer.concat(state.pending);
+    if (state.pending.bytes > 0) {
+      const last_part = state.pending.take(state.pending.bytes);
       const etag = await handle.upload_part(state.part_number, last_part);
       state.completed_parts.push({ ETag: etag, PartNumber: state.part_number });
     }
@@ -188,21 +177,12 @@ async function flush_pending_parts(
   handle: MultipartUploadHandle,
   state: PendingPartState,
 ): Promise<void> {
-  const combined = Buffer.concat(state.pending);
-  state.pending.length = 0;
-  state.pending_bytes = 0;
-
-  const part_data = combined.subarray(0, PART_SIZE);
-  if (combined.length > PART_SIZE) {
-    const remainder = Buffer.from(combined.subarray(PART_SIZE));
-    state.pending.push(remainder);
-    state.pending_bytes = remainder.length;
-  }
+  const part_data = state.pending.take(PART_SIZE);
 
   if (!state.first_part_data) {
-    state.first_part_data = Buffer.from(part_data);
+    state.first_part_data = part_data;
   } else {
-    const etag = await handle.upload_part(state.part_number, Buffer.from(part_data));
+    const etag = await handle.upload_part(state.part_number, part_data);
     state.completed_parts.push({ ETag: etag, PartNumber: state.part_number });
     state.part_number++;
   }

--- a/packages/core/tests/unit/services/shared/archive-backpressure.test.ts
+++ b/packages/core/tests/unit/services/shared/archive-backpressure.test.ts
@@ -115,4 +115,23 @@ describe('archive backpressure (issue #343)', () => {
       })(),
     ).rejects.toThrow(/no space left on device/);
   });
+
+  it('fails the entry and the byte count when the consumer walks away without an error', async () => {
+    const sink = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    const file_archive = create_file_archive(sink);
+    await add_file_to_archive(file_archive, 'reports', 'first.bin', Buffer.alloc(1024, 1));
+
+    // destroy() with no error emits `close` and neither `finish` nor `error`, so nothing would
+    // settle on its own.
+    sink.destroy();
+
+    await expect(
+      add_file_to_archive(file_archive, 'reports', 'second.bin', Buffer.alloc(1024, 2)),
+    ).rejects.toThrow(/destination (is closed|closed)/);
+    await expect(file_archive.promise).rejects.toThrow(/closed before the archive was finished/);
+  });
 });

--- a/packages/core/tests/unit/services/shared/archive-backpressure.test.ts
+++ b/packages/core/tests/unit/services/shared/archive-backpressure.test.ts
@@ -68,15 +68,15 @@ describe('archive backpressure (issue #343)', () => {
     await file_archive.abort();
   });
 
-  it('accepts entries again once the destination drains', async () => {
-    const consumed: Buffer[] = [];
+  it('writes every entry once the destination drains', async () => {
     const draining = new Writable({
-      write(chunk: Buffer, _encoding, callback) {
-        consumed.push(Buffer.from(chunk));
+      write(_chunk: Buffer, _encoding, callback) {
         callback();
       },
     });
     const file_archive = create_file_archive(draining);
+    const written: string[] = [];
+    file_archive.archive.on('entry', (entry: { name: string }) => written.push(entry.name));
 
     for (let index = 0; index < 3; index++) {
       await add_file_to_archive(
@@ -88,6 +88,31 @@ describe('archive backpressure (issue #343)', () => {
     }
     await file_archive.archive.finalize();
 
-    expect(Buffer.concat(consumed).length).toBeGreaterThan(0);
+    expect(written).toEqual(['reports/file-0.bin', 'reports/file-1.bin', 'reports/file-2.bin']);
+    expect(await file_archive.promise).toBeGreaterThan(0);
+  });
+
+  it('fails the next entry when the destination has died, rather than waiting on it', async () => {
+    const failing = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback(new Error('no space left on device'));
+      },
+    });
+    const file_archive = create_file_archive(failing);
+
+    // The destination's error lands on the byte-count promise, and a piped archive that lost its
+    // destination stops emitting `entry`, so without raising it here the producer waits forever.
+    await expect(
+      (async () => {
+        for (let index = 0; index < ENTRY_COUNT; index++) {
+          await add_file_to_archive(
+            file_archive,
+            'reports',
+            `file-${index}.bin`,
+            Buffer.alloc(ENTRY_BYTES, index),
+          );
+        }
+      })(),
+    ).rejects.toThrow(/no space left on device/);
   });
 });

--- a/packages/core/tests/unit/services/shared/archive-backpressure.test.ts
+++ b/packages/core/tests/unit/services/shared/archive-backpressure.test.ts
@@ -1,0 +1,93 @@
+import { Writable } from 'node:stream';
+import { describe, it, expect } from 'vitest';
+import { add_file_to_archive, create_file_archive } from '@/services/shared/file-save-zip-writer';
+
+/**
+ * Issue #343: `add_file_to_archive` resolved as soon as `append()` had queued the entry, so a
+ * destination that consumed one entry did not stop a producer from enqueuing a hundred. Every one
+ * of them sat in memory waiting for a consumer that was never going to catch up.
+ */
+
+const ENTRY_COUNT = 8;
+const ENTRY_BYTES = 64 * 1024;
+
+/** A destination that accepts nothing until it is released, and everything afterwards. */
+function stalled_destination(): { stream: Writable; release: () => void } {
+  const held: Array<() => void> = [];
+  let accepting = false;
+  const stream = new Writable({
+    highWaterMark: 1,
+    write(_chunk, _encoding, callback) {
+      if (accepting) {
+        callback();
+        return;
+      }
+      held.push(() => callback());
+    },
+  });
+  return {
+    stream,
+    release: () => {
+      accepting = true;
+      while (held.length > 0) held.shift()!();
+    },
+  };
+}
+
+/**
+ * Lets the archiver make whatever progress it can. The destination holds every write, so no number
+ * of turns unblocks it: this waits for a settled state rather than for a duration.
+ */
+async function flush_event_loop(turns = 5): Promise<void> {
+  for (let turn = 0; turn < turns; turn++) {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    setImmediate(resolve);
+    await promise;
+  }
+}
+
+describe('archive backpressure (issue #343)', () => {
+  it('stops accepting entries while the destination is not draining', async () => {
+    const destination = stalled_destination();
+    const file_archive = create_file_archive(destination.stream);
+    const accepted: number[] = [];
+
+    const appends = Array.from({ length: ENTRY_COUNT }, (_, index) =>
+      add_file_to_archive(file_archive, '/', `file-${index}.bin`, Buffer.alloc(ENTRY_BYTES, index))
+        .then(() => accepted.push(index))
+        .catch(() => undefined),
+    );
+
+    await flush_event_loop();
+
+    // The producer is bounded by the entry being written, not by how many it could decrypt.
+    expect(accepted.length).toBeLessThan(ENTRY_COUNT);
+
+    destination.release();
+    await Promise.allSettled(appends);
+    await file_archive.abort();
+  });
+
+  it('accepts entries again once the destination drains', async () => {
+    const consumed: Buffer[] = [];
+    const draining = new Writable({
+      write(chunk: Buffer, _encoding, callback) {
+        consumed.push(Buffer.from(chunk));
+        callback();
+      },
+    });
+    const file_archive = create_file_archive(draining);
+
+    for (let index = 0; index < 3; index++) {
+      await add_file_to_archive(
+        file_archive,
+        'reports',
+        `file-${index}.bin`,
+        Buffer.alloc(1024, index),
+      );
+    }
+    await file_archive.archive.finalize();
+
+    expect(Buffer.concat(consumed).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/tests/unit/services/shared/file-save-zip-writer.test.ts
+++ b/packages/core/tests/unit/services/shared/file-save-zip-writer.test.ts
@@ -22,9 +22,10 @@ afterEach(async () => {
 describe('create_file_archive', () => {
   it('writes an archive and reports the byte count', async () => {
     const output_path = join(dir, 'out.zip');
-    const { archive, promise, publish } = create_file_archive(output_path);
+    const file_archive = create_file_archive(output_path);
+    const { archive, promise, publish } = file_archive;
 
-    await add_file_to_archive(archive, '/Documents', 'report.txt', Buffer.from('hello'));
+    await add_file_to_archive(file_archive, '/Documents', 'report.txt', Buffer.from('hello'));
     await finalize_file_archive(archive);
     const total_bytes = await promise;
     await publish();
@@ -35,9 +36,10 @@ describe('create_file_archive', () => {
 
   it('writes nothing to the output path before it is published (issue #307)', async () => {
     const output_path = join(dir, 'out.zip');
-    const { archive } = create_file_archive(output_path);
+    const file_archive = create_file_archive(output_path);
+    const { archive } = file_archive;
 
-    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+    await add_file_to_archive(file_archive, '/', 'report.txt', Buffer.from('hello'));
 
     // Entries land in a sibling temporary file, so a truncated zip can never be mistaken for a
     // finished export at the path an operator was given. The temp file itself is not asserted:
@@ -49,8 +51,9 @@ describe('create_file_archive', () => {
 
   it('leaves no temporary file behind when the run aborts', async () => {
     const output_path = join(dir, 'partial.zip');
-    const { archive, abort } = create_file_archive(output_path);
-    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+    const file_archive = create_file_archive(output_path);
+    const { archive, abort } = file_archive;
+    await add_file_to_archive(file_archive, '/', 'report.txt', Buffer.from('hello'));
 
     await abort();
 
@@ -62,8 +65,9 @@ describe('create_file_archive', () => {
     const output_path = join(dir, 'existing.zip');
     writeFileSync(output_path, 'someone else data');
 
-    const { archive, abort } = create_file_archive(output_path);
-    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+    const file_archive = create_file_archive(output_path);
+    const { archive, abort } = file_archive;
+    await add_file_to_archive(file_archive, '/', 'report.txt', Buffer.from('hello'));
     await abort();
 
     // Not just present: unchanged. Opening the output path for writing truncated it before
@@ -75,8 +79,9 @@ describe('create_file_archive', () => {
     const output_path = join(dir, 'existing.zip');
     writeFileSync(output_path, 'someone else data');
 
-    const { archive, promise, publish } = create_file_archive(output_path);
-    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+    const file_archive = create_file_archive(output_path);
+    const { archive, promise, publish } = file_archive;
+    await add_file_to_archive(file_archive, '/', 'report.txt', Buffer.from('hello'));
     await finalize_file_archive(archive);
     await promise;
     await publish();
@@ -87,7 +92,8 @@ describe('create_file_archive', () => {
 
   it('does not raise when the archive is aborted twice', async () => {
     const output_path = join(dir, 'twice.zip');
-    const { abort } = create_file_archive(output_path);
+    const file_archive = create_file_archive(output_path);
+    const { abort } = file_archive;
 
     await abort();
     await expect(abort()).resolves.toBeUndefined();

--- a/packages/core/tests/unit/services/shared/multipart-copy-volume.test.ts
+++ b/packages/core/tests/unit/services/shared/multipart-copy-volume.test.ts
@@ -1,0 +1,115 @@
+import { randomBytes } from 'node:crypto';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { TenantContext } from '@wisecom/atlas-types';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+import { ByteQueue } from '@/services/shared/byte-queue';
+import { stream_encrypt_to_multipart } from '@/services/shared/stream-encrypt-upload';
+
+/**
+ * Issue #343: the multipart helper concatenated everything still pending on every flush and copied
+ * the remainder back, so the same 256 MiB payload cost 520 MiB of copying when it arrived in 4 MiB
+ * chunks and 8,456 MiB when it arrived in one. Copy volume has to follow the payload, not the size
+ * of the chunks it is delivered in.
+ */
+
+const PART_SIZE = 8 * 1024 * 1024;
+const PAYLOAD_BYTES = 32 * 1024 * 1024;
+
+function make_ctx(): { ctx: TenantContext; parts: Map<number, Buffer> } {
+  const parts = new Map<number, Buffer>();
+  const ctx = {
+    storage: {
+      begin_multipart_upload: vi.fn(async () => ({
+        upload_part: vi.fn(async (part_number: number, data: Buffer) => {
+          parts.set(part_number, Buffer.from(data));
+          return `etag-${part_number}`;
+        }),
+        complete: vi.fn(async () => undefined),
+        abort: vi.fn(async () => undefined),
+      })),
+      abort_incomplete_uploads: vi.fn(async () => 0),
+    },
+    create_cipher: stub_tenant_create_cipher,
+  } as unknown as TenantContext;
+  return { ctx, parts };
+}
+
+/** Bytes handed to `Buffer.concat`, which is the copying the flush path used to do per part. */
+function measure_concat_bytes(): { total: () => number } {
+  const spy = vi.spyOn(Buffer, 'concat');
+  return {
+    total: () =>
+      spy.mock.calls.reduce(
+        (sum, [list]) => sum + list.reduce((bytes, buf) => bytes + buf.length, 0),
+        0,
+      ),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('multipart copy volume (issue #343)', () => {
+  it.each([4 * 1024 * 1024, 16 * 1024 * 1024, PAYLOAD_BYTES])(
+    'copies no more than one part when the payload arrives in %d byte chunks',
+    async (chunk_size) => {
+      const payload = randomBytes(PAYLOAD_BYTES);
+      const { ctx } = make_ctx();
+      const measured = measure_concat_bytes();
+
+      await stream_encrypt_to_multipart(ctx, 'staging/object', {
+        async *[Symbol.asyncIterator]() {
+          for (let offset = 0; offset < payload.length; offset += chunk_size) {
+            yield payload.subarray(offset, Math.min(offset + chunk_size, payload.length));
+          }
+        },
+      });
+
+      // The only concatenation left is the IV and auth tag onto part 1, which is bounded by the
+      // part size no matter how large the object or the chunks it arrived in.
+      expect(measured.total()).toBeLessThanOrEqual(PART_SIZE + 28);
+    },
+  );
+
+  it('still assembles the parts in order and without gaps', async () => {
+    const payload = randomBytes(PART_SIZE * 2 + 1024);
+    const { ctx, parts } = make_ctx();
+
+    await stream_encrypt_to_multipart(ctx, 'staging/object', {
+      async *[Symbol.asyncIterator]() {
+        yield payload;
+      },
+    });
+
+    const assembled = [...parts.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([, data]) => data)
+      .reduce((total, part) => total + part.length, 0);
+    // 12-byte IV and 16-byte tag ride in part 1 on top of the ciphertext, which GCM keeps the same
+    // length as the plaintext.
+    expect(assembled).toBe(payload.length + 28);
+    expect(parts.get(1)!.length).toBe(PART_SIZE + 28);
+  });
+});
+
+describe('ByteQueue', () => {
+  it('hands out blocks that span the buffers they arrived in', () => {
+    const queue = new ByteQueue();
+    queue.push(Buffer.from([1, 2, 3]));
+    queue.push(Buffer.from([4, 5]));
+    queue.push(Buffer.from([6, 7, 8, 9]));
+
+    expect(queue.take(4)).toEqual(Buffer.from([1, 2, 3, 4]));
+    expect(queue.bytes).toBe(5);
+    expect(queue.take(5)).toEqual(Buffer.from([5, 6, 7, 8, 9]));
+    expect(queue.bytes).toBe(0);
+  });
+
+  it('refuses to hand out more than it holds', () => {
+    const queue = new ByteQueue();
+    queue.push(Buffer.from([1, 2]));
+
+    expect(() => queue.take(3)).toThrow(/only 2 queued/);
+  });
+});

--- a/packages/core/tests/unit/services/shared/save-archive-stream-target.test.ts
+++ b/packages/core/tests/unit/services/shared/save-archive-stream-target.test.ts
@@ -39,9 +39,10 @@ describe('create_file_archive with a stream target', () => {
   it('delivers the archive to the caller stream and writes no file (issue #44)', async () => {
     const sink = new PassThrough();
     const received = collect(sink);
-    const { archive, promise, publish } = create_file_archive(sink);
+    const file_archive = create_file_archive(sink);
+    const { archive, promise, publish } = file_archive;
 
-    await add_file_to_archive(archive, '/Documents', 'report.txt', Buffer.from('hello'));
+    await add_file_to_archive(file_archive, '/Documents', 'report.txt', Buffer.from('hello'));
     await finalize_file_archive(archive);
     const total_bytes = await promise;
     await publish();
@@ -56,8 +57,9 @@ describe('create_file_archive with a stream target', () => {
 
   it('destroys the stream on abort, so a truncated archive is never a successful transfer', async () => {
     const sink = new PassThrough();
-    const { archive, abort } = create_file_archive(sink);
-    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+    const file_archive = create_file_archive(sink);
+    const { archive, abort } = file_archive;
+    await add_file_to_archive(file_archive, '/', 'report.txt', Buffer.from('hello'));
 
     await abort();
 
@@ -68,11 +70,12 @@ describe('create_file_archive with a stream target', () => {
 
   it('reports a destination failure rather than a successful save', async () => {
     const sink = new PassThrough();
-    const { archive, promise } = create_file_archive(sink);
+    const file_archive = create_file_archive(sink);
+    const { archive, promise } = file_archive;
     const failure = new Error('consumer went away');
     sink.destroy(failure);
 
-    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello')).catch(
+    await add_file_to_archive(file_archive, '/', 'report.txt', Buffer.from('hello')).catch(
       () => undefined,
     );
     await expect(promise).rejects.toThrow(failure.message);
@@ -137,9 +140,10 @@ describe('settle_empty_save_target', () => {
 describe('create_file_archive with a path target', () => {
   it('still stages and publishes, so #307 holds for file exports', async () => {
     const output_path = join(dir, 'out.zip');
-    const { archive, promise, publish } = create_file_archive(output_path);
+    const file_archive = create_file_archive(output_path);
+    const { archive, promise, publish } = file_archive;
 
-    await add_file_to_archive(archive, '/', 'report.txt', Buffer.from('hello'));
+    await add_file_to_archive(file_archive, '/', 'report.txt', Buffer.from('hello'));
     await finalize_file_archive(archive);
     expect(existsSync(output_path)).toBe(false);
 

--- a/packages/drive/src/restore/upload-session.ts
+++ b/packages/drive/src/restore/upload-session.ts
@@ -1,5 +1,7 @@
 import { is_transient_error } from '@wisecom/atlas-m365-graph';
+import { ByteQueue } from '@wisecom/atlas-core/services/shared/byte-queue';
 import { logger } from '@wisecom/atlas-core/utils/logger';
+import type { LargeFileContent, StreamedFileContent } from '@wisecom/atlas-types';
 
 /** Bytes per chunk PUT into a Graph upload session. */
 export const LARGE_UPLOAD_CHUNK = 10 * 1024 * 1024;
@@ -57,13 +59,19 @@ interface UploadSessionStatus {
 }
 
 /**
- * Uploads a buffer into an open Graph upload session and returns only on a completed item.
+ * Uploads a file into an open Graph upload session and returns only on a completed item.
  *
  * The completion signal is the status code, not `response.ok`. Graph answers an intermediate chunk
  * with `202 Accepted` and the ranges it still wants, and the final chunk with `200` or `201`
  * carrying the finished `driveItem`. Treating every 2xx as success reported a file as restored when
  * the session was still waiting for bytes, so a truncated or absent file counted as a successful
  * restore (issue #342).
+ *
+ * A streamed source is uploaded as it arrives, so restoring a large file holds two chunks rather
+ * than the whole plaintext (issue #343). One chunk is always held back until the source has ended:
+ * the final PUT is what creates the item, so a source that fails late, an AES-GCM tag that does not
+ * authenticate or a checksum that does not match the manifest, leaves an abandoned session instead
+ * of a file. That is what lets a decrypt stream hand over unverified bytes at all.
  *
  * An upload still expecting ranges after the last chunk fails the file rather than resuming: the
  * bytes are all in hand, so a session that has not converged is a server-side or protocol problem
@@ -72,46 +80,93 @@ interface UploadSessionStatus {
  */
 export async function upload_content_to_session(
   upload_url: string,
-  content: Buffer,
+  content: LargeFileContent,
   label: string,
 ): Promise<void> {
-  let early_completion: string | undefined;
+  const source: StreamedFileContent = Buffer.isBuffer(content)
+    ? { chunks: [content], total_bytes: content.length }
+    : content;
+
+  let outcome: UploadOutcome;
   try {
-    for (let offset = 0; offset < content.length; offset += LARGE_UPLOAD_CHUNK) {
-      const end = Math.min(offset + LARGE_UPLOAD_CHUNK, content.length);
-      const range = `bytes ${offset}-${end - 1}/${content.length}`;
-      const completed = await put_chunk_with_retry(
-        upload_url,
-        range,
-        content.subarray(offset, end),
-      );
-      if (completed) {
-        if (end === content.length) return;
-        // Graph removed the session when it returned the item, so there is nothing left to cancel.
-        // Reported after the try so the catch below does not send a second DELETE to a session that
-        // is already gone and log that it stays reserved.
-        early_completion =
-          `Resumable upload of ${label} completed at ${range} with ` +
-          `${content.length - end} byte(s) unsent`;
-        break;
-      }
-    }
+    outcome = await put_source_chunks(upload_url, source, label);
   } catch (err) {
     // A thrown error takes the same exit as a terminal HTTP failure. Without this a socket reset on
-    // the last chunk left the session open and the file half written.
+    // a chunk, or a source that failed to authenticate, left the session open.
     await cancel_upload_session(upload_url, 'a failed chunk upload');
     throw err;
   }
 
-  if (early_completion) throw new Error(early_completion);
+  if (outcome.kind === 'completed') return;
 
-  // Every chunk was accepted and none of them completed the item.
+  if (outcome.kind === 'early') {
+    // Graph removed the session when it returned the item, so there is nothing left to cancel.
+    throw new Error(
+      `Resumable upload of ${label} completed at ${outcome.range} with ` +
+        `${outcome.unsent} byte(s) unsent`,
+    );
+  }
+
   const outstanding = await read_outstanding_ranges(upload_url);
   await cancel_upload_session(upload_url, 'an upload that never completed');
   throw new Error(
     `Resumable upload of ${label} sent every byte but Graph never returned a completed item; ` +
       `it still expects ${outstanding}`,
   );
+}
+
+/** How a session answered the last chunk it was given. */
+type UploadOutcome =
+  | { readonly kind: 'completed' }
+  | { readonly kind: 'early'; readonly range: string; readonly unsent: number }
+  | { readonly kind: 'incomplete' };
+
+/** Sends the source into the session, holding the committing chunk back until the source ends. */
+async function put_source_chunks(
+  upload_url: string,
+  source: StreamedFileContent,
+  label: string,
+): Promise<UploadOutcome> {
+  const pending = new ByteQueue();
+  let sent = 0;
+
+  for await (const chunk of source.chunks) {
+    pending.push(chunk);
+    // Strictly greater, so a source that ends on a chunk boundary still leaves a full chunk for the
+    // committing PUT below.
+    while (pending.bytes > LARGE_UPLOAD_CHUNK) {
+      const block = pending.take(LARGE_UPLOAD_CHUNK);
+      const range = `bytes ${sent}-${sent + block.length - 1}/${source.total_bytes}`;
+      if (await put_chunk_with_retry(upload_url, range, block)) {
+        return { kind: 'early', range, unsent: source.total_bytes - sent - block.length };
+      }
+      sent += block.length;
+    }
+  }
+
+  // The source ended without throwing, so everything it produced is authenticated and whatever is
+  // still pending is what creates the item.
+  const streamed = sent + pending.bytes;
+  if (streamed !== source.total_bytes) {
+    throw new Error(
+      `Resumable upload of ${label} has ${streamed} byte(s) to send but the session was opened ` +
+        `for ${source.total_bytes}`,
+    );
+  }
+
+  while (pending.bytes > 0) {
+    const block = pending.take(Math.min(LARGE_UPLOAD_CHUNK, pending.bytes));
+    const range = `bytes ${sent}-${sent + block.length - 1}/${source.total_bytes}`;
+    const completed = await put_chunk_with_retry(upload_url, range, block);
+    sent += block.length;
+    if (completed) {
+      return pending.bytes === 0
+        ? { kind: 'completed' }
+        : { kind: 'early', range, unsent: pending.bytes };
+    }
+  }
+
+  return { kind: 'incomplete' };
 }
 
 /** Uploads one chunk, returning whether Graph reported the item as complete. */

--- a/packages/drive/src/restore/upload-session.ts
+++ b/packages/drive/src/restore/upload-session.ts
@@ -100,10 +100,14 @@ export async function upload_content_to_session(
   if (outcome.kind === 'completed') return;
 
   if (outcome.kind === 'early') {
-    // Graph removed the session when it returned the item, so there is nothing left to cancel.
+    // Graph removed the session when it returned the item, so there is nothing left to cancel, and
+    // the item it created stays. Reaching this means Graph answered a chunk that was not the last
+    // one with a terminal status, against its own contract, so the file at the target is short and
+    // was assembled from bytes this upload had not finished verifying.
     throw new Error(
-      `Resumable upload of ${label} completed at ${outcome.range} with ` +
-        `${outcome.unsent} byte(s) unsent`,
+      `Resumable upload of ${label} was completed by Graph at ${outcome.range} with ` +
+        `${outcome.unsent} byte(s) unsent; a partial, unverified file now exists at the target ` +
+        `and has to be removed by hand`,
     );
   }
 
@@ -136,6 +140,16 @@ async function put_source_chunks(
     // committing PUT below.
     while (pending.bytes > LARGE_UPLOAD_CHUNK) {
       const block = pending.take(LARGE_UPLOAD_CHUNK);
+      // Holding bytes back is not enough on its own: Graph commits as soon as the ranges it has
+      // received cover the declared total, and the total comes from the manifest rather than from
+      // the source. A source longer than the manifest recorded would therefore commit here, while
+      // the tag and the digest are still unchecked, so it fails instead.
+      if (sent + block.length >= source.total_bytes) {
+        throw new Error(
+          `Resumable upload of ${label} has more content than the ${source.total_bytes} byte(s) ` +
+            `recorded for it; refusing to complete the session with unverified bytes`,
+        );
+      }
       const range = `bytes ${sent}-${sent + block.length - 1}/${source.total_bytes}`;
       if (await put_chunk_with_retry(upload_url, range, block)) {
         return { kind: 'early', range, unsent: source.total_bytes - sent - block.length };
@@ -144,25 +158,22 @@ async function put_source_chunks(
     }
   }
 
-  // The source ended without throwing, so everything it produced is authenticated and whatever is
-  // still pending is what creates the item.
+  // The source ended without throwing, so everything it produced carries an authenticated tag and a
+  // digest that matched, and whatever is still pending is what creates the item.
   const streamed = sent + pending.bytes;
   if (streamed !== source.total_bytes) {
     throw new Error(
-      `Resumable upload of ${label} has ${streamed} byte(s) to send but the session was opened ` +
-        `for ${source.total_bytes}`,
+      `Resumable upload of ${label} verified ${streamed} byte(s), but the manifest recorded ` +
+        `${source.total_bytes} and the session was opened for that`,
     );
   }
 
-  while (pending.bytes > 0) {
-    const block = pending.take(Math.min(LARGE_UPLOAD_CHUNK, pending.bytes));
-    const range = `bytes ${sent}-${sent + block.length - 1}/${source.total_bytes}`;
-    const completed = await put_chunk_with_retry(upload_url, range, block);
-    sent += block.length;
-    if (completed) {
-      return pending.bytes === 0
-        ? { kind: 'completed' }
-        : { kind: 'early', range, unsent: pending.bytes };
+  // The loop above only drains while strictly more than one chunk is pending, so at most one chunk
+  // is left and this single PUT is the one that creates the item.
+  if (pending.bytes > 0) {
+    const range = `bytes ${sent}-${source.total_bytes - 1}/${source.total_bytes}`;
+    if (await put_chunk_with_retry(upload_url, range, pending.take(pending.bytes))) {
+      return { kind: 'completed' };
     }
   }
 

--- a/packages/drive/src/restore/version-restore.ts
+++ b/packages/drive/src/restore/version-restore.ts
@@ -11,6 +11,7 @@ import type {
   DriveVersionPlacement,
   DriveVersionRestoreOptions,
   DriveVersionRestoreResult,
+  LargeFileContent,
   TenantContext,
   TenantContextFactory,
 } from '@wisecom/atlas-types';
@@ -21,8 +22,6 @@ import type {
 } from '@/drive-ports';
 import { select_versions_to_restore, type SelectedVersion } from '@/versioning/version-selection';
 import { build_restored_file_name, split_parent_path } from '@/versioning/version-placement';
-
-const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
 
 /** The upload surface of a drive connector; both provider connectors satisfy it structurally. */
 export interface DriveUploadConnector {
@@ -42,7 +41,7 @@ export interface DriveUploadConnector {
     drive_id: string,
     parent_id: string,
     file_name: string,
-    content: Buffer,
+    content: LargeFileContent,
     conflict_behavior?: string,
     file_system_info?: DriveFileSystemInfo,
   ): Promise<void>;
@@ -61,7 +60,7 @@ export interface DriveVersionRestoreDeps {
   readonly download_blob: (
     ctx: TenantContext,
     version: DriveFileVersionRecord,
-  ) => Promise<Buffer | undefined>;
+  ) => Promise<LargeFileContent | undefined>;
   /** Resolves or creates the folder chain the restored file goes into, within one drive. */
   readonly ensure_folder_path: (
     tenant_id: string,
@@ -214,20 +213,30 @@ async function restore_one_version(
     const file_system_info = version.last_modified_at
       ? { last_modified_at: version.last_modified_at }
       : undefined;
-    const args = [
-      tenant_id,
-      owner_id,
-      drive_id,
-      parent_id,
-      file_name,
-      content,
-      conflict,
-      file_system_info,
-    ] as const;
-    if (content.length <= SMALL_FILE_LIMIT) {
-      await deps.connector.upload_small_file(...args);
+    // The blob reader decides buffered or streamed by the recorded size, so the shape it returns
+    // is also the upload to use: a stream is only produced for a file past the small-file limit.
+    if (Buffer.isBuffer(content)) {
+      await deps.connector.upload_small_file(
+        tenant_id,
+        owner_id,
+        drive_id,
+        parent_id,
+        file_name,
+        content,
+        conflict,
+        file_system_info,
+      );
     } else {
-      await deps.connector.upload_large_file(...args);
+      await deps.connector.upload_large_file(
+        tenant_id,
+        owner_id,
+        drive_id,
+        parent_id,
+        file_name,
+        content,
+        conflict,
+        file_system_info,
+      );
     }
 
     const restored_to = parent_path === '/' ? `/${file_name}` : `${parent_path}/${file_name}`;

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -117,14 +117,15 @@ async function write_drive_snapshot_to_archive(
   options: FileSaveOptions,
 ): Promise<FileSaveResult> {
   const skip_integrity = options.skip_integrity_check ?? false;
-  const { archive, promise, publish, abort } = create_file_archive(target);
+  const file_archive = create_file_archive(target);
+  const { archive, promise, publish, abort } = file_archive;
 
   try {
     const integrity_failures: string[] = [];
     const { files_saved, files_skipped, errors } = await save_entries_to_archive(
       workload,
       ctx,
-      archive,
+      file_archive,
       entries,
       skip_integrity,
       integrity_failures,
@@ -186,7 +187,7 @@ async function write_drive_snapshot_to_archive(
 async function save_entries_to_archive(
   workload: DriveWorkload,
   ctx: TenantContext,
-  archive: Parameters<typeof add_file_to_archive>[0],
+  file_archive: Parameters<typeof add_file_to_archive>[0],
   entries: DriveManifestEntry[],
   skip_integrity: boolean,
   integrity_failures: string[],
@@ -210,7 +211,7 @@ async function save_entries_to_archive(
       if (!content) {
         files_skipped++;
       } else {
-        await add_file_to_archive(archive, entry.parent_path, entry.file_name, content);
+        await add_file_to_archive(file_archive, entry.parent_path, entry.file_name, content);
         files_saved++;
         logger.info(`Saved: ${entry.parent_path}/${entry.file_name}`);
       }

--- a/packages/onedrive/src/adapters/graph-onedrive-connector.adapter.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-connector.adapter.ts
@@ -10,6 +10,7 @@ import {
 import type {
   DriveFileSystemInfo,
   DriveItemIdentity,
+  LargeFileContent,
   OneDriveConnector,
   OneDriveDeltaItem,
   OneDriveDeltaResult,
@@ -197,7 +198,7 @@ export class GraphOneDriveConnector implements OneDriveConnector {
     drive_id: string,
     parent_id: string,
     file_name: string,
-    content: Buffer,
+    content: LargeFileContent,
     conflict_behavior?: string,
     file_system_info?: DriveFileSystemInfo,
   ): Promise<void> {

--- a/packages/onedrive/src/adapters/graph-onedrive-restore.adapter.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-restore.adapter.ts
@@ -1,4 +1,4 @@
-import type { DriveFileSystemInfo } from '@wisecom/atlas-types';
+import type { DriveFileSystemInfo, LargeFileContent } from '@wisecom/atlas-types';
 import type { Client } from '@microsoft/microsoft-graph-client';
 import { build_upload_file_system_info, with_graph_retry } from '@wisecom/atlas-m365-graph';
 import { logger } from '@wisecom/atlas-core/utils/logger';
@@ -142,7 +142,7 @@ export async function graph_onedrive_upload_large_file(
   drive_id: string,
   parent_id: string,
   file_name: string,
-  content: Buffer,
+  content: LargeFileContent,
   conflict_behavior: string = 'rename',
   file_system_info?: DriveFileSystemInfo,
 ): Promise<void> {

--- a/packages/onedrive/src/services/restore/blob-restore.ts
+++ b/packages/onedrive/src/services/restore/blob-restore.ts
@@ -1,54 +1,79 @@
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import { is_gcm_auth_failure } from '@wisecom/atlas-core/utils/gcm-auth';
-import type { StoredBlobRef, TenantContext } from '@wisecom/atlas-types';
-import {
-  should_stream_restore,
-  stream_decrypt_from_storage,
-  verify_streaming_checksum,
-} from '@wisecom/atlas-drive/restore/streaming-restore';
+import { stream_verified_plaintext } from '@wisecom/atlas-core/services/shared/stream-decrypt';
+import type {
+  LargeFileContent,
+  StoredBlobRef,
+  StreamedFileContent,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { should_stream_restore } from '@wisecom/atlas-drive/restore/streaming-restore';
 import {
   OneDriveDecryptAuthError,
   plaintext_sha256_equals_expected,
 } from '@/services/restore/restore-integrity';
 
 /**
- * Fetches and decrypts one stored blob, or undefined when it cannot be trusted.
+ * Fetches one stored blob for restore, or undefined when it cannot be trusted.
  *
- * Returning undefined rather than throwing lets a bulk restore skip one bad
- * object and report it, instead of losing the whole run. An AES-GCM auth
- * failure is thrown instead of swallowed, so a caller can tell "wrong key or
- * tampered ciphertext" from "one unreadable object" rather than reporting the
- * first as the second (issue #76).
+ * A file past the streaming threshold is handed back as a verified stream rather than a buffer, so
+ * restoring it costs two upload chunks of memory instead of the whole plaintext (issue #343). The
+ * shape is the caller's upload decision too: a stream is only produced for a file the small-file
+ * upload could not take anyway.
+ *
+ * Returning undefined rather than throwing lets a bulk restore skip one bad object and report it,
+ * instead of losing the whole run. An AES-GCM auth failure is thrown instead of swallowed, so a
+ * caller can tell "wrong key or tampered ciphertext" from "one unreadable object" rather than
+ * reporting the first as the second (issue #76).
  */
 export async function download_and_decrypt_blob(
   ctx: TenantContext,
   ref: StoredBlobRef,
-): Promise<Buffer | undefined> {
+): Promise<LargeFileContent | undefined> {
   if (!ref.storage_key) return undefined;
   return should_stream_restore(ref)
-    ? stream_download_and_decrypt(ctx, ref)
+    ? verified_blob_stream(ctx, ref)
     : buffered_download_and_decrypt(ctx, ref);
 }
 
-/** Streaming path: avoids holding the full ciphertext in memory for large files. */
-async function stream_download_and_decrypt(
+/**
+ * Streaming path: the plaintext is never held whole, so the checksum can only be compared once the
+ * last chunk has been produced.
+ *
+ * The upload the stream feeds must therefore not commit until the iteration ends, which the Graph
+ * upload session guarantees by holding its final chunk back. A mismatch or a failed tag then
+ * abandons the session rather than leaving a wrong file in the user's drive.
+ */
+function verified_blob_stream(
   ctx: TenantContext,
   ref: StoredBlobRef,
-): Promise<Buffer | undefined> {
+): StreamedFileContent | undefined {
+  if (!ref.checksum) {
+    logger.warn(`Missing checksum for ${ref.file_name}; skipping restore`);
+    return undefined;
+  }
+  return {
+    chunks: authenticated_chunks(ctx, ref.storage_key!, ref.checksum, ref.file_name),
+    total_bytes: ref.size_bytes,
+  };
+}
+
+/** Yields verified plaintext, reporting a failed tag as the operator-visible error it is. */
+async function* authenticated_chunks(
+  ctx: TenantContext,
+  storage_key: string,
+  expected_checksum: string,
+  file_name: string,
+): AsyncGenerator<Buffer> {
   try {
-    const { content, sha256_hex } = await stream_decrypt_from_storage(ctx, ref.storage_key!);
-    if (!verify_streaming_checksum(ref, sha256_hex)) return undefined;
-    return content;
+    yield* stream_verified_plaintext(ctx, storage_key, expected_checksum);
   } catch (err) {
     if (is_gcm_auth_failure(err)) {
-      throw new OneDriveDecryptAuthError(`AES-GCM authentication failed for ${ref.file_name}`, {
+      throw new OneDriveDecryptAuthError(`AES-GCM authentication failed for ${file_name}`, {
         cause: err,
       });
     }
-    logger.warn(
-      `Streaming decrypt failed for ${ref.file_name}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return undefined;
+    throw err;
   }
 }
 

--- a/packages/onedrive/src/services/restore/blob-restore.ts
+++ b/packages/onedrive/src/services/restore/blob-restore.ts
@@ -66,7 +66,7 @@ async function* authenticated_chunks(
   file_name: string,
 ): AsyncGenerator<Buffer> {
   try {
-    yield* stream_verified_plaintext(ctx, storage_key, expected_checksum);
+    yield* stream_verified_plaintext(ctx, storage_key, expected_checksum, file_name);
   } catch (err) {
     if (is_gcm_auth_failure(err)) {
       throw new OneDriveDecryptAuthError(`AES-GCM authentication failed for ${file_name}`, {

--- a/packages/onedrive/src/services/restore/restore.service.ts
+++ b/packages/onedrive/src/services/restore/restore.service.ts
@@ -41,8 +41,6 @@ import {
 import { count_created_folders } from '@wisecom/atlas-drive/restore/folder-path';
 import { ensure_onedrive_folder_path } from '@/services/restore/restore-folder-path';
 
-const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
-
 @injectable()
 export class OneDriveRestoreService implements OneDriveRestoreUseCase {
   constructor(
@@ -183,7 +181,9 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
         return { restored: false };
       }
 
-      if (content.length <= SMALL_FILE_LIMIT) {
+      // The blob reader streams anything past the small-file limit, so the shape it returned is
+      // the upload to use.
+      if (Buffer.isBuffer(content)) {
         await this._connector.upload_small_file(
           tenant_id,
           target_owner,

--- a/packages/onedrive/tests/unit/adapters/upload-session.test.ts
+++ b/packages/onedrive/tests/unit/adapters/upload-session.test.ts
@@ -79,7 +79,7 @@ describe('upload_content_to_session (issue #342)', () => {
     const calls = stub_session([201, 201]);
 
     await expect(upload_content_to_session(UPLOAD_URL, TWO_CHUNKS, 'Report.docx')).rejects.toThrow(
-      /completed at bytes 0-10485759\/10486784 with 1024 byte\(s\) unsent/,
+      /completed by Graph at bytes 0-10485759\/10486784 with 1024 byte\(s\) unsent; a partial, unverified file now exists/,
     );
 
     // Graph removed the session when it returned the item, so a DELETE would only 404 and log that

--- a/packages/onedrive/tests/unit/services/restore/streamed-large-restore.test.ts
+++ b/packages/onedrive/tests/unit/services/restore/streamed-large-restore.test.ts
@@ -84,7 +84,13 @@ function stored_object(options: { corrupt?: boolean; wrong_checksum?: boolean } 
   };
 }
 
-/** A Graph upload session that records what it was sent, answering the last chunk with 201. */
+/**
+ * A Graph upload session that records what it was sent.
+ *
+ * Completion follows the contract rather than the object: the session commits as soon as a
+ * `Content-Range` reaches the total it was opened for, which is what makes a declared total that
+ * understates the source dangerous.
+ */
 function stub_session(harness: Harness): {
   uploaded: Buffer[];
   ranges: string[];
@@ -112,13 +118,17 @@ function stub_session(harness: Harness): {
         if (method !== 'PUT') return new Response('{"nextExpectedRanges":["0-"]}', { status: 200 });
 
         const body = init!.body!;
+        const range = init!.headers!['Content-Range']!;
         uploaded.push(Buffer.from(body));
-        ranges.push(init!.headers!['Content-Range']!);
+        ranges.push(range);
         // Bytes decrypted but not yet handed to Graph: this is what restore has to hold.
         peak_in_flight = Math.max(peak_in_flight, harness.read_bytes() - sent);
         sent += body.length;
-        return new Response(sent === OBJECT_BYTES ? '{"id":"item-1"}' : '{}', {
-          status: sent === OBJECT_BYTES ? 201 : 202,
+
+        const [, last, total] = /bytes \d+-(\d+)\/(\d+)/.exec(range)!;
+        const committed = Number(last) === Number(total) - 1;
+        return new Response(committed ? '{"id":"item-1"}' : '{}', {
+          status: committed ? 201 : 202,
         });
       },
     ),
@@ -188,5 +198,28 @@ describe('streamed large restore (issue #343)', () => {
     } as StoredBlobRef);
 
     expect(content).toBeUndefined();
+  });
+
+  it('refuses to commit when the source is longer than the manifest recorded', async () => {
+    // Graph commits as soon as the ranges cover the total the session was opened for, and that
+    // total comes from the manifest. An object longer than its recorded size would otherwise fill
+    // the declared range from inside the stream, committing bytes no tag and no digest had passed.
+    const harness = stored_object();
+    const understated = 2 * LARGE_UPLOAD_CHUNK;
+    const session = stub_session(harness);
+
+    const content = await download_and_decrypt_blob(harness.ctx, {
+      ...harness.ref,
+      size_bytes: understated,
+    } as StoredBlobRef);
+
+    await expect(
+      upload_content_to_session(UPLOAD_URL, content!, harness.ref.file_name),
+    ).rejects.toThrow(/more content than the \d+ byte\(s\) recorded for it/);
+
+    expect(
+      session.ranges.some((range) => range.endsWith(`-${understated - 1}/${understated}`)),
+    ).toBe(false);
+    expect(session.deletes()).toBe(1);
   });
 });

--- a/packages/onedrive/tests/unit/services/restore/streamed-large-restore.test.ts
+++ b/packages/onedrive/tests/unit/services/restore/streamed-large-restore.test.ts
@@ -1,0 +1,192 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { Readable } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { StoredBlobRef, TenantContext } from '@wisecom/atlas-types';
+import { stub_encrypted_object_store } from '@wisecom/atlas-types/testing/stub-encrypted-object-store';
+import {
+  LARGE_UPLOAD_CHUNK,
+  upload_content_to_session,
+} from '@wisecom/atlas-drive/restore/upload-session';
+import { download_and_decrypt_blob } from '@/services/restore/blob-restore';
+import { OneDriveDecryptAuthError } from '@/services/restore/restore-integrity';
+
+/**
+ * Issue #343: restore decrypted the whole object into memory before the first byte went to Graph,
+ * so a 1 GiB file peaked near 2 GiB. The plaintext now flows into the upload session as it is
+ * decrypted, which means the session must not be allowed to create the item until the source has
+ * ended and the checksum has matched.
+ */
+
+const UPLOAD_URL = 'https://graph.test/upload/session-1';
+const OBJECT_BYTES = 48 * 1024 * 1024;
+const SOURCE_CHUNK = 4 * 1024 * 1024;
+
+/** Digest of what a party ended up with, which is how the two sides are compared. */
+function sha256_hex(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+interface Harness {
+  readonly ctx: TenantContext;
+  readonly ref: StoredBlobRef;
+  readonly plaintext: Buffer;
+  /** Ciphertext bytes the storage stream has produced so far. */
+  read_bytes: () => number;
+}
+
+/** A stored object served in fixed-size pieces, with the read position observable. */
+function stored_object(options: { corrupt?: boolean; wrong_checksum?: boolean } = {}): Harness {
+  const store = stub_encrypted_object_store();
+  const plaintext = randomBytes(OBJECT_BYTES);
+  const stored = store.encrypt(plaintext);
+  if (options.corrupt === true) stored[stored.length - 1] ^= 0xff;
+  let read_bytes = 0;
+
+  const ctx = {
+    storage: {
+      get_stream: async (): Promise<Readable> => {
+        let offset = 0;
+        return new Readable({
+          highWaterMark: SOURCE_CHUNK,
+          read() {
+            if (offset >= stored.length) {
+              this.push(null);
+              return;
+            }
+            const end = Math.min(offset + SOURCE_CHUNK, stored.length);
+            const piece = stored.subarray(offset, end);
+            offset = end;
+            read_bytes = end;
+            this.push(piece);
+          },
+        });
+      },
+    },
+    create_decipher: store.create_decipher,
+  } as unknown as TenantContext;
+
+  const checksum =
+    options.wrong_checksum === true
+      ? sha256_hex(Buffer.from('a different file'))
+      : sha256_hex(plaintext);
+
+  return {
+    ctx,
+    plaintext,
+    read_bytes: () => read_bytes,
+    ref: {
+      file_id: 'item-1',
+      file_name: 'Report.bin',
+      storage_key: 'onedrive/data/ab/cd/object',
+      checksum,
+      size_bytes: OBJECT_BYTES,
+    } as StoredBlobRef,
+  };
+}
+
+/** A Graph upload session that records what it was sent, answering the last chunk with 201. */
+function stub_session(harness: Harness): {
+  uploaded: Buffer[];
+  ranges: string[];
+  deletes: () => number;
+  peak_in_flight: () => number;
+} {
+  const uploaded: Buffer[] = [];
+  const ranges: string[] = [];
+  let deletes = 0;
+  let peak_in_flight = 0;
+  let sent = 0;
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async (
+        _url: string,
+        init?: { method?: string; headers?: Record<string, string>; body?: Buffer },
+      ) => {
+        const method = init?.method ?? 'GET';
+        if (method === 'DELETE') {
+          deletes++;
+          return new Response('', { status: 204 });
+        }
+        if (method !== 'PUT') return new Response('{"nextExpectedRanges":["0-"]}', { status: 200 });
+
+        const body = init!.body!;
+        uploaded.push(Buffer.from(body));
+        ranges.push(init!.headers!['Content-Range']!);
+        // Bytes decrypted but not yet handed to Graph: this is what restore has to hold.
+        peak_in_flight = Math.max(peak_in_flight, harness.read_bytes() - sent);
+        sent += body.length;
+        return new Response(sent === OBJECT_BYTES ? '{"id":"item-1"}' : '{}', {
+          status: sent === OBJECT_BYTES ? 201 : 202,
+        });
+      },
+    ),
+  );
+
+  return { uploaded, ranges, deletes: () => deletes, peak_in_flight: () => peak_in_flight };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('streamed large restore (issue #343)', () => {
+  it('uploads the object without ever holding it whole', async () => {
+    const harness = stored_object();
+    const session = stub_session(harness);
+
+    const content = await download_and_decrypt_blob(harness.ctx, harness.ref);
+    expect(Buffer.isBuffer(content)).toBe(false);
+
+    await upload_content_to_session(UPLOAD_URL, content!, harness.ref.file_name);
+
+    // Digests, not a deep buffer comparison: 48 MiB of element-by-element equality is minutes.
+    expect(sha256_hex(Buffer.concat(session.uploaded))).toBe(sha256_hex(harness.plaintext));
+    // Bounded by the chunk sizes in play, not by the size of the object.
+    expect(session.peak_in_flight()).toBeLessThanOrEqual(2 * LARGE_UPLOAD_CHUNK + SOURCE_CHUNK);
+    // The committing PUT is the one that carries the last byte, and it only goes out after the
+    // decrypt stream has ended.
+    expect(session.ranges.at(-1)).toMatch(new RegExp(`-${OBJECT_BYTES - 1}/${OBJECT_BYTES}$`));
+    expect(session.deletes()).toBe(0);
+  });
+
+  it('never creates the item when the checksum does not match the manifest', async () => {
+    const harness = stored_object({ wrong_checksum: true });
+    const session = stub_session(harness);
+
+    const content = await download_and_decrypt_blob(harness.ctx, harness.ref);
+
+    await expect(
+      upload_content_to_session(UPLOAD_URL, content!, harness.ref.file_name),
+    ).rejects.toThrow(/Checksum mismatch/);
+
+    // Everything Graph received is still uncommitted, and the session is gone.
+    expect(Buffer.concat(session.uploaded).length).toBeLessThan(OBJECT_BYTES);
+    expect(session.deletes()).toBe(1);
+  });
+
+  it('reports a failed authentication tag as an auth error and abandons the session', async () => {
+    const harness = stored_object({ corrupt: true });
+    const session = stub_session(harness);
+
+    const content = await download_and_decrypt_blob(harness.ctx, harness.ref);
+
+    await expect(
+      upload_content_to_session(UPLOAD_URL, content!, harness.ref.file_name),
+    ).rejects.toBeInstanceOf(OneDriveDecryptAuthError);
+    expect(session.deletes()).toBe(1);
+  });
+
+  it('skips an entry the manifest cannot verify rather than restoring it unchecked', async () => {
+    const harness = stored_object();
+
+    const content = await download_and_decrypt_blob(harness.ctx, {
+      ...harness.ref,
+      checksum: undefined,
+    } as StoredBlobRef);
+
+    expect(content).toBeUndefined();
+  });
+});

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -5,7 +5,7 @@ import type { SaveResult } from '@wisecom/atlas-types';
 import type { EntryResult } from '@/services/save/save-entry-writer';
 import { save_json_entry, save_mime_entry } from '@/services/save/save-entry-writer';
 import { verify_checksum } from '@/services/save/save-integrity-validator';
-import type { ArchiveWriter } from '@/services/save/save-zip-writer';
+import type { SaveArchive } from '@/services/save/save-zip-writer';
 import {
   create_save_archive,
   finalize_archive,
@@ -35,7 +35,8 @@ export async function save_entries_to_archive(
   is_interrupted: () => boolean,
   control: OperationControlOptions,
 ): Promise<Omit<SaveResult, 'snapshot_id'> & { processed: number }> {
-  const { archive, promise, publish, abort } = create_save_archive(target);
+  const save_archive = create_save_archive(target);
+  const { archive, promise, publish, abort } = save_archive;
 
   try {
     let global_saved = 0;
@@ -66,7 +67,7 @@ export async function save_entries_to_archive(
         folder_name,
         folder_index,
         skip_integrity,
-        archive,
+        save_archive,
         used_names,
         groups,
         global_total,
@@ -143,7 +144,7 @@ async function process_folder_entries(
   folder_name: string,
   folder_index: number,
   skip_integrity: boolean,
-  archive: ArchiveWriter,
+  archive: SaveArchive,
   used_names: Set<string>,
   groups: Map<string, ManifestEntry[]>,
   global_total: number,
@@ -223,7 +224,7 @@ async function process_single_entry(
   entry: ManifestEntry,
   folder_name: string,
   skip_integrity: boolean,
-  archive: ArchiveWriter,
+  archive: SaveArchive,
   used_names: Set<string>,
 ): Promise<EntryResult> {
   const result: EntryResult = {

--- a/packages/outlook/src/services/save/save-entry-writer.ts
+++ b/packages/outlook/src/services/save/save-entry-writer.ts
@@ -2,7 +2,7 @@ import type { TenantContext } from '@wisecom/atlas-types';
 import type { ManifestEntry, AttachmentEntry } from '@wisecom/atlas-types';
 import { build_eml, build_eml_filename, deduplicate_filename } from '@/services/save/eml-builder';
 import { verify_checksum } from '@/services/save/save-integrity-validator';
-import type { ArchiveWriter } from '@/services/save/save-zip-writer';
+import type { SaveArchive } from '@/services/save/save-zip-writer';
 import { add_eml_to_archive } from '@/services/save/save-zip-writer';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -32,7 +32,7 @@ export async function save_mime_entry(
   entry: ManifestEntry,
   folder_name: string,
   mime: Buffer,
-  archive: ArchiveWriter,
+  archive: SaveArchive,
   used_names: Set<string>,
 ): Promise<void> {
   const raw_filename = build_eml_filename(entry.received_at, entry.subject);
@@ -51,7 +51,7 @@ export async function save_json_entry(
   folder_name: string,
   plaintext: Buffer,
   skip_integrity: boolean,
-  archive: ArchiveWriter,
+  archive: SaveArchive,
   used_names: Set<string>,
   result: EntryResult,
 ): Promise<void> {

--- a/packages/outlook/src/services/save/save-zip-writer.ts
+++ b/packages/outlook/src/services/save/save-zip-writer.ts
@@ -1,5 +1,8 @@
 import { type Archiver } from 'archiver';
-import { create_file_archive } from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
+import {
+  append_archive_entry,
+  create_file_archive,
+} from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
 import type { ArchiveTarget } from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
 
 export type { ArchiveTarget };
@@ -7,6 +10,8 @@ export type { ArchiveTarget };
 export interface SaveArchive {
   readonly archive: ArchiveWriter;
   readonly promise: Promise<number>;
+  /** Resolves once the destination has taken what the archive has produced so far. */
+  drain(): Promise<void>;
   /**
    * Makes the completed archive available: a rename onto the output path for a file target,
    * nothing for a stream target, whose consumer already has the bytes.
@@ -26,27 +31,19 @@ export type ArchiveWriter = Archiver;
  * For a stream target, pipes directly to the caller's Writable without staging.
  */
 export function create_save_archive(target: ArchiveTarget): SaveArchive {
-  const { archive, promise, publish, abort } = create_file_archive(target, {
-    compression_level: 9,
-  });
-  return { archive, promise, publish, abort };
+  return create_file_archive(target, { compression_level: 9 });
 }
 
 /**
- * Appends an EML buffer and waits for it to be compressed and flushed.
+ * Appends an EML buffer and waits for it to be compressed and taken by the destination.
  *
- * Backpressure: archiver.append() is fire-and-forget — it queues the buffer
- * internally and compresses in the background. Without waiting, the loop in
- * save-entry-processor would download the next message from S3 immediately,
- * causing the queue (and heap) to grow without bound. For a 500 GB mailbox
- * that means OOM long before the archive is finished.
- *
- * By awaiting the 'entry' event we guarantee each EML is compressed and
- * written to the output stream before the next S3 download starts, keeping
- * peak memory at roughly one message + its attachments.
+ * `archiver.append()` only queues, so without waiting the loop in save-entry-processor would
+ * download the next message from S3 immediately and the queue, and the archive's readable buffer,
+ * would grow without bound. For a 500 GB mailbox that means OOM long before the archive is
+ * finished. Waiting keeps peak memory at roughly one message and its attachments.
  */
 export function add_eml_to_archive(
-  archive: ArchiveWriter,
+  save_archive: SaveArchive,
   folder_path: string,
   filename: string,
   content: Buffer,
@@ -61,20 +58,11 @@ export function add_eml_to_archive(
   // changes no existing archive; it means a future caller passing an item or attachment
   // name cannot reintroduce the traversal (issue #258).
   const dir_path = folder_path.split('/').map(sanitize_path_segment).join('/');
-  const entry_path = `${dir_path}/${sanitize_path_segment(filename)}`;
-  return new Promise<void>((resolve, reject) => {
-    const on_entry = (): void => {
-      archive.removeListener('error', on_error);
-      resolve();
-    };
-    const on_error = (err: Error): void => {
-      archive.removeListener('entry', on_entry);
-      reject(err);
-    };
-    archive.once('entry', on_entry);
-    archive.once('error', on_error);
-    archive.append(content, { name: entry_path });
-  });
+  return append_archive_entry(
+    save_archive,
+    `${dir_path}/${sanitize_path_segment(filename)}`,
+    content,
+  );
 }
 
 /** Finalizes the archive. The returned promise resolves to total bytes written. */

--- a/packages/outlook/tests/unit/services/save/zip-writer.test.ts
+++ b/packages/outlook/tests/unit/services/save/zip-writer.test.ts
@@ -31,8 +31,9 @@ describe('save-zip-writer', () => {
     const path = temp_path('create');
     created_files.push(path);
 
-    const { archive, promise, publish } = create_save_archive(path);
-    await add_eml_to_archive(archive, 'Inbox', 'test.eml', Buffer.from('EML content'));
+    const save_archive = create_save_archive(path);
+    const { archive, promise, publish } = save_archive;
+    await add_eml_to_archive(save_archive, 'Inbox', 'test.eml', Buffer.from('EML content'));
     await finalize_archive(archive);
     const bytes = await promise;
     await publish();
@@ -45,10 +46,11 @@ describe('save-zip-writer', () => {
     const path = temp_path('multi');
     created_files.push(path);
 
-    const { archive, promise, publish } = create_save_archive(path);
-    await add_eml_to_archive(archive, 'Inbox', 'a.eml', Buffer.from('Message A'));
-    await add_eml_to_archive(archive, 'Sent Items', 'b.eml', Buffer.from('Message B'));
-    await add_eml_to_archive(archive, 'Inbox', 'c.eml', Buffer.from('Message C'));
+    const save_archive = create_save_archive(path);
+    const { archive, promise, publish } = save_archive;
+    await add_eml_to_archive(save_archive, 'Inbox', 'a.eml', Buffer.from('Message A'));
+    await add_eml_to_archive(save_archive, 'Sent Items', 'b.eml', Buffer.from('Message B'));
+    await add_eml_to_archive(save_archive, 'Inbox', 'c.eml', Buffer.from('Message C'));
     await finalize_archive(archive);
     const bytes = await promise;
     await publish();
@@ -60,7 +62,8 @@ describe('save-zip-writer', () => {
     const path = temp_path('empty');
     created_files.push(path);
 
-    const { archive, promise, publish } = create_save_archive(path);
+    const save_archive = create_save_archive(path);
+    const { archive, promise, publish } = save_archive;
     await finalize_archive(archive);
     const bytes = await promise;
     await publish();
@@ -72,12 +75,13 @@ describe('save-zip-writer', () => {
     const path = temp_path('nested');
     created_files.push(path);
 
-    const { archive, promise, publish } = create_save_archive(path);
+    const save_archive = create_save_archive(path);
+    const { archive, promise, publish } = save_archive;
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
-    await add_eml_to_archive(archive, 'Inbox/Projects/2026', 'a.eml', Buffer.from('A'));
-    await add_eml_to_archive(archive, 'Archive/Projects/2026', 'b.eml', Buffer.from('B'));
+    await add_eml_to_archive(save_archive, 'Inbox/Projects/2026', 'a.eml', Buffer.from('A'));
+    await add_eml_to_archive(save_archive, 'Archive/Projects/2026', 'b.eml', Buffer.from('B'));
     await finalize_archive(archive);
     await promise;
     await publish();
@@ -89,11 +93,12 @@ describe('save-zip-writer', () => {
     const path = temp_path('sanitize');
     created_files.push(path);
 
-    const { archive, promise, publish } = create_save_archive(path);
+    const save_archive = create_save_archive(path);
+    const { archive, promise, publish } = save_archive;
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
-    await add_eml_to_archive(archive, 'Inbox/Q1:Q2/..', 'a.eml', Buffer.from('A'));
+    await add_eml_to_archive(save_archive, 'Inbox/Q1:Q2/..', 'a.eml', Buffer.from('A'));
     await finalize_archive(archive);
     await promise;
     await publish();
@@ -108,11 +113,12 @@ describe('save-zip-writer', () => {
     const path = temp_path('traversal');
     created_files.push(path);
 
-    const { archive, promise, publish } = create_save_archive(path);
+    const save_archive = create_save_archive(path);
+    const { archive, promise, publish } = save_archive;
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
-    await add_eml_to_archive(archive, 'Inbox', '../../../etc/passwd', Buffer.from('A'));
+    await add_eml_to_archive(save_archive, 'Inbox', '../../../etc/passwd', Buffer.from('A'));
     await finalize_archive(archive);
     await promise;
     await publish();
@@ -128,11 +134,12 @@ describe('save-zip-writer', () => {
     const path = temp_path('flatten');
     created_files.push(path);
 
-    const { archive, promise, publish } = create_save_archive(path);
+    const save_archive = create_save_archive(path);
+    const { archive, promise, publish } = save_archive;
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
-    await add_eml_to_archive(archive, 'Inbox', 'a/b\\c\x01d.eml', Buffer.from('A'));
+    await add_eml_to_archive(save_archive, 'Inbox', 'a/b\\c\x01d.eml', Buffer.from('A'));
     await finalize_archive(archive);
     await promise;
     await publish();
@@ -155,12 +162,13 @@ describe('save-zip-writer', () => {
       deduplicate_filename(build_eml_filename('2026-03-10T14:30:22Z', 'Same'), new Set(['x'])),
     ];
 
-    const { archive, promise, publish } = create_save_archive(path);
+    const save_archive = create_save_archive(path);
+    const { archive, promise, publish } = save_archive;
     const entries: string[] = [];
     archive.on('entry', (e) => entries.push(String(e.name)));
 
     for (const name of generated) {
-      await add_eml_to_archive(archive, 'Inbox', name, Buffer.from('A'));
+      await add_eml_to_archive(save_archive, 'Inbox', name, Buffer.from('A'));
     }
     await finalize_archive(archive);
     await promise;

--- a/packages/sharepoint/src/adapters/graph-sharepoint-connector.adapter.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-connector.adapter.ts
@@ -9,6 +9,7 @@ import {
 import type {
   DriveFileSystemInfo,
   DriveItemIdentity,
+  LargeFileContent,
   SharePointSiteConnector,
   SharePointSite,
   SharePointDocumentLibrary,
@@ -278,7 +279,7 @@ export class GraphSharePointConnector implements SharePointSiteConnector {
     drive_id: string,
     parent_id: string,
     file_name: string,
-    content: Buffer,
+    content: LargeFileContent,
     conflict_behavior?: string,
     file_system_info?: DriveFileSystemInfo,
   ): Promise<void> {

--- a/packages/sharepoint/src/adapters/graph-sharepoint-restore.adapter.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-restore.adapter.ts
@@ -2,7 +2,7 @@ import type { Client } from '@microsoft/microsoft-graph-client';
 import { build_upload_file_system_info, with_graph_retry } from '@wisecom/atlas-m365-graph';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import { upload_content_to_session } from '@wisecom/atlas-drive/restore/upload-session';
-import type { DriveFileSystemInfo } from '@wisecom/atlas-types';
+import type { DriveFileSystemInfo, LargeFileContent } from '@wisecom/atlas-types';
 
 async function find_child_folder_id_by_name(
   client: Client,
@@ -137,7 +137,7 @@ export async function graph_sharepoint_upload_large_file(
   drive_id: string,
   parent_id: string,
   file_name: string,
-  content: Buffer,
+  content: LargeFileContent,
   conflict_behavior: string = 'rename',
   file_system_info?: DriveFileSystemInfo,
 ): Promise<void> {

--- a/packages/sharepoint/src/services/restore/restore-content.ts
+++ b/packages/sharepoint/src/services/restore/restore-content.ts
@@ -78,7 +78,7 @@ async function* authenticated_chunks(
   file_name: string,
 ): AsyncGenerator<Buffer> {
   try {
-    yield* stream_verified_plaintext(ctx, storage_key, expected_checksum);
+    yield* stream_verified_plaintext(ctx, storage_key, expected_checksum, file_name);
   } catch (err) {
     if (is_gcm_auth_failure(err)) {
       throw new SharePointDecryptAuthError(`AES-GCM authentication failed for ${file_name}`, {

--- a/packages/sharepoint/src/services/restore/restore-content.ts
+++ b/packages/sharepoint/src/services/restore/restore-content.ts
@@ -11,14 +11,16 @@
  */
 
 import { createHash, timingSafeEqual } from 'node:crypto';
-import type { StoredBlobRef, TenantContext } from '@wisecom/atlas-types';
+import type {
+  LargeFileContent,
+  StoredBlobRef,
+  StreamedFileContent,
+  TenantContext,
+} from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import { is_gcm_auth_failure } from '@wisecom/atlas-core/utils/gcm-auth';
-import {
-  should_stream_restore,
-  stream_decrypt_from_storage,
-  verify_streaming_checksum,
-} from '@wisecom/atlas-drive/restore/streaming-restore';
+import { stream_verified_plaintext } from '@wisecom/atlas-core/services/shared/stream-decrypt';
+import { should_stream_restore } from '@wisecom/atlas-drive/restore/streaming-restore';
 
 /** Thrown when ciphertext decrypts with AES-GCM but fails the authentication tag check. */
 export class SharePointDecryptAuthError extends Error {
@@ -28,36 +30,62 @@ export class SharePointDecryptAuthError extends Error {
   }
 }
 
-/** Returns the entry's verified plaintext, or undefined when it cannot be restored. */
+/**
+ * Returns the entry's content for restore, or undefined when it cannot be restored.
+ *
+ * A file past the streaming threshold comes back as a verified stream rather than a buffer, so
+ * restoring it costs two upload chunks of memory instead of the whole plaintext (issue #343). The
+ * shape doubles as the upload decision: only a file too large for the small-file upload streams.
+ */
 export async function download_and_decrypt(
   ctx: TenantContext,
   entry: StoredBlobRef,
-): Promise<Buffer | undefined> {
+): Promise<LargeFileContent | undefined> {
   if (!entry.storage_key) return undefined;
 
   return should_stream_restore(entry)
-    ? stream_download_and_decrypt(ctx, entry)
+    ? verified_blob_stream(ctx, entry)
     : buffered_download_and_decrypt(ctx, entry);
 }
 
-async function stream_download_and_decrypt(
+/**
+ * Streaming path: the plaintext is never held whole, so the checksum is only comparable once the
+ * last chunk has been produced.
+ *
+ * The upload it feeds must therefore not commit until the iteration ends, which the Graph upload
+ * session guarantees by holding its final chunk back. A mismatch or a failed tag then abandons the
+ * session instead of leaving a wrong file in the library.
+ */
+function verified_blob_stream(
   ctx: TenantContext,
   entry: StoredBlobRef,
-): Promise<Buffer | undefined> {
+): StreamedFileContent | undefined {
+  if (!entry.checksum) {
+    logger.warn(`Missing checksum for ${entry.file_name}; skipping restore`);
+    return undefined;
+  }
+  return {
+    chunks: authenticated_chunks(ctx, entry.storage_key!, entry.checksum, entry.file_name),
+    total_bytes: entry.size_bytes,
+  };
+}
+
+/** Yields verified plaintext, reporting a failed tag as the operator-visible error it is. */
+async function* authenticated_chunks(
+  ctx: TenantContext,
+  storage_key: string,
+  expected_checksum: string,
+  file_name: string,
+): AsyncGenerator<Buffer> {
   try {
-    const { content, sha256_hex } = await stream_decrypt_from_storage(ctx, entry.storage_key!);
-    if (!verify_streaming_checksum(entry, sha256_hex)) return undefined;
-    return content;
+    yield* stream_verified_plaintext(ctx, storage_key, expected_checksum);
   } catch (err) {
     if (is_gcm_auth_failure(err)) {
-      throw new SharePointDecryptAuthError(`AES-GCM authentication failed for ${entry.file_name}`, {
+      throw new SharePointDecryptAuthError(`AES-GCM authentication failed for ${file_name}`, {
         cause: err,
       });
     }
-    logger.warn(
-      `Streaming decrypt failed for ${entry.file_name}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return undefined;
+    throw err;
   }
 }
 

--- a/packages/sharepoint/src/services/restore/restore.service.ts
+++ b/packages/sharepoint/src/services/restore/restore.service.ts
@@ -47,8 +47,6 @@ import {
   restore_parent_path,
 } from '@wisecom/atlas-core/services/shared/restore-destination';
 
-const SMALL_FILE_LIMIT = 4 * 1024 * 1024;
-
 /** Per-run state deciding which library each entry is written to. */
 interface EntryRouting {
   readonly cross_site: boolean;
@@ -263,7 +261,9 @@ export class SharePointRestoreService implements SharePointRestoreUseCase {
         return 'skipped';
       }
 
-      if (content.length <= SMALL_FILE_LIMIT) {
+      // The blob reader streams anything past the small-file limit, so the shape it returned is
+      // the upload to use.
+      if (Buffer.isBuffer(content)) {
         await this._connector.upload_small_file(
           tenant_id,
           target_site,

--- a/packages/types/src/ports/drive/large-file-content.port.ts
+++ b/packages/types/src/ports/drive/large-file-content.port.ts
@@ -1,0 +1,15 @@
+/**
+ * A file handed to a resumable upload, either whole or as a stream.
+ *
+ * Graph needs the total length in every `Content-Range`, which a stream cannot report, so a
+ * streamed source carries the length the manifest recorded alongside it. Restoring a large object
+ * from a buffer meant holding the whole plaintext while it uploaded, which put restore's peak
+ * memory at the size of the largest file in the backup (issue #343).
+ */
+export interface StreamedFileContent {
+  readonly chunks: AsyncIterable<Buffer> | Iterable<Buffer>;
+  readonly total_bytes: number;
+}
+
+/** Upload payload: a buffer for content already in hand, or a stream for content still arriving. */
+export type LargeFileContent = Buffer | StreamedFileContent;

--- a/packages/types/src/ports/index.ts
+++ b/packages/types/src/ports/index.ts
@@ -232,6 +232,8 @@ export type {
   DriveVersionRestoreResult,
 } from './drive/version-restore.port';
 
+export type { LargeFileContent, StreamedFileContent } from './drive/large-file-content.port';
+
 export type {
   SharePointSiteConnector,
   SharePointSite,

--- a/packages/types/src/ports/onedrive/connector.port.ts
+++ b/packages/types/src/ports/onedrive/connector.port.ts
@@ -1,4 +1,5 @@
 import type { DriveFileSystemInfo, DriveItemIdentity } from '@/domain/drive-item-metadata';
+import type { LargeFileContent } from '@/ports/drive/large-file-content.port';
 export interface OneDriveDrive {
   readonly drive_id: string;
   readonly drive_name: string;
@@ -120,14 +121,14 @@ export interface OneDriveConnector {
     file_system_info?: DriveFileSystemInfo,
   ): Promise<void>;
 
-  /** Uploads a large file via resumable upload session. */
+  /** Uploads a large file via resumable upload session, buffered or streamed. */
   upload_large_file(
     tenant_id: string,
     owner_id: string,
     drive_id: string,
     parent_id: string,
     file_name: string,
-    content: Buffer,
+    content: LargeFileContent,
     conflict_behavior?: string,
     file_system_info?: DriveFileSystemInfo,
   ): Promise<void>;

--- a/packages/types/src/ports/sharepoint/connector.port.ts
+++ b/packages/types/src/ports/sharepoint/connector.port.ts
@@ -1,4 +1,5 @@
 import type { DriveFileSystemInfo, DriveItemIdentity } from '@/domain/drive-item-metadata';
+import type { LargeFileContent } from '@/ports/drive/large-file-content.port';
 export interface SharePointSite {
   readonly site_id: string;
   readonly site_url: string;
@@ -140,14 +141,14 @@ export interface SharePointSiteConnector {
     file_system_info?: DriveFileSystemInfo,
   ): Promise<void>;
 
-  /** Uploads a large file via resumable upload session. */
+  /** Uploads a large file via resumable upload session, buffered or streamed. */
   upload_large_file(
     tenant_id: string,
     site_id: string,
     drive_id: string,
     parent_id: string,
     file_name: string,
-    content: Buffer,
+    content: LargeFileContent,
     conflict_behavior?: string,
     file_system_info?: DriveFileSystemInfo,
   ): Promise<void>;


### PR DESCRIPTION
## Summary

Closes #343.

Restore read a stored object, decrypted it into one buffer, and handed that buffer to the uploader. A 1 GiB file therefore peaked near 2 GiB, and the ceiling on a restore run was the largest file in the backup rather than anything Atlas controls. The plaintext now flows into the Graph upload session as it is decrypted: two upload chunks and one download chunk, whatever the file size.

Streaming plaintext that has not been verified yet is the part worth reading carefully. AES-256-GCM only authenticates at the end of the object, and the SHA-256 can only be compared once the last byte has passed through, so a streamed restore necessarily sends bytes before it knows they are right. What makes that safe is that an upload session creates nothing until it is committed, and the chunk that commits it is the one carrying the last byte. That chunk is held back until the decrypt stream has ended cleanly, so a failed tag or a checksum that does not match the manifest abandons the session with `DELETE` and Graph never creates the file. Bytes Graph already accepted live in a session nobody can read and expire with it.

I did not use the two options the issue lists (authenticated records or ciphertext staging). Both change the storage format or add scratch files; holding the committing chunk gets the same property, that nothing is released before it authenticates, with no format change and no new files on disk.

One behaviour change falls out of this: a large file whose checksum does not match is now a restore error rather than a silent skip, so the run exits non-zero. That is the same direction #341 took, and an entry whose stored object no longer matches the manifest is exactly the case an operator needs to hear about.

The other two parts of the issue:

**Multipart copying.** `flush_pending_parts` concatenated everything pending and copied the remainder back for each part, so copy volume followed the input chunk size instead of the payload. A shared `ByteQueue` hands out fixed-size blocks and copies only the bytes it hands out; what is still pending stays in the buffers it arrived in. The same queue does the chunking in the upload session, so the streaming restore does not reintroduce the pattern.

**Archive backpressure.** `add_file_to_archive` waited for archiver's `entry` event, which is not backpressure: archiver keeps compressing whatever it is handed and the result sits in its readable buffer. I measured it, with a destination that accepts nothing, every entry still completed. Appending now also waits for the destination to drain. Outlook held a second copy of the same helper carrying the same defect under a comment claiming it was solved, so both now call one `append_archive_entry`.

Export still buffers one file at a time while it is compressed. Bounding that too would mean streaming an unverified entry into an archive that publishes as it writes, which is the release the section above avoids, and it would turn one corrupt file into a failed export instead of a reported skip. The issue's acceptance criteria bound restore and ask for backpressure on the archive, which is what this does.

### Evidence

Peak retention during a restore, measured as bytes decrypted but not yet handed to Graph, against a 48 MiB object served in 4 MiB pieces:

```
peak in flight <= 2 * 10 MiB upload chunk + 4 MiB source chunk
uploaded digest == plaintext digest
DELETE requests: 0
```

Copy volume for a 32 MiB payload delivered as 4 MiB, 16 MiB and one 32 MiB chunk: bytes passed to `Buffer.concat` stay at or below one part plus the 28-byte header in all three, where it previously grew with the chunk size.

Archive backpressure, destination holding every write: appends stop completing instead of all of them resolving.

Not verified against a live tenant or a real S3 endpoint. The evidence here is unit-level, with real AES-256-GCM on both sides and a stubbed Graph session.

## Changes

- `packages/core/src/services/shared/byte-queue.ts`: new. Fixed-size blocks out of arriving buffers, copying only what it hands out.
- `packages/core/src/services/shared/stream-decrypt.ts`: `stream_verified_plaintext`, a generator that yields plaintext and throws at the end unless the digest matches the manifest.
- `packages/core/src/services/shared/stream-encrypt-upload.ts`: the multipart flush uses the queue instead of concatenating the remainder.
- `packages/core/src/services/shared/file-save-zip-writer.ts`: `FileArchive.drain()`, and `append_archive_entry` as the one place an entry is added and waited for.
- `packages/drive/src/restore/upload-session.ts`: takes a buffer or a stream with its total length, chunks it as it arrives, and holds the committing chunk until the source ends.
- `packages/types/src/ports/drive/large-file-content.port.ts`: new `LargeFileContent`, threaded through both connector ports and both adapters.
- `packages/onedrive/src/services/restore/blob-restore.ts`, `packages/sharepoint/src/services/restore/restore-content.ts`: a file past the streaming threshold comes back as a verified stream; the returned shape is also the upload decision, so both restore services and the shared version restore drop their own size comparison.
- `packages/outlook/src/services/save/save-zip-writer.ts`: delegates to the shared append instead of its own copy.
- Tests: streamed restore including the mismatch and failed-tag paths, multipart copy volume across three chunk sizes, and archive backpressure.
- Docs: memory during a large restore and export backpressure in `docs/onedrive-backup.md` and `docs/sharepoint-backup.md`, and a section in `docs/security.md` on why nothing is released before it authenticates.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`), unless this is a release or hotfix PR
- [x] No version bump in `packages/*/package.json` (releases only)
- [x] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Large OneDrive and SharePoint restores now stream content incrementally, reducing memory usage for large files.
  - Restores verify authentication and checksums before committing files; failed uploads are abandoned without creating invalid files.
  - Archive exports now process entries sequentially with backpressure, supporting slow destinations without unbounded memory growth.
  - Large-file uploads support both buffered and streamed content.

- **Documentation**
  - Added guidance on streaming behavior, memory usage, integrity validation, and upload failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->