### PR TITLE
feat(security)!: bind every ciphertext to the object it belongs to

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -73,10 +73,39 @@ Every encrypt operation uses **AES-256-GCM** (Galois/Counter Mode), which provid
 ### Ciphertext Format
 
 ```
-[12-byte IV][16-byte GCM auth tag][ciphertext]
+[ATLS][version][12-byte IV][16-byte GCM auth tag][ciphertext]
 ```
 
 Every encrypt operation generates a **fresh random 12-byte IV** (initialization vector). This is critical for GCM security -- reusing an IV with the same key would be catastrophic, potentially exposing the XOR of two plaintexts and compromising the authentication key. Atlas generates a new random IV for every single object it encrypts.
+
+### What a ciphertext is bound to
+
+One DEK encrypts every object of a tenant, so the GCM tag alone proves only that the bytes were
+produced under that tenant's key. It does not prove they are the bytes that belong at this key.
+Until the header above existed, any object therefore authenticated in any other object's place:
+overwriting one stored blob with another needed write access to the bucket, not the passphrase.
+
+The header and the object's scope are authenticated as associated data, so a ciphertext only
+decrypts where it was written. The scope is the key's directory, which names the purpose and the
+owner: `onedrive/data/{owner_id}/`, `manifests/{mailbox}/`, `_meta/replication/{owner}/{snapshot}/`.
+The directory rather than the whole key, because the large-file pipeline encrypts into a staging
+key and promotes the finished object onto a content-addressed key whose checksum is unknown while
+the cipher is running. The streamed writer therefore binds the canonical directory, not the staging
+one, and a reader derives the same value from the key it is reading.
+
+What this does and does not cover:
+
+| Attack                                                       | Result                                                        |
+| ------------------------------------------------------------ | --------------------------------------------------------------- |
+| Move one object over another owner's or another purpose's key | Decryption fails: the scope in the AAD no longer matches       |
+| Strip or lower the version header                             | Decryption fails: the header is inside the AAD                 |
+| Move an object within its own directory                       | Not prevented; the manifest checksum comparison covers that    |
+| Replay an older ciphertext of the same object                 | Not prevented; that is Object Lock's and versioning's job      |
+
+Objects written before the header existed carry no magic and are decrypted the way they always
+were, with no associated data. Every existing backup stays readable, there is no migration step and
+no configuration flag. A blob written from now on carries the header, so a bucket ends up with both
+until its older objects age out.
 
 ### What Is Encrypted at Rest
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -108,10 +108,16 @@ no configuration flag.
 
 That compatibility is also the limit of the protection. A headerless object has no scope to check,
 so the substitution above still works against one: it can be moved anywhere in the bucket and will
-decrypt. Only objects written since the binding reject a move across owners or purposes. A bucket
-gains the property object by object as new content is written, and a snapshot taken now is bound
-throughout, so an operator who wants the guarantee across an old backup takes a fresh one. Restore
-covers the rest either way, by comparing the manifest checksum before anything is written.
+decrypt. Only objects written since the binding reject a move across owners or purposes.
+
+A bucket gains the property object by object as content is encrypted, which is not the same as
+snapshot by snapshot. File content is stored by checksum, so a backup of a file whose bytes are
+already in the bucket deduplicates onto the existing object and does not rewrite it, and a forced
+full run behaves the same way. A new snapshot's manifests, indexes and cursors are bound because
+they are written fresh, while the content they point at keeps whatever protection it was written
+with. Taking a new backup therefore does not upgrade an old blob: an object becomes bound when its
+plaintext changes, or when it is deleted from the bucket and stored again. Restore covers the rest
+either way, by comparing the manifest checksum before anything is written.
 
 ### What Is Encrypted at Rest
 
@@ -364,11 +370,12 @@ When you run `atlas outlook verify`, Atlas performs a full integrity check for a
 
 ### What the GCM tag does not tell you
 
-The authentication tag proves the bytes were produced under the tenant DEK. It does not say which
-object they belong to. Content is encrypted with one key per tenant and nothing in the ciphertext
-names the object, so any object in the tenant authenticates in any other object's place. Moving one
-blob over another needs write access to the bucket, not the key or the passphrase, and the swapped
-object still decrypts cleanly.
+The authentication tag proves the bytes were produced under the tenant DEK. For an object written
+before the scope binding above, it says nothing about which object those bytes belong to: a
+headerless ciphertext names no object, so any such object authenticates in any other object's
+place. Moving one blob over another needs write access to the bucket, not the key or the
+passphrase, and the swapped object still decrypts cleanly. A scope-bound object refuses a move
+across owners or purposes, but within its own directory it decrypts the same way.
 
 The manifest checksum is what distinguishes them, so it is compared before anything acts on the
 bytes, not after:

--- a/docs/security.md
+++ b/docs/security.md
@@ -104,8 +104,14 @@ What this does and does not cover:
 
 Objects written before the header existed carry no magic and are decrypted the way they always
 were, with no associated data. Every existing backup stays readable, there is no migration step and
-no configuration flag. A blob written from now on carries the header, so a bucket ends up with both
-until its older objects age out.
+no configuration flag.
+
+That compatibility is also the limit of the protection. A headerless object has no scope to check,
+so the substitution above still works against one: it can be moved anywhere in the bucket and will
+decrypt. Only objects written since the binding reject a move across owners or purposes. A bucket
+gains the property object by object as new content is written, and a snapshot taken now is bound
+throughout, so an operator who wants the guarantee across an old backup takes a fresh one. Restore
+covers the rest either way, by comparing the manifest checksum before anything is written.
 
 ### What Is Encrypted at Rest
 

--- a/packages/core/src/adapters/keystore/content-envelope.ts
+++ b/packages/core/src/adapters/keystore/content-envelope.ts
@@ -1,0 +1,78 @@
+/**
+ * The versioned header that binds a stored object to the place it belongs.
+ *
+ * One DEK encrypts every object of a tenant and, until this header existed, nothing tied a
+ * ciphertext to its key: the GCM tag proved the bytes were produced under the tenant key, not that
+ * they are the bytes that belong here, so any object authenticated in any other object's place.
+ * Moving one blob over another needed write access to the bucket, not the passphrase (issue #350).
+ *
+ * Layout: `[MAGIC][version][IV 12][auth tag 16][ciphertext]`. The header itself is part of the
+ * AAD, so the version cannot be stripped or lowered without failing the tag, which is the same
+ * construction `wrap_dek` already uses for the wrapped DEK.
+ *
+ * A blob that does not start with the magic is read the way it always was, with no AAD. Every
+ * backup written before this change stays readable and no migration step exists.
+ */
+
+/** Marks a blob as carrying the versioned, scope-bound envelope. */
+export const CONTENT_MAGIC = Buffer.from('ATLS', 'ascii');
+
+/** Current content envelope version. */
+export const CONTENT_FORMAT_VERSION = 1;
+
+/** Bytes the header occupies before the IV. */
+export const CONTENT_HEADER_LENGTH = CONTENT_MAGIC.length + 1;
+
+/** Builds the header for a newly written object. */
+export function build_content_header(): Buffer {
+  return Buffer.concat([CONTENT_MAGIC, Buffer.of(CONTENT_FORMAT_VERSION)]);
+}
+
+/** Whether a blob, or the first bytes of one, carries the versioned envelope. */
+export function has_content_header(blob: Buffer): boolean {
+  return (
+    blob.length >= CONTENT_HEADER_LENGTH &&
+    blob.subarray(0, CONTENT_MAGIC.length).equals(CONTENT_MAGIC)
+  );
+}
+
+/**
+ * Reads and checks the header of a blob that carries one.
+ *
+ * A version this build does not know is refused rather than guessed at: the layout after the
+ * header is what a future version would change.
+ */
+export function read_content_header(blob: Buffer): Buffer {
+  const header = blob.subarray(0, CONTENT_HEADER_LENGTH);
+  const version = header[CONTENT_MAGIC.length];
+  if (version !== CONTENT_FORMAT_VERSION) {
+    throw new Error(
+      `Unsupported content envelope version ${String(version)}; this build writes and reads ` +
+        `version ${CONTENT_FORMAT_VERSION}`,
+    );
+  }
+  return header;
+}
+
+/**
+ * The associated data an object is authenticated against: its header and its scope.
+ *
+ * A `\0` separates the two so a scope cannot be confused with a longer one that starts the same
+ * way, which is what would let `onedrive/data/user1/` pass for `onedrive/data/user10/`.
+ */
+export function content_aad(header: Buffer, scope: string): Buffer {
+  return Buffer.concat([header, Buffer.of(0), Buffer.from(scope, 'utf-8')]);
+}
+
+/**
+ * The scope a storage key belongs to: everything up to and including its last `/`.
+ *
+ * The directory rather than the whole key, because the large-file pipeline encrypts into a staging
+ * key and copies the finished object onto its content-addressed key, so the final key is not known
+ * when the cipher is created. The directory names the purpose and the owner, which is what an
+ * attacker moving a blob has to defeat; the checksum comparison in restore covers the rest.
+ */
+export function content_scope(storage_key: string): string {
+  const last_separator = storage_key.lastIndexOf('/');
+  return last_separator === -1 ? '' : storage_key.slice(0, last_separator + 1);
+}

