### PR TITLE
fix(replicate): build the primary target from the config the factory reads

### DIFF
--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -966,7 +966,7 @@ Every error carries the underlying failure as `cause`, so the Graph or AWS SDK e
 - Instance types: `AtlasInstance`, `AtlasInstanceConfig`
 - Sub-API types: `OutlookApi`, `OneDriveApi`, `SharePointApi`
 - Workload options and results: the named `Outlook*`, `OneDriveSdk*` and `SharePointSdk*` types used by each API
-- Storage targets: `StorageTarget`, `StorageTargetSdkConfig`
+- Storage targets: `StorageTarget`, `StorageTargetConfig`
 - Factory functions: `createAtlasInstance`, `createStorageTarget`
 - Operation control types: `SdkOperationOptions`, `OperationProgressEvent`, `OperationProgressCallback`, `OperationProgressPhase`
 - Cost helpers: `getGraphCost`

--- a/packages/core/src/services/replication/primary-target-factory.ts
+++ b/packages/core/src/services/replication/primary-target-factory.ts
@@ -7,10 +7,10 @@ export function create_primary_target(
   config: AtlasConfig,
 ): StorageTarget {
   return factory({
-    s3_endpoint: config.s3_endpoint,
-    s3_access_key: config.s3_access_key,
-    s3_secret_key: config.s3_secret_key,
-    s3_region: config.s3_region,
-    encryption_passphrase: config.encryption_passphrase,
+    s3Endpoint: config.s3_endpoint,
+    s3AccessKey: config.s3_access_key,
+    s3SecretKey: config.s3_secret_key,
+    s3Region: config.s3_region,
+    encryptionPassphrase: config.encryption_passphrase,
   });
 }

