### PR TITLE
fix(backup): report an owner with no drives as empty, not as a permission fault

### DIFF
--- a/packages/onedrive/src/services/backup/backup-file-processor.ts
+++ b/packages/onedrive/src/services/backup/backup-file-processor.ts
@@ -24,11 +24,3 @@ export async function process_backup_file(
     abort_signal,
   );
 }
-
-/** @throws Error when no drives are returned (likely missing Graph permissions). */
-export function ensure_drives_discovered(drive_count: number): void {
-  if (drive_count > 0) return;
-  throw new Error(
-    'Missing Microsoft Graph application permissions for OneDrive: Files.Read.All, Sites.Read.All.',
-  );
-}

--- a/packages/onedrive/src/services/backup/backup.service.ts
+++ b/packages/onedrive/src/services/backup/backup.service.ts
@@ -38,7 +38,6 @@ import {
   persist_snapshot_backup,
 } from '@/services/backup/backup-builders';
 import type { RunVersionCollector } from '@/services/versioning/version-sync';
-import { ensure_drives_discovered } from '@/services/backup/backup-file-processor';
 import { scan_all_drives } from '@/services/backup/backup-drive-processor';
 import type { PackageReportTotals } from '@/services/backup/package-report';
 import { cleanup_stale_staging } from '@/services/backup/large-file-pipeline';
@@ -95,7 +94,13 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
       const previous_cursor =
         options.force_full === true || scope_changed ? undefined : stored_cursor;
       const drives = await this._connector.list_drives(tenant_id, owner_id);
-      ensure_drives_discovered(drives.length);
+      // An empty list is what Graph answers for an owner whose OneDrive was never provisioned.
+      // A revoked grant is a 403, which `list_drives` has already turned into the permission
+      // error, so reading empty as a permission fault sent the operator to check a consent grant
+      // that was fine (issue #369). Nothing to back up is a clean run with no snapshot.
+      if (drives.length === 0) {
+        logger.warn(`Owner ${owner_id} has no OneDrive drives; there is nothing to back up`);
+      }
       progress = options.create_progress?.(
         drives.map((drive) => ({ name: drive.drive_name, total_items: 0 })),
       );

--- a/packages/onedrive/tests/unit/services/backup/unprovisioned-owner.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/unprovisioned-owner.test.ts
@@ -1,0 +1,77 @@
+/**
+ * An owner whose OneDrive was never provisioned.
+ *
+ * Graph answers `GET /users/{id}/drives` with an empty list for one, and answers 403 for a
+ * revoked grant, which the connector has already turned into the permission error. Reading empty
+ * as a permission fault sent the operator to check a consent grant that was fine (issue #369).
+ */
+
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import type { OneDriveDrive, TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
+import { OneDriveBackupService } from '@/services/backup/backup.service';
+
+interface Harness {
+  service: OneDriveBackupService;
+  manifest_save: Mock;
+}
+
+function make_harness(list_drives: () => Promise<OneDriveDrive[]>): Harness {
+  const context = {
+    tenant_id: 't',
+    storage: {
+      exists: vi.fn().mockResolvedValue(false),
+      put: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(undefined),
+      list_stale: vi.fn(async () => []),
+      abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+    },
+    encrypt: (buffer: Buffer) => buffer,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(context),
+    create_readonly: vi.fn().mockResolvedValue(context),
+    create_storage_only: vi.fn(),
+  };
+
+  const manifest_save = vi.fn();
+  const service = new OneDriveBackupService(
+    factory,
+    { list_drives: vi.fn(list_drives), fetch_delta: vi.fn(), list_file_versions: vi.fn() } as never,
+    { save: manifest_save } as never,
+    { load_version_watermarks: vi.fn().mockResolvedValue({}), write_run_index: vi.fn() } as never,
+    { load: vi.fn().mockResolvedValue(undefined), save: vi.fn() } as never,
+  );
+
+  return { service, manifest_save };
+}
+
+describe('OneDrive backup for an owner with no drives', () => {
+  it('completes as an empty run and writes no snapshot', async () => {
+    const { service, manifest_save } = make_harness(async () => []);
+
+    const result = await service.backup_onedrive('tenant-1', 'owner-1', {});
+
+    expect(result.snapshot).toBeUndefined();
+    expect(result.summary.snapshot_created).toBe(false);
+    expect(result.summary.drives_scanned).toBe(0);
+    expect(result.summary.files_stored).toBe(0);
+    expect(result.summary.errors).toEqual([]);
+    expect(result.summary.healthy).toBe(true);
+    expect(manifest_save).not.toHaveBeenCalled();
+  });
+
+  it('still fails the run when the drives endpoint refuses', async () => {
+    const { service } = make_harness(() => {
+      throw new Error(
+        'Missing Microsoft Graph application permissions for OneDrive: Files.Read.All.',
+      );
+    });
+
+    await expect(service.backup_onedrive('tenant-1', 'owner-1', {})).rejects.toThrow(
+      /Missing Microsoft Graph application permissions/,
+    );
+  });
+});

--- a/packages/sharepoint/src/services/backup/backup-file-processor.ts
+++ b/packages/sharepoint/src/services/backup/backup-file-processor.ts
@@ -28,11 +28,3 @@ export async function process_backup_file(
     abort_signal,
   );
 }