--- a/packages/core/src/adapters/keystore/content-envelope.ts
+++ b/packages/core/src/adapters/keystore/content-envelope.ts
@@ -74,5 +74,8 @@ export function content_aad(header: Buffer, scope: string): Buffer {
  */
 export function content_scope(storage_key: string): string {
   const last_separator = storage_key.lastIndexOf('/');
-  return last_separator === -1 ? '' : storage_key.slice(0, last_separator + 1);
+  // A key at the bucket root, `identity-registry.json`, has no directory to name its purpose. The
+  // key itself is the scope there: an empty one would make every root object interchangeable,
+  // which is the substitution this exists to stop.
+  return last_separator === -1 ? storage_key : storage_key.slice(0, last_separator + 1);
 }

--- a/packages/core/src/adapters/keystore/envelope-key-service.adapter.ts
+++ b/packages/core/src/adapters/keystore/envelope-key-service.adapter.ts
@@ -9,6 +9,14 @@ import { WrongPassphraseError } from '@wisecom/atlas-types';
 import { DEFAULT_KDF_STRATEGY, KDF_STRATEGIES } from '@/adapters/keystore/kdf-strategy';
 import { parse_dek_blob, build_header_bytes } from '@/adapters/keystore/dek-blob-codec';
 import type { DekBlobHeader } from '@/adapters/keystore/dek-blob-codec';
+import {
+  build_content_header,
+  content_aad,
+  content_scope,
+  has_content_header,
+  read_content_header,
+  CONTENT_HEADER_LENGTH,
+} from '@/adapters/keystore/content-envelope';
 
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
@@ -24,7 +32,9 @@ const KEY_LENGTH = 32;
  *   versioned, AAD-authenticated blob (see `dek-blob-codec`).
  * - All tenant data is encrypted with the DEK (buffer or streaming).
  *
- * Content format: [12-byte IV] [16-byte auth tag] [ciphertext]
+ * Content format: [magic] [version] [12-byte IV] [16-byte auth tag] [ciphertext], with the header
+ * and the object's scope authenticated as AAD so a ciphertext only decrypts where it belongs
+ * (issue #350). A blob written before that header existed has no AAD and is read as it always was.
  */
 export class EnvelopeKeyService {
   // Stored as a Buffer so it can be zeroed via destroy(). The caller-side JS
@@ -40,30 +50,64 @@ export class EnvelopeKeyService {
     this._passphrase_buf.fill(0);
   }
 
-  /** Encrypts plaintext using the given DEK. */
-  encrypt(data: Buffer, dek: Buffer): Buffer {
-    return aes_gcm_encrypt(data, dek);
-  }
-
-  /** Decrypts ciphertext using the given DEK. Throws on tampered data. */
-  decrypt(data: Buffer, dek: Buffer): Buffer {
-    return aes_gcm_decrypt(data, dek);
+  /**
+   * Encrypts plaintext using the given DEK, bound to the object's storage key.
+   *
+   * The binding is the key's directory, so the result decrypts under that prefix and nowhere else.
+   */
+  encrypt(data: Buffer, dek: Buffer, storage_key: string): Buffer {
+    const header = build_content_header();
+    const aad = content_aad(header, content_scope(storage_key));
+    return Buffer.concat([header, aes_gcm_encrypt(data, dek, aad)]);
   }
 
   /**
-   * Creates a streaming AES-256-GCM cipher using the DEK (same parameters as
-   * {@link EnvelopeKeyService.encrypt}); finalize with auth tag for the envelope format.
+   * Decrypts ciphertext using the given DEK. Throws on tampered data, and on a blob that carries
+   * the versioned header but was written for another scope.
+   *
+   * A blob with no header predates the binding and is decrypted without AAD.
    */
-  create_encrypt_cipher(dek: Buffer): { cipher: CipherGCM; iv: Buffer } {
-    const iv = randomBytes(IV_LENGTH);
-    const cipher = createCipheriv(ALGORITHM, dek, iv, { authTagLength: AUTH_TAG_LENGTH });
-    return { cipher, iv };
+  decrypt(data: Buffer, dek: Buffer, storage_key: string): Buffer {
+    if (!has_content_header(data)) return aes_gcm_decrypt(data, dek);
+    const header = read_content_header(data);
+    const aad = content_aad(header, content_scope(storage_key));
+    return aes_gcm_decrypt(data.subarray(CONTENT_HEADER_LENGTH), dek, aad);
   }
 
-  /** Creates a streaming AES-256-GCM decipher initialized with IV and auth tag. */
-  create_decrypt_decipher(dek: Buffer, iv: Buffer, auth_tag: Buffer): DecipherGCM {
+  /**
+   * Creates a streaming AES-256-GCM cipher bound to a scope, plus the header the caller has to
+   * write ahead of the IV for the object to be readable.
+   *
+   * `scope_key` is any key in the directory the finished object will live in, which for the
+   * large-file pipeline is the content-addressed key rather than the staging key it streams into.
+   */
+  create_encrypt_cipher(
+    dek: Buffer,
+    scope_key: string,
+  ): { cipher: CipherGCM; iv: Buffer; header: Buffer } {
+    const iv = randomBytes(IV_LENGTH);
+    const cipher = createCipheriv(ALGORITHM, dek, iv, { authTagLength: AUTH_TAG_LENGTH });
+    const header = build_content_header();
+    cipher.setAAD(content_aad(header, content_scope(scope_key)));
+    return { cipher, iv, header };
+  }
+
+  /**
+   * Creates a streaming AES-256-GCM decipher initialized with IV and auth tag.
+   *
+   * `header` is the envelope header the reader found ahead of the IV, or undefined for an object
+   * written before the header existed, which authenticates without AAD.
+   */
+  create_decrypt_decipher(
+    dek: Buffer,
+    iv: Buffer,
+    auth_tag: Buffer,
+    scope_key: string,
+    header?: Buffer,
+  ): DecipherGCM {
     const decipher = createDecipheriv(ALGORITHM, dek, iv, { authTagLength: AUTH_TAG_LENGTH });
     decipher.setAuthTag(auth_tag);
+    if (header) decipher.setAAD(content_aad(header, content_scope(scope_key)));
     return decipher;
   }
 

--- a/packages/core/src/services/catalog/catalog.service.ts
+++ b/packages/core/src/services/catalog/catalog.service.ts
@@ -75,7 +75,7 @@ export class CatalogService implements CatalogUseCase {
       if (!entry) return undefined;
 
       const encrypted = await ctx.storage.get(entry.storage_key);
-      const raw = ctx.decrypt(encrypted);
+      const raw = ctx.decrypt(encrypted, entry.storage_key);
       if (entry.payload_format === 'mime') {
         return { raw, payload_format: 'mime', attachments: [] };
       }

--- a/packages/core/src/services/replication/replication-integrity-verifier.ts
+++ b/packages/core/src/services/replication/replication-integrity-verifier.ts
@@ -60,7 +60,7 @@ async function verify_single_object(
 ): Promise<boolean> {
   try {
     const ciphertext = await ctx.storage.get(key);
-    const plaintext = ctx.decrypt(ciphertext);
+    const plaintext = ctx.decrypt(ciphertext, key);
     const actual = createHash('sha256').update(plaintext).digest('hex');
     if (actual.length !== expected_checksum.length) return false;
     return timingSafeEqual(Buffer.from(actual, 'utf8'), Buffer.from(expected_checksum, 'utf8'));

--- a/packages/core/src/services/replication/replication-status-repository.ts
+++ b/packages/core/src/services/replication/replication-status-repository.ts
@@ -15,7 +15,7 @@ export async function save_replication_status(
 ): Promise<void> {
   const key = status_key(record.owner_id, record.snapshot_id, record.target_id);
   const plaintext = Buffer.from(JSON.stringify(record), 'utf-8');
-  const ciphertext = ctx.encrypt(plaintext);
+  const ciphertext = ctx.encrypt(plaintext, key);
   await ctx.storage.put(key, ciphertext);
 }
 
@@ -77,7 +77,7 @@ async function decrypt_status_record(
     const exists = await ctx.storage.exists(key);
     if (!exists) return undefined;
     const ciphertext = await ctx.storage.get(key);
-    const plaintext = ctx.decrypt(ciphertext);
+    const plaintext = ctx.decrypt(ciphertext, key);
     return JSON.parse(plaintext.toString('utf-8')) as ReplicationStatusRecord;
   } catch {
     return undefined;

--- a/packages/core/src/services/shared/stream-decrypt.ts
+++ b/packages/core/src/services/shared/stream-decrypt.ts
@@ -1,6 +1,12 @@
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { Readable } from 'node:stream';
 import type { TenantContext } from '@wisecom/atlas-types';
+import {
+  has_content_header,
+  read_content_header,
+  CONTENT_HEADER_LENGTH,
+  CONTENT_MAGIC,
+} from '@/adapters/keystore/content-envelope';
 
 const IV_LENGTH = 12;
 const AUTH_TAG_LENGTH = 16;
@@ -94,13 +100,13 @@ export async function* stream_verified_plaintext(
 /**
  * Yields decrypted plaintext chunks in one pass over the stored object.
  *
- * The IV and auth tag occupy the first {@link HEADER_LENGTH} bytes, which may
- * arrive split across chunks, so the header is assembled inside the single
- * iteration over the stream. Reading it in a separate `for await` loop and
- * breaking out is what issue #143 was: an early exit from `for await` calls the
- * async iterator's `return()`, which destroys the stream, and every subsequent
- * read rejects with `AbortError: The operation was aborted`. One pass, no early
- * exit, no `unshift`. Consumers must drain this generator for the same reason.
+ * The IV and auth tag occupy the first {@link HEADER_LENGTH} bytes, preceded by the envelope
+ * header on any object written since the scope binding existed (issue #350). Both may arrive split
+ * across chunks, so they are assembled inside the single iteration over the stream. Reading them
+ * in a separate `for await` loop and breaking out is what issue #143 was: an early exit from
+ * `for await` calls the async iterator's `return()`, which destroys the stream, and every
+ * subsequent read rejects with `AbortError: The operation was aborted`. One pass, no early exit,
+ * no `unshift`. Consumers must drain this generator for the same reason.
  */
 async function* decrypt_plaintext_chunks(
   ctx: TenantContext,
@@ -112,8 +118,7 @@ async function* decrypt_plaintext_chunks(
       ? raw_stream
       : Readable.from(raw_stream as AsyncIterable<Buffer>);
 
-  const header_chunks: Buffer[] = [];
-  let header_length = 0;
+  const prefix = new PrefixReader();
   let decipher: ReturnType<TenantContext['create_decipher']> | undefined;
 
   for await (const chunk of readable) {
@@ -125,25 +130,75 @@ async function* decrypt_plaintext_chunks(
       continue;
     }
 
-    header_chunks.push(buf);
-    header_length += buf.length;
-    if (header_length < HEADER_LENGTH) continue;
-
-    const combined = Buffer.concat(header_chunks);
-    decipher = ctx.create_decipher(
-      combined.subarray(0, IV_LENGTH),
-      combined.subarray(IV_LENGTH, HEADER_LENGTH),
-    );
-    const decrypted = decipher.update(combined.subarray(HEADER_LENGTH));
+    const complete = prefix.push(buf);
+    if (complete === undefined) continue;
+    decipher = open_decipher(ctx, storage_key, complete, prefix.length);
+    const decrypted = decipher.update(complete.subarray(prefix.length));
     if (decrypted.length > 0) yield decrypted;
   }
 
   if (decipher === undefined) {
     throw new Error(
-      `Stream for ${storage_key} ended after ${header_length} bytes; expected at least ${HEADER_LENGTH}`,
+      `Stream for ${storage_key} ended after ${prefix.collected} bytes; expected at least ` +
+        `${prefix.length}`,
     );
   }
 
   const final_block = decipher.final();
   if (final_block.length > 0) yield final_block;
+}
+
+/**
+ * Starts the decipher from the object's prefix: its envelope header when it has one, then the IV
+ * and auth tag.
+ */
+function open_decipher(
+  ctx: TenantContext,
+  storage_key: string,
+  prefix: Buffer,
+  prefix_length: number,
+): ReturnType<TenantContext['create_decipher']> {
+  const envelope = prefix_length === HEADER_LENGTH ? undefined : read_content_header(prefix);
+  const body = envelope === undefined ? prefix : prefix.subarray(CONTENT_HEADER_LENGTH);
+  return ctx.create_decipher(
+    body.subarray(0, IV_LENGTH),
+    body.subarray(IV_LENGTH, HEADER_LENGTH),
+    storage_key,
+    envelope,
+  );
+}
+
+/**
+ * Collects the bytes ahead of the ciphertext across however many chunks they arrive in.
+ *
+ * How many there are is only known once the magic has arrived: an object written since the scope
+ * binding carries a header before its IV, one written before it does not (issue #350).
+ */
+class PrefixReader {
+  private readonly _chunks: Buffer[] = [];
+  private _collected = 0;
+  private _length = CONTENT_HEADER_LENGTH + HEADER_LENGTH;
+
+  /** Bytes seen so far. */
+  get collected(): number {
+    return this._collected;
+  }
+
+  /** Bytes the prefix occupies, once the magic has settled it. */
+  get length(): number {
+    return this._length;
+  }
+
+  /** Adds a chunk, returning everything read so far once the whole prefix has arrived. */
+  push(chunk: Buffer): Buffer | undefined {
+    this._chunks.push(chunk);
+    this._collected += chunk.length;
+    const combined = Buffer.concat(this._chunks);
+    if (this._collected >= CONTENT_MAGIC.length) {
+      this._length = has_content_header(combined)
+        ? CONTENT_HEADER_LENGTH + HEADER_LENGTH
+        : HEADER_LENGTH;
+    }
+    return this._collected >= this._length ? combined : undefined;
+  }
 }

--- a/packages/core/src/services/shared/stream-encrypt-upload.ts
+++ b/packages/core/src/services/shared/stream-encrypt-upload.ts
@@ -39,6 +39,14 @@ export interface ContentAddressedStreamTarget {
   readonly staging_prefix: string;
   /** Builds the canonical key from the plaintext checksum. */
   build_data_key(checksum: string): string;
+  /**
+   * The directory the finished object lives in, which the ciphertext is bound to.
+   *
+   * Not the staging key's: the object is promoted onto its content-addressed key and has to
+   * decrypt from there, and the checksum that key is built from is unknown when the cipher is
+   * created (issue #350).
+   */
+  readonly data_scope: string;
   readonly object_lock_policy?: StorageObjectLockPolicy;
 }
 
@@ -59,6 +67,7 @@ export async function stream_to_content_addressed_storage(
     ctx,
     target.staging_key,
     chunks,
+    target.data_scope,
   );
 
   const canonical_key = target.build_data_key(checksum);
@@ -120,8 +129,9 @@ export async function stream_encrypt_to_multipart(
   ctx: TenantContext,
   staging_key: string,
   chunks: AsyncIterable<Buffer>,
+  scope_key: string = staging_key,
 ): Promise<StreamEncryptUploadResult> {
-  const { cipher, iv } = ctx.create_cipher();
+  const { cipher, iv, header } = ctx.create_cipher(scope_key);
   const hash = createHash('sha256');
   const handle = await ctx.storage.begin_multipart_upload(staging_key);
 
@@ -155,7 +165,7 @@ export async function stream_encrypt_to_multipart(
     }
 
     const auth_tag = cipher.getAuthTag();
-    const header_part = Buffer.concat([iv, auth_tag, state.first_part_data]);
+    const header_part = Buffer.concat([header, iv, auth_tag, state.first_part_data]);
     const part1_etag = await handle.upload_part(1, header_part);
     state.completed_parts.push({ ETag: part1_etag, PartNumber: 1 });
 

--- a/packages/core/src/services/verification/verification.service.ts
+++ b/packages/core/src/services/verification/verification.service.ts
@@ -183,7 +183,7 @@ export class VerificationService implements VerificationUseCase {
   private async is_item_corrupt(ctx: TenantContext, item: CheckItem): Promise<boolean> {
     try {
       const ciphertext = await ctx.storage.get(item.storage_key);
-      const plaintext = ctx.decrypt(ciphertext);
+      const plaintext = ctx.decrypt(ciphertext, item.storage_key);
       const actual_checksum = compute_sha256(plaintext);
       return is_checksum_mismatch(actual_checksum, item.checksum);
     } catch {

--- a/packages/core/tests/unit/adapters/keystore/content-binding.test.ts
+++ b/packages/core/tests/unit/adapters/keystore/content-binding.test.ts
@@ -1,0 +1,93 @@
+import { createCipheriv, randomBytes } from 'node:crypto';
+import { describe, it, expect } from 'vitest';
+import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
+import { CONTENT_HEADER_LENGTH, CONTENT_MAGIC } from '@/adapters/keystore/content-envelope';
+
+/**
+ * Issue #350: one DEK covers a whole tenant and nothing tied a ciphertext to the object it belongs
+ * to, so any blob authenticated in any other blob's place. Overwriting one stored object with
+ * another needed write access to the bucket, not the passphrase.
+ */
+
+const PASSPHRASE = 'test-passphrase';
+const OWNER_A = 'onedrive/data/owner-a/abc';
+const OWNER_B = 'onedrive/data/owner-b/def';
+const SAME_SCOPE = 'onedrive/data/owner-a/zzz';
+const STAGING = 'onedrive/staging/owner-a/item-1-9f2c';
+
+function service(): { svc: EnvelopeKeyService; dek: Buffer } {
+  const svc = new EnvelopeKeyService(PASSPHRASE);
+  return { svc, dek: svc.generate_dek() };
+}
+
+describe('content scope binding (issue #350)', () => {
+  it('refuses a ciphertext moved into another owner place', () => {
+    const { svc, dek } = service();
+    const stored = svc.encrypt(Buffer.from("owner a's file"), dek, OWNER_A);
+
+    expect(() => svc.decrypt(stored, dek, OWNER_B)).toThrow();
+  });
+
+  it('still decrypts from another key in the same directory', () => {
+    // The binding is the directory, not the whole key: the large-file pipeline encrypts into a
+    // staging key and promotes the object onto a content-addressed key it cannot know yet.
+    const { svc, dek } = service();
+    const plaintext = Buffer.from('content addressed');
+    const stored = svc.encrypt(plaintext, dek, OWNER_A);
+
+    expect(svc.decrypt(stored, dek, SAME_SCOPE)).toEqual(plaintext);
+  });
+
+  it('refuses a ciphertext whose header was stripped', () => {
+    const { svc, dek } = service();
+    const stored = svc.encrypt(Buffer.from('bound'), dek, OWNER_A);
+
+    // Without the header the blob reads as one written before the binding existed, so removing it
+    // is the downgrade the header is inside the AAD to prevent.
+    const stripped = stored.subarray(CONTENT_HEADER_LENGTH);
+    expect(() => svc.decrypt(stripped, dek, OWNER_A)).toThrow();
+  });
+
+  it('refuses a version this build does not know', () => {
+    const { svc, dek } = service();
+    const stored = svc.encrypt(Buffer.from('bound'), dek, OWNER_A);
+    stored[CONTENT_MAGIC.length] = 99;
+
+    expect(() => svc.decrypt(stored, dek, OWNER_A)).toThrow(/Unsupported content envelope version/);
+  });
+
+  it('reads an object written before the binding existed', () => {
+    // Everything already in a bucket has no header and no AAD. It stays readable with no
+    // migration step, which is the whole reason the header is optional on read.
+    const { svc, dek } = service();
+    const plaintext = Buffer.from('written by an older Atlas');
+    const legacy = legacy_encrypt(plaintext, dek);
+
+    expect(svc.decrypt(legacy, dek, OWNER_A)).toEqual(plaintext);
+  });
+
+  it('binds a streamed object to the directory it is promoted into', () => {
+    const { svc, dek } = service();
+    const plaintext = Buffer.from('streamed through staging');
+
+    // What the large-file pipeline does: encrypt for the canonical directory while writing to a
+    // staging key, then read the finished object back from its canonical key.
+    const { cipher, iv, header } = svc.create_encrypt_cipher(dek, OWNER_A);
+    const body = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const auth_tag = cipher.getAuthTag();
+
+    const readable = svc.create_decrypt_decipher(dek, iv, auth_tag, SAME_SCOPE, header);
+    expect(Buffer.concat([readable.update(body), readable.final()])).toEqual(plaintext);
+
+    const wrong_scope = svc.create_decrypt_decipher(dek, iv, auth_tag, STAGING, header);
+    expect(() => Buffer.concat([wrong_scope.update(body), wrong_scope.final()])).toThrow();
+  });
+});
+
+/** The envelope as it was written before the scope binding: IV, auth tag, ciphertext, no AAD. */
+function legacy_encrypt(plaintext: Buffer, dek: Buffer): Buffer {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', dek, iv, { authTagLength: 16 });
+  const body = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return Buffer.concat([iv, cipher.getAuthTag(), body]);
+}

--- a/packages/core/tests/unit/adapters/keystore/content-binding.test.ts
+++ b/packages/core/tests/unit/adapters/keystore/content-binding.test.ts
@@ -56,6 +56,15 @@ describe('content scope binding (issue #350)', () => {
     expect(() => svc.decrypt(stored, dek, OWNER_A)).toThrow(/Unsupported content envelope version/);
   });
 
+  it('binds a key with no directory to the whole key', () => {
+    // `identity-registry.json` lives at the bucket root, so the directory is empty and every root
+    // object would otherwise share one scope.
+    const { svc, dek } = service();
+    const stored = svc.encrypt(Buffer.from('registry'), dek, 'identity-registry.json');
+
+    expect(() => svc.decrypt(stored, dek, 'something-else.json')).toThrow();
+  });
+
   it('reads an object written before the binding existed', () => {
     // Everything already in a bucket has no header and no AAD. It stays readable with no
     // migration step, which is the whole reason the header is optional on read.

--- a/packages/core/tests/unit/adapters/keystore/envelope-key-service.test.ts
+++ b/packages/core/tests/unit/adapters/keystore/envelope-key-service.test.ts
@@ -7,6 +7,7 @@ import { DEK_BLOB_VERSION, parse_dek_blob } from '@/adapters/keystore/dek-blob-c
 describe('EnvelopeKeyService', () => {
   const passphrase = 'test-passphrase';
   const tenant_id = 'tenant-1';
+  const storage_key = 'onedrive/data/owner-1/abc123';
 
   describe('encrypt / decrypt round-trip', () => {
     it('round-trips arbitrary data', () => {
@@ -14,8 +15,8 @@ describe('EnvelopeKeyService', () => {
       const dek = svc.generate_dek();
       const plaintext = Buffer.from('hello world, this is a test message');
 
-      const ciphertext = svc.encrypt(plaintext, dek);
-      const decrypted = svc.decrypt(ciphertext, dek);
+      const ciphertext = svc.encrypt(plaintext, dek, storage_key);
+      const decrypted = svc.decrypt(ciphertext, dek, storage_key);
       expect(decrypted.equals(plaintext)).toBe(true);
     });
 
@@ -24,8 +25,8 @@ describe('EnvelopeKeyService', () => {
       const dek = svc.generate_dek();
       const plaintext = Buffer.from('same data');
 
-      const ct1 = svc.encrypt(plaintext, dek);
-      const ct2 = svc.encrypt(plaintext, dek);
+      const ct1 = svc.encrypt(plaintext, dek, storage_key);
+      const ct2 = svc.encrypt(plaintext, dek, storage_key);
       expect(ct1.equals(ct2)).toBe(false);
     });
 
@@ -34,17 +35,18 @@ describe('EnvelopeKeyService', () => {
       const dek = svc.generate_dek();
       const plaintext = Buffer.from('test');
 
-      const ciphertext = svc.encrypt(plaintext, dek);
-      expect(ciphertext.length).toBe(plaintext.length + 12 + 16);
+      const ciphertext = svc.encrypt(plaintext, dek, storage_key);
+      // Envelope header (5) plus IV (12) and auth tag (16).
+      expect(ciphertext.length).toBe(plaintext.length + 5 + 12 + 16);
     });
 
     it('rejects tampered ciphertext', () => {
       const svc = new EnvelopeKeyService(passphrase);
       const dek = svc.generate_dek();
-      const ciphertext = svc.encrypt(Buffer.from('data'), dek);
+      const ciphertext = svc.encrypt(Buffer.from('data'), dek, storage_key);
 
       ciphertext[ciphertext.length - 1] ^= 0xff;
-      expect(() => svc.decrypt(ciphertext, dek)).toThrow();
+      expect(() => svc.decrypt(ciphertext, dek, storage_key)).toThrow();
     });
 
     it('rejects truncated ciphertext', () => {
@@ -52,7 +54,7 @@ describe('EnvelopeKeyService', () => {
       const dek = svc.generate_dek();
       const short = Buffer.alloc(10);
 
-      expect(() => svc.decrypt(short, dek)).toThrow('too short');
+      expect(() => svc.decrypt(short, dek, storage_key)).toThrow('too short');
     });
   });
 

--- a/packages/core/tests/unit/services/catalog-read-message.test.ts
+++ b/packages/core/tests/unit/services/catalog-read-message.test.ts
@@ -34,7 +34,7 @@ describe('CatalogService.read_message', () => {
     expect(result?.payload_format).toBeUndefined();
     expect(result?.attachments).toEqual([]);
     expect(mock_context.storage.get).toHaveBeenCalledWith('data/u/abc');
-    expect(mock_context.decrypt).toHaveBeenCalledWith(ciphertext);
+    expect(mock_context.decrypt).toHaveBeenCalledWith(ciphertext, 'data/u/abc');
   });
 
   it('returns attachment metadata from a JSON manifest entry', async () => {

--- a/packages/core/tests/unit/services/replication/replication-status-repository.test.ts
+++ b/packages/core/tests/unit/services/replication/replication-status-repository.test.ts
@@ -85,6 +85,7 @@ describe('replication-status-repository', () => {
     expect(key).toBe('_meta/replication/mbx-1/snap-1/offsite.json');
     expect(ctx.encrypt).toHaveBeenCalledWith(
       expect.objectContaining(Buffer.from(JSON.stringify(record))),
+      '_meta/replication/mbx-1/snap-1/offsite.json',
     );
     expect(data).toBeInstanceOf(Buffer);
   });

--- a/packages/core/tests/unit/services/shared/stream-encrypt-upload.test.ts
+++ b/packages/core/tests/unit/services/shared/stream-encrypt-upload.test.ts
@@ -63,7 +63,11 @@ function make_ctx(
     },
     create_cipher: () => {
       const iv = randomBytes(12);
-      return { cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }), iv };
+      return {
+        cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }),
+        iv,
+        header: Buffer.alloc(0),
+      };
     },
   } as unknown as TenantContext;
 
@@ -241,6 +245,7 @@ describe('stream_encrypt_to_multipart', () => {
 describe('stream_to_content_addressed_storage', () => {
   const target = (staging_key = 'staging/a') => ({
     staging_key,
+    data_scope: 'data/',
     staging_prefix: 'staging/',
     build_data_key: (checksum: string) => `data/${checksum}`,
   });

--- a/packages/core/tests/unit/services/shared/streamed-scope-roundtrip.test.ts
+++ b/packages/core/tests/unit/services/shared/streamed-scope-roundtrip.test.ts
@@ -1,0 +1,106 @@
+import { randomBytes } from 'node:crypto';
+import { Readable } from 'node:stream';
+import { describe, it, expect } from 'vitest';
+import type { TenantContext } from '@wisecom/atlas-types';
+import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
+import { stream_to_content_addressed_storage } from '@/services/shared/stream-encrypt-upload';
+import { stream_decrypt_from_storage } from '@/services/shared/stream-decrypt';
+
+/**
+ * Issue #350: the streamed path encrypts into a staging key and promotes the object onto a
+ * content-addressed key, so it has to bind the directory it ends up in rather than the one it is
+ * written to. If it bound the staging key the object would be unreadable the moment it was
+ * promoted, which no unit test of the cipher alone would catch.
+ */
+
+const OWNER = 'owner-1';
+const DATA_SCOPE = `onedrive/data/${OWNER}/`;
+
+/** An in-memory bucket with just enough multipart to assemble what the writer uploads. */
+function make_ctx(): { ctx: TenantContext; objects: Map<string, Buffer> } {
+  const objects = new Map<string, Buffer>();
+  const key_service = new EnvelopeKeyService('test-passphrase');
+  const dek = key_service.generate_dek();
+
+  const storage = {
+    begin_multipart_upload: async (key: string) => {
+      const parts = new Map<number, Buffer>();
+      return {
+        upload_part: async (part_number: number, data: Buffer) => {
+          parts.set(part_number, Buffer.from(data));
+          return `etag-${part_number}`;
+        },
+        complete: async () => {
+          const assembled = [...parts.entries()].sort(([a], [b]) => a - b).map(([, data]) => data);
+          objects.set(key, Buffer.concat(assembled));
+        },
+        abort: async () => parts.clear(),
+      };
+    },
+    exists: async (key: string) => objects.has(key),
+    copy: async (from: string, to: string) => {
+      objects.set(to, objects.get(from)!);
+    },
+    delete: async (key: string) => {
+      objects.delete(key);
+    },
+    get: async (key: string) => objects.get(key)!,
+    get_stream: async (key: string) => Readable.from([objects.get(key)!]),
+    abort_incomplete_uploads: async () => 0,
+    list_stale: async () => [],
+  };
+
+  const ctx = {
+    tenant_id: 'tenant-1',
+    storage,
+    encrypt: (data: Buffer, storage_key: string) => key_service.encrypt(data, dek, storage_key),
+    decrypt: (data: Buffer, storage_key: string) => key_service.decrypt(data, dek, storage_key),
+    create_cipher: (scope_key: string) => key_service.create_encrypt_cipher(dek, scope_key),
+    create_decipher: (iv: Buffer, auth_tag: Buffer, scope_key: string, header?: Buffer) =>
+      key_service.create_decrypt_decipher(dek, iv, auth_tag, scope_key, header),
+    destroy: () => key_service.destroy(),
+  } as unknown as TenantContext;
+
+  return { ctx, objects };
+}
+
+describe('streamed object scope binding (issue #350)', () => {
+  it('decrypts from the canonical key it was promoted onto', async () => {
+    const { ctx, objects } = make_ctx();
+    const plaintext = randomBytes(64 * 1024);
+
+    const result = await stream_to_content_addressed_storage(
+      ctx,
+      (async function* () {
+        yield plaintext;
+      })(),
+      {
+        staging_key: `onedrive/staging/${OWNER}/item-1-a1b2`,
+        staging_prefix: `onedrive/staging/${OWNER}/`,
+        build_data_key: (checksum) => `${DATA_SCOPE}${checksum}`,
+        data_scope: DATA_SCOPE,
+      },
+    );
+
+    expect(result.stored).toBe(true);
+    const read_back = await stream_decrypt_from_storage(ctx, result.storage_key);
+    expect(read_back.content).toEqual(plaintext);
+
+    // The same bytes under another owner's prefix authenticate nowhere.
+    objects.set(`onedrive/data/owner-2/stolen`, objects.get(result.storage_key)!);
+    await expect(
+      stream_decrypt_from_storage(ctx, 'onedrive/data/owner-2/stolen'),
+    ).rejects.toThrow();
+  });
+
+  it('reads a buffered object back from the key it was written to', async () => {
+    const { ctx, objects } = make_ctx();
+    const key = `${DATA_SCOPE}buffered`;
+    const plaintext = Buffer.from('small enough for a single put');
+
+    objects.set(key, ctx.encrypt(plaintext, key));
+
+    expect(ctx.decrypt(objects.get(key)!, key)).toEqual(plaintext);
+    expect(() => ctx.decrypt(objects.get(key)!, 'onedrive/data/owner-2/buffered')).toThrow();
+  });
+});

--- a/packages/drive/src/backup/file-processor.ts
+++ b/packages/drive/src/backup/file-processor.ts
@@ -63,7 +63,7 @@ export async function process_drive_backup_file(
   const exists = await ctx.storage.exists(storage_key);
 
   if (!exists) {
-    await ctx.storage.put(storage_key, ctx.encrypt(raw_body));
+    await ctx.storage.put(storage_key, ctx.encrypt(raw_body, storage_key));
     return { storage_key, checksum, stored: true, deduplicated: false };
   }
 

--- a/packages/drive/src/backup/large-file-pipeline.ts
+++ b/packages/drive/src/backup/large-file-pipeline.ts
@@ -68,6 +68,7 @@ export async function process_large_drive_file(
       staging_key,
       staging_prefix: deps.keys.staging_prefix_for(owner_id),
       build_data_key: (checksum) => deps.keys.data_key(owner_id, checksum),
+      data_scope: deps.keys.data_prefix_for(owner_id),
       ...(object_lock_policy && { object_lock_policy }),
     },
   );

--- a/packages/drive/src/save/save-snapshot.ts
+++ b/packages/drive/src/save/save-snapshot.ts
@@ -276,7 +276,7 @@ async function buffered_decrypt(
   integrity_failures: string[],
 ): Promise<Buffer | undefined> {
   const ciphertext = await ctx.storage.get(entry.storage_key!);
-  const content = ctx.decrypt(ciphertext);
+  const content = ctx.decrypt(ciphertext, entry.storage_key!);
   // A missing checksum is not a pass. The streaming path already refuses it, and an entry nobody
   // can verify is exactly the one a substituted blob hides behind, so it is an integrity failure
   // rather than a file written into the archive unchecked (issues #340, #341).

--- a/packages/drive/src/shared/storage-keys.ts
+++ b/packages/drive/src/shared/storage-keys.ts
@@ -24,6 +24,8 @@ export interface DriveStorageKeys {
   validate_key_segment(value: string): void;
   /** Builds the content-addressed key for a stored file blob. */
   data_key(owner_id: string, checksum: string): string;
+  /** The directory every blob of one owning segment lives in, which its ciphertext is bound to. */
+  data_prefix_for(owner_id: string): string;
   /** Builds the key for a snapshot manifest. */
   manifest_key(owner_id: string, snapshot_id: string): string;
   /** Builds the prefix for listing all manifests of one owning segment. */
@@ -98,6 +100,9 @@ export function build_drive_storage_keys(
       const owner = owning_segment(owner_id);
       validate_key_segment(checksum);
       return `${data_prefix}/${owner}/${checksum}`;
+    },
+    data_prefix_for(owner_id) {
+      return `${data_prefix}/${owning_segment(owner_id)}/`;
     },
     manifest_key(owner_id, snapshot_id) {
       const owner = owning_segment(owner_id);

--- a/packages/drive/src/versioning/version-content-store.ts
+++ b/packages/drive/src/versioning/version-content-store.ts
@@ -68,6 +68,7 @@ async function store_streamed(
       staging_key: keys.staging_key(owner_id, item.item_id),
       staging_prefix: keys.staging_prefix_for(owner_id),
       build_data_key: (checksum) => keys.data_key(owner_id, checksum),
+      data_scope: keys.data_prefix_for(owner_id),
     },
   );
 
@@ -100,7 +101,7 @@ async function store_buffered(
   const checksum = createHash('sha256').update(content).digest('hex');
   const storage_key = keys.data_key(owner_id, checksum);
   const deduplicated = await ctx.storage.exists(storage_key);
-  if (!deduplicated) await ctx.storage.put(storage_key, ctx.encrypt(content));
+  if (!deduplicated) await ctx.storage.put(storage_key, ctx.encrypt(content, storage_key));
 
   return { checksum, storage_key, deduplicated };
 }

--- a/packages/onedrive/src/adapters/s3-onedrive-delta-cursor-repository.adapter.ts
+++ b/packages/onedrive/src/adapters/s3-onedrive-delta-cursor-repository.adapter.ts
@@ -17,7 +17,7 @@ export class S3OneDriveDeltaCursorRepository implements OneDriveDeltaCursorRepos
 
     try {
       const payload = await ctx.storage.get(key);
-      const json = ctx.decrypt(payload).toString('utf-8');
+      const json = ctx.decrypt(payload, key).toString('utf-8');
       return JSON.parse(json) as OneDriveDeltaCursor;
     } catch {
       return undefined;
@@ -28,6 +28,6 @@ export class S3OneDriveDeltaCursorRepository implements OneDriveDeltaCursorRepos
   async save(ctx: TenantContext, cursor: OneDriveDeltaCursor): Promise<void> {
     const key = onedrive_delta_cursor_key(cursor.owner_id);
     const payload = Buffer.from(JSON.stringify(cursor));
-    await ctx.storage.put(key, ctx.encrypt(payload));
+    await ctx.storage.put(key, ctx.encrypt(payload, key));
   }
 }

--- a/packages/onedrive/src/adapters/s3-onedrive-file-version-index-repository.adapter.ts
+++ b/packages/onedrive/src/adapters/s3-onedrive-file-version-index-repository.adapter.ts
@@ -85,10 +85,8 @@ export class S3OneDriveFileVersionIndexRepository implements OneDriveFileVersion
     if (indexes.length === 0) return;
     validate_key_segment(snapshot_id);
     const payload: RunIndexPayload = { owner_id, snapshot_id, indexes };
-    await ctx.storage.put(
-      onedrive_run_index_key(owner_id, snapshot_id),
-      ctx.encrypt(Buffer.from(JSON.stringify(payload), 'utf-8')),
-    );
+    const key = onedrive_run_index_key(owner_id, snapshot_id);
+    await ctx.storage.put(key, ctx.encrypt(Buffer.from(JSON.stringify(payload), 'utf-8'), key));
   }
 
   /** Lists per-file version histories for an owner, merged across all index objects. */
@@ -145,7 +143,7 @@ export class S3OneDriveFileVersionIndexRepository implements OneDriveFileVersion
   ): Promise<OneDriveFileVersionIndex[]> {
     const payload = await ctx.storage.get(key);
     try {
-      const parsed = JSON.parse(ctx.decrypt(payload).toString('utf-8')) as StoredIndexPayload;
+      const parsed = JSON.parse(ctx.decrypt(payload, key).toString('utf-8')) as StoredIndexPayload;
       return 'indexes' in parsed ? parsed.indexes : [parsed];
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);

--- a/packages/onedrive/src/adapters/s3-onedrive-manifest-repository.adapter.ts
+++ b/packages/onedrive/src/adapters/s3-onedrive-manifest-repository.adapter.ts
@@ -40,7 +40,7 @@ export class S3OneDriveManifestRepository implements OneDriveManifestRepository 
   async save(ctx: TenantContext, manifest: OneDriveSnapshotManifest): Promise<void> {
     const key = onedrive_manifest_key(manifest.owner_id, manifest.snapshot_id);
     const payload = Buffer.from(JSON.stringify(manifest));
-    await ctx.storage.put(key, ctx.encrypt(payload));
+    await ctx.storage.put(key, ctx.encrypt(payload, key));
   }
 
   /** Loads a manifest by listing only that owner's manifest prefix. */
@@ -105,7 +105,7 @@ export class S3OneDriveManifestRepository implements OneDriveManifestRepository 
   ): Promise<OneDriveSnapshotManifest | undefined> {
     try {
       const payload = await ctx.storage.get(key);
-      const json = ctx.decrypt(payload).toString('utf-8');
+      const json = ctx.decrypt(payload, key).toString('utf-8');
       const parsed = JSON.parse(json) as OneDriveSnapshotManifest;
       if (onedrive_manifest_key(parsed.owner_id, parsed.snapshot_id) !== key) {
         throw new MismatchedOneDriveManifestError(key, parsed.owner_id, parsed.snapshot_id);

--- a/packages/onedrive/src/services/restore/blob-restore.ts
+++ b/packages/onedrive/src/services/restore/blob-restore.ts
@@ -92,7 +92,7 @@ async function buffered_download_and_decrypt(
     return undefined;
   }
   try {
-    const content = ctx.decrypt(encrypted);
+    const content = ctx.decrypt(encrypted, ref.storage_key!);
     if (!ref.checksum || !plaintext_sha256_equals_expected(content, ref.checksum)) {
       logger.warn(
         ref.checksum

--- a/packages/onedrive/tests/unit/services/backup/cancelled-item-not-ledgered.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/cancelled-item-not-ledgered.test.ts
@@ -25,6 +25,7 @@ const ITEM = {
 
 const KEYS = {
   data_key: (owner_id: string, checksum: string) => `onedrive/data/${owner_id}/${checksum}`,
+  data_prefix_for: (owner_id: string) => `onedrive/data/${owner_id}/`,
   staging_key: (owner_id: string, item_id: string) => `onedrive/staging/${owner_id}/${item_id}`,
   staging_prefix_for: (owner_id: string) => `onedrive/staging/${owner_id}/`,
 };

--- a/packages/onedrive/tests/unit/services/backup/large-file-pipeline.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/large-file-pipeline.test.ts
@@ -57,7 +57,11 @@ function make_ctx(options: { exists?: boolean; list?: string[] } = {}): Recorded
     },
     create_cipher: () => {
       const iv = randomBytes(12);
-      return { cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }), iv };
+      return {
+        cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }),
+        iv,
+        header: Buffer.alloc(0),
+      };
     },
   } as unknown as TenantContext;
 

--- a/packages/onedrive/tests/unit/services/backup/version-source-close.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/version-source-close.test.ts
@@ -24,6 +24,7 @@ const SOURCE_CHUNK = 4 * 1024 * 1024;
 
 const KEYS: DriveStorageKeys = {
   data_key: (owner_id: string, checksum: string) => `onedrive/data/${owner_id}/${checksum}`,
+  data_prefix_for: (owner_id: string) => `onedrive/data/${owner_id}/`,
   staging_key: (owner_id: string, item_id: string) => `onedrive/staging/${owner_id}/${item_id}`,
   staging_prefix_for: (owner_id: string) => `onedrive/staging/${owner_id}/`,
 } as unknown as DriveStorageKeys;

--- a/packages/onedrive/tests/unit/services/versioning/version-content-store.test.ts
+++ b/packages/onedrive/tests/unit/services/versioning/version-content-store.test.ts
@@ -52,7 +52,11 @@ function make_ctx(): TenantContext {
     encrypt: vi.fn((data: Buffer) => data),
     create_cipher: () => {
       const iv = randomBytes(12);
-      return { cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }), iv };
+      return {
+        cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }),
+        iv,
+        header: Buffer.alloc(0),
+      };
     },
     destroy: vi.fn(),
   } as unknown as TenantContext;

--- a/packages/outlook/src/services/backup/attachment-storage-sync.ts
+++ b/packages/outlook/src/services/backup/attachment-storage-sync.ts
@@ -45,7 +45,7 @@ async function store_single_attachment(
   if (has_content) {
     const exists = await ctx.storage.exists(storage_key);
     if (!exists) {
-      const ciphertext = ctx.encrypt(att.content);
+      const ciphertext = ctx.encrypt(att.content, storage_key);
       await ctx.storage.put(storage_key, ciphertext, undefined, object_lock_policy);
     }
   }

--- a/packages/outlook/src/services/backup/message-payload-store.ts
+++ b/packages/outlook/src/services/backup/message-payload-store.ts
@@ -53,7 +53,7 @@ export async function store_single_message(
 
   const already_stored = await ctx.storage.exists(storage_key);
   if (!already_stored) {
-    const ciphertext = ctx.encrypt(payload);
+    const ciphertext = ctx.encrypt(payload, storage_key);
     await ctx.storage.put(
       storage_key,
       ciphertext,

--- a/packages/outlook/src/services/restore/restore-attachment-writer.ts
+++ b/packages/outlook/src/services/restore/restore-attachment-writer.ts
@@ -97,7 +97,7 @@ export async function restore_parsed_attachments(
  */
 async function decrypt_attachment(ctx: TenantContext, att: AttachmentEntry): Promise<Buffer> {
   const ciphertext = await ctx.storage.get(att.storage_key);
-  const content = ctx.decrypt(ciphertext);
+  const content = ctx.decrypt(ciphertext, att.storage_key);
   assert_restored_content_matches(`attachment "${att.name}"`, content, att.checksum);
   return content;
 }

--- a/packages/outlook/src/services/restore/restore-message-transformer.ts
+++ b/packages/outlook/src/services/restore/restore-message-transformer.ts
@@ -78,7 +78,7 @@ export async function decrypt_and_parse_mime(
 /** Fetches, decrypts and checksum-verifies one entry's stored payload. */
 async function decrypt_verified_entry(ctx: TenantContext, entry: ManifestEntry): Promise<Buffer> {
   const ciphertext = await ctx.storage.get(entry.storage_key);
-  const plaintext = ctx.decrypt(ciphertext);
+  const plaintext = ctx.decrypt(ciphertext, entry.storage_key);
   assert_restored_content_matches(`message ${entry.object_id}`, plaintext, entry.checksum);
   return plaintext;
 }

--- a/packages/outlook/src/services/save/save-entry-processor.ts
+++ b/packages/outlook/src/services/save/save-entry-processor.ts
@@ -246,7 +246,7 @@ async function process_single_entry(
   };
 
   const ciphertext = await ctx.storage.get(entry.storage_key);
-  const plaintext = ctx.decrypt(ciphertext);
+  const plaintext = ctx.decrypt(ciphertext, entry.storage_key);
 
   if (!skip_integrity && entry.checksum) {
     if (!verify_checksum(plaintext, entry.checksum)) {

--- a/packages/outlook/src/services/save/save-entry-writer.ts
+++ b/packages/outlook/src/services/save/save-entry-writer.ts
@@ -107,7 +107,7 @@ async function decrypt_and_verify_attachment(
   result: EntryResult,
 ): Promise<Buffer> {
   const ciphertext = await ctx.storage.get(att.storage_key);
-  const plaintext = ctx.decrypt(ciphertext);
+  const plaintext = ctx.decrypt(ciphertext, att.storage_key);
 
   if (!skip_integrity && att.checksum) {
     if (!verify_checksum(plaintext, att.checksum)) {

--- a/packages/outlook/tests/unit/services/backup/mailbox-sync.service.test.ts
+++ b/packages/outlook/tests/unit/services/backup/mailbox-sync.service.test.ts
@@ -235,7 +235,12 @@ describe('MailboxSyncService', () => {
 
     await service.sync_mailbox('t', 'user@test.com');
 
-    expect(mock_context.encrypt).toHaveBeenCalledWith(msg.raw_body);
+    // The key travels with the plaintext: the ciphertext is bound to where it is stored, so a
+    // blob moved to another key stops decrypting (issue #350).
+    expect(mock_context.encrypt).toHaveBeenCalledWith(
+      msg.raw_body,
+      expect.stringContaining('data/user@test.com/'),
+    );
     const [, stored_data] = (mock_context.storage.put as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(stored_data[0]).toBe(0x45);
   });

--- a/packages/s3/src/adapters/s3-identity-registry-repository.adapter.ts
+++ b/packages/s3/src/adapters/s3-identity-registry-repository.adapter.ts
@@ -18,7 +18,7 @@ export class S3IdentityRegistryRepository implements IdentityRegistryRepository 
       const exists = await ctx.storage.exists(REGISTRY_KEY);
       if (!exists) return undefined;
       const encrypted = await ctx.storage.get(REGISTRY_KEY);
-      const json = ctx.decrypt(encrypted);
+      const json = ctx.decrypt(encrypted, REGISTRY_KEY);
       return JSON.parse(json.toString('utf-8')) as IdentityRegistry;
     } catch {
       return undefined;
@@ -27,7 +27,7 @@ export class S3IdentityRegistryRepository implements IdentityRegistryRepository 
 
   async save(ctx: TenantContext, registry: IdentityRegistry): Promise<void> {
     const json = Buffer.from(JSON.stringify(registry));
-    const encrypted = ctx.encrypt(json);
+    const encrypted = ctx.encrypt(json, REGISTRY_KEY);
     await ctx.storage.put(REGISTRY_KEY, encrypted);
   }
 }

--- a/packages/s3/src/adapters/s3-manifest-repository.adapter.ts
+++ b/packages/s3/src/adapters/s3-manifest-repository.adapter.ts
@@ -51,16 +51,20 @@ export class S3ManifestRepository implements ManifestRepository {
   async save(ctx: TenantContext, manifest: Manifest): Promise<void> {
     const key = manifest_key(manifest.owner_id, manifest.snapshot_id);
     const json = Buffer.from(JSON.stringify(manifest));
-    const encrypted = ctx.encrypt(json);
+    const encrypted = ctx.encrypt(json, key);
     const object_lock_policy = to_storage_object_lock_policy(manifest);
     await ctx.storage.put(key, encrypted, undefined, object_lock_policy);
 
-    const pointer = ctx.encrypt(
-      Buffer.from(JSON.stringify({ manifest_key: key } satisfies ManifestPointer)),
+    // Encrypted once per destination: the two pointers live in different directories, and the
+    // binding is what stops one being moved onto the other (issue #350).
+    const pointer_json = Buffer.from(
+      JSON.stringify({ manifest_key: key } satisfies ManifestPointer),
     );
+    const snapshot_key = snapshot_pointer_key(manifest.snapshot_id);
+    const latest_key = latest_pointer_key(manifest.owner_id);
     await Promise.all([
-      ctx.storage.put(snapshot_pointer_key(manifest.snapshot_id), pointer),
-      ctx.storage.put(latest_pointer_key(manifest.owner_id), pointer),
+      ctx.storage.put(snapshot_key, ctx.encrypt(pointer_json, snapshot_key)),
+      ctx.storage.put(latest_key, ctx.encrypt(pointer_json, latest_key)),
     ]);
   }
 
@@ -110,7 +114,7 @@ export class S3ManifestRepository implements ManifestRepository {
   private async download_pointer(ctx: TenantContext, key: string): Promise<string | undefined> {
     try {
       const encrypted = await ctx.storage.get(key);
-      const json = ctx.decrypt(encrypted);
+      const json = ctx.decrypt(encrypted, key);
       const parsed = JSON.parse(json.toString('utf-8')) as Partial<ManifestPointer>;
       return typeof parsed.manifest_key === 'string' ? parsed.manifest_key : undefined;
     } catch {
@@ -149,7 +153,7 @@ export class S3ManifestRepository implements ManifestRepository {
   ): Promise<Manifest | undefined> {
     try {
       const encrypted = await ctx.storage.get(key);
-      const json = ctx.decrypt(encrypted);
+      const json = ctx.decrypt(encrypted, key);
       const parsed = JSON.parse(json.toString('utf-8')) as Manifest;
       if (manifest_key(parsed.owner_id, parsed.snapshot_id) !== key) {
         throw new MismatchedManifestError(key, parsed.owner_id, parsed.snapshot_id);

--- a/packages/s3/src/adapters/storage-target.factory.ts
+++ b/packages/s3/src/adapters/storage-target.factory.ts
@@ -106,11 +106,13 @@ export class DefaultStorageTarget implements StorageTarget {
       return {
         tenant_id,
         storage,
-        encrypt: (data: Buffer): Buffer => key_service.encrypt(data, dek),
-        decrypt: (data: Buffer): Buffer => key_service.decrypt(data, dek),
-        create_cipher: () => key_service.create_encrypt_cipher(dek),
-        create_decipher: (iv: Buffer, auth_tag: Buffer) =>
-          key_service.create_decrypt_decipher(dek, iv, auth_tag),
+        encrypt: (data: Buffer, storage_key: string): Buffer =>
+          key_service.encrypt(data, dek, storage_key),
+        decrypt: (data: Buffer, storage_key: string): Buffer =>
+          key_service.decrypt(data, dek, storage_key),
+        create_cipher: (scope_key: string) => key_service.create_encrypt_cipher(dek, scope_key),
+        create_decipher: (iv: Buffer, auth_tag: Buffer, scope_key: string, header?: Buffer) =>
+          key_service.create_decrypt_decipher(dek, iv, auth_tag, scope_key, header),
         destroy: (): void => key_service.destroy(),
       };
     }

--- a/packages/s3/src/adapters/tenant-context.factory.ts
+++ b/packages/s3/src/adapters/tenant-context.factory.ts
@@ -135,11 +135,13 @@ function build_context(
   return {
     tenant_id,
     storage,
-    encrypt: (data: Buffer): Buffer => key_service.encrypt(data, dek),
-    decrypt: (data: Buffer): Buffer => key_service.decrypt(data, dek),
-    create_cipher: () => key_service.create_encrypt_cipher(dek),
-    create_decipher: (iv: Buffer, auth_tag: Buffer) =>
-      key_service.create_decrypt_decipher(dek, iv, auth_tag),
+    encrypt: (data: Buffer, storage_key: string): Buffer =>
+      key_service.encrypt(data, dek, storage_key),
+    decrypt: (data: Buffer, storage_key: string): Buffer =>
+      key_service.decrypt(data, dek, storage_key),
+    create_cipher: (scope_key: string) => key_service.create_encrypt_cipher(dek, scope_key),
+    create_decipher: (iv: Buffer, auth_tag: Buffer, scope_key: string, header?: Buffer) =>
+      key_service.create_decrypt_decipher(dek, iv, auth_tag, scope_key, header),
     destroy: (): void => key_service.destroy(),
   };
 }

--- a/packages/s3/tests/unit/s3-manifest-repository.test.ts
+++ b/packages/s3/tests/unit/s3-manifest-repository.test.ts
@@ -82,7 +82,9 @@ describe('S3ManifestRepository', () => {
       const manifest = make_manifest();
       await repo.save(ctx, manifest);
 
-      expect(ctx.encrypt).toHaveBeenCalledTimes(2);
+      // Manifest, snapshot pointer, latest pointer: the two pointers carry the same JSON but
+      // live in different directories, and each is bound to its own (issue #350).
+      expect(ctx.encrypt).toHaveBeenCalledTimes(3);
       const put_calls = vi.mocked(ctx.storage.put).mock.calls;
       expect(put_calls.map((call) => call[0])).toEqual([
         'manifests/user@test.com/snap-1.json',

--- a/packages/s3/tests/unit/storage-target.factory.test.ts
+++ b/packages/s3/tests/unit/storage-target.factory.test.ts
@@ -76,7 +76,11 @@ describe('create_storage_target', () => {
     expect(ctx.storage).toBeDefined();
     // Round-trip proves unwrap_dek recovered the original DEK.
     const plaintext = Buffer.from('round-trip');
-    expect(ctx.decrypt(ctx.encrypt(plaintext)).equals(plaintext)).toBe(true);
+    expect(
+      ctx
+        .decrypt(ctx.encrypt(plaintext, 'onedrive/data/owner-1/blob'), 'onedrive/data/owner-1/blob')
+        .equals(plaintext),
+    ).toBe(true);
   });
 
   it('creates a storage-only context when no DEK exists', async () => {
@@ -86,8 +90,8 @@ describe('create_storage_target', () => {
 
     expect(ctx.tenant_id).toBe('tenant-1');
     expect(ctx.storage).toBeDefined();
-    expect(() => ctx.encrypt(Buffer.from('x'))).toThrow('no DEK');
-    expect(() => ctx.decrypt(Buffer.from('x'))).toThrow('no DEK');
+    expect(() => ctx.encrypt(Buffer.from('x'), 'onedrive/data/owner-1/blob')).toThrow('no DEK');
+    expect(() => ctx.decrypt(Buffer.from('x'), 'onedrive/data/owner-1/blob')).toThrow('no DEK');
     mock_exists_returns = true;
   });
 

--- a/packages/s3/tests/unit/tenant-context-dek-bootstrap.test.ts
+++ b/packages/s3/tests/unit/tenant-context-dek-bootstrap.test.ts
@@ -81,8 +81,18 @@ describe('DEK bootstrap race (issue #25)', () => {
 
     // data encrypted by either context decrypts with the other
     const secret = Buffer.from('cross-process payload');
-    expect(ctx_b.decrypt(ctx_a.encrypt(secret))).toEqual(secret);
-    expect(ctx_a.decrypt(ctx_b.encrypt(secret))).toEqual(secret);
+    expect(
+      ctx_b.decrypt(
+        ctx_a.encrypt(secret, 'onedrive/data/owner-1/blob'),
+        'onedrive/data/owner-1/blob',
+      ),
+    ).toEqual(secret);
+    expect(
+      ctx_a.decrypt(
+        ctx_b.encrypt(secret, 'onedrive/data/owner-1/blob'),
+        'onedrive/data/owner-1/blob',
+      ),
+    ).toEqual(secret);
   });
 
   it('a later bootstrap loads the existing DEK instead of writing', async () => {
@@ -100,7 +110,12 @@ describe('DEK bootstrap race (issue #25)', () => {
     expect(put_calls_total).toBe(put_calls_after_first);
 
     const secret = Buffer.from('same key across runs');
-    expect(ctx_second.decrypt(ctx_first.encrypt(secret))).toEqual(secret);
+    expect(
+      ctx_second.decrypt(
+        ctx_first.encrypt(secret, 'onedrive/data/owner-1/blob'),
+        'onedrive/data/owner-1/blob',
+      ),
+    ).toEqual(secret);
   });
 
   it('every DEK write is create-only', async () => {

--- a/packages/s3/tests/unit/tenant-context-readonly.test.ts
+++ b/packages/s3/tests/unit/tenant-context-readonly.test.ts
@@ -68,7 +68,14 @@ describe('read-only tenant context (issue #93)', () => {
     const factory = new DefaultTenantContextFactory(make_s3(objects) as never, CONFIG, buckets);
     const ctx = await factory.create_readonly(TENANT_ID);
 
-    expect(ctx.decrypt(ctx.encrypt(Buffer.from('payload'))).toString()).toBe('payload');
+    expect(
+      ctx
+        .decrypt(
+          ctx.encrypt(Buffer.from('payload'), 'onedrive/data/owner-1/blob'),
+          'onedrive/data/owner-1/blob',
+        )
+        .toString(),
+    ).toBe('payload');
     ctx.destroy();
   });
 

--- a/packages/sharepoint/src/adapters/s3-sharepoint-delta-cursor-repository.adapter.ts
+++ b/packages/sharepoint/src/adapters/s3-sharepoint-delta-cursor-repository.adapter.ts
@@ -17,7 +17,7 @@ export class S3SharePointDeltaCursorRepository implements SharePointDeltaCursorR
 
     try {
       const payload = await ctx.storage.get(key);
-      const json = ctx.decrypt(payload).toString('utf-8');
+      const json = ctx.decrypt(payload, key).toString('utf-8');
       return JSON.parse(json) as SharePointDeltaCursor;
     } catch {
       return undefined;
@@ -28,6 +28,6 @@ export class S3SharePointDeltaCursorRepository implements SharePointDeltaCursorR
   async save(ctx: TenantContext, cursor: SharePointDeltaCursor): Promise<void> {
     const key = sharepoint_delta_cursor_key(cursor.site_id);
     const payload = Buffer.from(JSON.stringify(cursor));
-    await ctx.storage.put(key, ctx.encrypt(payload));
+    await ctx.storage.put(key, ctx.encrypt(payload, key));
   }
 }

--- a/packages/sharepoint/src/adapters/s3-sharepoint-file-version-index-repository.adapter.ts
+++ b/packages/sharepoint/src/adapters/s3-sharepoint-file-version-index-repository.adapter.ts
@@ -85,10 +85,8 @@ export class S3SharePointFileVersionIndexRepository implements SharePointFileVer
     if (indexes.length === 0) return;
     validate_key_segment(snapshot_id);
     const payload: RunIndexPayload = { site_id, snapshot_id, indexes };
-    await ctx.storage.put(
-      sharepoint_run_index_key(site_id, snapshot_id),
-      ctx.encrypt(Buffer.from(JSON.stringify(payload), 'utf-8')),
-    );
+    const key = sharepoint_run_index_key(site_id, snapshot_id);
+    await ctx.storage.put(key, ctx.encrypt(Buffer.from(JSON.stringify(payload), 'utf-8'), key));
   }
 
   /** Lists per-file version histories for a site, merged across all index objects. */
@@ -145,7 +143,7 @@ export class S3SharePointFileVersionIndexRepository implements SharePointFileVer
   ): Promise<SharePointFileVersionIndex[]> {
     const payload = await ctx.storage.get(key);
     try {
-      const parsed = JSON.parse(ctx.decrypt(payload).toString('utf-8')) as StoredIndexPayload;
+      const parsed = JSON.parse(ctx.decrypt(payload, key).toString('utf-8')) as StoredIndexPayload;
       return 'indexes' in parsed ? parsed.indexes : [parsed];
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);

--- a/packages/sharepoint/src/adapters/s3-sharepoint-manifest-repository.adapter.ts
+++ b/packages/sharepoint/src/adapters/s3-sharepoint-manifest-repository.adapter.ts
@@ -40,7 +40,7 @@ export class S3SharePointManifestRepository implements SharePointManifestReposit
   async save(ctx: TenantContext, manifest: SharePointSnapshotManifest): Promise<void> {
     const key = sharepoint_manifest_key(manifest.site_id, manifest.snapshot_id);
     const payload = Buffer.from(JSON.stringify(manifest));
-    await ctx.storage.put(key, ctx.encrypt(payload));
+    await ctx.storage.put(key, ctx.encrypt(payload, key));
   }
 
   /** Loads a manifest by listing only that site's manifest prefix. */
@@ -105,7 +105,7 @@ export class S3SharePointManifestRepository implements SharePointManifestReposit
   ): Promise<SharePointSnapshotManifest | undefined> {
     try {
       const payload = await ctx.storage.get(key);
-      const json = ctx.decrypt(payload).toString('utf-8');
+      const json = ctx.decrypt(payload, key).toString('utf-8');
       const parsed = JSON.parse(json) as SharePointSnapshotManifest;
       if (sharepoint_manifest_key(parsed.site_id, parsed.snapshot_id) !== key) {
         throw new MismatchedSharePointManifestError(key, parsed.site_id, parsed.snapshot_id);

--- a/packages/sharepoint/src/services/restore/restore-content.ts
+++ b/packages/sharepoint/src/services/restore/restore-content.ts
@@ -104,7 +104,7 @@ async function buffered_download_and_decrypt(
   }
 
   try {
-    const content = ctx.decrypt(encrypted);
+    const content = ctx.decrypt(encrypted, entry.storage_key!);
     const expected = entry.checksum;
     if (!expected || !plaintext_sha256_equals_expected(content, expected)) {
       logger.warn(

--- a/packages/sharepoint/tests/unit/services/backup/large-file-pipeline.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/large-file-pipeline.test.ts
@@ -57,7 +57,11 @@ function make_ctx(options: { exists?: boolean; list?: string[] } = {}): Recorded
     },
     create_cipher: () => {
       const iv = randomBytes(12);
-      return { cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }), iv };
+      return {
+        cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }),
+        iv,
+        header: Buffer.alloc(0),
+      };
     },
   } as unknown as TenantContext;
 

--- a/packages/sharepoint/tests/unit/services/versioning/version-content-store.test.ts
+++ b/packages/sharepoint/tests/unit/services/versioning/version-content-store.test.ts
@@ -52,7 +52,11 @@ function make_ctx(): TenantContext {
     encrypt: vi.fn((data: Buffer) => data),
     create_cipher: () => {
       const iv = randomBytes(12);
-      return { cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }), iv };
+      return {
+        cipher: createCipheriv('aes-256-gcm', KEY, iv, { authTagLength: 16 }),
+        iv,
+        header: Buffer.alloc(0),
+      };
     },
     destroy: vi.fn(),
   } as unknown as TenantContext;

--- a/packages/types/src/ports/tenant/context.port.ts
+++ b/packages/types/src/ports/tenant/context.port.ts
@@ -8,22 +8,36 @@ export interface TenantStorageContext {
   readonly storage: ObjectStorage;
 }
 
-/** Tenant-scoped encryption/decryption operations. */
+/**
+ * Tenant-scoped encryption and decryption.
+ *
+ * Every method takes the key the object lives under, because one DEK covers the whole tenant and
+ * the ciphertext is bound to its scope: an object moved to another key stops decrypting instead of
+ * authenticating in its place (issue #350). The key is required rather than optional, since an
+ * optional binding is one a call site forgets and the protection then disappears silently.
+ */
 export interface TenantCryptoContext {
-  /** Encrypts plaintext with this tenant's data encryption key. */
-  encrypt(data: Buffer): Buffer;
+  /** Encrypts plaintext for the object that will live at `storage_key`. */
+  encrypt(data: Buffer, storage_key: string): Buffer;
 
-  /** Decrypts ciphertext with this tenant's data encryption key. */
-  decrypt(data: Buffer): Buffer;
+  /** Decrypts the object read from `storage_key`. */
+  decrypt(data: Buffer, storage_key: string): Buffer;
 
   /**
-   * Creates a streaming AES-256-GCM cipher and IV for payloads that match
-   * the non-streaming {@link TenantCryptoContext.encrypt} envelope layout on read.
+   * Creates a streaming AES-256-GCM cipher, its IV, and the envelope header to write ahead of it.
+   *
+   * `scope_key` is a key in the directory the finished object belongs to, which for a staged
+   * large-file upload is its content-addressed key rather than the staging key.
    */
-  create_cipher(): { cipher: CipherGCM; iv: Buffer };
+  create_cipher(scope_key: string): { cipher: CipherGCM; iv: Buffer; header: Buffer };
 
-  /** Creates a streaming AES-256-GCM decipher for the given IV and auth tag. */
-  create_decipher(iv: Buffer, auth_tag: Buffer): DecipherGCM;
+  /**
+   * Creates a streaming AES-256-GCM decipher for the given IV and auth tag.
+   *
+   * `header` is the envelope header found ahead of the IV, absent for an object written before the
+   * binding existed.
+   */
+  create_decipher(iv: Buffer, auth_tag: Buffer, scope_key: string, header?: Buffer): DecipherGCM;
 }
 
 /** Bundles tenant-scoped storage and encryption for a single tenant. */

--- a/packages/types/src/testing/stub-tenant-create-cipher.ts
+++ b/packages/types/src/testing/stub-tenant-create-cipher.ts
@@ -2,10 +2,18 @@ import { createCipheriv, randomBytes, type CipherGCM } from 'node:crypto';
 
 /**
  * Returns a fresh AES-256-GCM cipher for use as `TenantContext.create_cipher` in unit tests.
+ *
+ * The scope is accepted and ignored: the key is random, so this is for wiring and control-flow
+ * assertions rather than round-trips, and a test that needs the real binding wants
+ * `stub_encrypted_object_store`.
  */
-export function stub_tenant_create_cipher(): { cipher: CipherGCM; iv: Buffer } {
+export function stub_tenant_create_cipher(_scope_key?: string): {
+  cipher: CipherGCM;
+  iv: Buffer;
+  header: Buffer;
+} {
   const iv = randomBytes(12);
   const key = randomBytes(32);
   const cipher = createCipheriv('aes-256-gcm', key, iv, { authTagLength: 16 });
-  return { cipher, iv };
+  return { cipher, iv, header: Buffer.alloc(0) };
 }

--- a/packages/types/src/testing/stub-tenant-create-decipher.ts
+++ b/packages/types/src/testing/stub-tenant-create-decipher.ts
@@ -4,7 +4,12 @@ import { createDecipheriv, randomBytes, type DecipherGCM } from 'node:crypto';
  * Returns an AES-256-GCM decipher for use as `TenantContext.create_decipher` in unit tests.
  * The key is random, so this is for wiring and control-flow assertions, not round-trips.
  */
-export function stub_tenant_create_decipher(iv: Buffer, auth_tag: Buffer): DecipherGCM {
+export function stub_tenant_create_decipher(
+  iv: Buffer,
+  auth_tag: Buffer,
+  _scope_key?: string,
+  _header?: Buffer,
+): DecipherGCM {
   const decipher = createDecipheriv('aes-256-gcm', randomBytes(32), iv, { authTagLength: 16 });
   decipher.setAuthTag(auth_tag);
   return decipher;


### PR DESCRIPTION
## Summary

Closes #350. Closes #340: its remaining acceptance criterion is the binding that was split out into #350, and the rest of that issue landed in #351.

One DEK covers a whole tenant, and until now nothing tied a ciphertext to the object it belongs to. The GCM tag proves the bytes were produced under the tenant key; it never proved they are the bytes that belong at this key. Any object therefore authenticated in any other object's place, and moving one blob over another needed write access to the bucket rather than the passphrase. #340 closed the exploitable half at read time by comparing the manifest checksum before any restore side effect. This is prevention at decrypt time, and it also covers the objects that have no manifest entry to check against: delta cursors, version indexes, manifest pointers, replication status sidecars.

Newly written objects carry a versioned header, `[ATLS][version]`, ahead of the IV, and the header plus the object's scope are authenticated as associated data. Stripping the header or lowering the version fails the tag instead of falling back to the unbound path, which is the construction `wrap_dek` already used for the wrapped DEK.

**The scope is the key's directory**, not the whole key. The large-file pipeline encrypts into a staging key and promotes the finished object onto a content-addressed key whose checksum is unknown while the cipher is still running, so the streamed writer binds the canonical directory it will be promoted into and readers derive the same value from the key they read. What the directory names is the purpose and the owner, which is what an attacker moving a blob has to defeat; moving an object within its own directory is left to the checksum comparison from #340.

**Existing backups stay readable.** A blob with no magic is decrypted exactly as before, with no associated data. No migration step, no configuration flag, and a bucket simply ends up with both shapes until its older objects age out. Content is addressed by checksum, so a new backup of a file already in the bucket deduplicates onto the existing headerless object rather than rewriting it: a bucket gains the binding as content is encrypted, not as snapshots are taken, and the docs now say so.

**The scope is a required argument** on `encrypt`, `decrypt`, `create_cipher` and `create_decipher`. An optional one is forgotten at a call site and the protection disappears with no signal, which is why this is a breaking change to `TenantCryptoContext` rather than an additive one. All 30-odd call sites pass the key they already had in hand.

One behaviour worth naming: `S3ManifestRepository.save` wrote one encrypted pointer to two keys. Those live in different directories, so it now encrypts once per destination, which is exactly the move the binding is meant to catch.

### What is and is not covered

| Attack | Result |
| --- | --- |
| Move an object onto another owner's or another purpose's key | Fails: the scope in the AAD no longer matches |
| Strip the header, or lower the version | Fails: the header is inside the AAD |
| Move an object within its own directory | Not prevented; the manifest checksum comparison from #340 covers it |
| Replay an older ciphertext of the same object | Not prevented; that stays Object Lock's and versioning's job |

### Evidence

`content-binding.test.ts` covers cross-owner substitution, a stripped header, an unknown version, a same-directory read, a pre-binding blob, and the streamed cipher and decipher pair. `streamed-scope-roundtrip.test.ts` runs the real pipeline against an in-memory bucket: an object streamed through staging is read back from its content-addressed key, and the same bytes copied under another owner's prefix fail to decrypt.

Backward compatibility is not only asserted directly: every existing test that streams a stored object through `stub_encrypted_object_store` writes the old format, and all of them still pass, which is the legacy read path exercised end to end.

Not verified against a real bucket or a live tenant. No agent review was run on this branch; the audit is CodeRabbit's.

## Changes

- `packages/core/src/adapters/keystore/content-envelope.ts`: new. Magic, version, the AAD assembly, and the scope derivation, with the scope and the header separated by a `\0` so one prefix cannot pass for a longer one.
- `packages/core/src/adapters/keystore/envelope-key-service.adapter.ts`: `encrypt`, `decrypt`, `create_encrypt_cipher` and `create_decrypt_decipher` take the scope; the cipher now returns the header its caller has to write.
- `packages/types/src/ports/tenant/context.port.ts`: `TenantCryptoContext` takes the storage key on every method.
- `packages/core/src/services/shared/stream-encrypt-upload.ts`: part 1 carries the header ahead of the IV, and the target declares the canonical directory it is bound to.
- `packages/core/src/services/shared/stream-decrypt.ts`: reads the header when it is there, and reads a pre-binding object when it is not.
- `packages/drive/src/shared/storage-keys.ts`: `data_prefix_for`, so a streamed target can name its canonical directory the way it already names its staging prefix.
- Every call site that encrypts or decrypts passes the key it stores under, across `core`, `s3`, `drive`, `onedrive`, `sharepoint` and `outlook`.
- `docs/security.md`: the new ciphertext format, what the binding covers, and what it deliberately does not. The scope-binding section no longer promises that a fresh snapshot rebinds everything it references, and the "What the GCM tag does not tell you" section now scopes its substitution claim to headerless objects.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`), unless this is a release or hotfix PR
- [x] No version bump in `packages/*/package.json` (releases only)
- [x] Labelled for release notes (`enhancement`, `bug`, `documentation`, `security`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Enhancements**
  - Encrypted content is authenticated against its storage scope, preventing decryption after moves between owners or purposes.
  - Streamed and buffered uploads consistently include scope-aware encryption metadata.
  - Tampered, stripped, or unsupported envelope headers are rejected.

- **Compatibility**
  - Existing ciphertext remains readable without migration.
  - Content retains the protection applied when it was written.

- **Documentation**
  - Added details on ciphertext headers, scope binding, and supported attack scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->