### PR TITLE
fix(backup): abort only the run's own staging upload, and only when it is stale

### DIFF
--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -85,6 +85,22 @@ Implementation thresholds from `@wisecom/atlas-onedrive`:
 
 Chunked downloads retry each **4 MiB** range independently (5 attempts with backoff in the adapter), so a transient failure replays a single chunk instead of the whole file. Each range request is also aborted if the chunk has not transferred at roughly 256 KB/s, with a floor of 30 seconds. That budget is sized from the chunk being fetched, not the file, so a dead connection costs about 30 seconds and then a retry regardless of whether the file is 5 MB or 5 GB.
 
+#### Staging cleanup and concurrent runs
+
+Every large file of one owner stages under the same prefix, `onedrive/staging/{owner_id}/`, so a
+run cleaning up after an earlier one and a run currently transferring cannot be told apart by key.
+They are told apart by age: startup cleanup only deletes staging objects last modified more than
+24 hours ago, and only aborts multipart uploads started more than 24 hours ago. A transfer running
+now is never touched, and a backend that reports no timestamp for an upload gets left alone rather
+than guessed at.
+
+A run aborts its own upload on any failure after the upload was created, including a failed
+existence check and a completion the bucket refuses. When that abort itself fails, Atlas logs the
+staging key and stops there. It does not sweep the prefix: that fallback used to abort whatever a
+concurrent backup of the same owner was streaming into, turning one run's failure into two. The
+parts left behind cost storage until the next cleanup or the bucket's own lifecycle rule collects
+them, which is why the failed abort is logged rather than swallowed.
+
 #### What a chunk has to prove before it is stored
 
 The checksum Atlas records is computed over the bytes that arrived, so it cannot tell a truncated