-
-/** @throws Error when no document libraries are returned (likely missing Graph permissions). */
-export function ensure_libraries_discovered(library_count: number): void {
-  if (library_count > 0) return;
-  throw new Error(
-    'Missing Microsoft Graph application permissions for SharePoint: Sites.Read.All.',
-  );
-}

--- a/packages/sharepoint/src/services/backup/backup.service.ts
+++ b/packages/sharepoint/src/services/backup/backup.service.ts
@@ -41,7 +41,6 @@ import {
   build_snapshot_manifest,
   persist_snapshot_backup,
 } from '@/services/backup/backup-builders';
-import { ensure_libraries_discovered } from '@/services/backup/backup-file-processor';
 import type {
   FileTrackingState,
   VersionStatsState,
@@ -90,7 +89,12 @@ export class SharePointBackupService implements SharePointBackupUseCase {
       const stored_cursor = await this._cursors.load(ctx, site_id);
       const previous_cursor = options.force_full === true ? undefined : stored_cursor;
       const libraries = await this._connector.list_document_libraries(tenant_id, site_id);
-      ensure_libraries_discovered(libraries.length);
+      // Same reasoning as the OneDrive twin: a revoked grant is a 403 that
+      // `list_document_libraries` has already named, so an empty list is a site with no document
+      // library rather than a permission fault (issue #369).
+      if (libraries.length === 0) {
+        logger.warn(`Site ${site_id} has no document libraries; there is nothing to back up`);
+      }
       emit_operation_progress(options, {
         operation: 'backup',
         workload: 'sharepoint',


### PR DESCRIPTION
## Summary

Fixes #369. A OneDrive that was never provisioned makes Graph answer `GET /users/{id}/drives` with an empty list, and `ensure_drives_discovered` turned that into "Missing Microsoft Graph application permissions". The operator then goes and checks consent grants that are fine.

An empty list is not how a permission failure arrives. `list_drives` wraps its call in `rethrow_if_access_denied`, so a revoked grant is a 403 that is already named as one before the guard ever runs. The guard could only ever fire on a genuinely empty owner.

The SharePoint twin had the same guard on document libraries, same reasoning, so it goes with it. Both services already handle a run with no entries: `build_empty_result`, no snapshot object, cursor saved, healthy.

## Changes

- `packages/onedrive/src/services/backup/backup-file-processor.ts`: `ensure_drives_discovered` removed.
- `packages/sharepoint/src/services/backup/backup-file-processor.ts`: `ensure_libraries_discovered` removed.
- Both backup services warn that there is nothing to back up and continue.
- `packages/onedrive/tests/unit/services/backup/unprovisioned-owner.test.ts`: new. An empty list completes healthy with no manifest write; a refusing endpoint still fails the run.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] No relative imports (use `@/` path aliases)
- [x] Targets `dev`
- [x] Labelled for release notes (`bug`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OneDrive backups now complete successfully when an owner has no provisioned drives, without creating an empty snapshot or manifest.
  - SharePoint backups now proceed normally when a site has no document libraries.
  - Genuine errors retrieving drives or libraries continue to fail with the appropriate permission error.

- **Tests**
  - Added coverage for unprovisioned OneDrive owners and related backup outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->