--- a/packages/s3/src/adapters/index.ts
+++ b/packages/s3/src/adapters/index.ts
@@ -12,6 +12,5 @@ export {
 export { validate_dek_match, DekMismatchError } from './dek-validator';
 export { DefaultTenantContextFactory } from './tenant-context.factory';
 export { create_storage_target, DefaultStorageTarget } from './storage-target.factory';
-export type { StorageTargetSdkConfig } from './storage-target.factory';
 export { S3IdentityRegistryRepository } from './s3-identity-registry-repository.adapter';
 export { BucketCache } from './bucket-cache';

--- a/packages/s3/src/adapters/storage-target.factory.ts
+++ b/packages/s3/src/adapters/storage-target.factory.ts
@@ -10,47 +10,19 @@ import { EnvelopeKeyService } from '@wisecom/atlas-core';
 
 const DEK_META_KEY = '_meta/dek.enc';
 
-/** SDK-facing camelCase config, consistent with AtlasInstanceConfig. */
-export interface StorageTargetSdkConfig {
-  readonly targetId?: string;
-  readonly s3Endpoint: string;
-  readonly s3AccessKey: string;
-  readonly s3SecretKey: string;
-  readonly s3Region?: string;
-  readonly encryptionPassphrase: string;
-}
-
 function derive_target_id(endpoint: string, region?: string): string {
   const raw = `${endpoint}|${region ?? 'us-east-1'}`;
   return createHash('sha256').update(raw).digest('hex').slice(0, 16);
 }
 
 /**
- * Maps the public camelCase config to the internal shape.
+ * Creates a lightweight storage-only target for replication.
  *
- * Only the camelCase form is accepted. Taking both was the dual vocabulary v5.0.0 removes: the
- * SDK's documented convention is camelCase, and a factory that quietly accepted the internal
- * spelling made the internal one look public (issue #45).
+ * Bound into the container by symbol, which is untyped, so this signature is the only thing
+ * standing between a caller and an S3 client built from undefined credentials (issue #377).
  */
-function normalize_target_config(config: StorageTargetSdkConfig): StorageTargetConfig {
-  let result: StorageTargetConfig = {
-    s3_endpoint: config.s3Endpoint,
-    s3_access_key: config.s3AccessKey,
-    s3_secret_key: config.s3SecretKey,
-    encryption_passphrase: config.encryptionPassphrase,
-  };
-  if (config.targetId !== undefined) {
-    result = { ...result, target_id: config.targetId };
-  }
-  if (config.s3Region !== undefined) {
-    result = { ...result, s3_region: config.s3Region };
-  }
-  return result;
-}
-
-/** Creates a lightweight storage-only target for replication from camelCase config. */
-export function create_storage_target(config: StorageTargetSdkConfig): StorageTarget {
-  return new DefaultStorageTarget(normalize_target_config(config));
+export function create_storage_target(config: StorageTargetConfig): StorageTarget {
+  return new DefaultStorageTarget(config);
 }
 
 /**
@@ -71,17 +43,17 @@ export class DefaultStorageTarget implements StorageTarget {
   private readonly _buckets = new BucketCache();
 
   constructor(config: StorageTargetConfig) {
-    this.target_id = config.target_id ?? derive_target_id(config.s3_endpoint, config.s3_region);
-    this.endpoint = config.s3_endpoint;
-    this._passphrase = config.encryption_passphrase;
-    this._region = config.s3_region ?? 'us-east-1';
+    this.target_id = config.targetId ?? derive_target_id(config.s3Endpoint, config.s3Region);
+    this.endpoint = config.s3Endpoint;
+    this._passphrase = config.encryptionPassphrase;
+    this._region = config.s3Region ?? 'us-east-1';
 
     this._client = new S3Client({
-      endpoint: config.s3_endpoint,
+      endpoint: config.s3Endpoint,
       region: this._region,
       credentials: {
-        accessKeyId: config.s3_access_key,
-        secretAccessKey: config.s3_secret_key,
+        accessKeyId: config.s3AccessKey,
+        secretAccessKey: config.s3SecretKey,
       },
       forcePathStyle: true,
     });

--- a/packages/s3/src/container.ts
+++ b/packages/s3/src/container.ts
@@ -9,7 +9,7 @@ import {
   STORAGE_DISPOSER_TOKEN,
   IDENTITY_REGISTRY_REPOSITORY_TOKEN,
 } from '@wisecom/atlas-types';
-import type { StorageDisposer } from '@wisecom/atlas-types';
+import type { StorageDisposer, StorageTargetFactory } from '@wisecom/atlas-types';
 import { create_s3_client, S3_CLIENT_TOKEN } from '@/adapters/s3-client.factory';
 import { S3ManifestRepository } from '@/adapters/s3-manifest-repository.adapter';
 import { S3IdentityRegistryRepository } from '@/adapters/s3-identity-registry-repository.adapter';
@@ -33,7 +33,9 @@ export function bind_s3_storage(container: Container, config: S3Config & CryptoC
     .to(S3IdentityRegistryRepository)
     .inSingletonScope();
   container.bind(DEK_VALIDATION_FN_TOKEN).toConstantValue(validate_dek_match);
-  container.bind(STORAGE_TARGET_FACTORY_TOKEN).toConstantValue(create_storage_target);
+  container
+    .bind<StorageTargetFactory>(STORAGE_TARGET_FACTORY_TOKEN)
+    .toConstantValue(create_storage_target);
 
   container.bind(StorageCheckService).toSelf();
   container.bind(STORAGE_CHECK_USE_CASE_TOKEN).toService(StorageCheckService);

--- a/packages/s3/tests/unit/primary-target-wiring.test.ts
+++ b/packages/s3/tests/unit/primary-target-wiring.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { create_primary_target } from '@wisecom/atlas-core/services/replication/primary-target-factory';
+import type { AtlasConfig } from '@wisecom/atlas-core/utils/config';
+import { create_storage_target } from '@/adapters/storage-target.factory';
+
+/**
+ * The seam between `create_primary_target` and the real factory.
+ *
+ * Both sides are bound by symbol in the container, which inversify does not typecheck, so the two
+ * spelled the same shape differently for a whole release: the factory read camelCase and the
+ * caller sent snake_case. Every field arrived undefined, and rehydrate died inside the AWS SDK
+ * with "Resolved credential object is not valid" while unit tests, using their own stub factories,
+ * stayed green (issue #377).
+ */
+const config: AtlasConfig = {
+  tenant_id: 'tenant-1',
+  client_id: 'client-1',
+  client_secret: 'secret-1',
+  s3_endpoint: 'http://primary:9000',
+  s3_access_key: 'primary-access',
+  s3_secret_key: 'primary-secret',
+  s3_region: 'eu-north-1',
+  encryption_passphrase: 'a-passphrase-long-enough',
+};
+
+describe('create_primary_target against the real factory', () => {
+  it('opens the endpoint the tenant config names', () => {
+    const target = create_primary_target(create_storage_target, config);
+
+    expect(target.endpoint).toBe('http://primary:9000');
+  });
+
+  it('derives a stable target id from the endpoint and region', () => {
+    const first = create_primary_target(create_storage_target, config);
+    const second = create_primary_target(create_storage_target, config);
+    const elsewhere = create_primary_target(create_storage_target, {
+      ...config,
+      s3_endpoint: 'http://replica:9002',
+    });
+
+    expect(first.target_id).toHaveLength(16);
+    expect(second.target_id).toBe(first.target_id);
+    expect(elsewhere.target_id).not.toBe(first.target_id);
+  });
+});

--- a/packages/s3/tests/unit/storage-target.factory.test.ts
+++ b/packages/s3/tests/unit/storage-target.factory.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { create_storage_target } from '@/adapters/storage-target.factory';
 import { EnvelopeKeyService } from '@wisecom/atlas-core';
-import type { StorageTargetSdkConfig } from '@/adapters/storage-target.factory';
+import type { StorageTargetConfig } from '@wisecom/atlas-types';
 
 // Holder the hoisted mock can close over; populated by the crypto test before use.
 const crypto_state = vi.hoisted(() => ({ wrapped_dek: Buffer.alloc(0) }));
@@ -40,7 +40,7 @@ vi.mock('@/adapters/tenant-bucket-name', () => ({
 }));
 
 describe('create_storage_target', () => {
-  const base_config: StorageTargetSdkConfig = {
+  const base_config: StorageTargetConfig = {
     s3Endpoint: 'http://offsite:9000',
     s3AccessKey: 'access',
     s3SecretKey: 'secret',

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,8 +11,7 @@ export { create_storage_target as createStorageTarget } from '@wisecom/atlas-s3'
 export { getGraphCost, GRAPH_SERVICE_LIMITS } from './public-values';
 
 export type { AtlasInstance, AtlasInstanceConfig } from '@wisecom/atlas-types';
-export type { StorageTarget } from '@wisecom/atlas-types';
-export type { StorageTargetSdkConfig } from '@wisecom/atlas-s3';
+export type { StorageTarget, StorageTargetConfig } from '@wisecom/atlas-types';
 export type { LogSink, LogFields } from '@wisecom/atlas-types';
 
 export type {

--- a/packages/sdk/tests/unit/public-surface-camel-case.test.ts
+++ b/packages/sdk/tests/unit/public-surface-camel-case.test.ts
@@ -25,7 +25,7 @@ import type {
   SharePointSdkRestoreOptions,
   SharePointSdkStatusResult,
   SdkOperationOptions,
-  StorageTargetSdkConfig,
+  StorageTargetConfig,
 } from '@/index';
 import { camelize } from '@wisecom/atlas-types/public/case-convert';
 import { GRAPH_SERVICE_LIMITS } from '@/public-values';
@@ -64,7 +64,7 @@ const config_is_camel: NoSnakeKeys<AtlasInstanceConfig> = true;
 const cost_is_camel: NoSnakeKeys<OperationCost> = true;
 const object_lock_request_is_camel: NoSnakeKeys<ObjectLockRequest> = true;
 const operation_options_are_camel: NoSnakeKeys<SdkOperationOptions> = true;
-const storage_target_config_is_camel: NoSnakeKeys<StorageTargetSdkConfig> = true;
+const storage_target_config_is_camel: NoSnakeKeys<StorageTargetConfig> = true;
 
 const outlook_options_are_camel: NoSnakeKeys<
   OutlookBackupOptions | OutlookRestoreOptions | OutlookSaveOptions

--- a/packages/types/src/ports/replication/storage-target.port.ts
+++ b/packages/types/src/ports/replication/storage-target.port.ts
@@ -1,12 +1,17 @@
 import type { TenantContext } from '@/ports/tenant/context.port';
 
+/**
+ * camelCase, matching `AtlasInstanceConfig`. The factory is bound in the DI container by symbol,
+ * which is untyped, so a second snake_case spelling of this shape is not a synonym: it resolves
+ * to `undefined` fields at runtime and an S3 client with no credentials (issue #377).
+ */
 export interface StorageTargetConfig {
-  readonly target_id?: string;
-  readonly s3_endpoint: string;
-  readonly s3_access_key: string;
-  readonly s3_secret_key: string;
-  readonly s3_region?: string;
-  readonly encryption_passphrase: string;
+  readonly targetId?: string;
+  readonly s3Endpoint: string;
+  readonly s3AccessKey: string;
+  readonly s3SecretKey: string;
+  readonly s3Region?: string;
+  readonly encryptionPassphrase: string;
 }
 
 export interface StorageTarget {


### PR DESCRIPTION
## Summary

Closes #377. `atlas rehydrate` fails on every path in v5 before it copies a byte, which I found by dispatching the E2E suite against `dev` ahead of cutting the release. The nightly runs against `main`, so it had never seen any of this.

`create_primary_target` passes snake_case fields to the factory bound at `STORAGE_TARGET_FACTORY_TOKEN`. That factory has read camelCase only since #323. The binding is `container.bind(SYMBOL).toConstantValue(...)`, which inversify does not typecheck, and the port type still declared the snake_case shape, so both sides compiled while agreeing on nothing. The primary target came out with `endpoint: undefined` and undefined credentials, the AWS SDK fell through to its default chain, and every recovery died with `Resolved credential object is not valid`. All three workloads, plus `--all`, because each rehydrate copies the source DEK onto the primary first. `replicate` was unaffected: the CLI builds those targets itself and already spoke camelCase.

The fix is one vocabulary rather than a translation layer. `StorageTargetConfig` in `packages/types` is now the camelCase shape, the duplicate `StorageTargetSdkConfig` in `packages/s3` is gone along with the mapping function that existed only to bridge the two, and the container binding is typed so a future caller that disagrees fails to compile.

A second symptom went with it: `derive_target_id` was hashing `undefined|us-east-1`, so every primary target in every tenant shared one identifier.

## Changes

- `packages/types/src/ports/replication/storage-target.port.ts`: `StorageTargetConfig` is camelCase, and `StorageTargetFactory` therefore declares the shape the factory actually reads.
- `packages/s3/src/adapters/storage-target.factory.ts`: drops `StorageTargetSdkConfig` and `normalize_target_config`; the target reads the port type directly.
- `packages/s3/src/container.ts`: `bind<StorageTargetFactory>(...)`, so the binding is checked.
- `packages/core/src/services/replication/primary-target-factory.ts`: passes camelCase.
- `packages/sdk/src/index.ts`: exports `StorageTargetConfig` instead of the removed alias, and `docs/reference/sdk.md` uses the one name it already used in its options table.
- `packages/s3/tests/unit/primary-target-wiring.test.ts`: new. Wires the real factory to the real caller.

## Evidence

The new test fails on `dev` and passes here:

```text
AssertionError: expected undefined to be 'http://primary:9000'
AssertionError: expected 'b3579bb9356874b6' not to be 'b3579bb9356874b6'
```

It deliberately does not live beside the replication service tests. Those stub the factory, which is exactly why they stayed green through the whole break.

`pnpm run build`, `typecheck`, `test` and `docs:build` pass; lint reports no new errors. Not verified against a live tenant here: the E2E suite is the check, and it runs on `dev` once this and the suite's own v5 update are in.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`)
- [x] No version bump in `packages/*/package.json`
- [x] Labelled for release notes (`bug`)
