### PR TITLE
docs(security): say plainly that no command re-wraps an existing DEK

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -25,7 +25,9 @@ Envelope encryption separates the key that protects your data (DEK) from the key
 
 - The DEK is a random 256-bit key with maximum entropy -- it does not depend on passphrase strength.
 - The KEK is derived from your passphrase and only used to wrap/unwrap the DEK.
-- If you need to change the passphrase in the future, only the DEK wrapper needs to be re-encrypted -- not every object in storage.
+- Changing the passphrase only has to re-encrypt the DEK wrapper, not every object in storage. The
+  blob format is built for that, but no command performs it today. Read the warning below before
+  you change `ATLAS_ENCRYPTION_PASSPHRASE` on a tenant that already has backups.
 
 ### KEK Derivation: scrypt
 
@@ -42,7 +44,7 @@ Parameters used by Atlas for **new** DEK wraps:
 | Output              | 32 bytes (256 bits)            | AES-256 key length                                                                        |
 | Minimum N on unwrap | 16384                          | Blobs with weaker parameters are rejected                                                 |
 
-The **tenant-domain salt** ensures that the same passphrase and random salt produce different KEKs for different tenants. A fresh random salt is generated on every DEK wrap, so re-wrapping the DEK after a passphrase change uses new scrypt parameters without relying on a separate `_meta/kek_params.json` file.
+The **tenant-domain salt** ensures that the same passphrase and random salt produce different KEKs for different tenants. A fresh random salt is generated on every DEK wrap, so a re-wrap picks up new scrypt parameters without relying on a separate `_meta/kek_params.json` file. Atlas wraps a DEK when it first creates one, and nothing re-wraps an existing one: the parameters a tenant was bootstrapped with are the parameters it keeps.
 
 The v5 SDK rejects passphrases shorter than 14 UTF-8 bytes at construction, matching the existing KDF warning threshold. Byte length is only a minimum, not an entropy guarantee: use at least five random words or 20 random characters for production. The CLI's existing passphrase handling is unchanged. Never pad or replace an existing passphrase without migrating its wrapped DEK; use the previous SDK or CLI to recover short-passphrase backups.
 
@@ -77,6 +79,15 @@ Every encrypt operation uses **AES-256-GCM** (Galois/Counter Mode), which provid
 ```
 
 Every encrypt operation generates a **fresh random 12-byte IV** (initialization vector). This is critical for GCM security -- reusing an IV with the same key would be catastrophic, potentially exposing the XOR of two plaintexts and compromising the authentication key. Atlas generates a new random IV for every single object it encrypts.
+
+Random IVs carry a birthday bound, so one key cannot be used an unlimited number of times. NIST SP
+800-38D caps random-IV GCM at 2^32 invocations per key, where the chance of any IV repeating is
+still about 2^-33. One DEK covers a whole tenant, and Atlas runs one encrypt per object, streamed
+objects included: a multipart upload takes a single IV for the whole object rather than one per
+part. The budget is therefore 4.3 billion distinct objects in one tenant bucket, and content is
+addressed by checksum, so backing up unchanged bytes again does not spend another one. At ten
+million new objects a year that is a four-century limit, which is why Atlas has no re-key
+threshold.
 
 ### What a ciphertext is bound to
 

--- a/packages/types/src/ports/tenant/context.port.ts
+++ b/packages/types/src/ports/tenant/context.port.ts
@@ -42,7 +42,14 @@ export interface TenantCryptoContext {
 
 /** Bundles tenant-scoped storage and encryption for a single tenant. */
 export interface TenantContext extends TenantStorageContext, TenantCryptoContext {
-  /** Zeros sensitive key material. Call when the context is no longer needed. */
+  /**
+   * Zeros the passphrase buffer the context derived its KEK from. Call when the context is no
+   * longer needed.
+   *
+   * The DEK itself is left to garbage collection, and the passphrase also survives as an
+   * immutable string in the process configuration, so this is hygiene rather than a guarantee
+   * that no key material is left in memory.
+   */
   destroy(): void;
 }
 


### PR DESCRIPTION
## Summary

Three accuracy fixes in the key-material documentation, found while closing the encryption audit epic #337. No behaviour changes.

`docs/security.md` contradicted itself about passphrase rotation. Under "Why Envelope Encryption" it said, in the present tense, that changing the passphrase only needs the DEK wrapper re-encrypted, and the scrypt section said re-wrapping after a passphrase change picks up new parameters. Twenty lines further down the danger block says there is no key rotation mechanism, and `docs/troubleshooting.md` explains what happens after you have already locked yourself out. Nothing in `packages/cli/src` re-wraps anything. An operator who reads the first claim and stops changes `ATLAS_ENCRYPTION_PASSPHRASE` and loses the bucket, so both claims now say the format supports a re-wrap and no command performs one. The command itself is #374.

The per-DEK IV budget was undocumented, so an auditor has to derive it from scratch to decide whether one tenant DEK forever is a problem. It is not, and the numbers are now written down: NIST SP 800-38D caps random-IV GCM at 2^32 invocations per key, Atlas spends one IV per object with a multipart upload taking one for the whole object rather than one per part, and content is addressed by checksum so re-backing up unchanged bytes spends nothing.

`TenantContext.destroy()` claimed to zero sensitive key material. It zeroes the passphrase buffer. The DEK is left to garbage collection, and the passphrase survives anyway as an immutable string in the process configuration, which re-derives the KEK and unwraps `_meta/dek.enc`. I did not make the code match the comment: zeroing the DEK protects nothing while that string is live, and it would turn any use of a destroyed context from working code into a GCM authentication failure.

## Changes

- `docs/security.md`: the envelope and scrypt sections no longer describe a re-wrap that no command performs.
- `docs/security.md`: the ciphertext format section records the per-DEK IV budget and why there is no re-key threshold.
- `packages/types/src/ports/tenant/context.port.ts`: `destroy()` documents what it actually clears and what it leaves behind.

## Checklist

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run docs:build` succeeds without warnings
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`)
- [x] No version bump in `packages/*/package.json`
- [x] Labelled for release notes (`documentation`)
