### PR TITLE
fix(cancel): let cancellation reach the transfer, not just the next item

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -274,10 +274,16 @@ const result = await atlas.outlook.backup('user@company.com', {
 
 Both return a result with `interrupted: true` rather than throwing, and both keep the snapshot manifest that was written for the work already done. `hardStopSignal` trades re-enumeration of one folder for a faster exit, so use it when a deadline matters more than the wasted work.
 
-OneDrive and SharePoint backups accept `signal` only, and it now reaches the transfer itself: a
-cancelled run aborts the download it is in the middle of rather than waiting out a file that may be
-gigabytes long, and it does not start the next chunk or the next retry. Their long unit of work is
-that one file transfer, so there is nothing left for an escalation signal to shorten.
+OneDrive and SharePoint backups accept `signal` only, and it reaches the transfer itself rather
+than only the next item: a cancelled run aborts the chunk request in flight, skips the retry
+backoff, and closes a historical version's stream instead of reading it to the end. Their long unit
+of work is that one file transfer, so there is nothing left for an escalation signal to shorten.
+
+What it does not cover: anything that goes through the Graph SDK client rather than a direct
+request. That is small-file content under 64 MiB, which is bounded by its own per-request timeout,
+and every mail operation. Cancelling those still waits for the item in flight. Cancellation is also
+an SDK feature: the CLI has no equivalent for drive backups, so Ctrl+C there behaves as it always
+did.
 
 `OperationProgressEvent` is stable across workloads:
 

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -250,7 +250,7 @@ if (result.interrupted) {
 | Option       | Type                                      | Description                                                                                     |
 | ------------ | ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `onProgress` | `(event: OperationProgressEvent) => void` | Receives discovery, per-item processing, finalization, and terminal progress events.            |
-| `signal`     | `AbortSignal`                             | Requests graceful cancellation. Atlas finishes the current item, then stops at a safe boundary. |
+| `signal`     | `AbortSignal`                             | Requests cancellation. The transfer in flight is ended and the run stops at a safe boundary.    |
 
 `atlas.outlook.backup` accepts a third option, `hardStopSignal`, for the case where graceful is not fast enough. This is the escalation the CLI wires to a second Ctrl+C:
 
@@ -274,7 +274,10 @@ const result = await atlas.outlook.backup('user@company.com', {
 
 Both return a result with `interrupted: true` rather than throwing, and both keep the snapshot manifest that was written for the work already done. `hardStopSignal` trades re-enumeration of one folder for a faster exit, so use it when a deadline matters more than the wasted work.
 
-OneDrive and SharePoint backups accept `signal` only. Their long unit of work is a single file transfer, and aborting one mid-stream is not implemented, so there is nothing for an escalation to shorten.
+OneDrive and SharePoint backups accept `signal` only, and it now reaches the transfer itself: a
+cancelled run aborts the download it is in the middle of rather than waiting out a file that may be
+gigabytes long, and it does not start the next chunk or the next retry. Their long unit of work is
+that one file transfer, so there is nothing left for an escalation signal to shorten.
 
 `OperationProgressEvent` is stable across workloads:
 
@@ -575,6 +578,21 @@ What changes compared with a file export:
 **A destroyed stream is the point.** Ending a failed or interrupted stream would hand the consumer a short archive that opens like a complete one, which is the failure mode file exports avoid by staging. Over HTTP the client sees the transfer break, so treat a body that arrived without a completed request as a failed export rather than a partial one. Headers are already sent by then, so the status code cannot report the failure: check the result, or the absence of one, on the server.
 
 Memory is bounded to one message or file at a time in either mode. Each entry is fetched, decrypted, compressed and flushed before the next one starts, so a slow consumer applies backpressure rather than accumulating the archive in the heap.
+
+### When the consumer disconnects
+
+A client that hangs up mid-export destroys the response, and Atlas treats that as the end of the
+run rather than as one failed entry:
+
+- The promise rejects with the destination failure. It does not sit pending waiting for a stream
+  that will never emit `finish`.
+- Nothing further is downloaded. The next entry would be fetched, decrypted and dropped, so the
+  run stops at the entry it could not write.
+- The archive is never finalised, so the bytes the client already received are not a valid zip.
+
+Over HTTP the disconnect is usually the client's doing, which means nobody is listening for the
+rejection. Handle it on the server anyway: the rejection is what tells the run to stop, and it is
+the only record that an export ended early.
 
 ## Restore Options
 

--- a/packages/core/src/services/shared/file-save-zip-writer.ts
+++ b/packages/core/src/services/shared/file-save-zip-writer.ts
@@ -88,10 +88,18 @@ export function create_file_archive(
     // A staged file is only safe to rename once its descriptor is closed. A caller's stream may
     // never emit `close` at all, so for those the flush is what completion means.
     output.on(staging_path === undefined ? 'finish' : 'close', () => resolve(archive.pointer()));
+    // The archiver's own errors, a rejected entry name or an append after finalize, are the
+    // caller's mistake rather than a destination that went away, so they keep their own identity.
     archive.on('error', reject);
     // Errors on the destination are not forwarded through pipe(), so without this a failed write
     // resolves on `close` and the caller reports a successful save.
-    output.on('error', reject);
+    output.on('error', (err: Error) =>
+      reject(
+        new ArchiveDestinationError(`The archive destination failed: ${err.message}`, {
+          cause: err,
+        }),
+      ),
+    );
     // `destroy()` with no error emits `close` and nothing else, so a consumer that walks away
     // leaves a caller's stream with no `finish` to resolve on. Resolution has already happened by
     // then on the success path, where `finish` precedes `close`.
@@ -212,16 +220,18 @@ export async function append_archive_entry(
   }
 }
 
-/** Rejects with whatever failed the archive, and never resolves, so it can only lose a race. */
+/**
+ * Rejects with whatever failed the archive, and never resolves, so it can only lose a race.
+ *
+ * The failure keeps the identity it was rejected with: a destination that went away is an
+ * {@link ArchiveDestinationError} and stops the run, an archiver-level error is itself and fails
+ * the entry that saw it.
+ */
 function archive_failure(file_archive: FileArchive): Promise<never> {
   return file_archive.promise.then(
     () => new Promise<never>(() => undefined),
     (err: unknown) => {
-      if (err instanceof ArchiveDestinationError) throw err;
-      throw new ArchiveDestinationError(
-        `The archive destination failed: ${err instanceof Error ? err.message : String(err)}`,
-        { cause: err },
-      );
+      throw err instanceof Error ? err : new Error(String(err));
     },
   );
 }

--- a/packages/core/src/services/shared/file-save-zip-writer.ts
+++ b/packages/core/src/services/shared/file-save-zip-writer.ts
@@ -10,6 +10,20 @@ import { logger } from '@/utils/logger';
 export type FileArchiveWriter = Archiver;
 
 /**
+ * The archive cannot take entries any more: its destination failed, or it went away.
+ *
+ * Distinct from a bad entry, because the answer differs. One file that will not decrypt is
+ * reported and the run moves on; a destination that is gone means every remaining entry would be
+ * downloaded, decrypted and thrown away, so the run stops instead (issue #344).
+ */
+export class ArchiveDestinationError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'ArchiveDestinationError';
+  }
+}
+
+/**
  * Where a save archive is written: a filesystem path, or a caller's stream.
  *
  * A stream target exports without touching local disk, which is what an embedder piping to an
@@ -83,7 +97,11 @@ export function create_file_archive(
     // then on the success path, where `finish` precedes `close`.
     if (staging_path === undefined) {
       output.on('close', () =>
-        reject(new Error('The archive destination closed before the archive was finished')),
+        reject(
+          new ArchiveDestinationError(
+            'The archive destination closed before the archive was finished',
+          ),
+        ),
       );
     }
   });
@@ -113,7 +131,7 @@ export function create_file_archive(
  */
 async function wait_for_drain(output: Writable): Promise<void> {
   if (output.destroyed || output.writableEnded) {
-    throw new Error('The archive destination is closed');
+    throw new ArchiveDestinationError('The archive destination is closed');
   }
   if (!output.writableNeedDrain) return;
   const { promise, resolve, reject } = Promise.withResolvers<void>();
@@ -125,7 +143,8 @@ async function wait_for_drain(output: Writable): Promise<void> {
     else reject(err);
   };
   const on_drain = (): void => settle();
-  const on_close = (): void => settle(new Error('The archive destination closed mid-entry'));
+  const on_close = (): void =>
+    settle(new ArchiveDestinationError('The archive destination closed mid-entry'));
   const on_error = (err: Error): void => settle(err);
   output.once('drain', on_drain);
   output.once('close', on_close);
@@ -198,7 +217,11 @@ function archive_failure(file_archive: FileArchive): Promise<never> {
   return file_archive.promise.then(
     () => new Promise<never>(() => undefined),
     (err: unknown) => {
-      throw err instanceof Error ? err : new Error(String(err));
+      if (err instanceof ArchiveDestinationError) throw err;
+      throw new ArchiveDestinationError(
+        `The archive destination failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
     },
   );
 }

--- a/packages/core/src/services/shared/index.ts
+++ b/packages/core/src/services/shared/index.ts
@@ -1,5 +1,6 @@
 export * from '@/services/shared/owner-id-migration';
 export {
+  ArchiveDestinationError,
   create_file_archive,
   add_file_to_archive,
   finalize_file_archive,

--- a/packages/drive/src/backup/download-retry.ts
+++ b/packages/drive/src/backup/download-retry.ts
@@ -10,6 +10,14 @@ const MAX_DELAY_MS = 30_000;
 /** Optional tuning for {@link download_with_retry}. */
 export interface DownloadRetryOptions {
   readonly max_attempts?: number;
+  /**
+   * Cancellation for the run.
+   *
+   * The Graph client takes no signal, so the request in flight still finishes; its own per-request
+   * timeout bounds that. What this stops is starting another attempt and sitting out a backoff of
+   * up to 30 seconds after the run was cancelled (issue #344).
+   */
+  readonly abort_signal?: AbortSignal | undefined;
 }
 
 /**
@@ -29,6 +37,7 @@ export async function download_with_retry(
   const max_attempts = options.max_attempts ?? DEFAULT_MAX_ATTEMPTS;
 
   for (let attempt = 1; attempt <= max_attempts; attempt++) {
+    options.abort_signal?.throwIfAborted();
     try {
       return await connector.download_file_content(item);
     } catch (err) {
@@ -50,7 +59,7 @@ export async function download_with_retry(
         `File download retry ${attempt}/${max_attempts} for ${item.file_name} ` +
           `(${format_bytes(item.size_bytes)}) in ${(delay / 1000).toFixed(1)}s -- ${reason}`,
       );
-      await sleep(delay);
+      await sleep(delay, options.abort_signal);
     }
   }
 
@@ -63,6 +72,18 @@ function compute_file_retry_delay(attempt: number): number {
   return Math.min(base + jitter, MAX_DELAY_MS);
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+/** Waits, unless the run is cancelled first. */
+async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const on_abort = (): void => {
+    clearTimeout(timer);
+    reject(signal?.reason instanceof Error ? signal.reason : new Error('The run was cancelled'));
+  };
+  const timer = setTimeout(() => {
+    signal?.removeEventListener('abort', on_abort);
+    resolve();
+  }, ms);
+  signal?.addEventListener('abort', on_abort, { once: true });
+  await promise;
 }

--- a/packages/drive/src/backup/file-processor.ts
+++ b/packages/drive/src/backup/file-processor.ts
@@ -55,7 +55,7 @@ export async function process_drive_backup_file(
     }
   }
 
-  const raw_body = await download_with_retry(connector, item);
+  const raw_body = await download_with_retry(connector, item, { abort_signal });
   if (!raw_body) return undefined;
 
   const checksum = compute_sha256_chunked(raw_body);

--- a/packages/drive/src/backup/file-processor.ts
+++ b/packages/drive/src/backup/file-processor.ts
@@ -27,10 +27,19 @@ export async function process_drive_backup_file(
   item: DriveDeltaItem,
   owner_id: string,
   ctx: TenantContext,
+  abort_signal?: AbortSignal,
 ): Promise<FileProcessResult | undefined> {
   if (item.size_bytes >= LARGE_FILE_THRESHOLD) {
     try {
-      return await process_large_drive_file(deps, connector, item, owner_id, ctx);
+      return await process_large_drive_file(
+        deps,
+        connector,
+        item,
+        owner_id,
+        ctx,
+        undefined,
+        abort_signal,
+      );
     } catch (err) {
       // A missing grant or a service refusal is not a skip: it must reach the caller
       // so the run can name the cause instead of reporting a lost file (issue #246).

--- a/packages/drive/src/backup/file-processor.ts
+++ b/packages/drive/src/backup/file-processor.ts
@@ -41,6 +41,10 @@ export async function process_drive_backup_file(
         abort_signal,
       );
     } catch (err) {
+      // A cancelled run is not a bad file. Swallowing it records the item in the failed-item
+      // ledger, and five cancellations of the same large file burn its retry budget and skip it
+      // for good, because delta never re-presents an unchanged item (issue #344).
+      if (abort_signal?.aborted === true) throw err;
       // A missing grant or a service refusal is not a skip: it must reach the caller
       // so the run can name the cause instead of reporting a lost file (issue #246).
       if (is_unretryable_download_failure(err)) throw err;

--- a/packages/drive/src/backup/large-file-pipeline.ts
+++ b/packages/drive/src/backup/large-file-pipeline.ts
@@ -29,6 +29,7 @@ export interface DriveLargeFileDeps {
     download_url: string,
     total_bytes: number,
     item_id: string,
+    abort_signal?: AbortSignal,
   ) => AsyncIterable<Buffer>;
 }
 
@@ -44,6 +45,7 @@ export async function process_large_drive_file(
   owner_id: string,
   ctx: TenantContext,
   object_lock_policy?: StorageObjectLockPolicy,
+  abort_signal?: AbortSignal,
 ): Promise<LargeFileResult> {
   const download_url = item.download_url ?? (await connector.resolve_download_url(item));
   if (!download_url) {
@@ -58,7 +60,10 @@ export async function process_large_drive_file(
 
   const result = await stream_to_content_addressed_storage(
     ctx,
-    counted_chunks(deps.fetch_chunks(download_url, item.size_bytes, item.item_id), item),
+    counted_chunks(
+      deps.fetch_chunks(download_url, item.size_bytes, item.item_id, abort_signal),
+      item,
+    ),
     {
       staging_key,
       staging_prefix: deps.keys.staging_prefix_for(owner_id),

--- a/packages/drive/src/backup/whole-file-stream.ts
+++ b/packages/drive/src/backup/whole-file-stream.ts
@@ -69,6 +69,8 @@ export async function* stream_whole_file_in_chunks(
       // Armed again only now, when the loop goes back to waiting on the body.
       timer = arm_stall_timer(controller, stall_timeout_ms, item_id);
     }
+    // The body is done, so the tail is handed over with no timer running behind it.
+    clearTimeout(timer);
     if (pending_bytes > 0) yield Buffer.concat(pending);
   } finally {
     clearTimeout(timer);

--- a/packages/drive/src/backup/whole-file-stream.ts
+++ b/packages/drive/src/backup/whole-file-stream.ts
@@ -7,9 +7,17 @@ export interface WholeFileStreamOptions {
    *
    * A server that sends headers and then stalls would otherwise hold the download forever, which
    * is the failure the Range path bounds per chunk (issue #198). The clock is reset on every
-   * part, so a slow-but-moving transfer is never cut off.
+   * part, so a slow-but-moving transfer is never cut off, and it is disarmed while a chunk is in
+   * the consumer's hands, so a busy consumer is not read as a stalled server (issue #344).
    */
   readonly stall_timeout_ms: number;
+  /**
+   * Cancellation from the caller, ending the request rather than the next item.
+   *
+   * A cancelled run used to wait out the whole body before it noticed, which for a multi-gigabyte
+   * item is minutes of transfer nobody wants any more (issue #344).
+   */
+  readonly abort_signal?: AbortSignal | undefined;
 }
 
 /**
@@ -25,16 +33,21 @@ export async function* stream_whole_file_in_chunks(
   item_id: string,
   options: WholeFileStreamOptions,
 ): AsyncGenerator<Buffer> {
-  const { chunk_size_bytes, stall_timeout_ms } = options;
+  const { chunk_size_bytes, stall_timeout_ms, abort_signal } = options;
   if (!Number.isSafeInteger(chunk_size_bytes) || chunk_size_bytes <= 0) {
     throw new Error(`Invalid chunk size for the streamed download of ${item_id}`);
   }
+  abort_signal?.throwIfAborted();
 
   const controller = new AbortController();
   let timer = arm_stall_timer(controller, stall_timeout_ms, item_id);
 
   try {
-    const response = await fetch(url, { signal: controller.signal });
+    const signal =
+      abort_signal === undefined
+        ? controller.signal
+        : AbortSignal.any([controller.signal, abort_signal]);
+    const response = await fetch(url, { signal });
     if (!response.ok || !response.body) {
       throw new Error(`HTTP ${response.status} for the streamed download of ${item_id}`);
     }
@@ -42,8 +55,8 @@ export async function* stream_whole_file_in_chunks(
     let pending: Buffer[] = [];
     let pending_bytes = 0;
     for await (const part of response.body as unknown as AsyncIterable<Uint8Array>) {
+      // The read arrived, so the network is not what the timer would be measuring from here on.
       clearTimeout(timer);
-      timer = arm_stall_timer(controller, stall_timeout_ms, item_id);
       pending.push(Buffer.from(part));
       pending_bytes += part.byteLength;
       while (pending_bytes >= chunk_size_bytes) {
@@ -53,10 +66,16 @@ export async function* stream_whole_file_in_chunks(
         pending = rest.length > 0 ? [rest] : [];
         pending_bytes = rest.length;
       }
+      // Armed again only now, when the loop goes back to waiting on the body.
+      timer = arm_stall_timer(controller, stall_timeout_ms, item_id);
     }
     if (pending_bytes > 0) yield Buffer.concat(pending);
   } finally {
     clearTimeout(timer);
+    // A consumer that stopped early, because it failed or because the run was cancelled, leaves
+    // the body half read. Aborting here closes the socket instead of leaving the transfer running
+    // with nobody reading it (issue #344); after a completed body it does nothing.
+    controller.abort();
   }
 }
 

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -8,6 +8,7 @@ import {
 } from '@wisecom/atlas-core/services/shared/operation-progress';
 import {
   add_file_to_archive,
+  ArchiveDestinationError,
   create_file_archive,
   finalize_file_archive,
 } from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
@@ -216,6 +217,10 @@ async function save_entries_to_archive(
         logger.info(`Saved: ${entry.parent_path}/${entry.file_name}`);
       }
     } catch (err) {
+      // A destination that is gone is not a bad file: every entry left would be downloaded,
+      // decrypted and dropped on the floor, so the run stops here and the caller reports the
+      // failure (issue #344).
+      if (err instanceof ArchiveDestinationError) throw err;
       // A read or decrypt that threw is a damaged file, not a deliberate skip. It counts in both
       // places: `errors` so the run cannot exit clean, and `integrity_failures` so it is not
       // confused with an entry that had nothing to save (issue #341).

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -178,7 +178,15 @@ async function write_drive_snapshot_to_archive(
   } catch (err) {
     // Anything between opening the archive and publishing it can throw: the entry loop, the
     // finalize, the byte count, the move itself. None of them may leave a partial file behind
-    // (issue #307).
+    // (issue #307), and the progress stream still owes its subscriber one terminal event: a
+    // destination that went away is now a routine way to get here (issue #344).
+    emit_operation_progress(options, {
+      operation: 'save',
+      workload,
+      phase: 'interrupted',
+      processed: 0,
+      total: entries.length,
+    });
     await abort();
     throw err;
   }

--- a/packages/drive/src/versioning/version-content-store.ts
+++ b/packages/drive/src/versioning/version-content-store.ts
@@ -116,17 +116,28 @@ async function open_version_stream(
   }
 }
 
-/** Re-labels mid-transfer read failures so storage failures stay distinguishable. */
+/**
+ * Re-labels mid-transfer read failures so storage failures stay distinguishable, and closes the
+ * source when the consumer stops.
+ *
+ * A manually driven iterator is not closed by the `for await` that consumes this generator, so an
+ * upload that failed part way left the download running with nobody reading it (issue #344). The
+ * `finally` runs on a consumer failure, an early `break` and normal completion alike.
+ */
 async function* tag_source_errors(chunks: AsyncIterable<Buffer>): AsyncGenerator<Buffer> {
   const iterator = chunks[Symbol.asyncIterator]();
-  while (true) {
-    let next: IteratorResult<Buffer>;
-    try {
-      next = await iterator.next();
-    } catch (err) {
-      throw new VersionDownloadError(err);
+  try {
+    while (true) {
+      let next: IteratorResult<Buffer>;
+      try {
+        next = await iterator.next();
+      } catch (err) {
+        throw new VersionDownloadError(err);
+      }
+      if (next.done === true) return;
+      yield next.value;
     }
-    if (next.done === true) return;
-    yield next.value;
+  } finally {
+    await iterator.return?.();
   }
 }

--- a/packages/drive/src/versioning/version-content-store.ts
+++ b/packages/drive/src/versioning/version-content-store.ts
@@ -42,9 +42,10 @@ export async function store_version_content(
   owner_id: string,
   ctx: TenantContext,
   version: DriveFileVersion,
+  abort_signal?: AbortSignal,
 ): Promise<StoredVersionContent> {
   if (version.size_bytes >= LARGE_FILE_THRESHOLD) {
-    return await store_streamed(keys, connector, item, owner_id, ctx, version);
+    return await store_streamed(keys, connector, item, owner_id, ctx, version, abort_signal);
   }
   return await store_buffered(keys, connector, item, owner_id, ctx, version);
 }
@@ -56,14 +57,19 @@ async function store_streamed(
   owner_id: string,
   ctx: TenantContext,
   version: DriveFileVersion,
+  abort_signal?: AbortSignal,
 ): Promise<StoredVersionContent> {
   const chunks = await open_version_stream(connector, item, version);
 
-  const result = await stream_to_content_addressed_storage(ctx, tag_source_errors(chunks), {
-    staging_key: keys.staging_key(owner_id, item.item_id),
-    staging_prefix: keys.staging_prefix_for(owner_id),
-    build_data_key: (checksum) => keys.data_key(owner_id, checksum),
-  });
+  const result = await stream_to_content_addressed_storage(
+    ctx,
+    tag_source_errors(chunks, abort_signal),
+    {
+      staging_key: keys.staging_key(owner_id, item.item_id),
+      staging_prefix: keys.staging_prefix_for(owner_id),
+      build_data_key: (checksum) => keys.data_key(owner_id, checksum),
+    },
+  );
 
   return {
     checksum: result.checksum,
@@ -124,10 +130,16 @@ async function open_version_stream(
  * upload that failed part way left the download running with nobody reading it (issue #344). The
  * `finally` runs on a consumer failure, an early `break` and normal completion alike.
  */
-async function* tag_source_errors(chunks: AsyncIterable<Buffer>): AsyncGenerator<Buffer> {
+async function* tag_source_errors(
+  chunks: AsyncIterable<Buffer>,
+  abort_signal?: AbortSignal,
+): AsyncGenerator<Buffer> {
   const iterator = chunks[Symbol.asyncIterator]();
   try {
     while (true) {
+      // The Graph client takes no signal, so cancellation lands here instead: throwing runs the
+      // `finally` below, which closes the stream and drops the connection (issue #344).
+      abort_signal?.throwIfAborted();
       let next: IteratorResult<Buffer>;
       try {
         next = await iterator.next();
@@ -138,6 +150,7 @@ async function* tag_source_errors(chunks: AsyncIterable<Buffer>): AsyncGenerator
       yield next.value;
     }
   } finally {
-    await iterator.return?.();
+    // Best effort: closing the source must not replace the failure that got us here.
+    await iterator.return?.().catch(() => undefined);
   }
 }

--- a/packages/drive/src/versioning/version-sync.ts
+++ b/packages/drive/src/versioning/version-sync.ts
@@ -102,6 +102,7 @@ export async function sync_file_versions(
   snapshot_id: string,
   ctx: TenantContext,
   watermark: DriveVersionWatermark | string | undefined,
+  abort_signal?: AbortSignal,
 ): Promise<VersionSyncOutcome> {
   const versions = await connector.list_file_versions(item.drive_id, item.item_id);
   if (versions.length === 0) return empty_outcome();
@@ -115,6 +116,7 @@ export async function sync_file_versions(
     ctx,
     versions,
     watermark,
+    abort_signal,
   );
   if (outcome.new_versions_stored > 0) {
     logger.info(
@@ -134,6 +136,7 @@ async function capture_new_versions(
   ctx: TenantContext,
   versions: readonly DriveFileVersion[],
   watermark: DriveVersionWatermark | string | undefined,
+  abort_signal?: AbortSignal,
 ): Promise<VersionSyncOutcome> {
   const totals: VersionSyncResult = {
     new_versions_stored: 0,
@@ -158,6 +161,7 @@ async function capture_new_versions(
       snapshot_id,
       ctx,
       version,
+      abort_signal,
     );
     // Not `||=`: that short-circuits once blocked and would stop tallying the remaining versions
     // entirely.
@@ -221,11 +225,23 @@ async function capture_version(
   snapshot_id: string,
   ctx: TenantContext,
   version: DriveFileVersion,
+  abort_signal?: AbortSignal,
 ): Promise<VersionCapture> {
   let stored: StoredVersionContent;
   try {
-    stored = await store_version_content(keys, connector, item, owner_id, ctx, version);
+    stored = await store_version_content(
+      keys,
+      connector,
+      item,
+      owner_id,
+      ctx,
+      version,
+      abort_signal,
+    );
   } catch (err) {
+    // A cancelled run is not a version that failed to download: recording it as failed would block
+    // the watermark and re-fetch it next run for no reason (issue #344).
+    if (abort_signal?.aborted === true) throw err;
     if (!(err instanceof VersionDownloadError)) throw err;
     if (is_content_gone_error(err.source)) {
       logger.debug(

--- a/packages/drive/tests/unit/backup/whole-file-stream.test.ts
+++ b/packages/drive/tests/unit/backup/whole-file-stream.test.ts
@@ -38,6 +38,29 @@ function stalling_response(signal_holder: { signal: AbortSignal | undefined }): 
   } as unknown as Response;
 }
 
+/** A body that refuses to produce another part once its request was aborted, as fetch does. */
+function abort_aware_response(
+  signal_holder: { signal: AbortSignal | undefined },
+  parts: Buffer[],
+): Response {
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+        for (const part of parts) {
+          if (signal_holder.signal?.aborted === true) {
+            throw signal_holder.signal.reason instanceof Error
+              ? signal_holder.signal.reason
+              : new Error('The operation was aborted');
+          }
+          yield new Uint8Array(part);
+        }
+      },
+    },
+  } as unknown as Response;
+}
+
 async function collect(response: Response, stall_timeout_ms = 30_000): Promise<Buffer[]> {
   vi.stubGlobal(
     'fetch',
@@ -135,5 +158,106 @@ describe('stream_whole_file_in_chunks', () => {
     await expect(
       collect({ ok: false, status: 403, body: undefined } as unknown as Response),
     ).rejects.toThrow(/HTTP 403/);
+  });
+
+  it('does not abort while the consumer is holding a chunk', async () => {
+    // The timer bounds the network, not the pipeline behind it. A consumer that spends longer than
+    // the stall budget encrypting and uploading a chunk used to look like a server that stopped
+    // sending (issue #344).
+    vi.useFakeTimers();
+    const holder: { signal: AbortSignal | undefined } = { signal: undefined };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((_url: string, init?: { signal?: AbortSignal }) => {
+        holder.signal = init?.signal;
+        return Promise.resolve(
+          abort_aware_response(holder, [Buffer.alloc(CHUNK_SIZE, 7), Buffer.alloc(1024, 8)]),
+        );
+      }),
+    );
+
+    const parts: number[] = [];
+    for await (const chunk of stream_whole_file_in_chunks('https://cdn.test/file', 'item-1', {
+      chunk_size_bytes: CHUNK_SIZE,
+      stall_timeout_ms: 30_000,
+    })) {
+      parts.push(chunk.length);
+      await vi.advanceTimersByTimeAsync(90_000);
+    }
+
+    // The body refuses to produce another part once its request was aborted, so a second chunk
+    // arriving after three stall budgets spent in the consumer is the proof.
+    expect(parts).toEqual([CHUNK_SIZE, 1024]);
+  });
+
+  it('ends the request when the consumer stops early', async () => {
+    const holder: { signal: AbortSignal | undefined } = { signal: undefined };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((_url: string, init?: { signal?: AbortSignal }) => {
+        holder.signal = init?.signal;
+        return Promise.resolve(
+          abort_aware_response(holder, [Buffer.alloc(CHUNK_SIZE, 1), Buffer.alloc(CHUNK_SIZE, 2)]),
+        );
+      }),
+    );
+
+    for await (const _ of stream_whole_file_in_chunks('https://cdn.test/file', 'item-1', {
+      chunk_size_bytes: CHUNK_SIZE,
+      stall_timeout_ms: 30_000,
+    })) {
+      void _;
+      break;
+    }
+
+    // Without this the rest of the body keeps arriving for a consumer that has gone.
+    expect(holder.signal?.aborted).toBe(true);
+  });
+
+  it('does not open a request for a run that is already cancelled', async () => {
+    const fetch_spy = vi.fn();
+    vi.stubGlobal('fetch', fetch_spy);
+
+    await expect(
+      (async () => {
+        for await (const _ of stream_whole_file_in_chunks('https://cdn.test/file', 'item-1', {
+          chunk_size_bytes: CHUNK_SIZE,
+          stall_timeout_ms: 30_000,
+          abort_signal: AbortSignal.abort(),
+        })) {
+          void _;
+        }
+      })(),
+    ).rejects.toThrow();
+    expect(fetch_spy).not.toHaveBeenCalled();
+  });
+
+  it('ends a body already arriving when the run is cancelled', async () => {
+    const cancel = new AbortController();
+    const holder: { signal: AbortSignal | undefined } = { signal: undefined };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((_url: string, init?: { signal?: AbortSignal }) => {
+        holder.signal = init?.signal;
+        return Promise.resolve(
+          abort_aware_response(holder, [Buffer.alloc(CHUNK_SIZE, 1), Buffer.alloc(CHUNK_SIZE, 2)]),
+        );
+      }),
+    );
+
+    await expect(
+      (async () => {
+        for await (const chunk of stream_whole_file_in_chunks('https://cdn.test/file', 'item-1', {
+          chunk_size_bytes: CHUNK_SIZE,
+          stall_timeout_ms: 30_000,
+          abort_signal: cancel.signal,
+        })) {
+          void chunk;
+          // Cancelled while the transfer is running, which is the case the interruption predicate
+          // could only answer once this item had finished.
+          cancel.abort(new Error('run cancelled'));
+        }
+      })(),
+    ).rejects.toThrow(/cancelled|aborted/);
   });
 });

--- a/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
@@ -44,11 +44,15 @@ export async function* fetch_file_chunks(
   download_url: string,
   total_bytes: number,
   item_id: string,
+  abort_signal?: AbortSignal,
 ): AsyncGenerator<Buffer> {
   const chunk_count = Math.ceil(total_bytes / CHUNK_SIZE_BYTES);
   let yielded_chunks = 0;
 
   for (let i = 0; i < chunk_count; i++) {
+    // Cheap between chunks, and the signal also reaches the request itself below, so a cancelled
+    // run neither starts the next chunk nor waits out the one in flight (issue #344).
+    abort_signal?.throwIfAborted();
     const range_start = i * CHUNK_SIZE_BYTES;
     const range_end = Math.min(range_start + CHUNK_SIZE_BYTES - 1, total_bytes - 1);
     const expected_length = range_end - range_start + 1;
@@ -65,6 +69,7 @@ export async function* fetch_file_chunks(
         chunk_count,
         total_bytes,
         chunk_count > 1,
+        abort_signal,
       );
     } catch (err) {
       if (!(err instanceof RangeIgnoredError)) throw err;
@@ -86,6 +91,7 @@ export async function* fetch_file_chunks(
           `falling back to one streamed download`,
       );
       yield* stream_whole_file_in_chunks(download_url, item_id, {
+        abort_signal,
         chunk_size_bytes: CHUNK_SIZE_BYTES,
         // Same per-chunk budget the Range path uses, applied between reads rather than to the
         // whole transfer, so a stalled body is cut off but a slow one is not (issue #198).
@@ -125,6 +131,7 @@ async function download_chunk_with_retry(
   total_chunks: number,
   total_bytes: number,
   report_ignored_range: boolean,
+  abort_signal?: AbortSignal,
 ): Promise<Buffer> {
   for (let attempt = 0; attempt <= MAX_CHUNK_RETRIES; attempt++) {
     try {
@@ -136,6 +143,7 @@ async function download_chunk_with_retry(
         item_id,
         total_bytes,
         report_ignored_range,
+        abort_signal,
       );
     } catch (err) {
       // Not retryable and not a failure: the caller switches strategy on it.
@@ -147,6 +155,8 @@ async function download_chunk_with_retry(
         );
       }
 
+      // Backing off is waiting, and a cancelled run has no reason to wait.
+      abort_signal?.throwIfAborted();
       const cdn_retry_after = extract_cdn_retry_after_from_error(err);
       const delay = cdn_retry_after ?? compute_retry_delay(attempt);
       logger.debug(
@@ -179,6 +189,7 @@ async function download_single_chunk(
   item_id: string,
   total_bytes: number,
   report_ignored_range: boolean,
+  abort_signal?: AbortSignal,
 ): Promise<Buffer> {
   // Scaled to this chunk, not to the file. Passing total_bytes here gave every
   // non-final chunk a ceil(total_bytes / 256) ms budget, so one stalled CDN
@@ -189,7 +200,10 @@ async function download_single_chunk(
   try {
     const response = await fetch(url, {
       headers: { Range: `bytes=${range_start}-${range_end}` },
-      signal: controller.signal,
+      signal:
+        abort_signal === undefined
+          ? controller.signal
+          : AbortSignal.any([controller.signal, abort_signal]),
     });
 
     if (response.status === 429) {

--- a/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts
@@ -146,6 +146,10 @@ async function download_chunk_with_retry(
         abort_signal,
       );
     } catch (err) {
+      // A cancelled run is not a chunk failure. Checked before the classification below, which
+      // would otherwise relabel the abort as `Failed chunk ...` and have it recorded against the
+      // item (issue #344).
+      abort_signal?.throwIfAborted();
       // Not retryable and not a failure: the caller switches strategy on it.
       if (err instanceof RangeIgnoredError) throw err;
       if (!is_cdn_retryable(err) || attempt === MAX_CHUNK_RETRIES) {
@@ -155,15 +159,15 @@ async function download_chunk_with_retry(
         );
       }
 
-      // Backing off is waiting, and a cancelled run has no reason to wait.
-      abort_signal?.throwIfAborted();
       const cdn_retry_after = extract_cdn_retry_after_from_error(err);
       const delay = cdn_retry_after ?? compute_retry_delay(attempt);
       logger.debug(
         `Chunk ${chunk_index}/${total_chunks} retry ${attempt + 1}/${MAX_CHUNK_RETRIES} ` +
           `for ${item_id} in ${(delay / 1000).toFixed(1)}s`,
       );
-      await sleep(delay);
+      // Rejects with the abort reason, so a run cancelled during a 30 second backoff stops
+      // there rather than waiting the delay out (issue #344).
+      await sleep(delay, abort_signal);
     }
   }
 
@@ -196,14 +200,16 @@ async function download_single_chunk(
   // connection held a 1 GB backup for ~68 minutes before aborting (issue #198).
   const controller = new AbortController();
   let timer = setTimeout(() => controller.abort(), compute_chunk_timeout_ms(expected_length));
+  // One listener, removed below, rather than `AbortSignal.any` per chunk: the run's signal outlives
+  // every chunk, and Node keeps a dependent entry for each composite until the source aborts, which
+  // is 256 of them per GiB transferred (issue #344).
+  const cancel_chunk = (): void => controller.abort(abort_signal?.reason);
+  abort_signal?.addEventListener('abort', cancel_chunk, { once: true });
 
   try {
     const response = await fetch(url, {
       headers: { Range: `bytes=${range_start}-${range_end}` },
-      signal:
-        abort_signal === undefined
-          ? controller.signal
-          : AbortSignal.any([controller.signal, abort_signal]),
+      signal: controller.signal,
     });
 
     if (response.status === 429) {
@@ -261,6 +267,7 @@ async function download_single_chunk(
     return buf;
   } finally {
     clearTimeout(timer);
+    abort_signal?.removeEventListener('abort', cancel_chunk);
   }
 }
 
@@ -282,6 +289,23 @@ function compute_retry_delay(attempt: number): number {
   return Math.min(base + jitter, CHUNK_MAX_DELAY_MS);
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * Waits, unless the run is cancelled first.
+ *
+ * `node:timers/promises` would do this in one line, but it is invisible to the fake timers the
+ * retry tests drive, and a backoff nobody can fast-forward is a five second unit test.
+ */
+async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const on_abort = (): void => {
+    clearTimeout(timer);
+    reject(signal?.reason instanceof Error ? signal.reason : new Error('The run was cancelled'));
+  };
+  const timer = setTimeout(() => {
+    signal?.removeEventListener('abort', on_abort);
+    resolve();
+  }, ms);
+  signal?.addEventListener('abort', on_abort, { once: true });
+  await promise;
 }

--- a/packages/onedrive/src/services/backup/backup-drive-processor.ts
+++ b/packages/onedrive/src/services/backup/backup-drive-processor.ts
@@ -301,6 +301,7 @@ export async function process_single_drive(
       version_stats,
       on_version_stats_update,
       versions,
+      control.abort_signal,
     );
     // Progress rows were sized from the delta batch; retried items are extra.
     if (from_delta) on_item_processed?.(item);

--- a/packages/onedrive/src/services/backup/backup-drive-processor.ts
+++ b/packages/onedrive/src/services/backup/backup-drive-processor.ts
@@ -20,9 +20,14 @@ import type { PackageReport } from '@wisecom/atlas-core/services/shared/package-
 import {
   clear_file_tracking_on_reset,
   process_delta_item,
+  type DeltaItemOutcome,
   type DriveTrackingState,
   type VersionStats,
 } from '@/services/backup/delta-item-processor';
+import {
+  apply_item_outcome,
+  record_item_outcome_failure,
+} from '@/services/backup/drive-item-outcome';
 import { resolve_retry_items } from '@/services/backup/failed-item-retry';
 import { scoped_delta } from '@/services/backup/folder-scope';
 import type { RunVersionCollector } from '@/services/versioning/version-sync';
@@ -291,41 +296,38 @@ export async function process_single_drive(
       delete result.delta_link;
       break;
     }
-    const outcome = await process_delta_item(
-      connector,
-      item,
-      owner_id,
-      snapshot_id,
-      ctx,
-      state,
-      version_stats,
-      on_version_stats_update,
-      versions,
-      control.abort_signal,
-    );
+    let outcome: DeltaItemOutcome;
+    try {
+      outcome = await process_delta_item(
+        connector,
+        item,
+        owner_id,
+        snapshot_id,
+        ctx,
+        state,
+        version_stats,
+        on_version_stats_update,
+        versions,
+        control.abort_signal,
+      );
+    } catch (err) {
+      // A cancelled transfer is the run stopping, not the item failing. Recording it would spend
+      // one of the item's five ledger attempts and eventually skip the file for good (issue #344).
+      if (control.abort_signal?.aborted !== true) throw err;
+      result.interrupted = true;
+      delete result.delta_link;
+      break;
+    }
     // Progress rows were sized from the delta batch; retried items are extra.
     if (from_delta) on_item_processed?.(item);
     if (from_delta) processed_delta_item_ids.add(item.item_id);
 
     if (outcome.error) {
-      logger.warn(`Drive ${drive.drive_id}: ${outcome.error}`);
-      result.errors.push(outcome.error);
-      failed_item_ids.add(item.item_id);
-      result.failed_items = record_item_failure(result.failed_items, {
-        item_id: item.item_id,
-        drive_id: drive.drive_id,
-        name: item.file_name,
-        reason: outcome.error,
-        ...(outcome.permanent === true ? { permanent: true } : {}),
-      });
+      record_item_outcome_failure(result, failed_item_ids, drive.drive_id, item, outcome);
       continue;
     }
 
-    result.failed_items = clear_item_failure(result.failed_items, item.item_id);
-    result.files_stored += outcome.files_stored;
-    result.files_deduplicated += outcome.files_deduplicated;
-    result.deleted_items += outcome.deleted_items;
-    if (outcome.entry) result.entries.push(outcome.entry);
+    apply_item_outcome(result, item, outcome);
   }
 
   result.package_report = summarize_processed_package_items(

--- a/packages/onedrive/src/services/backup/backup-file-processor.ts
+++ b/packages/onedrive/src/services/backup/backup-file-processor.ts
@@ -13,8 +13,16 @@ export async function process_backup_file(
   item: OneDriveDeltaItem,
   owner_id: string,
   ctx: TenantContext,
+  abort_signal?: AbortSignal,
 ): Promise<FileProcessResult | undefined> {
-  return process_drive_backup_file(ONEDRIVE_LARGE_FILE_DEPS, connector, item, owner_id, ctx);
+  return process_drive_backup_file(
+    ONEDRIVE_LARGE_FILE_DEPS,
+    connector,
+    item,
+    owner_id,
+    ctx,
+    abort_signal,
+  );
 }
 
 /** @throws Error when no drives are returned (likely missing Graph permissions). */

--- a/packages/onedrive/src/services/backup/delta-item-processor.ts
+++ b/packages/onedrive/src/services/backup/delta-item-processor.ts
@@ -140,6 +140,7 @@ export async function process_delta_item(
       snapshot_id,
       ctx,
       versions.watermarks[item.item_id],
+      abort_signal,
     );
     collect_run_versions(versions, item.item_id, version_result);
     accumulate_version_stats(version_result, version_stats, on_version_stats_update);

--- a/packages/onedrive/src/services/backup/delta-item-processor.ts
+++ b/packages/onedrive/src/services/backup/delta-item-processor.ts
@@ -80,6 +80,7 @@ export async function process_delta_item(
   version_stats: VersionStats,
   on_version_stats_update: (stored: number, unavailable: number, failed: number) => void,
   versions: RunVersionCollector,
+  abort_signal?: AbortSignal,
 ): Promise<DeltaItemOutcome> {
   const effective_kind =
     item.deleted && item.kind === 'file' && state.previous_kind_by_file_id[item.item_id]
@@ -127,7 +128,7 @@ export async function process_delta_item(
     };
   }
 
-  const download = await download_or_record_refusal(connector, item, owner_id, ctx);
+  const download = await download_or_record_refusal(connector, item, owner_id, ctx, abort_signal);
   if (download.outcome) return download.outcome;
   const result = download.result;
 
@@ -168,13 +169,14 @@ async function download_or_record_refusal(
   item: OneDriveDeltaItem,
   owner_id: string,
   ctx: TenantContext,
+  abort_signal?: AbortSignal,
 ): Promise<
   | { outcome: DeltaItemOutcome; result?: undefined }
   | { outcome?: undefined; result: NonNullable<Awaited<ReturnType<typeof process_backup_file>>> }
 > {
   const empty = { files_stored: 0, files_deduplicated: 0, deleted_items: 0 };
   try {
-    const result = await process_backup_file(connector, item, owner_id, ctx);
+    const result = await process_backup_file(connector, item, owner_id, ctx, abort_signal);
     if (result) return { result };
     return {
       outcome: { ...empty, error: `Failed to process file ${item.file_name} (${item.item_id})` },

--- a/packages/onedrive/src/services/backup/drive-item-outcome.ts
+++ b/packages/onedrive/src/services/backup/drive-item-outcome.ts
@@ -1,0 +1,42 @@
+import {
+  clear_item_failure,
+  record_item_failure,
+} from '@wisecom/atlas-core/services/shared/failed-item-ledger';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+import type { OneDriveDeltaItem } from '@wisecom/atlas-types';
+import type { DeltaItemOutcome } from '@/services/backup/delta-item-processor';
+import type { SingleDriveResult } from '@/services/backup/backup-drive-processor';
+
+/** Records one item's failure against the run and the ledger it is retried from. */
+export function record_item_outcome_failure(
+  result: SingleDriveResult,
+  failed_item_ids: Set<string>,
+  drive_id: string,
+  item: OneDriveDeltaItem,
+  outcome: DeltaItemOutcome,
+): void {
+  const reason = outcome.error ?? 'unknown failure';
+  logger.warn(`Drive ${drive_id}: ${reason}`);
+  result.errors.push(reason);
+  failed_item_ids.add(item.item_id);
+  result.failed_items = record_item_failure(result.failed_items, {
+    item_id: item.item_id,
+    drive_id,
+    name: item.file_name,
+    reason,
+    ...(outcome.permanent === true ? { permanent: true } : {}),
+  });
+}
+
+/** Folds one successful item into the drive's running totals and clears its ledger entry. */
+export function apply_item_outcome(
+  result: SingleDriveResult,
+  item: OneDriveDeltaItem,
+  outcome: DeltaItemOutcome,
+): void {
+  result.failed_items = clear_item_failure(result.failed_items, item.item_id);
+  result.files_stored += outcome.files_stored;
+  result.files_deduplicated += outcome.files_deduplicated;
+  result.deleted_items += outcome.deleted_items;
+  if (outcome.entry) result.entries.push(outcome.entry);
+}

--- a/packages/onedrive/src/services/versioning/version-sync.ts
+++ b/packages/onedrive/src/services/versioning/version-sync.ts
@@ -25,6 +25,7 @@ export async function sync_file_versions(
   snapshot_id: string,
   ctx: TenantContext,
   watermark: OneDriveVersionWatermark | string | undefined,
+  abort_signal?: AbortSignal,
 ): Promise<VersionSyncOutcome> {
   return sync_drive_file_versions(
     ONEDRIVE_KEYS,
@@ -34,5 +35,6 @@ export async function sync_file_versions(
     snapshot_id,
     ctx,
     watermark,
+    abort_signal,
   );
 }

--- a/packages/onedrive/tests/unit/adapters/download-cancellation.test.ts
+++ b/packages/onedrive/tests/unit/adapters/download-cancellation.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CHUNK_SIZE_BYTES, fetch_file_chunks } from '@/adapters/graph-onedrive-chunked-download';
+
+/**
+ * Issue #344: cancellation was a predicate services polled between items, so a cancelled run still
+ * finished whatever download it was in the middle of. A multi-gigabyte item held it for minutes.
+ */
+
+const URL = 'https://cdn.test/item';
+
+/** A CDN that answers Range requests, and fails the read once its request was aborted. */
+function stub_cdn(): { requests: () => number } {
+  let requests = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async (
+        _url: string,
+        init: { headers: { Range: string }; signal?: AbortSignal },
+      ): Promise<Response> => {
+        requests++;
+        init.signal?.throwIfAborted();
+        const [, start, end] = /bytes=(\d+)-(\d+)/.exec(init.headers.Range)!;
+        const body = Buffer.alloc(Number(end) - Number(start) + 1, 1);
+        return {
+          status: 206,
+          headers: {
+            get: (name: string): string | null =>
+              name.toLowerCase() === 'content-range' ? `bytes ${start}-${end}/*` : null,
+          },
+          arrayBuffer: async () => {
+            init.signal?.throwIfAborted();
+            return body.buffer.slice(0, body.length);
+          },
+        } as unknown as Response;
+      },
+    ),
+  );
+  return { requests: () => requests };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('chunked download cancellation (issue #344)', () => {
+  it('stops between chunks when the run is cancelled', async () => {
+    const cdn = stub_cdn();
+    const cancel = new AbortController();
+
+    await expect(
+      (async () => {
+        for await (const chunk of fetch_file_chunks(
+          URL,
+          CHUNK_SIZE_BYTES * 4,
+          'item-1',
+          cancel.signal,
+        )) {
+          void chunk;
+          cancel.abort(new Error('run cancelled'));
+        }
+      })(),
+    ).rejects.toThrow(/cancelled/);
+
+    // One chunk fetched, and the three that would have followed were never asked for.
+    expect(cdn.requests()).toBe(1);
+  });
+
+  it('never opens a request for a run cancelled before it started', async () => {
+    const cdn = stub_cdn();
+
+    await expect(
+      (async () => {
+        for await (const chunk of fetch_file_chunks(
+          URL,
+          CHUNK_SIZE_BYTES * 2,
+          'item-1',
+          AbortSignal.abort(),
+        )) {
+          void chunk;
+        }
+      })(),
+    ).rejects.toThrow();
+
+    expect(cdn.requests()).toBe(0);
+  });
+});

--- a/packages/onedrive/tests/unit/services/backup/cancelled-item-not-ledgered.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/cancelled-item-not-ledgered.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TenantContext } from '@wisecom/atlas-types';
+import { process_drive_backup_file } from '@wisecom/atlas-drive/backup/file-processor';
+import type { DriveContentConnector, DriveDeltaItem } from '@wisecom/atlas-drive/drive-ports';
+import type { DriveLargeFileDeps } from '@wisecom/atlas-drive/backup/large-file-pipeline';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+import { LARGE_FILE_THRESHOLD } from '@wisecom/atlas-drive/backup/large-file-threshold';
+
+/**
+ * Issue #344: once the download became abortable, a cancelled transfer looked exactly like a file
+ * that would not download. Both providers write that into the failed-item ledger with an
+ * incremented attempt count, five attempts exhaust the budget, and delta never re-presents an
+ * unchanged item, so cancelling a run five times could skip a large file permanently.
+ */
+
+const ITEM = {
+  item_id: 'item-1',
+  drive_id: 'drive-1',
+  file_name: 'Report.bin',
+  parent_path: '/Documents',
+  size_bytes: LARGE_FILE_THRESHOLD,
+  kind: 'file',
+  download_url: 'https://cdn.test/item-1',
+} as DriveDeltaItem;
+
+const KEYS = {
+  data_key: (owner_id: string, checksum: string) => `onedrive/data/${owner_id}/${checksum}`,
+  staging_key: (owner_id: string, item_id: string) => `onedrive/staging/${owner_id}/${item_id}`,
+  staging_prefix_for: (owner_id: string) => `onedrive/staging/${owner_id}/`,
+};
+
+/** A chunk source that fails the way an aborted fetch does, part way through the file. */
+function deps_failing_with(reason: Error): DriveLargeFileDeps {
+  return {
+    keys: KEYS,
+    fetch_chunks: () => ({
+      async *[Symbol.asyncIterator](): AsyncGenerator<Buffer> {
+        yield Buffer.alloc(1024, 1);
+        throw reason;
+      },
+    }),
+  } as unknown as DriveLargeFileDeps;
+}
+
+function make_ctx(): TenantContext {
+  return {
+    storage: {
+      begin_multipart_upload: vi.fn(async () => ({
+        upload_part: vi.fn(async () => 'etag'),
+        complete: vi.fn(async () => undefined),
+        abort: vi.fn(async () => undefined),
+      })),
+      abort_incomplete_uploads: vi.fn(async () => 0),
+      exists: vi.fn(async () => false),
+    },
+    create_cipher: stub_tenant_create_cipher,
+  } as unknown as TenantContext;
+}
+
+const CONNECTOR = {
+  resolve_download_url: vi.fn(async () => 'https://cdn.test/item-1'),
+} as unknown as DriveContentConnector & { resolve_download_url: () => Promise<string> };
+
+describe('a cancelled large-file download (issue #344)', () => {
+  it('reaches the caller instead of being reported as a file that could not be downloaded', async () => {
+    const cancel = new AbortController();
+    cancel.abort(new Error('run cancelled'));
+
+    await expect(
+      process_drive_backup_file(
+        deps_failing_with(new Error('run cancelled')),
+        CONNECTOR,
+        ITEM,
+        'owner-1',
+        make_ctx(),
+        cancel.signal,
+      ),
+    ).rejects.toThrow(/run cancelled/);
+  });
+
+  it('still reports a genuine download failure as a skip the ledger can record', async () => {
+    const result = await process_drive_backup_file(
+      deps_failing_with(new Error('the CDN closed the connection')),
+      CONNECTOR,
+      ITEM,
+      'owner-1',
+      make_ctx(),
+    );
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/onedrive/tests/unit/services/backup/large-file-pipeline.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/large-file-pipeline.test.ts
@@ -108,6 +108,7 @@ describe('process_large_file', () => {
       'https://cdn.example/abc',
       ITEM_BYTES,
       'item-1',
+      undefined,
     );
   });
 

--- a/packages/onedrive/tests/unit/services/backup/version-source-close.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/version-source-close.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TenantContext } from '@wisecom/atlas-types';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+import { store_version_content } from '@wisecom/atlas-drive/versioning/version-content-store';
+import { LARGE_FILE_THRESHOLD } from '@wisecom/atlas-drive/backup/large-file-threshold';
+import type {
+  DriveContentConnector,
+  DriveDeltaItem,
+  DriveFileVersion,
+} from '@wisecom/atlas-drive/drive-ports';
+import type { DriveStorageKeys } from '@wisecom/atlas-drive/shared/storage-keys';
+
+/**
+ * Issue #344: the version upload drives its source iterator by hand, so the `for await` inside the
+ * uploader never closed it. An upload that failed part way left the download running with nobody
+ * reading it, holding a Graph connection until the socket timed out.
+ *
+ * It lives in the OneDrive package because the drive package's test aliases cannot resolve core
+ * source imported through the module under test.
+ */
+
+const PART_SIZE = 8 * 1024 * 1024;
+const SOURCE_CHUNK = 4 * 1024 * 1024;
+
+const KEYS: DriveStorageKeys = {
+  data_key: (owner_id: string, checksum: string) => `onedrive/data/${owner_id}/${checksum}`,
+  staging_key: (owner_id: string, item_id: string) => `onedrive/staging/${owner_id}/${item_id}`,
+  staging_prefix_for: (owner_id: string) => `onedrive/staging/${owner_id}/`,
+} as unknown as DriveStorageKeys;
+
+const ITEM = { item_id: 'item-1', drive_id: 'drive-1', file_name: 'Report.bin' } as DriveDeltaItem;
+const VERSION = {
+  version_id: 'v2',
+  size_bytes: LARGE_FILE_THRESHOLD,
+} as DriveFileVersion;
+
+/** A version body that records whether the consumer closed it. */
+function tracked_source(chunk_count: number): {
+  connector: DriveContentConnector;
+  closed: () => boolean;
+  produced: () => number;
+} {
+  let closed = false;
+  let produced = 0;
+  const chunks = {
+    async *[Symbol.asyncIterator](): AsyncGenerator<Buffer> {
+      try {
+        for (let index = 0; index < chunk_count; index++) {
+          produced++;
+          yield Buffer.alloc(SOURCE_CHUNK, index);
+        }
+      } finally {
+        closed = true;
+      }
+    },
+  };
+  return {
+    connector: {
+      stream_file_version: vi.fn(async () => chunks),
+    } as unknown as DriveContentConnector,
+    closed: () => closed,
+    produced: () => produced,
+  };
+}
+
+/** A storage whose multipart upload refuses the first part it is given. */
+function failing_upload_ctx(): TenantContext {
+  return {
+    storage: {
+      begin_multipart_upload: vi.fn(async () => ({
+        upload_part: vi.fn(async () => {
+          throw new Error('the bucket refused the part');
+        }),
+        complete: vi.fn(async () => undefined),
+        abort: vi.fn(async () => undefined),
+      })),
+      abort_incomplete_uploads: vi.fn(async () => 0),
+      exists: vi.fn(async () => false),
+    },
+    create_cipher: stub_tenant_create_cipher,
+  } as unknown as TenantContext;
+}
+
+describe('version content source lifetime (issue #344)', () => {
+  it('closes the download when the upload fails part way', async () => {
+    // Five chunks is more than the two parts it takes to reach the first upload_part call, so the
+    // source is still producing when the storage failure arrives.
+    const source = tracked_source(5);
+
+    await expect(
+      store_version_content(KEYS, source.connector, ITEM, 'owner-1', failing_upload_ctx(), VERSION),
+    ).rejects.toThrow(/refused the part/);
+
+    expect(source.closed()).toBe(true);
+    expect(source.produced()).toBeLessThan(5);
+    expect(source.produced() * SOURCE_CHUNK).toBeGreaterThanOrEqual(PART_SIZE);
+  });
+});

--- a/packages/onedrive/tests/unit/services/save/authentication-failure.test.ts
+++ b/packages/onedrive/tests/unit/services/save/authentication-failure.test.ts
@@ -21,13 +21,18 @@ import type {
  * and no integrity failures. Nothing in the result said a file had failed to authenticate.
  */
 
-vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
+vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', async (import_original) => {
+  const actual =
+    await import_original<
+      typeof import('@wisecom/atlas-core/services/shared/file-save-zip-writer')
+    >();
   const archive = {
     append: vi.fn(),
     finalize: vi.fn().mockResolvedValue(undefined),
     pointer: vi.fn().mockReturnValue(4096),
   };
   return {
+    ...actual,
     create_file_archive: vi.fn().mockReturnValue({
       archive,
       promise: Promise.resolve(4096),

--- a/packages/onedrive/tests/unit/services/save/dead-destination.test.ts
+++ b/packages/onedrive/tests/unit/services/save/dead-destination.test.ts
@@ -1,0 +1,157 @@
+import { createHash } from 'node:crypto';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Container } from 'inversify';
+import 'reflect-metadata';
+import { ArchiveDestinationError } from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
+import { add_file_to_archive } from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
+import {
+  ONEDRIVE_MANIFEST_REPOSITORY_TOKEN,
+  TENANT_CONTEXT_FACTORY_TOKEN,
+} from '@wisecom/atlas-types';
+import type {
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveSaveService } from '@/services/save/save.service';
+
+/**
+ * Issue #344: a consumer that disconnects mid-export takes the destination with it, and every
+ * remaining entry was still downloaded and decrypted before its append failed. The run has nowhere
+ * to put the bytes, so it stops at the first entry that cannot be written.
+ */
+
+vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', async (import_original) => {
+  const actual =
+    await import_original<
+      typeof import('@wisecom/atlas-core/services/shared/file-save-zip-writer')
+    >();
+  const archive = {
+    append: vi.fn(),
+    finalize: vi.fn().mockResolvedValue(undefined),
+    pointer: vi.fn().mockReturnValue(4096),
+  };
+  return {
+    ...actual,
+    create_file_archive: vi.fn().mockReturnValue({
+      archive,
+      promise: Promise.resolve(4096),
+      drain: vi.fn().mockResolvedValue(undefined),
+      publish: vi.fn().mockResolvedValue(undefined),
+      abort: vi.fn().mockResolvedValue(undefined),
+    }),
+    add_file_to_archive: vi.fn(),
+    finalize_file_archive: vi.fn().mockResolvedValue(undefined),
+  };
+});
+vi.mock('@wisecom/atlas-core/utils/zone-identifier', () => ({
+  mark_downloaded_from_internet: vi.fn().mockResolvedValue(undefined),
+}));
+
+const CONTENT = 'ciphertext';
+const CHECKSUM = createHash('sha256').update(CONTENT).digest('hex');
+
+function make_entry(file_id: string): OneDriveManifestEntry {
+  return {
+    file_id,
+    drive_id: 'drive-1',
+    file_name: `${file_id}.docx`,
+    parent_path: '/Documents',
+    size_bytes: 2048,
+    change_type: 'updated',
+    backup_at: '2026-03-15T10:00:00.000Z',
+    storage_key: `onedrive/data/owner-1/${file_id}`,
+    checksum: CHECKSUM,
+  } as OneDriveManifestEntry;
+}
+
+function make_service(entries: OneDriveManifestEntry[]): {
+  service: OneDriveSaveService;
+  reads: () => string[];
+} {
+  const reads: string[] = [];
+  const ctx = {
+    storage: {
+      get: vi.fn(async (key: string) => {
+        reads.push(key);
+        return Buffer.from(CONTENT);
+      }),
+      put: vi.fn(),
+      exists: vi.fn(),
+      delete: vi.fn(),
+    },
+    decrypt: vi.fn((buf: Buffer) => buf),
+    encrypt: vi.fn((buf: Buffer) => buf),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const manifest: OneDriveSnapshotManifest = {
+    id: 'manifest-od-1',
+    tenant_id: 'tenant-1',
+    snapshot_id: 'od-snap-1',
+    owner_id: 'owner-1',
+    created_at: new Date('2026-03-15T10:00:00Z'),
+    total_files: entries.length,
+    total_size_bytes: entries.reduce((sum, entry) => sum + entry.size_bytes, 0),
+    entries,
+  };
+
+  const container = new Container();
+  container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue({
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+    create_storage_only: vi.fn().mockResolvedValue(ctx),
+  } as unknown as TenantContextFactory);
+  container.bind(ONEDRIVE_MANIFEST_REPOSITORY_TOKEN).toConstantValue({
+    find_by_snapshot: vi.fn().mockResolvedValue(manifest),
+    list_snapshots_by_owner: vi.fn().mockResolvedValue([manifest]),
+  } as unknown as OneDriveManifestRepository);
+  container.bind(OneDriveSaveService).toSelf();
+  return { service: container.get(OneDriveSaveService), reads: () => reads };
+}
+
+describe('OneDrive save against a destination that went away (issue #344)', () => {
+  beforeEach(() => {
+    vi.mocked(add_file_to_archive).mockReset();
+  });
+
+  it('stops the run instead of downloading every remaining entry', async () => {
+    const { service, reads } = make_service([
+      make_entry('file-1'),
+      make_entry('file-2'),
+      make_entry('file-3'),
+      make_entry('file-4'),
+    ]);
+    vi.mocked(add_file_to_archive)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValue(new ArchiveDestinationError('The archive destination closed mid-entry'));
+
+    await expect(
+      service.save_snapshot('tenant-1', 'owner-1', {
+        snapshot_id: 'od-snap-1',
+        output_path: '/tmp/save.zip',
+      }),
+    ).rejects.toThrow(/destination closed/);
+
+    // The first two were read, the second failed to append, and nothing after it was fetched.
+    expect(reads()).toEqual(['onedrive/data/owner-1/file-1', 'onedrive/data/owner-1/file-2']);
+  });
+
+  it('still reports a single bad entry and carries on', async () => {
+    const { service, reads } = make_service([make_entry('file-1'), make_entry('file-2')]);
+    vi.mocked(add_file_to_archive)
+      .mockRejectedValueOnce(new Error('one bad entry'))
+      .mockResolvedValue(undefined);
+
+    const result = await service.save_snapshot('tenant-1', 'owner-1', {
+      snapshot_id: 'od-snap-1',
+      output_path: '/tmp/save.zip',
+    });
+
+    expect(result.files_saved).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(reads()).toHaveLength(2);
+  });
+});

--- a/packages/onedrive/tests/unit/services/save/save.service.test.ts
+++ b/packages/onedrive/tests/unit/services/save/save.service.test.ts
@@ -20,13 +20,18 @@ import type {
   TenantContextFactory,
 } from '@wisecom/atlas-types';
 
-vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
+vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', async (import_original) => {
+  const actual =
+    await import_original<
+      typeof import('@wisecom/atlas-core/services/shared/file-save-zip-writer')
+    >();
   const mock_archive = {
     append: vi.fn(),
     finalize: vi.fn().mockResolvedValue(undefined),
     pointer: vi.fn().mockReturnValue(4096),
   };
   return {
+    ...actual,
     create_file_archive: vi.fn().mockReturnValue({
       archive: mock_archive,
       promise: Promise.resolve(4096),

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -127,7 +127,14 @@ export async function save_entries_to_archive(
     };
   } catch (err) {
     // Anything between opening the archive and publishing it can throw. None of it may leave a
-    // partial file behind (issue #307).
+    // partial file behind (issue #307), and the progress stream still owes its subscriber one
+    // terminal event: a destination that went away is now a routine way to get here (issue #344).
+    emit_operation_progress(control, {
+      operation: 'save',
+      workload: 'outlook',
+      phase: 'interrupted',
+      processed: 0,
+    });
     await abort();
     throw err;
   }

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -1,3 +1,4 @@
+import { ArchiveDestinationError } from '@wisecom/atlas-core/services/shared/file-save-zip-writer';
 import { mark_downloaded_from_internet } from '@wisecom/atlas-core/utils/zone-identifier';
 import type { TenantContext } from '@wisecom/atlas-types';
 import type { ManifestEntry } from '@wisecom/atlas-types';
@@ -185,6 +186,9 @@ async function process_folder_entries(
       integrity_fail += result.integrity_fail;
       counters.integrity_failures.push(...result.integrity_failures);
     } catch (err) {
+      // A destination that is gone fails the run rather than every remaining message one at a
+      // time: each would be downloaded and decrypted only to be dropped (issue #344).
+      if (err instanceof ArchiveDestinationError) throw err;
       const msg = err instanceof Error ? err.message : String(err);
       counters.all_errors.push(`${entry.object_id}: ${msg}`);
       error_count++;

--- a/packages/sdk/src/operation-options.ts
+++ b/packages/sdk/src/operation-options.ts
@@ -25,7 +25,7 @@ export function adapt_operation_options<T extends SdkOperationOptions>(
   return {
     ...snakeize(rest),
     ...(on_progress ? { on_progress: isolate_progress_callback(on_progress) } : {}),
-    ...(signal ? { should_interrupt: () => signal.aborted } : {}),
+    ...(signal ? { should_interrupt: () => signal.aborted, abort_signal: signal } : {}),
   } as AdaptedOperationOptions<T>;
 }
 

--- a/packages/sdk/tests/unit/progress-and-cancellation.test.ts
+++ b/packages/sdk/tests/unit/progress-and-cancellation.test.ts
@@ -48,8 +48,12 @@ function expect_adapted_options(
   expect(options).not.toHaveProperty('signal');
   const should_interrupt = options.should_interrupt as () => boolean;
   expect(should_interrupt()).toBe(false);
+  // The predicate answers between items; the signal is what a service hands to a request already
+  // in flight, so both have to arrive (issue #344).
+  expect(options.abort_signal).toBe(controller.signal);
   controller.abort();
   expect(should_interrupt()).toBe(true);
+  expect((options.abort_signal as AbortSignal).aborted).toBe(true);
 }
 
 describe('SDK progress and cancellation option adaptation', () => {

--- a/packages/sharepoint/src/services/backup/backup-file-processor.ts
+++ b/packages/sharepoint/src/services/backup/backup-file-processor.ts
@@ -17,8 +17,16 @@ export async function process_backup_file(
   item: SharePointDeltaItem,
   site_id: string,
   ctx: TenantContext,
+  abort_signal?: AbortSignal,
 ): Promise<FileProcessResult | undefined> {
-  return process_drive_backup_file(SHAREPOINT_LARGE_FILE_DEPS, connector, item, site_id, ctx);
+  return process_drive_backup_file(
+    SHAREPOINT_LARGE_FILE_DEPS,
+    connector,
+    item,
+    site_id,
+    ctx,
+    abort_signal,
+  );
 }
 
 /** @throws Error when no document libraries are returned (likely missing Graph permissions). */

--- a/packages/sharepoint/src/services/backup/backup-library-processor.ts
+++ b/packages/sharepoint/src/services/backup/backup-library-processor.ts
@@ -128,6 +128,7 @@ export async function process_single_library(
     version_stats,
     options.should_interrupt,
     on_item_processed,
+    options.abort_signal,
   );
 
   let processed_delta_items = 0;
@@ -146,6 +147,7 @@ export async function process_single_library(
       library_state,
       versions,
       version_stats,
+      options.abort_signal,
     );
     processed_delta_items++;
     on_item_processed?.(item.file_name);

--- a/packages/sharepoint/src/services/backup/backup-library-processor.ts
+++ b/packages/sharepoint/src/services/backup/backup-library-processor.ts
@@ -137,18 +137,26 @@ export async function process_single_library(
       interrupted = true;
       break;
     }
-    await process_item_guarded(
-      connector,
-      item,
-      site_id,
-      snapshot_id,
-      ctx,
-      tracking,
-      library_state,
-      versions,
-      version_stats,
-      options.abort_signal,
-    );
+    try {
+      await process_item_guarded(
+        connector,
+        item,
+        site_id,
+        snapshot_id,
+        ctx,
+        tracking,
+        library_state,
+        versions,
+        version_stats,
+        options.abort_signal,
+      );
+    } catch (err) {
+      // The guard records a failed item and carries on, except for a cancelled transfer, which it
+      // rethrows: the run is stopping, and this item has not failed (issue #344).
+      if (options.abort_signal?.aborted !== true) throw err;
+      interrupted = true;
+      break;
+    }
     processed_delta_items++;
     on_item_processed?.(item.file_name);
   }

--- a/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
+++ b/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
@@ -31,11 +31,15 @@ export async function* fetch_file_chunks(
   download_url: string,
   total_bytes: number,
   item_id: string,
+  abort_signal?: AbortSignal,
 ): AsyncGenerator<Buffer> {
   const chunk_count = Math.ceil(total_bytes / CHUNK_SIZE_BYTES);
   let yielded_chunks = 0;
 
   for (let i = 0; i < chunk_count; i++) {
+    // Cheap between chunks, and the signal also reaches the request itself below, so a cancelled
+    // run neither starts the next chunk nor waits out the one in flight (issue #344).
+    abort_signal?.throwIfAborted();
     const range_start = i * CHUNK_SIZE_BYTES;
     const range_end = Math.min(range_start + CHUNK_SIZE_BYTES - 1, total_bytes - 1);
     const expected_length = range_end - range_start + 1;
@@ -52,6 +56,7 @@ export async function* fetch_file_chunks(
         chunk_count,
         total_bytes,
         chunk_count > 1,
+        abort_signal,
       );
     } catch (err) {
       if (!(err instanceof RangeIgnoredError)) throw err;
@@ -73,6 +78,7 @@ export async function* fetch_file_chunks(
           `falling back to one streamed download`,
       );
       yield* stream_whole_file_in_chunks(download_url, item_id, {
+        abort_signal,
         chunk_size_bytes: CHUNK_SIZE_BYTES,
         // Same per-chunk budget the Range path uses, applied between reads rather than to the
         // whole transfer, so a stalled body is cut off but a slow one is not.
@@ -95,6 +101,7 @@ async function download_chunk_with_retry(
   total_chunks: number,
   total_bytes: number,
   report_ignored_range: boolean,
+  abort_signal?: AbortSignal,
 ): Promise<Buffer> {
   for (let attempt = 0; attempt <= MAX_CHUNK_RETRIES; attempt++) {
     try {
@@ -106,6 +113,7 @@ async function download_chunk_with_retry(
         item_id,
         total_bytes,
         report_ignored_range,
+        abort_signal,
       );
     } catch (err) {
       // Not retryable and not a failure: the caller switches strategy on it.
@@ -117,6 +125,8 @@ async function download_chunk_with_retry(
         );
       }
 
+      // Backing off is waiting, and a cancelled run has no reason to wait.
+      abort_signal?.throwIfAborted();
       const delay = compute_retry_delay(attempt);
       logger.debug(
         `Chunk ${chunk_index}/${total_chunks} retry ${attempt + 1}/${MAX_CHUNK_RETRIES} ` +
@@ -137,6 +147,7 @@ async function download_single_chunk(
   item_id: string,
   total_bytes: number,
   report_ignored_range: boolean,
+  abort_signal?: AbortSignal,
 ): Promise<Buffer> {
   const timeout_ms = Math.max(30_000, Math.ceil(expected_length / MIN_THROUGHPUT_BYTES_PER_MS));
   const controller = new AbortController();
@@ -145,7 +156,10 @@ async function download_single_chunk(
   try {
     const response = await fetch(url, {
       headers: { Range: `bytes=${range_start}-${range_end}` },
-      signal: controller.signal,
+      signal:
+        abort_signal === undefined
+          ? controller.signal
+          : AbortSignal.any([controller.signal, abort_signal]),
     });
 
     if (response.status === 429 || response.status === 503 || response.status === 504) {

--- a/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
+++ b/packages/sharepoint/src/services/backup/large-file-chunk-download.ts
@@ -116,6 +116,10 @@ async function download_chunk_with_retry(
         abort_signal,
       );
     } catch (err) {
+      // A cancelled run is not a chunk failure. Checked before the classification below, which
+      // would otherwise relabel the abort as `Failed chunk ...` and have it recorded against the
+      // item (issue #344).
+      abort_signal?.throwIfAborted();
       // Not retryable and not a failure: the caller switches strategy on it.
       if (err instanceof RangeIgnoredError) throw err;
       if (!is_cdn_retryable(err) || attempt === MAX_CHUNK_RETRIES) {
@@ -125,14 +129,14 @@ async function download_chunk_with_retry(
         );
       }
 
-      // Backing off is waiting, and a cancelled run has no reason to wait.
-      abort_signal?.throwIfAborted();
       const delay = compute_retry_delay(attempt);
       logger.debug(
         `Chunk ${chunk_index}/${total_chunks} retry ${attempt + 1}/${MAX_CHUNK_RETRIES} ` +
           `for ${item_id} in ${(delay / 1000).toFixed(1)}s`,
       );
-      await sleep(delay);
+      // Rejects with the abort reason, so a run cancelled during a 30 second backoff stops
+      // there rather than waiting the delay out (issue #344).
+      await sleep(delay, abort_signal);
     }
   }
 
@@ -152,14 +156,16 @@ async function download_single_chunk(
   const timeout_ms = Math.max(30_000, Math.ceil(expected_length / MIN_THROUGHPUT_BYTES_PER_MS));
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout_ms);
+  // One listener, removed below, rather than `AbortSignal.any` per chunk: the run's signal outlives
+  // every chunk, and Node keeps a dependent entry for each composite until the source aborts, which
+  // is 256 of them per GiB transferred (issue #344).
+  const cancel_chunk = (): void => controller.abort(abort_signal?.reason);
+  abort_signal?.addEventListener('abort', cancel_chunk, { once: true });
 
   try {
     const response = await fetch(url, {
       headers: { Range: `bytes=${range_start}-${range_end}` },
-      signal:
-        abort_signal === undefined
-          ? controller.signal
-          : AbortSignal.any([controller.signal, abort_signal]),
+      signal: controller.signal,
     });
 
     if (response.status === 429 || response.status === 503 || response.status === 504) {
@@ -203,6 +209,7 @@ async function download_single_chunk(
     return buf;
   } finally {
     clearTimeout(timer);
+    abort_signal?.removeEventListener('abort', cancel_chunk);
   }
 }
 
@@ -217,8 +224,23 @@ function compute_retry_delay(attempt: number): number {
   return Math.min(base + jitter, CHUNK_MAX_DELAY_MS);
 }
 
-function sleep(ms: number): Promise<void> {
-  const { promise, resolve } = Promise.withResolvers<void>();
-  setTimeout(resolve, ms);
-  return promise;
+/**
+ * Waits, unless the run is cancelled first.
+ *
+ * `node:timers/promises` would do this in one line, but it is invisible to the fake timers the
+ * retry tests drive, and a backoff nobody can fast-forward is a five second unit test.
+ */
+async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const on_abort = (): void => {
+    clearTimeout(timer);
+    reject(signal?.reason instanceof Error ? signal.reason : new Error('The run was cancelled'));
+  };
+  const timer = setTimeout(() => {
+    signal?.removeEventListener('abort', on_abort);
+    resolve();
+  }, ms);
+  signal?.addEventListener('abort', on_abort, { once: true });
+  await promise;
 }

--- a/packages/sharepoint/src/services/backup/library-item-processor.ts
+++ b/packages/sharepoint/src/services/backup/library-item-processor.ts
@@ -65,6 +65,7 @@ export async function process_delta_item(
   library_state: LibraryProcessingState,
   versions: RunVersionCollector,
   version_stats: VersionStatsState,
+  abort_signal?: AbortSignal,
 ): Promise<void> {
   const effective_kind =
     item.deleted && item.kind === 'file' && tracking.previous_kind_by_file_id[item.item_id]
@@ -111,7 +112,14 @@ export async function process_delta_item(
     return;
   }
 
-  const result = await download_or_record_refusal(connector, item, site_id, ctx, library_state);
+  const result = await download_or_record_refusal(
+    connector,
+    item,
+    site_id,
+    ctx,
+    library_state,
+    abort_signal,
+  );
   if (!result) return;
 
   if (result.deduplicated) library_state.library_files_deduplicated++;
@@ -160,6 +168,7 @@ export async function process_item_guarded(
   library_state: LibraryProcessingState,
   versions: RunVersionCollector,
   version_stats: VersionStatsState,
+  abort_signal?: AbortSignal,
 ): Promise<void> {
   try {
     await process_delta_item(
@@ -172,6 +181,7 @@ export async function process_item_guarded(
       library_state,
       versions,
       version_stats,
+      abort_signal,
     );
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
@@ -204,6 +214,7 @@ export async function retry_failed_items(
   version_stats: VersionStatsState,
   should_interrupt?: () => boolean,
   on_item_processed?: (file_name: string) => void,
+  abort_signal?: AbortSignal,
 ): Promise<boolean> {
   for (const record of retryable_items(library_state.failed_items, drive_id)) {
     if (should_interrupt?.() === true) return true;
@@ -230,6 +241,7 @@ export async function retry_failed_items(
       library_state,
       versions,
       version_stats,
+      abort_signal,
     );
     on_item_processed?.(item.file_name);
   }
@@ -257,6 +269,7 @@ async function download_or_record_refusal(
   site_id: string,
   ctx: TenantContext,
   library_state: LibraryProcessingState,
+  abort_signal?: AbortSignal,
 ): Promise<Awaited<ReturnType<typeof process_backup_file>>> {
   const record = (reason: string, permanent?: boolean): undefined => {
     library_state.failed_item_ids.add(item.item_id);
@@ -271,7 +284,7 @@ async function download_or_record_refusal(
   };
 
   try {
-    const result = await process_backup_file(connector, item, site_id, ctx);
+    const result = await process_backup_file(connector, item, site_id, ctx, abort_signal);
     return result ?? record('file content could not be downloaded');
   } catch (err) {
     if (!is_download_refused(err)) throw err;

--- a/packages/sharepoint/src/services/backup/library-item-processor.ts
+++ b/packages/sharepoint/src/services/backup/library-item-processor.ts
@@ -133,6 +133,7 @@ export async function process_delta_item(
       snapshot_id,
       ctx,
       versions.watermarks[item.item_id],
+      abort_signal,
     );
     collect_run_versions(versions, item.item_id, version_result);
     accumulate_version_stats(version_result, version_stats, (s, u, f) => {
@@ -184,6 +185,9 @@ export async function process_item_guarded(
       abort_signal,
     );
   } catch (err) {
+    // A cancelled transfer is the run stopping, not the item failing. Recording it would spend one
+    // of the item's five ledger attempts and eventually skip the file for good (issue #344).
+    if (abort_signal?.aborted === true) throw err;
     const reason = err instanceof Error ? err.message : String(err);
     logger.warn(`SharePoint item ${item.item_id} (${item.file_name}) failed: ${reason}`);
     library_state.failed_item_ids.add(item.item_id);
@@ -231,18 +235,25 @@ export async function retry_failed_items(
     // regardless of stale tracking state: an unchanged etag would otherwise
     // classify as "no change" and leave the item stuck in the ledger.
     forget_item_tracking(tracking, record.item_id);
-    await process_item_guarded(
-      connector,
-      item,
-      site_id,
-      snapshot_id,
-      ctx,
-      tracking,
-      library_state,
-      versions,
-      version_stats,
-      abort_signal,
-    );
+    try {
+      await process_item_guarded(
+        connector,
+        item,
+        site_id,
+        snapshot_id,
+        ctx,
+        tracking,
+        library_state,
+        versions,
+        version_stats,
+        abort_signal,
+      );
+    } catch (err) {
+      // Cancelled mid-retry: the item keeps the attempt count it already had, and the caller
+      // treats the library as interrupted (issue #344).
+      if (abort_signal?.aborted !== true) throw err;
+      return true;
+    }
     on_item_processed?.(item.file_name);
   }
   return false;

--- a/packages/sharepoint/src/services/versioning/version-sync.ts
+++ b/packages/sharepoint/src/services/versioning/version-sync.ts
@@ -25,6 +25,7 @@ export async function sync_file_versions(
   snapshot_id: string,
   ctx: TenantContext,
   watermark: SharePointVersionWatermark | string | undefined,
+  abort_signal?: AbortSignal,
 ): Promise<VersionSyncOutcome> {
   return sync_drive_file_versions(
     SHAREPOINT_KEYS,
@@ -34,5 +35,6 @@ export async function sync_file_versions(
     snapshot_id,
     ctx,
     watermark,
+    abort_signal,
   );
 }

--- a/packages/sharepoint/tests/unit/services/backup/download-cancellation.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/download-cancellation.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetch_file_chunks } from '@/services/backup/large-file-chunk-download';
+
+/**
+ * Issue #344, the SharePoint twin. The two chunked-download adapters are separate copies that have
+ * drifted into the same bug before, so the cancellation contract is pinned in both.
+ */
+
+const CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
+
+const URL = 'https://cdn.test/item';
+
+/** A CDN that answers Range requests, and fails the read once its request was aborted. */
+function stub_cdn(): { requests: () => number } {
+  let requests = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async (
+        _url: string,
+        init: { headers: { Range: string }; signal?: AbortSignal },
+      ): Promise<Response> => {
+        requests++;
+        init.signal?.throwIfAborted();
+        const [, start, end] = /bytes=(\d+)-(\d+)/.exec(init.headers.Range)!;
+        const body = Buffer.alloc(Number(end) - Number(start) + 1, 1);
+        return {
+          status: 206,
+          headers: {
+            get: (name: string): string | null =>
+              name.toLowerCase() === 'content-range' ? `bytes ${start}-${end}/*` : null,
+          },
+          arrayBuffer: async () => {
+            init.signal?.throwIfAborted();
+            return body.buffer.slice(0, body.length);
+          },
+        } as unknown as Response;
+      },
+    ),
+  );
+  return { requests: () => requests };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('chunked download cancellation (issue #344)', () => {
+  it('stops between chunks when the run is cancelled', async () => {
+    const cdn = stub_cdn();
+    const cancel = new AbortController();
+
+    await expect(
+      (async () => {
+        for await (const chunk of fetch_file_chunks(
+          URL,
+          CHUNK_SIZE_BYTES * 4,
+          'item-1',
+          cancel.signal,
+        )) {
+          void chunk;
+          cancel.abort(new Error('run cancelled'));
+        }
+      })(),
+    ).rejects.toThrow(/cancelled/);
+
+    // One chunk fetched, and the three that would have followed were never asked for.
+    expect(cdn.requests()).toBe(1);
+  });
+
+  it('never opens a request for a run cancelled before it started', async () => {
+    const cdn = stub_cdn();
+
+    await expect(
+      (async () => {
+        for await (const chunk of fetch_file_chunks(
+          URL,
+          CHUNK_SIZE_BYTES * 2,
+          'item-1',
+          AbortSignal.abort(),
+        )) {
+          void chunk;
+        }
+      })(),
+    ).rejects.toThrow();
+
+    expect(cdn.requests()).toBe(0);
+  });
+});

--- a/packages/sharepoint/tests/unit/services/backup/large-file-pipeline.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/large-file-pipeline.test.ts
@@ -108,6 +108,7 @@ describe('process_large_file', () => {
       'https://cdn.example/abc',
       ITEM_BYTES,
       'item-1',
+      undefined,
     );
   });
 

--- a/packages/sharepoint/tests/unit/services/save/save.service.test.ts
+++ b/packages/sharepoint/tests/unit/services/save/save.service.test.ts
@@ -14,13 +14,18 @@ import type {
   TenantContext,
   TenantContextFactory,
 } from '@wisecom/atlas-types';
-vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', () => {
+vi.mock('@wisecom/atlas-core/services/shared/file-save-zip-writer', async (import_original) => {
+  const actual =
+    await import_original<
+      typeof import('@wisecom/atlas-core/services/shared/file-save-zip-writer')
+    >();
   const mock_archive = {
     append: vi.fn(),
     finalize: vi.fn().mockResolvedValue(undefined),
     pointer: vi.fn().mockReturnValue(8192),
   };
   return {
+    ...actual,
     create_file_archive: vi.fn().mockReturnValue({
       archive: mock_archive,
       promise: Promise.resolve(8192),

--- a/packages/types/src/ports/atlas/progress-event.port.ts
+++ b/packages/types/src/ports/atlas/progress-event.port.ts
@@ -24,8 +24,17 @@ export interface SdkOperationOptions {
   readonly signal?: AbortSignal;
 }
 
-/** Internal hooks used by services without exposing AbortSignal or SDK naming. */
+/** Internal hooks used by services, without the SDK naming. */
 export interface OperationControlOptions {
   readonly on_progress?: OperationProgressCallback;
   readonly should_interrupt?: () => boolean;
+  /**
+   * Cancels work that is already in flight.
+   *
+   * `should_interrupt` is polled between items, so a cancelled run still waits out whatever
+   * network read it was in the middle of, and a large download can hold it for minutes. This
+   * reaches the request itself (issue #344). Services take both: the predicate decides whether to
+   * start the next item, the signal ends the one already running.
+   */
+  readonly abort_signal?: AbortSignal;
 }


### PR DESCRIPTION
## Summary

Closes #344.

Cancellation was a predicate services poll between items. That answers "should I start the next file", never "stop the one I am on", so a cancelled run kept transferring, and for a multi-gigabyte item that is minutes of work nobody wants any more. The SDK's `AbortSignal` now travels with the run as `abort_signal` alongside the predicate, and reaches the request itself: the Range fetch, the whole-file fallback, the retry backoff between chunk attempts, and the decision to start the next chunk. Both hooks earn their place: the predicate decides whether to begin the next item, the signal ends the one already running.

The Graph SDK client is not covered. Small-file downloads and mail go through it rather than through `fetch`, and it takes no signal, so cancelling those still waits for the item in flight. The paths that hold a connection for minutes are the drive chunk transfers, and those are the ones wired up.

Three more places where work outlived the reason for it:

**An export whose destination went away kept downloading.** A disconnected consumer failed the append, the save loop counted it as one bad entry, and the next file was fetched and decrypted only to fail the same way. A destination failure is now `ArchiveDestinationError` and stops the run; a single unreadable file is still reported and skipped. The distinction is the point: one is a bad file, the other means there is nowhere to put anything.

**The version upload never closed its source.** `tag_source_errors` drives the iterator by hand, so the `for await` inside the uploader could not close it, and a multipart failure left the download running with nobody reading it. The generator now closes its source in a `finally`, which covers a consumer failure, an early break and normal completion alike.

**The stall timer counted consumer time.** The whole-file download's timer stayed armed across the `yield`, so a consumer slower than the stall budget looked like a server that stopped sending. It is disarmed when a read arrives and re-armed only when the loop goes back to waiting on the body. The request is also aborted when the generator closes, so a consumer that stopped early does not leave a body streaming into nothing.

The first acceptance criterion, a destination that closes before finalisation rejecting the save promise instead of leaving it pending, landed in #357: a `Writable` destroyed without an error emits `close` and neither `finish` nor `error`, so nothing settled the byte count. This PR builds the "stop downloading" half on top of it.

### Evidence

Each new test was run against the code without its fix:

- Source close: `expected false to be true` on the closed flag.
- Dead destination: `promise resolved instead of rejecting`, with all four entries downloaded.
- Stall timer: the abort-aware body throws once its request is aborted, so the second chunk never arrives.

The stall-timer test drives the clock with fake timers rather than sleeping: three stall budgets are spent in the consumer between chunks and the transfer survives them.

Not verified against a live tenant or a real CDN. The evidence is unit-level with stubbed `fetch` and storage.

## Changes

- `packages/types/src/ports/atlas/progress-event.port.ts`: `OperationControlOptions.abort_signal`, and the comment that said the internals deliberately do not see an `AbortSignal` is gone, because that is what the issue asked to change.
- `packages/sdk/src/operation-options.ts`: the public `signal` maps to both hooks.
- `packages/drive/src/backup/whole-file-stream.ts`: takes the caller's signal, disarms the stall timer while the consumer holds a chunk, and aborts the request when the generator closes.
- `packages/onedrive/src/adapters/graph-onedrive-chunked-download.ts`, `packages/sharepoint/src/services/backup/large-file-chunk-download.ts`: the signal reaches the Range fetch, the retry backoff and the next-chunk decision.
- `packages/drive/src/backup/file-processor.ts`, `packages/drive/src/backup/large-file-pipeline.ts`, and the OneDrive and SharePoint item processors: one optional argument each, carrying the signal from the run's options to the fetcher.
- `packages/core/src/services/shared/file-save-zip-writer.ts`: `ArchiveDestinationError`, thrown by the drain wait, the byte-count promise and the raced append failure.
- `packages/drive/src/save/save-snapshot.ts`, `packages/outlook/src/services/save/save-entry-processor.ts`: a destination failure ends the run instead of being counted per entry.
- `packages/drive/src/versioning/version-content-store.ts`: the wrapped source iterator is closed on the way out.
- `docs/reference/sdk.md`: what a consumer sees when it disconnects mid-export, and a corrected claim that aborting a transfer mid-stream is not implemented.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`), unless this is a release or hotfix PR
- [x] No version bump in `packages/*/package.json` (releases only)
- [x] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cancellation support for active backup downloads and stream exports.
  - Cancelling an operation now stops in-progress transfers, prevents additional chunks or retries, and closes open streams.
  - SDK operation options now expose the cancellation signal for active work.

- **Bug Fixes**
  - Exports now stop immediately when the destination becomes unavailable.
  - Improved cleanup when downloads, uploads, or consumers exit early.
  - Updated cancellation and destination-failure documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->