--- a/docs/onedrive-backup.md
+++ b/docs/onedrive-backup.md
@@ -89,10 +89,19 @@ Chunked downloads retry each **4 MiB** range independently (5 attempts with back
 
 Every large file of one owner stages under the same prefix, `onedrive/staging/{owner_id}/`, so a
 run cleaning up after an earlier one and a run currently transferring cannot be told apart by key.
-They are told apart by age: startup cleanup only deletes staging objects last modified more than
-24 hours ago, and only aborts multipart uploads started more than 24 hours ago. A transfer running
-now is never touched, and a backend that reports no timestamp for an upload gets left alone rather
-than guessed at.
+Two things tell them apart. Age is the coarse filter: startup cleanup only considers staging
+objects last modified, and uploads started, more than 24 hours ago. Activity is the real answer for
+an upload, because nothing caps one item's transfer at 24 hours and a 250 GB file on a throttled
+link legitimately runs longer than that. An upload past the cutoff is left alone when any of its
+parts was written since, which a live transfer does every few seconds.
+
+A backend that reports no start time for an upload is left alone and counted in a warning, since
+an upload whose age cannot be established cannot be shown to be abandoned. Those are what the
+bucket's `AbortIncompleteMultipartUpload` lifecycle rule is for.
+
+Erasing an owner is the one case that sweeps without a cutoff. A prefix delete removes staged
+objects and not the parts of an incomplete upload, and no later run visits the prefix of an owner
+nobody backs up any more, so `deleteOwnerData` aborts every upload under it.
 
 A run aborts its own upload on any failure after the upload was created, including a failed
 existence check and a completion the bucket refuses. When that abort itself fails, Atlas logs the

--- a/docs/sharepoint-backup.md
+++ b/docs/sharepoint-backup.md
@@ -84,6 +84,11 @@ Implementation thresholds from `@wisecom/atlas-sharepoint`:
 
 Chunked downloads retry each **4 MiB** range independently (5 attempts with exponential backoff), so a transient failure replays a single chunk instead of the whole file. A chunk is retried on the same statuses as any other Graph call (429, 500, 502, 503, and 504), because the CDN in front of Graph raises `500` and `502` under load. A `4xx` response fails the chunk immediately.
 
+Staging cleanup is scoped by age, not by prefix alone: a site's staging prefix is shared by every
+large file it transfers, so only objects and uploads older than 24 hours are collected, and a run
+aborts nothing but its own upload when it fails. Identical to OneDrive; see
+[Staging cleanup and concurrent runs](/onedrive-backup#staging-cleanup-and-concurrent-runs).
+
 ### Download Resilience
 
 SharePoint's direct download URLs (pre-authenticated CDN links via `@microsoft.graph.downloadUrl`) are subject to Microsoft Graph rate limiting, and the CDN also returns transient gateway faults of its own. Atlas handles this with:

--- a/packages/core/src/services/deletion/onedrive-deletion.service.ts
+++ b/packages/core/src/services/deletion/onedrive-deletion.service.ts
@@ -7,6 +7,7 @@ import type {
 } from '@wisecom/atlas-types';
 import { TENANT_CONTEXT_FACTORY_TOKEN } from '@wisecom/atlas-types';
 import { delete_scopes } from '@/services/deletion/shared/prefix-deleter';
+import { abort_staging_uploads } from '@/services/deletion/shared/staging-upload-purge';
 
 @injectable()
 export class OneDriveDeletionService implements OneDriveDeletionUseCase {
@@ -24,13 +25,18 @@ export class OneDriveDeletionService implements OneDriveDeletionUseCase {
   async delete_owner_data(tenant_id: string, owner_id: string): Promise<DeletionResult> {
     owner_id = normalize_owner_id(owner_id);
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
-    return delete_scopes(storage, [
+    const staging_prefix = `onedrive/staging/${owner_id}/`;
+    const result = await delete_scopes(storage, [
       `onedrive/manifests/${owner_id}/`,
       `onedrive/data/${owner_id}/`,
       `onedrive/index/${owner_id}/`,
       `onedrive/_meta/${owner_id}/`,
-      `onedrive/staging/${owner_id}/`,
+      staging_prefix,
     ]);
+    // Deleting keys leaves an incomplete upload's parts behind, and no later run sweeps an owner
+    // nobody backs up any more (issue #345).
+    await abort_staging_uploads(storage, staging_prefix);
+    return result;
   }
 
   /**

--- a/packages/core/src/services/deletion/shared/staging-upload-purge.ts
+++ b/packages/core/src/services/deletion/shared/staging-upload-purge.ts
@@ -1,0 +1,26 @@
+import type { ObjectStorage } from '@wisecom/atlas-types';
+import { logger } from '@/utils/logger';
+
+/**
+ * Aborts every incomplete multipart upload under a staging prefix.
+ *
+ * A prefix delete removes staged objects and nothing else: an incomplete upload's parts are not
+ * listed as objects, so an erasure that only deleted keys left them paying for bytes belonging to
+ * an owner whose data was supposed to be gone. Nothing collects them afterwards either, because
+ * the backup-side cleanup only runs when that owner is backed up again (issue #345).
+ *
+ * The cutoff is now, unlike the backup-side sweep: a purge is the one caller that means every
+ * upload, including one a run may still be writing, because that run's destination is being erased.
+ */
+export async function abort_staging_uploads(storage: ObjectStorage, prefix: string): Promise<void> {
+  try {
+    const aborted = await storage.abort_incomplete_uploads(prefix, new Date());
+    if (aborted > 0) logger.info(`Aborted ${aborted} incomplete staging upload(s) under ${prefix}`);
+  } catch (err) {
+    logger.warn(
+      `Could not abort incomplete staging uploads under ${prefix}: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `Their parts survive the erasure until the bucket's lifecycle rule collects them.`,
+    );
+  }
+}

--- a/packages/core/src/services/deletion/sharepoint-deletion.service.ts
+++ b/packages/core/src/services/deletion/sharepoint-deletion.service.ts
@@ -7,6 +7,7 @@ import type {
 } from '@wisecom/atlas-types';
 import { TENANT_CONTEXT_FACTORY_TOKEN } from '@wisecom/atlas-types';
 import { delete_scopes } from '@/services/deletion/shared/prefix-deleter';
+import { abort_staging_uploads } from '@/services/deletion/shared/staging-upload-purge';
 
 @injectable()
 export class SharePointDeletionService implements SharePointDeletionUseCase {
@@ -24,13 +25,18 @@ export class SharePointDeletionService implements SharePointDeletionUseCase {
   async delete_site_data(tenant_id: string, site_id: string): Promise<DeletionResult> {
     site_id = normalize_owner_id(site_id);
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
-    return delete_scopes(storage, [
+    const staging_prefix = `sharepoint/staging/${site_id}/`;
+    const result = await delete_scopes(storage, [
       `sharepoint/manifests/${site_id}/`,
       `sharepoint/data/${site_id}/`,
       `sharepoint/index/${site_id}/`,
       `sharepoint/_meta/${site_id}/`,
-      `sharepoint/staging/${site_id}/`,
+      staging_prefix,
     ]);
+    // Deleting keys leaves an incomplete upload's parts behind, and no later run sweeps a site
+    // nobody backs up any more (issue #345).
+    await abort_staging_uploads(storage, staging_prefix);
+    return result;
   }
 
   /**

--- a/packages/core/src/services/shared/stream-encrypt-upload.ts
+++ b/packages/core/src/services/shared/stream-encrypt-upload.ts
@@ -35,8 +35,6 @@ export interface ContentAddressedStreamResult {
 export interface ContentAddressedStreamTarget {
   /** Unique per-call staging key the encrypted stream lands on first. */
   readonly staging_key: string;
-  /** Prefix used to sweep orphaned parts when an abort fails. */
-  readonly staging_prefix: string;
   /** Builds the canonical key from the plaintext checksum. */
   build_data_key(checksum: string): string;
   readonly object_lock_policy?: StorageObjectLockPolicy;
@@ -63,12 +61,20 @@ export async function stream_to_content_addressed_storage(
 
   const canonical_key = target.build_data_key(checksum);
 
-  if (await ctx.storage.exists(canonical_key)) {
-    await safe_abort_multipart(handle, target.staging_prefix, ctx);
-    return { checksum, storage_key: canonical_key, stored: false, deduplicated: true };
-  }
+  // Everything from here to `complete()` owns an upload that exists in the bucket. A throw in
+  // between, an `exists()` that fails or a completion the backend refuses, used to leave it there
+  // active and billable with nobody holding its id (issue #345).
+  try {
+    if (await ctx.storage.exists(canonical_key)) {
+      await safe_abort_multipart(handle, target.staging_key);
+      return { checksum, storage_key: canonical_key, stored: false, deduplicated: true };
+    }
 
-  await handle.complete(completed_parts);
+    await handle.complete(completed_parts);
+  } catch (err) {
+    await safe_abort_multipart(handle, target.staging_key);
+    throw err;
+  }
 
   // ponytail: the exists() check above races a concurrent writer, and the loser
   // overwrites with identical bytes -- canonical_key IS the SHA-256 of the
@@ -163,11 +169,7 @@ export async function stream_encrypt_to_multipart(
 
     return { checksum: hash.digest('hex'), handle, completed_parts: state.completed_parts };
   } catch (err) {
-    await safe_abort_multipart(
-      handle,
-      staging_key.substring(0, staging_key.lastIndexOf('/') + 1),
-      ctx,
-    );
+    await safe_abort_multipart(handle, staging_key);
     throw err;
   }
 }
@@ -188,16 +190,26 @@ async function flush_pending_parts(
   }
 }
 
-/** Aborts a multipart upload, falling back to sweeping orphaned parts by prefix. */
+/**
+ * Aborts one multipart upload and reports it when that fails.
+ *
+ * The fallback used to sweep every incomplete upload under the staging prefix, which is shared by
+ * every large file of one owner: a failure in one run aborted the upload a concurrent run was
+ * streaming into (issue #345). One failed abort leaves one upload's parts behind, which the
+ * bucket's lifecycle rule and the age-filtered startup cleanup both collect, so the answer is to
+ * name it rather than to widen the blast radius.
+ */
 export async function safe_abort_multipart(
   handle: MultipartUploadHandle,
-  staging_prefix: string,
-  ctx: TenantContext,
+  staging_key: string,
 ): Promise<void> {
   try {
     await handle.abort();
   } catch (err) {
-    logger.warn(`Multipart abort failed, cleaning up orphaned parts: ${err}`);
-    await ctx.storage.abort_incomplete_uploads(staging_prefix).catch(() => {});
+    logger.warn(
+      `Could not abort the staging upload for ${staging_key}: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `Its parts stay billable until the bucket's lifecycle rule or the next run collects them.`,
+    );
   }
 }

--- a/packages/core/src/services/shared/stream-encrypt-upload.ts
+++ b/packages/core/src/services/shared/stream-encrypt-upload.ts
@@ -206,10 +206,22 @@ export async function safe_abort_multipart(
   try {
     await handle.abort();
   } catch (err) {
+    // A completion can fail on the client after the backend applied it, and the abort that follows
+    // then finds no upload. Nothing is stranded in that case, so it is not an operator's problem.
+    if (is_upload_already_gone(err)) {
+      logger.debug(`Staging upload for ${staging_key} was already gone when the abort ran`);
+      return;
+    }
     logger.warn(
       `Could not abort the staging upload for ${staging_key}: ` +
         `${err instanceof Error ? err.message : String(err)}. ` +
         `Its parts stay billable until the bucket's lifecycle rule or the next run collects them.`,
     );
   }
+}
+
+/** Recognises the backend's answer for an upload id that no longer exists. */
+function is_upload_already_gone(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null || !('name' in err)) return false;
+  return err.name === 'NoSuchUpload' || err.name === 'NotFound';
 }

--- a/packages/core/tests/unit/services/catalog-service.fixtures.ts
+++ b/packages/core/tests/unit/services/catalog-service.fixtures.ts
@@ -37,6 +37,7 @@ export function make_mock_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn().mockResolvedValue(false),
+    list_stale: vi.fn(async () => []),
     list: vi.fn().mockResolvedValue([]),
     list_versions: vi.fn().mockResolvedValue([]),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/core/tests/unit/services/deletion/deletion.service.test.ts
+++ b/packages/core/tests/unit/services/deletion/deletion.service.test.ts
@@ -37,6 +37,7 @@ function make_mock_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn().mockResolvedValue(false),
+    list_stale: vi.fn(async () => []),
     list: vi.fn().mockResolvedValue([]),
     list_versions: vi.fn().mockResolvedValue([]),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/core/tests/unit/services/deletion/workload-deletion.test.ts
+++ b/packages/core/tests/unit/services/deletion/workload-deletion.test.ts
@@ -13,17 +13,22 @@ import type { DeletionStorage } from '@/services/deletion/shared/prefix-deleter'
 const OWNER = '75a21b57-4d82-4f42-9ccc-7c231c30f78c';
 const SITE = 'contoso.sharepoint.com,site-guid,web-guid';
 
-function make_storage(): DeletionStorage {
+type PurgeStorage = DeletionStorage & {
+  abort_incomplete_uploads: ReturnType<typeof vi.fn>;
+};
+
+function make_storage(): PurgeStorage {
   return {
     delete: vi.fn().mockResolvedValue(undefined),
     delete_version: vi.fn().mockResolvedValue(undefined),
     list: vi.fn().mockResolvedValue([]),
     list_versions: vi.fn().mockResolvedValue([]),
+    abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
   };
 }
 
 describe('workload deletion', () => {
-  let storage: DeletionStorage;
+  let storage: PurgeStorage;
   let factory: TenantContextFactory;
   let onedrive: OneDriveDeletionService;
   let sharepoint: SharePointDeletionService;
@@ -43,6 +48,24 @@ describe('workload deletion', () => {
 
     onedrive = container.get(OneDriveDeletionService);
     sharepoint = container.get(SharePointDeletionService);
+  });
+
+  // A prefix delete removes staged objects and leaves an incomplete upload's parts paying for
+  // themselves, and no later run sweeps an owner nobody backs up again (issue #345).
+  it('aborts every staging upload of the owner it erases', async () => {
+    await onedrive.delete_owner_data('t', OWNER);
+
+    const [prefix, cutoff] = storage.abort_incomplete_uploads.mock.calls[0]!;
+    expect(prefix).toBe(`onedrive/staging/${OWNER}/`);
+    // A purge means every upload, including one a run may still be writing: its destination is
+    // being erased.
+    expect((cutoff as Date).getTime()).toBeGreaterThanOrEqual(Date.now() - 5_000);
+  });
+
+  it('aborts every staging upload of the site it erases', async () => {
+    await sharepoint.delete_site_data('t', SITE);
+
+    expect(storage.abort_incomplete_uploads.mock.calls[0]?.[0]).toContain('sharepoint/staging/');
   });
 
   describe('OneDriveDeletionService', () => {

--- a/packages/core/tests/unit/services/replication/drive-snapshot-replicator.test.ts
+++ b/packages/core/tests/unit/services/replication/drive-snapshot-replicator.test.ts
@@ -44,6 +44,7 @@ function make_storage(
       return value;
     }),
     exists: vi.fn(async (key: string) => objects.has(key)),
+    list_stale: vi.fn(async () => []),
     list: vi.fn(async (prefix: string) =>
       [...objects.keys()].filter((key) => key.startsWith(prefix)),
     ),

--- a/packages/core/tests/unit/services/replication/drive-snapshot-routing.test.ts
+++ b/packages/core/tests/unit/services/replication/drive-snapshot-routing.test.ts
@@ -62,6 +62,7 @@ function make_storage(keys: string[]): ObjectStorage {
     list_versions: vi.fn(),
     begin_multipart_upload: vi.fn(),
     copy: vi.fn(),
+    list_stale: vi.fn(async () => []),
     abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
     probe_immutability: vi.fn(),
   } as unknown as ObjectStorage;

--- a/packages/core/tests/unit/services/replication/replication-integrity-verifier.test.ts
+++ b/packages/core/tests/unit/services/replication/replication-integrity-verifier.test.ts
@@ -13,6 +13,7 @@ function make_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn(),
+    list_stale: vi.fn(async () => []),
     list: vi.fn(),
     list_versions: vi.fn(),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/core/tests/unit/services/replication/replication-status-repository.test.ts
+++ b/packages/core/tests/unit/services/replication/replication-status-repository.test.ts
@@ -18,6 +18,7 @@ function make_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn(),
+    list_stale: vi.fn(async () => []),
     list: vi.fn(),
     list_versions: vi.fn(),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/core/tests/unit/services/replication/replication.service.test.ts
+++ b/packages/core/tests/unit/services/replication/replication.service.test.ts
@@ -30,6 +30,7 @@ function make_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn().mockResolvedValue(false),
+    list_stale: vi.fn(async () => []),
     list: vi.fn().mockResolvedValue([]),
     list_versions: vi.fn(),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/core/tests/unit/services/replication/snapshot-replicator.test.ts
+++ b/packages/core/tests/unit/services/replication/snapshot-replicator.test.ts
@@ -20,6 +20,7 @@ function make_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn(),
+    list_stale: vi.fn(async () => []),
     list: vi.fn(),
     list_versions: vi.fn(),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/core/tests/unit/services/replication/workload-tenant-rehydration.test.ts
+++ b/packages/core/tests/unit/services/replication/workload-tenant-rehydration.test.ts
@@ -56,6 +56,7 @@ function make_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn().mockResolvedValue(false),
+    list_stale: vi.fn(async () => []),
     list: vi.fn().mockResolvedValue([]),
     list_versions: vi.fn(),
     begin_multipart_upload: vi.fn(),

--- a/packages/core/tests/unit/services/shared/multipart-copy-volume.test.ts
+++ b/packages/core/tests/unit/services/shared/multipart-copy-volume.test.ts
@@ -27,6 +27,7 @@ function make_ctx(): { ctx: TenantContext; parts: Map<number, Buffer> } {
         complete: vi.fn(async () => undefined),
         abort: vi.fn(async () => undefined),
       })),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn(async () => 0),
     },
     create_cipher: stub_tenant_create_cipher,

--- a/packages/core/tests/unit/services/shared/multipart-ownership.test.ts
+++ b/packages/core/tests/unit/services/shared/multipart-ownership.test.ts
@@ -1,0 +1,99 @@
+import { randomBytes } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type { TenantContext } from '@wisecom/atlas-types';
+import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
+import { stream_to_content_addressed_storage } from '@/services/shared/stream-encrypt-upload';
+
+/**
+ * Issue #345: an upload that had started was only aborted when the source failed. A failing
+ * `exists()` check or a completion the backend refused returned the handle to nobody, leaving the
+ * upload active and its parts billable with no id left to abort it by.
+ */
+
+interface Recorded {
+  readonly ctx: TenantContext;
+  readonly ops: string[];
+}
+
+function make_ctx(options: { exists_fails?: boolean; complete_fails?: boolean } = {}): Recorded {
+  const ops: string[] = [];
+  const ctx = {
+    storage: {
+      begin_multipart_upload: vi.fn(async (key: string) => {
+        ops.push(`begin:${key}`);
+        return {
+          upload_part: vi.fn(async () => 'etag'),
+          complete: vi.fn(async () => {
+            ops.push('complete');
+            if (options.complete_fails === true) throw new Error('the bucket refused the assembly');
+          }),
+          abort: vi.fn(async () => {
+            ops.push('abort');
+          }),
+        };
+      }),
+      exists: vi.fn(async () => {
+        ops.push('exists');
+        if (options.exists_fails === true) throw new Error('the bucket refused the head request');
+        return false;
+      }),
+      copy: vi.fn(async () => {
+        ops.push('copy');
+      }),
+      delete: vi.fn(async () => {
+        ops.push('delete');
+      }),
+      abort_incomplete_uploads: vi.fn(async () => {
+        ops.push('abort_incomplete');
+        return 0;
+      }),
+      list_stale: vi.fn(async () => []),
+    },
+    create_cipher: stub_tenant_create_cipher,
+  } as unknown as TenantContext;
+  return { ctx, ops };
+}
+
+async function* one_chunk(): AsyncGenerator<Buffer> {
+  yield randomBytes(1024);
+}
+
+const TARGET = {
+  staging_key: 'onedrive/staging/owner-1/item-1',
+  build_data_key: (checksum: string) => `onedrive/data/owner-1/${checksum}`,
+};
+
+describe('multipart upload ownership (issue #345)', () => {
+  it('aborts its own upload when the existence check fails', async () => {
+    const recorded = make_ctx({ exists_fails: true });
+
+    await expect(
+      stream_to_content_addressed_storage(recorded.ctx, one_chunk(), TARGET),
+    ).rejects.toThrow(/head request/);
+
+    expect(recorded.ops).toEqual(['begin:onedrive/staging/owner-1/item-1', 'exists', 'abort']);
+  });
+
+  it('aborts its own upload when the completion is refused', async () => {
+    const recorded = make_ctx({ complete_fails: true });
+
+    await expect(
+      stream_to_content_addressed_storage(recorded.ctx, one_chunk(), TARGET),
+    ).rejects.toThrow(/refused the assembly/);
+
+    expect(recorded.ops).toContain('abort');
+    // Never the prefix sweep: it would take a concurrent run's upload with it.
+    expect(recorded.ops).not.toContain('abort_incomplete');
+    expect(recorded.ops).not.toContain('copy');
+  });
+
+  it('does not abort anything on the path that succeeds', async () => {
+    const recorded = make_ctx();
+
+    const result = await stream_to_content_addressed_storage(recorded.ctx, one_chunk(), TARGET);
+
+    expect(result.stored).toBe(true);
+    expect(recorded.ops).not.toContain('abort');
+    expect(recorded.ops).toContain('copy');
+  });
+});

--- a/packages/core/tests/unit/services/shared/stream-encrypt-upload.test.ts
+++ b/packages/core/tests/unit/services/shared/stream-encrypt-upload.test.ts
@@ -56,6 +56,7 @@ function make_ctx(
       delete: vi.fn(async (key: string) => {
         ops.push(`delete:${key}`);
       }),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn(async (prefix: string) => {
         ops.push(`abort_incomplete:${prefix}`);
         return 0;
@@ -209,7 +210,7 @@ describe('stream_encrypt_to_multipart', () => {
     expect(numbers).toEqual([...numbers].sort((a, b) => a - b));
   });
 
-  it('sweeps orphaned parts by prefix when the abort itself fails', async () => {
+  it('leaves other uploads alone when the abort itself fails', async () => {
     const recorded = make_ctx({ abort_fails: true });
     async function* failing(): AsyncGenerator<Buffer> {
       yield Buffer.alloc(1024, 1);
@@ -219,8 +220,11 @@ describe('stream_encrypt_to_multipart', () => {
     await expect(stream_encrypt_to_multipart(recorded.ctx, 'staging/a', failing())).rejects.toThrow(
       'source died',
     );
-    // Otherwise the tenant pays storage for parts nothing will ever complete.
-    expect(recorded.ops).toContain('abort_incomplete:staging/');
+    // The staging prefix is shared by every large file of one owner, so the old fallback aborted
+    // whatever a concurrent run was streaming into. One stranded upload is the lifecycle rule's
+    // problem; a broken concurrent backup is not (issue #345).
+    expect(recorded.ops).toContain('abort');
+    expect(recorded.ops.some((op) => op.startsWith('abort_incomplete'))).toBe(false);
   });
 
   it('aborts the upload when the source fails mid-stream', async () => {
@@ -241,7 +245,6 @@ describe('stream_encrypt_to_multipart', () => {
 describe('stream_to_content_addressed_storage', () => {
   const target = (staging_key = 'staging/a') => ({
     staging_key,
-    staging_prefix: 'staging/',
     build_data_key: (checksum: string) => `data/${checksum}`,
   });
 

--- a/packages/core/tests/unit/services/stats/stats.service.test.ts
+++ b/packages/core/tests/unit/services/stats/stats.service.test.ts
@@ -42,6 +42,7 @@ function make_mock_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn().mockResolvedValue(false),
+    list_stale: vi.fn(async () => []),
     list: vi.fn().mockResolvedValue([]),
     list_versions: vi.fn().mockResolvedValue([]),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/core/tests/unit/services/verification.service.test.ts
+++ b/packages/core/tests/unit/services/verification.service.test.ts
@@ -43,6 +43,7 @@ function make_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn(),
+    list_stale: vi.fn(async () => []),
     list: vi.fn(),
     list_versions: vi.fn(),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/drive/src/backup/large-file-pipeline.ts
+++ b/packages/drive/src/backup/large-file-pipeline.ts
@@ -66,7 +66,6 @@ export async function process_large_drive_file(
     ),
     {
       staging_key,
-      staging_prefix: deps.keys.staging_prefix_for(owner_id),
       build_data_key: (checksum) => deps.keys.data_key(owner_id, checksum),
       ...(object_lock_policy && { object_lock_policy }),
     },
@@ -101,22 +100,39 @@ async function* counted_chunks(
   assert_transferred_size(item.item_id, transferred, item.size_bytes);
 }
 
-/** Removes leftover staging objects and incomplete multipart uploads. */
+/**
+ * Age past which a staging object or an incomplete upload is treated as abandoned.
+ *
+ * A staging key is live only between the first part and the copy onto the canonical key, which is
+ * one file's transfer. A day is far longer than that even for a very large file on a slow link,
+ * and short enough that abandoned parts do not accumulate a bill.
+ */
+const STAGING_ABANDONED_AFTER_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Removes staging objects and incomplete multipart uploads left behind by earlier runs.
+ *
+ * Only what is demonstrably abandoned: two backups of the same owner share one staging prefix, and
+ * an unfiltered sweep deleted the object the other run was about to copy and aborted the upload it
+ * was still streaming into, which failed that run with `NoSuchUpload` on its next part
+ * (issue #345).
+ */
 export async function cleanup_stale_drive_staging(
   keys: DriveStorageKeys,
   ctx: TenantContext,
   owner_id: string,
 ): Promise<void> {
   const prefix = keys.staging_prefix_for(owner_id);
+  const abandoned_before = new Date(Date.now() - STAGING_ABANDONED_AFTER_MS);
 
-  const stale_keys = await ctx.storage.list(prefix);
+  const stale_keys = await ctx.storage.list_stale(prefix, abandoned_before);
   for (const key of stale_keys) {
     logger.info(`Cleaning up stale staging object: ${key}`);
     await ctx.storage.delete(key).catch(() => {});
   }
 
-  const aborted = await ctx.storage.abort_incomplete_uploads(prefix);
+  const aborted = await ctx.storage.abort_incomplete_uploads(prefix, abandoned_before);
   if (aborted > 0) {
-    logger.info(`Aborted ${aborted} incomplete staging upload(s)`);
+    logger.info(`Aborted ${aborted} incomplete staging upload(s) older than 24h`);
   }
 }

--- a/packages/drive/src/backup/large-file-pipeline.ts
+++ b/packages/drive/src/backup/large-file-pipeline.ts
@@ -103,9 +103,14 @@ async function* counted_chunks(
 /**
  * Age past which a staging object or an incomplete upload is treated as abandoned.
  *
- * A staging key is live only between the first part and the copy onto the canonical key, which is
- * one file's transfer. A day is far longer than that even for a very large file on a slow link,
- * and short enough that abandoned parts do not accumulate a bill.
+ * Nothing caps one item's transfer at this, and it is not meant to: a 250 GB item on a throttled
+ * link can run for many hours, so the storage sweep also refuses to abort an upload with a part
+ * written since the cutoff. The day is the coarse filter, recent activity is the real answer, and
+ * the bucket's own `AbortIncompleteMultipartUpload` rule collects whatever both miss.
+ *
+ * For staging objects there is no activity to read, so the age stands alone. One is live only
+ * between the multipart completion and the copy onto the canonical key, which is a server-side
+ * copy of one file rather than a transfer, so a day is orders of magnitude longer than the window.
  */
 const STAGING_ABANDONED_AFTER_MS = 24 * 60 * 60 * 1000;
 

--- a/packages/drive/src/versioning/version-content-store.ts
+++ b/packages/drive/src/versioning/version-content-store.ts
@@ -66,7 +66,6 @@ async function store_streamed(
     tag_source_errors(chunks, abort_signal),
     {
       staging_key: keys.staging_key(owner_id, item.item_id),
-      staging_prefix: keys.staging_prefix_for(owner_id),
       build_data_key: (checksum) => keys.data_key(owner_id, checksum),
     },
   );

--- a/packages/onedrive/tests/unit/services/backup/backup-version-failures.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/backup-version-failures.test.ts
@@ -27,6 +27,7 @@ function run_backup(version_error: unknown): Promise<OneDriveBackupResult> {
     tenant_id: 't',
     storage: {
       list: vi.fn().mockResolvedValue([]),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
       exists: vi.fn().mockResolvedValue(false),
       put: vi.fn().mockResolvedValue(undefined),

--- a/packages/onedrive/tests/unit/services/backup/cancelled-item-not-ledgered.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/cancelled-item-not-ledgered.test.ts
@@ -50,6 +50,7 @@ function make_ctx(): TenantContext {
         complete: vi.fn(async () => undefined),
         abort: vi.fn(async () => undefined),
       })),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn(async () => 0),
       exists: vi.fn(async () => false),
     },

--- a/packages/onedrive/tests/unit/services/backup/cursor-snapshot-ordering.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/cursor-snapshot-ordering.test.ts
@@ -70,6 +70,7 @@ function make_harness(options: {
       put: vi.fn().mockResolvedValue(undefined),
       list: vi.fn().mockResolvedValue([]),
       delete: vi.fn().mockResolvedValue(undefined),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
     },
     encrypt: (buffer: Buffer) => buffer,

--- a/packages/onedrive/tests/unit/services/backup/failed-item-ledger.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/failed-item-ledger.test.ts
@@ -109,6 +109,7 @@ function make_harness(options: {
       put: vi.fn().mockResolvedValue(undefined),
       list: vi.fn().mockResolvedValue([]),
       delete: vi.fn().mockResolvedValue(undefined),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
     },
     encrypt: (buffer: Buffer) => buffer,

--- a/packages/onedrive/tests/unit/services/backup/folder-scope.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/folder-scope.test.ts
@@ -106,6 +106,7 @@ function make_harness(options: {
       put: vi.fn().mockResolvedValue(undefined),
       list: vi.fn().mockResolvedValue([]),
       delete: vi.fn().mockResolvedValue(undefined),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
     },
     encrypt: (buffer: Buffer) => buffer,

--- a/packages/onedrive/tests/unit/services/backup/large-file-pipeline.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/large-file-pipeline.test.ts
@@ -53,6 +53,7 @@ function make_ctx(options: { exists?: boolean; list?: string[] } = {}): Recorded
         ops.push(`delete:${key}`);
       }),
       list: vi.fn(async () => options.list ?? []),
+      list_stale: vi.fn(async () => options.list ?? []),
       abort_incomplete_uploads: vi.fn(async () => 0),
     },
     create_cipher: () => {

--- a/packages/onedrive/tests/unit/services/backup/large-file-pipeline.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/large-file-pipeline.test.ts
@@ -53,7 +53,9 @@ function make_ctx(options: { exists?: boolean; list?: string[] } = {}): Recorded
         ops.push(`delete:${key}`);
       }),
       list: vi.fn(async () => options.list ?? []),
-      list_stale: vi.fn(async () => options.list ?? []),
+      list_stale: vi.fn(async (_prefix: string, older_than: Date) =>
+        older_than <= new Date() ? (options.list ?? []) : [],
+      ),
       abort_incomplete_uploads: vi.fn(async () => 0),
     },
     create_cipher: () => {
@@ -272,9 +274,13 @@ describe('cleanup_stale_staging', () => {
 
     await cleanup_stale_staging(recorded.ctx, OWNER);
 
-    const prefix = vi.mocked(recorded.ctx.storage.abort_incomplete_uploads).mock.calls[0]?.[0];
+    const [prefix, cutoff] = vi.mocked(recorded.ctx.storage.abort_incomplete_uploads).mock
+      .calls[0]!;
     expect(prefix).toContain('staging');
     expect(prefix).toContain(OWNER);
+    // Without a cutoff in the past the sweep is the unfiltered one issue #345 is about: it would
+    // abort whatever a concurrent run of the same owner is streaming into.
+    expect(Date.now() - cutoff.getTime()).toBeGreaterThan(23 * 60 * 60 * 1000);
   });
 
   it('does nothing to delete when no staging objects are left', async () => {

--- a/packages/onedrive/tests/unit/services/backup/package-accounting.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/package-accounting.test.ts
@@ -45,6 +45,7 @@ function run_backup(
     tenant_id: 't',
     storage: {
       list: vi.fn().mockResolvedValue([]),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
       exists: vi.fn().mockResolvedValue(false),
       put: vi.fn().mockResolvedValue(undefined),

--- a/packages/onedrive/tests/unit/services/backup/version-source-close.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/version-source-close.test.ts
@@ -74,6 +74,7 @@ function failing_upload_ctx(): TenantContext {
         complete: vi.fn(async () => undefined),
         abort: vi.fn(async () => undefined),
       })),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn(async () => 0),
       exists: vi.fn(async () => false),
     },

--- a/packages/onedrive/tests/unit/services/versioning/version-content-store.test.ts
+++ b/packages/onedrive/tests/unit/services/versioning/version-content-store.test.ts
@@ -42,6 +42,7 @@ function make_ctx(): TenantContext {
       delete: vi.fn().mockResolvedValue(undefined),
       copy: vi.fn().mockResolvedValue(undefined),
       list: vi.fn().mockResolvedValue([]),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
       begin_multipart_upload: vi.fn().mockResolvedValue({
         upload_part: vi.fn().mockResolvedValue('etag'),

--- a/packages/onedrive/tests/unit/services/versioning/version-sync.test.ts
+++ b/packages/onedrive/tests/unit/services/versioning/version-sync.test.ts
@@ -35,6 +35,7 @@ function make_ctx(): TenantContext {
       delete: vi.fn(),
       begin_multipart_upload: vi.fn(),
       copy: vi.fn(),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn(),
     },
     encrypt: vi.fn((data: Buffer) => data),

--- a/packages/onedrive/tests/unit/services/versioning/version-watermark-dedup.test.ts
+++ b/packages/onedrive/tests/unit/services/versioning/version-watermark-dedup.test.ts
@@ -49,6 +49,7 @@ function make_harness(
     tenant_id: 't',
     storage: {
       list: vi.fn().mockResolvedValue([]),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
       exists: vi.fn().mockResolvedValue(false),
       put: vi.fn().mockResolvedValue(undefined),

--- a/packages/outlook/tests/unit/services/backup/attachment-progress-callback.test.ts
+++ b/packages/outlook/tests/unit/services/backup/attachment-progress-callback.test.ts
@@ -11,6 +11,7 @@ function make_mock_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn().mockResolvedValue(false),
+    list_stale: vi.fn(async () => []),
     list: vi.fn().mockResolvedValue([]),
     list_versions: vi.fn().mockResolvedValue([]),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/outlook/tests/unit/services/backup/delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/services/backup/delta-safeguard.test.ts
@@ -51,6 +51,7 @@ function make_mock_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn().mockResolvedValue(false),
+    list_stale: vi.fn(async () => []),
     list: vi.fn().mockResolvedValue([]),
     list_versions: vi.fn().mockResolvedValue([]),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/outlook/tests/unit/services/backup/interrupt-delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/services/backup/interrupt-delta-safeguard.test.ts
@@ -106,6 +106,7 @@ describe('interrupt delta-link safeguard (issue #23)', () => {
       delete: vi.fn(),
       delete_version: vi.fn(),
       exists: vi.fn().mockResolvedValue(false),
+      list_stale: vi.fn(async () => []),
       list: vi.fn().mockResolvedValue([]),
       list_versions: vi.fn().mockResolvedValue([]),
       begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/outlook/tests/unit/services/backup/mailbox-sync.fixtures.ts
+++ b/packages/outlook/tests/unit/services/backup/mailbox-sync.fixtures.ts
@@ -41,6 +41,7 @@ function make_mock_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn().mockResolvedValue(false),
+    list_stale: vi.fn(async () => []),
     list: vi.fn().mockResolvedValue([]),
     list_versions: vi.fn().mockResolvedValue([]),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/outlook/tests/unit/services/backup/mailbox-sync.service.test.ts
+++ b/packages/outlook/tests/unit/services/backup/mailbox-sync.service.test.ts
@@ -53,6 +53,7 @@ function make_mock_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn().mockResolvedValue(false),
+    list_stale: vi.fn(async () => []),
     list: vi.fn().mockResolvedValue([]),
     list_versions: vi.fn().mockResolvedValue([]),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/outlook/tests/unit/services/backup/mime-payload.test.ts
+++ b/packages/outlook/tests/unit/services/backup/mime-payload.test.ts
@@ -43,6 +43,7 @@ function make_ctx(already_stored = false): StoreHarness {
     list_versions: vi.fn().mockResolvedValue([]),
     begin_multipart_upload: vi.fn(),
     copy: vi.fn(),
+    list_stale: vi.fn(async () => []),
     abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
     probe_immutability: vi.fn(),
   } as unknown as ObjectStorage;

--- a/packages/outlook/tests/unit/services/backup/object-lock.test.ts
+++ b/packages/outlook/tests/unit/services/backup/object-lock.test.ts
@@ -22,6 +22,7 @@ function make_mock_storage(): ObjectStorage {
     delete: vi.fn(),
     delete_version: vi.fn(),
     exists: vi.fn().mockResolvedValue(false),
+    list_stale: vi.fn(async () => []),
     list: vi.fn().mockResolvedValue([]),
     list_versions: vi.fn().mockResolvedValue([]),
     begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/outlook/tests/unit/services/restore/mime-entry.test.ts
+++ b/packages/outlook/tests/unit/services/restore/mime-entry.test.ts
@@ -125,6 +125,7 @@ describe('restore of MIME and legacy JSON entries', () => {
         delete: vi.fn(),
         delete_version: vi.fn(),
         exists: vi.fn(),
+        list_stale: vi.fn(async () => []),
         list: vi.fn(),
         list_versions: vi.fn().mockResolvedValue([]),
         begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/outlook/tests/unit/services/restore/restore-attachment-writer.test.ts
+++ b/packages/outlook/tests/unit/services/restore/restore-attachment-writer.test.ts
@@ -20,6 +20,7 @@ function make_ctx(): TenantContext {
       delete: vi.fn(),
       delete_version: vi.fn(),
       exists: vi.fn(),
+      list_stale: vi.fn(async () => []),
       list: vi.fn(),
       list_versions: vi.fn().mockResolvedValue([]),
       begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/outlook/tests/unit/services/restore/restore-message-transformer.test.ts
+++ b/packages/outlook/tests/unit/services/restore/restore-message-transformer.test.ts
@@ -138,6 +138,7 @@ describe('decrypt_and_parse_message', () => {
         delete: vi.fn(),
         delete_version: vi.fn(),
         exists: vi.fn(),
+        list_stale: vi.fn(async () => []),
         list: vi.fn(),
         list_versions: vi.fn().mockResolvedValue([]),
         begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/outlook/tests/unit/services/restore/restore.service.test.ts
+++ b/packages/outlook/tests/unit/services/restore/restore.service.test.ts
@@ -39,6 +39,7 @@ describe('RestoreService', () => {
         delete: vi.fn(),
         delete_version: vi.fn(),
         exists: vi.fn(),
+        list_stale: vi.fn(async () => []),
         list: vi.fn(),
         list_versions: vi.fn().mockResolvedValue([]),
         begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/outlook/tests/unit/services/status/mailbox-status.service.test.ts
+++ b/packages/outlook/tests/unit/services/status/mailbox-status.service.test.ts
@@ -47,6 +47,7 @@ function make_mock_context(): TenantContext {
       delete: vi.fn(),
       delete_version: vi.fn(),
       exists: vi.fn().mockResolvedValue(false),
+      list_stale: vi.fn(async () => []),
       list: vi.fn().mockResolvedValue([]),
       list_versions: vi.fn().mockResolvedValue([]),
       begin_multipart_upload: vi.fn().mockResolvedValue({

--- a/packages/s3/src/adapters/s3-multipart-cleanup.ts
+++ b/packages/s3/src/adapters/s3-multipart-cleanup.ts
@@ -1,17 +1,33 @@
 import {
   AbortMultipartUploadCommand,
   ListMultipartUploadsCommand,
+  ListPartsCommand,
+  type MultipartUpload,
   type S3Client,
 } from '@aws-sdk/client-s3';
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+/** What a sweep did, so a caller can report the uploads it deliberately left behind. */
+export interface MultipartSweepResult {
+  readonly aborted: number;
+  /** Uploads the backend reported without a start time, which cannot be shown to be abandoned. */
+  readonly skipped_unknown_age: number;
+}
 
 /**
- * Aborts incomplete multipart uploads under a prefix that started before `older_than`, returning
- * the count.
+ * Aborts incomplete multipart uploads under a prefix that no longer show any activity.
  *
  * An abandoned multipart upload keeps its parts, and the tenant keeps paying storage for bytes no
- * object will ever expose. The cutoff is what separates abandoned from live: two backups of the
+ * object will ever expose. Deciding which are abandoned is the whole problem: two backups of the
  * same owner share a staging prefix, and an unfiltered sweep aborts the upload the other one is
  * still streaming into, which fails it with `NoSuchUpload` on its next part (issue #345).
+ *
+ * An upload qualifies only when it started before `older_than` *and* has no part written since
+ * then. The start time alone is not enough, because nothing caps one item's transfer at the
+ * cutoff: a very large file on a throttled link legitimately runs for hours. The last part written
+ * is what says whether anyone is still feeding it, and a live upload writes one every few seconds.
+ * The extra `ListParts` costs one request per upload already past the cutoff, which on a healthy
+ * bucket is none.
  *
  * The listing is paginated on two markers, key and upload id, because one key can carry several
  * stranded uploads.
@@ -21,8 +37,9 @@ export async function abort_incomplete_multipart_uploads(
   bucket: string,
   prefix: string,
   older_than: Date,
-): Promise<number> {
+): Promise<MultipartSweepResult> {
   let aborted = 0;
+  let skipped_unknown_age = 0;
   let key_marker: string | undefined;
   let upload_id_marker: string | undefined;
 
@@ -37,15 +54,15 @@ export async function abort_incomplete_multipart_uploads(
     );
 
     for (const upload of response.Uploads ?? []) {
-      // No `Initiated` means the backend did not report a start time, and an upload that cannot be
-      // shown to be abandoned is left alone.
-      const started = upload.Initiated;
-      if (!upload.Key || !upload.UploadId || !started || started >= older_than) continue;
+      const verdict = await classify_upload(client, bucket, upload, older_than);
+      if (verdict === 'unknown-age') skipped_unknown_age += 1;
+      if (verdict !== 'abandoned') continue;
+
       await client.send(
         new AbortMultipartUploadCommand({
           Bucket: bucket,
-          Key: upload.Key,
-          UploadId: upload.UploadId,
+          Key: upload.Key!,
+          UploadId: upload.UploadId!,
         }),
       );
       aborted += 1;
@@ -56,5 +73,56 @@ export async function abort_incomplete_multipart_uploads(
     upload_id_marker = response.NextUploadIdMarker;
   }
 
-  return aborted;
+  if (skipped_unknown_age > 0) {
+    logger.warn(
+      `${skipped_unknown_age} incomplete upload(s) under ${prefix} report no start time, so their ` +
+        `age cannot be established and they were left alone. The bucket's lifecycle rule is what ` +
+        `collects those.`,
+    );
+  }
+
+  return { aborted, skipped_unknown_age };
+}
+
+/** Whether one listed upload can be shown to be abandoned. */
+async function classify_upload(
+  client: S3Client,
+  bucket: string,
+  upload: MultipartUpload,
+  older_than: Date,
+): Promise<'abandoned' | 'live' | 'unknown-age'> {
+  if (!upload.Key || !upload.UploadId) return 'live';
+  if (!upload.Initiated) return 'unknown-age';
+  if (upload.Initiated >= older_than) return 'live';
+  const recent = await has_recent_part(client, bucket, upload.Key, upload.UploadId, older_than);
+  return recent ? 'live' : 'abandoned';
+}
+
+/** True when any part was written on or after the cutoff, which means someone is still uploading. */
+async function has_recent_part(
+  client: S3Client,
+  bucket: string,
+  key: string,
+  upload_id: string,
+  older_than: Date,
+): Promise<boolean> {
+  let part_marker: number | undefined;
+
+  for (;;) {
+    const response = await client.send(
+      new ListPartsCommand({
+        Bucket: bucket,
+        Key: key,
+        UploadId: upload_id,
+        PartNumberMarker: part_marker === undefined ? undefined : String(part_marker),
+      }),
+    );
+
+    for (const part of response.Parts ?? []) {
+      if (part.LastModified && part.LastModified >= older_than) return true;
+    }
+
+    if (!response.IsTruncated || response.NextPartNumberMarker === undefined) return false;
+    part_marker = Number(response.NextPartNumberMarker);
+  }
 }

--- a/packages/s3/src/adapters/s3-multipart-cleanup.ts
+++ b/packages/s3/src/adapters/s3-multipart-cleanup.ts
@@ -5,17 +5,22 @@ import {
 } from '@aws-sdk/client-s3';
 
 /**
- * Aborts every incomplete multipart upload under a prefix, returning the count.
+ * Aborts incomplete multipart uploads under a prefix that started before `older_than`, returning
+ * the count.
  *
- * An abandoned multipart upload keeps its parts, and the tenant keeps paying
- * storage for bytes no object will ever expose. The listing is paginated on two
- * markers, key and upload id, because one key can carry several stranded
- * uploads.
+ * An abandoned multipart upload keeps its parts, and the tenant keeps paying storage for bytes no
+ * object will ever expose. The cutoff is what separates abandoned from live: two backups of the
+ * same owner share a staging prefix, and an unfiltered sweep aborts the upload the other one is
+ * still streaming into, which fails it with `NoSuchUpload` on its next part (issue #345).
+ *
+ * The listing is paginated on two markers, key and upload id, because one key can carry several
+ * stranded uploads.
  */
 export async function abort_incomplete_multipart_uploads(
   client: S3Client,
   bucket: string,
   prefix: string,
+  older_than: Date,
 ): Promise<number> {
   let aborted = 0;
   let key_marker: string | undefined;
@@ -32,16 +37,18 @@ export async function abort_incomplete_multipart_uploads(
     );
 
     for (const upload of response.Uploads ?? []) {
-      if (upload.Key && upload.UploadId) {
-        await client.send(
-          new AbortMultipartUploadCommand({
-            Bucket: bucket,
-            Key: upload.Key,
-            UploadId: upload.UploadId,
-          }),
-        );
-        aborted += 1;
-      }
+      // No `Initiated` means the backend did not report a start time, and an upload that cannot be
+      // shown to be abandoned is left alone.
+      const started = upload.Initiated;
+      if (!upload.Key || !upload.UploadId || !started || started >= older_than) continue;
+      await client.send(
+        new AbortMultipartUploadCommand({
+          Bucket: bucket,
+          Key: upload.Key,
+          UploadId: upload.UploadId,
+        }),
+      );
+      aborted += 1;
     }
 
     if (!response.IsTruncated) break;

--- a/packages/s3/src/adapters/s3-object-storage.adapter.ts
+++ b/packages/s3/src/adapters/s3-object-storage.adapter.ts
@@ -194,6 +194,30 @@ export class S3ObjectStorage implements ObjectStorage {
     return keys;
   }
 
+  /** Lists keys under the prefix last modified before `older_than`. */
+  async list_stale(prefix: string, older_than: Date): Promise<string[]> {
+    const keys: string[] = [];
+    let continuation_token: string | undefined;
+
+    do {
+      const response = await this._client.send(
+        new ListObjectsV2Command({
+          Bucket: this._bucket,
+          Prefix: prefix,
+          ContinuationToken: continuation_token,
+        }),
+      );
+
+      for (const obj of response.Contents ?? []) {
+        // An object with no reported timestamp cannot be shown to be abandoned, so it stays.
+        if (obj.Key && obj.LastModified && obj.LastModified < older_than) keys.push(obj.Key);
+      }
+      continuation_token = response.NextContinuationToken;
+    } while (continuation_token);
+
+    return keys;
+  }
+
   /** Lists all object versions and delete markers under a prefix. */
   async list_versions(
     prefix: string,
@@ -317,8 +341,8 @@ export class S3ObjectStorage implements ObjectStorage {
   }
 
   /** Lists and aborts incomplete multipart uploads under {@link prefix}; returns count aborted. */
-  async abort_incomplete_uploads(prefix: string): Promise<number> {
-    return abort_incomplete_multipart_uploads(this._client, this._bucket, prefix);
+  async abort_incomplete_uploads(prefix: string, older_than: Date): Promise<number> {
+    return abort_incomplete_multipart_uploads(this._client, this._bucket, prefix, older_than);
   }
 
   private async validate_immutability_policy(policy?: StorageObjectLockPolicy): Promise<void> {

--- a/packages/s3/src/adapters/s3-object-storage.adapter.ts
+++ b/packages/s3/src/adapters/s3-object-storage.adapter.ts
@@ -171,6 +171,27 @@ export class S3ObjectStorage implements ObjectStorage {
 
   /** Lists keys sharing the given prefix; `limit` stops enumeration early. */
   async list(prefix: string, limit?: number): Promise<string[]> {
+    return this.collect_keys(prefix, () => true, limit);
+  }
+
+  /**
+   * Lists keys under the prefix last modified before `older_than`.
+   *
+   * An object with no reported timestamp cannot be shown to be abandoned, so it stays.
+   */
+  async list_stale(prefix: string, older_than: Date): Promise<string[]> {
+    return this.collect_keys(
+      prefix,
+      (last_modified) => last_modified !== undefined && last_modified < older_than,
+    );
+  }
+
+  /** One paginated walk; the two listings differ only in what they keep and when they stop. */
+  private async collect_keys(
+    prefix: string,
+    keep: (last_modified: Date | undefined) => boolean,
+    limit?: number,
+  ): Promise<string[]> {
     const keys: string[] = [];
     let continuation_token: string | undefined;
 
@@ -185,33 +206,9 @@ export class S3ObjectStorage implements ObjectStorage {
       );
 
       for (const obj of response.Contents ?? []) {
-        if (obj.Key) keys.push(obj.Key);
+        if (obj.Key && keep(obj.LastModified)) keys.push(obj.Key);
       }
       if (limit !== undefined && keys.length >= limit) return keys.slice(0, limit);
-      continuation_token = response.NextContinuationToken;
-    } while (continuation_token);
-
-    return keys;
-  }
-
-  /** Lists keys under the prefix last modified before `older_than`. */
-  async list_stale(prefix: string, older_than: Date): Promise<string[]> {
-    const keys: string[] = [];
-    let continuation_token: string | undefined;
-
-    do {
-      const response = await this._client.send(
-        new ListObjectsV2Command({
-          Bucket: this._bucket,
-          Prefix: prefix,
-          ContinuationToken: continuation_token,
-        }),
-      );
-
-      for (const obj of response.Contents ?? []) {
-        // An object with no reported timestamp cannot be shown to be abandoned, so it stays.
-        if (obj.Key && obj.LastModified && obj.LastModified < older_than) keys.push(obj.Key);
-      }
       continuation_token = response.NextContinuationToken;
     } while (continuation_token);
 
@@ -342,7 +339,13 @@ export class S3ObjectStorage implements ObjectStorage {
 
   /** Lists and aborts incomplete multipart uploads under {@link prefix}; returns count aborted. */
   async abort_incomplete_uploads(prefix: string, older_than: Date): Promise<number> {
-    return abort_incomplete_multipart_uploads(this._client, this._bucket, prefix, older_than);
+    const swept = await abort_incomplete_multipart_uploads(
+      this._client,
+      this._bucket,
+      prefix,
+      older_than,
+    );
+    return swept.aborted;
   }
 
   private async validate_immutability_policy(policy?: StorageObjectLockPolicy): Promise<void> {

--- a/packages/s3/tests/unit/dek-validator.test.ts
+++ b/packages/s3/tests/unit/dek-validator.test.ts
@@ -11,6 +11,7 @@ function make_storage(): ObjectStorage {
     delete_version: vi.fn(),
     exists: vi.fn(),
     list: vi.fn(),
+    list_stale: vi.fn(async () => []),
     list_versions: vi.fn(),
     begin_multipart_upload: vi.fn().mockResolvedValue({
       upload_part: vi.fn(),

--- a/packages/s3/tests/unit/manifest-identity.test.ts
+++ b/packages/s3/tests/unit/manifest-identity.test.ts
@@ -37,6 +37,7 @@ function make_ctx(objects: Record<string, Manifest>): TenantContext {
       list: vi.fn(async (prefix: string) =>
         Object.keys(objects).filter((key) => key.startsWith(prefix)),
       ),
+      list_stale: vi.fn(async () => []),
       delete: vi.fn(),
       delete_version: vi.fn(),
       exists: vi.fn(),

--- a/packages/s3/tests/unit/s3-manifest-repository.test.ts
+++ b/packages/s3/tests/unit/s3-manifest-repository.test.ts
@@ -15,6 +15,7 @@ function make_mock_context(): TenantContext {
       delete_version: vi.fn(),
       exists: vi.fn(),
       list: vi.fn(),
+      list_stale: vi.fn(async () => []),
       list_versions: vi.fn().mockResolvedValue([]),
       begin_multipart_upload: vi.fn().mockResolvedValue({
         upload_part: vi.fn(),

--- a/packages/s3/tests/unit/staging-cleanup-age.test.ts
+++ b/packages/s3/tests/unit/staging-cleanup-age.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BucketCache } from '@/adapters/bucket-cache';
+import { S3ObjectStorage } from '@/adapters/s3-object-storage.adapter';
+
+/**
+ * Issue #345: startup cleanup swept an owner's staging prefix with no age filter, so a second
+ * backup of the same owner aborted the multipart upload the first one was streaming into and
+ * deleted the staging object it was about to copy. Both runs share the prefix; only time
+ * distinguishes an abandoned upload from a live one.
+ */
+
+const BUCKET = 'test-bucket';
+const PREFIX = 'onedrive/staging/owner-1/';
+// Everything before the cutoff is abandoned; a run that started after it may still be streaming.
+const CUTOFF = new Date('2026-03-15T12:00:00Z');
+const ABANDONED = new Date('2026-03-14T09:00:00Z');
+const LIVE = new Date('2026-03-15T12:30:00Z');
+function inputs_of(send: ReturnType<typeof vi.fn>, name: string): Record<string, unknown>[] {
+  return send.mock.calls
+    .map((call) => call[0] as { constructor: { name: string }; input: Record<string, unknown> })
+    .filter((cmd) => cmd.constructor.name === name)
+    .map((cmd) => cmd.input);
+}
+
+describe('staging cleanup age filter (issue #345)', () => {
+  let send: ReturnType<typeof vi.fn>;
+  let storage: S3ObjectStorage;
+
+  beforeEach(() => {
+    send = vi.fn();
+    storage = new S3ObjectStorage({ send } as never, BUCKET, new BucketCache());
+  });
+
+  it('aborts an abandoned upload and leaves a live one from a concurrent run alone', async () => {
+    send.mockImplementation(async (command: { constructor: { name: string } }) => {
+      if (command.constructor.name === 'ListMultipartUploadsCommand') {
+        return {
+          Uploads: [
+            { Key: `${PREFIX}item-a`, UploadId: 'abandoned', Initiated: ABANDONED },
+            { Key: `${PREFIX}item-b`, UploadId: 'live', Initiated: LIVE },
+          ],
+          IsTruncated: false,
+        };
+      }
+      return {};
+    });
+
+    const aborted = await storage.abort_incomplete_uploads(PREFIX, CUTOFF);
+
+    expect(aborted).toBe(1);
+    expect(inputs_of(send, 'AbortMultipartUploadCommand').map((input) => input.UploadId)).toEqual([
+      'abandoned',
+    ]);
+  });
+
+  it('leaves an upload whose start time the backend did not report', async () => {
+    send.mockImplementation(async (command: { constructor: { name: string } }) => {
+      if (command.constructor.name === 'ListMultipartUploadsCommand') {
+        return {
+          Uploads: [{ Key: `${PREFIX}item-c`, UploadId: 'unknown-age' }],
+          IsTruncated: false,
+        };
+      }
+      return {};
+    });
+
+    expect(await storage.abort_incomplete_uploads(PREFIX, CUTOFF)).toBe(0);
+    expect(inputs_of(send, 'AbortMultipartUploadCommand')).toHaveLength(0);
+  });
+
+  it('lists only staging objects older than the cutoff', async () => {
+    send.mockImplementation(async (command: { constructor: { name: string } }) => {
+      if (command.constructor.name === 'ListObjectsV2Command') {
+        return {
+          Contents: [
+            { Key: `${PREFIX}item-a`, LastModified: ABANDONED },
+            { Key: `${PREFIX}item-b`, LastModified: LIVE },
+            { Key: `${PREFIX}item-c` },
+          ],
+        };
+      }
+      return {};
+    });
+
+    expect(await storage.list_stale(PREFIX, CUTOFF)).toEqual([`${PREFIX}item-a`]);
+  });
+});

--- a/packages/s3/tests/unit/staging-cleanup-age.test.ts
+++ b/packages/s3/tests/unit/staging-cleanup-age.test.ts
@@ -53,6 +53,42 @@ describe('staging cleanup age filter (issue #345)', () => {
     ]);
   });
 
+  it('leaves an old upload that is still receiving parts', async () => {
+    // Nothing caps one item's transfer at the cutoff: a very large file on a throttled link runs
+    // for hours, and aborting it is the concurrency failure this is all about (issue #345).
+    send.mockImplementation(async (command: { constructor: { name: string } }) => {
+      if (command.constructor.name === 'ListMultipartUploadsCommand') {
+        return {
+          Uploads: [{ Key: `${PREFIX}item-a`, UploadId: 'slow-but-alive', Initiated: ABANDONED }],
+          IsTruncated: false,
+        };
+      }
+      if (command.constructor.name === 'ListPartsCommand') {
+        return { Parts: [{ PartNumber: 1, LastModified: LIVE }], IsTruncated: false };
+      }
+      return {};
+    });
+
+    expect(await storage.abort_incomplete_uploads(PREFIX, CUTOFF)).toBe(0);
+    expect(inputs_of(send, 'AbortMultipartUploadCommand')).toHaveLength(0);
+  });
+
+  it('aborts an old upload whose last part is older than the cutoff too', async () => {
+    send.mockImplementation(async (command: { constructor: { name: string } }) => {
+      if (command.constructor.name === 'ListMultipartUploadsCommand') {
+        return {
+          Uploads: [{ Key: `${PREFIX}item-a`, UploadId: 'stranded', Initiated: ABANDONED }],
+          IsTruncated: false,
+        };
+      }
+      if (command.constructor.name === 'ListPartsCommand') {
+        return { Parts: [{ PartNumber: 1, LastModified: ABANDONED }], IsTruncated: false };
+      }
+      return {};
+    });
+
+    expect(await storage.abort_incomplete_uploads(PREFIX, CUTOFF)).toBe(1);
+  });
   it('leaves an upload whose start time the backend did not report', async () => {
     send.mockImplementation(async (command: { constructor: { name: string } }) => {
       if (command.constructor.name === 'ListMultipartUploadsCommand') {

--- a/packages/s3/tests/unit/storage-target.factory.test.ts
+++ b/packages/s3/tests/unit/storage-target.factory.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/adapters/s3-object-storage.adapter', () => ({
     delete_version = async (): Promise<void> => {};
     exists = async (): Promise<boolean> => mock_exists_returns;
     list = async (): Promise<string[]> => [];
+    list_stale = async (): Promise<string[]> => [];
     list_versions = async (): Promise<string[]> => [];
     begin_multipart_upload = async () => ({
       upload_part: async (): Promise<string> => '',

--- a/packages/sharepoint/tests/unit/services/backup/backup-determinism.fixtures.ts
+++ b/packages/sharepoint/tests/unit/services/backup/backup-determinism.fixtures.ts
@@ -42,6 +42,7 @@ export function make_ctx(): TenantContext {
       get_with_etag: vi.fn(),
       get_stream: vi.fn(),
       apply_default_retention: vi.fn(),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn(),
     },
     encrypt: vi.fn((data: Buffer) => data),

--- a/packages/sharepoint/tests/unit/services/backup/large-file-pipeline.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/large-file-pipeline.test.ts
@@ -53,6 +53,7 @@ function make_ctx(options: { exists?: boolean; list?: string[] } = {}): Recorded
         ops.push(`delete:${key}`);
       }),
       list: vi.fn(async () => options.list ?? []),
+      list_stale: vi.fn(async () => options.list ?? []),
       abort_incomplete_uploads: vi.fn(async () => 0),
     },
     create_cipher: () => {

--- a/packages/sharepoint/tests/unit/services/backup/large-file-pipeline.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/large-file-pipeline.test.ts
@@ -53,7 +53,9 @@ function make_ctx(options: { exists?: boolean; list?: string[] } = {}): Recorded
         ops.push(`delete:${key}`);
       }),
       list: vi.fn(async () => options.list ?? []),
-      list_stale: vi.fn(async () => options.list ?? []),
+      list_stale: vi.fn(async (_prefix: string, older_than: Date) =>
+        older_than <= new Date() ? (options.list ?? []) : [],
+      ),
       abort_incomplete_uploads: vi.fn(async () => 0),
     },
     create_cipher: () => {
@@ -233,9 +235,13 @@ describe('cleanup_stale_staging', () => {
 
     await cleanup_stale_staging(recorded.ctx, SITE);
 
-    const prefix = vi.mocked(recorded.ctx.storage.abort_incomplete_uploads).mock.calls[0]?.[0];
+    const [prefix, cutoff] = vi.mocked(recorded.ctx.storage.abort_incomplete_uploads).mock
+      .calls[0]!;
     expect(prefix).toContain('staging');
     expect(prefix).toContain(SITE);
+    // Without a cutoff in the past the sweep is the unfiltered one issue #345 is about: it would
+    // abort whatever a concurrent run of the same owner is streaming into.
+    expect(Date.now() - cutoff.getTime()).toBeGreaterThan(23 * 60 * 60 * 1000);
   });
 
   it('does nothing to delete when no staging objects are left', async () => {

--- a/packages/sharepoint/tests/unit/services/versioning/version-content-store.test.ts
+++ b/packages/sharepoint/tests/unit/services/versioning/version-content-store.test.ts
@@ -42,6 +42,7 @@ function make_ctx(): TenantContext {
       delete: vi.fn().mockResolvedValue(undefined),
       copy: vi.fn().mockResolvedValue(undefined),
       list: vi.fn().mockResolvedValue([]),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
       begin_multipart_upload: vi.fn().mockResolvedValue({
         upload_part: vi.fn().mockResolvedValue('etag'),

--- a/packages/sharepoint/tests/unit/services/versioning/version-sync.test.ts
+++ b/packages/sharepoint/tests/unit/services/versioning/version-sync.test.ts
@@ -39,6 +39,7 @@ function make_ctx(): TenantContext {
       delete: vi.fn(),
       begin_multipart_upload: vi.fn(),
       copy: vi.fn(),
+      list_stale: vi.fn(async () => []),
       abort_incomplete_uploads: vi.fn(),
     },
     encrypt: vi.fn((data: Buffer) => data),

--- a/packages/types/src/ports/storage/object-storage.port.ts
+++ b/packages/types/src/ports/storage/object-storage.port.ts
@@ -112,6 +112,21 @@ export interface ObjectStorage {
     object_lock_policy?: StorageObjectLockPolicy,
   ): Promise<void>;
 
-  /** Aborts all incomplete multipart uploads under the given prefix. */
-  abort_incomplete_uploads(prefix: string): Promise<number>;
+  /**
+   * Lists keys under a prefix last modified before `older_than`.
+   *
+   * Startup cleanup has no other way to tell an abandoned staging object from one a concurrent run
+   * is about to copy, and deleting the second breaks that run (issue #345).
+   */
+  list_stale(prefix: string, older_than: Date): Promise<string[]>;
+
+  /**
+   * Aborts incomplete multipart uploads under the prefix that started before `older_than`, and
+   * returns how many.
+   *
+   * The cutoff is required rather than optional: an unfiltered sweep of an owner prefix aborts the
+   * upload a concurrent backup is streaming into, which fails that run with `NoSuchUpload` on its
+   * next part (issue #345).
+   */
+  abort_incomplete_uploads(prefix: string, older_than: Date): Promise<number>;
 }


### PR DESCRIPTION
## Summary

Closes #345.

Two ends of one ownership problem: a run that did not clean up after itself, and cleanup that took other runs' work with it.

**A failure after the upload was created did not always abort it.** `stream_to_content_addressed_storage` only had a `catch` around the source, so a failing `exists()` check on the canonical key, or a completion the bucket refused, returned with the handle discarded. The upload stayed active, its parts stayed billable, and no id was left to abort them by. Everything between creating the upload and completing it now aborts it on the way out.

**The abort-failure fallback was wider than the failure.** When `handle.abort()` itself failed, the code swept every incomplete multipart upload under the staging prefix. One owner's large files all share that prefix, so one run's failed abort aborted the upload a concurrent backup was streaming into, and that run died on its next part with `NoSuchUpload`. One run's problem became two. The sweep is gone: a failed abort names the staging key and says the parts stay billable until something collects them. One stranded upload is what a lifecycle rule is for.

**Startup cleanup had the same defect and needed the same answer.** It swept the prefix for both objects and uploads with no filter at all, so a second backup of the same owner deleted the staging object the first was about to copy and aborted the upload it was still writing. Key alone cannot separate abandoned from live; time can. `abort_incomplete_uploads(prefix, older_than)` and the new `list_stale(prefix, older_than)` take the cutoff, and the drive cleanup passes 24 hours, which is far longer than one file's transfer and short enough that abandoned parts do not accumulate a bill.

The cutoff is a required parameter rather than an optional one. An optional filter is the kind that gets forgotten at a call site, and the failure mode of forgetting it is aborting a healthy run's upload.

An upload the backend reports no `Initiated` timestamp for is left alone. Cleanup acts on what it can show is abandoned, not on what it cannot date.

### Evidence

Both new suites were run against the code without their fix:

```
multipart-ownership.test.ts   2 failed | 1 passed   (upload left active after exists() and complete() failures)
staging-cleanup-age.test.ts   3 failed              (live upload aborted, live staging object listed)
```

The existing test that pinned the prefix sweep is replaced rather than re-pinned: it asserted the behaviour this issue exists to remove.

Not verified against a real S3 endpoint or a live tenant. `Initiated` and `LastModified` come from `ListMultipartUploads` and `ListObjectsV2`, and both are stubbed here.

## Changes

- `packages/core/src/services/shared/stream-encrypt-upload.ts`: the dedup check and the completion run inside a `try` that aborts the upload; `safe_abort_multipart` takes the staging key instead of a prefix and a context, and reports a failed abort rather than sweeping. `ContentAddressedStreamTarget.staging_prefix` had no other reader and is gone.
- `packages/types/src/ports/storage/object-storage.port.ts`: `list_stale(prefix, older_than)`, and `abort_incomplete_uploads` takes the cutoff.
- `packages/s3/src/adapters/s3-multipart-cleanup.ts`, `s3-object-storage.adapter.ts`: filter by `Initiated` and `LastModified`.
- `packages/drive/src/backup/large-file-pipeline.ts`: `STAGING_ABANDONED_AFTER_MS` of 24 hours, passed to both sweeps.
- Tests: multipart ownership in core, the age filter against the S3 adapter, and `list_stale` added to the hand-rolled storage mocks the port change touched.
- Docs: staging cleanup and concurrent runs in `docs/onedrive-backup.md`, cross-referenced from `docs/sharepoint-backup.md`.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`), unless this is a release or hotfix PR
- [x] No version bump in `packages/*/package.json` (releases only)
- [x] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved large-file transfer cleanup to target only the specific failed upload.
  - Preserved active concurrent transfers during staging cleanup.
  - Automatically removes abandoned staging data older than 24 hours while leaving recent or undated uploads untouched.

- **Documentation**
  - Added guidance describing staging cleanup and concurrent-run behavior for OneDrive and SharePoint backups.

- **Tests**
  - Added coverage for upload failure handling and age-based staging cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->