### PR TITLE
fix(e2e): call the v5 flags and fields the suite still spells the v4 way

### DIFF
--- a/e2e/sdk_smoke.mjs
+++ b/e2e/sdk_smoke.mjs
@@ -29,4 +29,4 @@ const atlas = createAtlasInstance({
 });
 
 const snapshots = await atlas.outlook.listSnapshots(required('E2E_MAILBOX'));
-process.stdout.write(JSON.stringify(snapshots.map((manifest) => manifest.snapshot_id)));
+process.stdout.write(JSON.stringify(snapshots.map((manifest) => manifest.snapshotId)));

--- a/e2e/tests/test_10_outlook.py
+++ b/e2e/tests/test_10_outlook.py
@@ -69,7 +69,7 @@ def test_04_verify_passes_on_a_fresh_snapshot(cli: Cli, settings: Settings) -> N
 def test_05_save_exports_an_eml_archive(cli: Cli, exports: Path, run_marker: str) -> None:
     """`outlook save` produces a zip containing the message as `.eml`."""
     archive = exports / f"{run_marker}.zip"
-    cli.ok("outlook", "save", "-s", STATE["snapshot"], "-o", str(archive))
+    cli.ok("outlook", "save", "-s", STATE["snapshot"], "--output", str(archive))
 
     assert archive.exists(), f"{archive} was not written"
     with zipfile.ZipFile(archive) as zf:

--- a/e2e/tests/test_20_onedrive.py
+++ b/e2e/tests/test_20_onedrive.py
@@ -140,8 +140,7 @@ def test_05_save_exports_the_file(
 ) -> None:
     """`onedrive save` writes a zip that mirrors the drive hierarchy.
 
-    Note the capital `-O` for output: `onedrive save` differs from `outlook save` here, and `-o` is
-    the owner.
+    The output flag is spelled in full (`--output`) in v5 because `-o` means owner.
     """
     archive = exports / f"{run_marker}-onedrive.zip"
     cli.ok(
@@ -151,7 +150,7 @@ def test_05_save_exports_the_file(
         settings.onedrive_owner,
         "-s",
         STATE["snapshot"],
-        "-O",
+        "--output",
         str(archive),
         timeout=WHOLE_DRIVE_TIMEOUT,
     )

--- a/e2e/tests/test_30_sharepoint.py
+++ b/e2e/tests/test_30_sharepoint.py
@@ -105,7 +105,7 @@ def test_06_save_exports_the_file(
         settings.sharepoint_site,
         "-s",
         STATE["snapshot"],
-        "-O",
+        "--output",
         str(archive),
     )
 

--- a/e2e/tests/test_40_replication.py
+++ b/e2e/tests/test_40_replication.py
@@ -74,8 +74,8 @@ def test_02_replicate_copies_every_workload_and_the_key(
 
 
 def test_03_status_records_the_replication(cli: Cli, settings: Settings, s3: Any) -> None:
-    """`replicate --status` reads the sidecar records replication wrote on primary."""
-    cli.ok("replicate", "--status", "-m", settings.mailbox)
+    """`replicate status` reads the sidecar records replication wrote on primary."""
+    cli.ok("replicate", "status", "-m", settings.mailbox)
     assert storage.list_keys(s3, settings.bucket, "_meta/replication/"), (
         "no replication record written"
     )


### PR DESCRIPTION
## Summary

The E2E suite still speaks v4. Dispatching it against `dev` before cutting v5.0.0 returned 10 failures, and five of them are the suite calling flags and fields the release deliberately renamed. Atlas was right in each case, and in the `-o` case it printed the migration hint itself:

```text
error: option '-o <value>' argument '...zip' is invalid.
-o no longer means --output in v5.0.0. Pass --output instead
```

The remaining five failures are a real product bug, fixed separately in #378 for #377, and the cascade behind it. Nothing here accommodates them.

## Changes

- `e2e/tests/test_10_outlook.py`: `outlook save` takes `--output` for the archive path.
- `e2e/tests/test_20_onedrive.py`, `e2e/tests/test_30_sharepoint.py`: same, replacing `-O`. `-o` still means the owner on the drive workloads, which is why the flag is spelled in full now, and the docstring that explained the old distinction says that instead.
- `e2e/tests/test_40_replication.py`: `replicate status` as a subcommand, replacing `replicate --status`.
- `e2e/sdk_smoke.mjs`: reads `snapshotId`. The snake_case field returned `undefined` for every snapshot, so the assertion compared `{None}` against the real ids.

## Evidence

`ruff check`, `ruff format --check` and `mypy` clean from inside `e2e/`. The suite itself needs live tenant credentials, so the real check is a dispatch against `dev` once this and #378 have merged.

## Checklist

- [x] `pnpm run lint` passes with no new errors
- [x] Secrets and credentials are not committed
- [x] Targets `dev` (not `main`)
- [x] No version bump in `packages/*/package.json`
- [x] Labelled for release notes (`bug`)
