### PR TITLE
fix(cli): give restore-version the exit-code contract the other restores have

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -671,6 +671,11 @@ A file with no version stored at or before the cutoff is **reported, not
 skipped silently**, and counts toward the skipped total. Treat that list as the
 work still outstanding: those files have no pre-incident copy in the backup.
 
+The exit code follows the same contract as snapshot `restore`: `0` when every
+file was rolled back, `2` when files were skipped, and `1` when any restore
+errored. A scripted rollback that only checks for `0` therefore sees the
+difference between a clean run and one that recovered nothing.
+
 ::: details Why Atlas uploads its own bytes instead of calling Graph
 Microsoft Graph can promote a previous version in place with `restoreVersion`,
 and Atlas deliberately does not use it. That call only works on a version the

--- a/packages/cli/src/commands/drive-version-restore.handlers.tsx
+++ b/packages/cli/src/commands/drive-version-restore.handlers.tsx
@@ -25,6 +25,7 @@ import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { render_static_view } from '@/ui/render';
+import { report_skipped_items, EXIT_PARTIAL } from '@/command-run-outcome';
 
 /** Flags shared by both drives; only the scope flag differs. */
 interface VersionRestoreFlags {
@@ -161,4 +162,11 @@ async function report_version_restore(
   );
 
   if (result.interrupted) logger.warn('Run was interrupted before every version was restored.');
+
+  // Same contract as snapshot restore: skips exit 2, errors exit 1, and errors win. A scripted
+  // rollback could not tell a clean run from a total failure while this exited 0 either way
+  // (issue #362).
+  report_skipped_items(result.files_skipped, 'File');
+  if (result.interrupted) process.exitCode = EXIT_PARTIAL;
+  if (result.errors.length > 0) process.exitCode = 1;
 }

--- a/packages/cli/tests/unit/drive-version-restore-exit-code.test.ts
+++ b/packages/cli/tests/unit/drive-version-restore-exit-code.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Container } from 'inversify';
+import { Command } from 'commander';
+import { register_onedrive_command } from '@/commands/onedrive.command';
+import {
+  ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN,
+  USER_IDENTITY_RESOLVER_TOKEN,
+} from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
+import { EXIT_PARTIAL } from '@/command-run-outcome';
+
+/**
+ * Issue #362. `restore-version` never set an exit code, so a rollback where every file failed
+ * printed a warning and exited 0. A scripted rollback could not tell that from success.
+ */
+function make_result(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    files_restored: 1,
+    files_skipped: 0,
+    restored: [],
+    errors: [],
+    placement: 'copy',
+    interrupted: false,
+    ...overrides,
+  };
+}
+
+describe('drive restore-version exit codes', () => {
+  let container: Container;
+  let program: Command;
+  let restore_version: ReturnType<typeof vi.fn>;
+  let previous: typeof process.exitCode;
+
+  beforeEach(() => {
+    previous = process.exitCode;
+    process.exitCode = undefined;
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    restore_version = vi.fn().mockResolvedValue(make_result());
+
+    container = new Container();
+    container
+      .bind(ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN)
+      .toConstantValue({ restore_onedrive_version: restore_version });
+    container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({ tenant_id: 'tenant-1' });
+    container.bind(USER_IDENTITY_RESOLVER_TOKEN).toConstantValue({
+      resolve_user: vi
+        .fn()
+        .mockResolvedValue({ object_id: 'owner-1', user_principal_name: 'john.doe@example.com' }),
+    });
+
+    program = new Command();
+    register_onedrive_command(program, () => container);
+  });
+
+  afterEach(() => {
+    process.exitCode = previous;
+    vi.restoreAllMocks();
+  });
+
+  const run = (): Promise<unknown> =>
+    program.parseAsync(
+      ['onedrive', 'restore-version', '-o', 'john.doe@example.com', '--before', '2026-03-10'],
+      { from: 'user' },
+    );
+
+  it('exits 1 when a version restore failed', async () => {
+    restore_version.mockResolvedValue(
+      make_result({ files_restored: 0, errors: ['/Report.docx: content missing from storage'] }),
+    );
+
+    await run();
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('exits partial when files were skipped without errors', async () => {
+    restore_version.mockResolvedValue(make_result({ files_restored: 0, files_skipped: 2 }));
+
+    await run();
+
+    expect(process.exitCode).toBe(EXIT_PARTIAL);
+  });
+
+  it('reports an error over a skip when both happened', async () => {
+    restore_version.mockResolvedValue(
+      make_result({ files_skipped: 1, errors: ['/Budget.xlsx: upload refused'] }),
+    );
+
+    await run();
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('leaves a clean rollback at 0', async () => {
+    await run();
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #362. `restore-version` never set `process.exitCode`. Restore errors were logged with `logger.warn`, a run where every file failed printed `Nothing restored` as a warning, and the process exited 0. A scheduled rollback could not tell that from a clean one.

It now follows the contract the snapshot restore handlers already implement and `docs/reference/cli.md` already documents for restore: skipped files exit 2 through the shared `report_skipped_items`, errors exit 1, an interrupt exits 2, and errors win when both happened. A clean rollback still exits 0.

## Changes

- `packages/cli/src/commands/drive-version-restore.handlers.tsx`: sets the exit code after reporting, for both OneDrive and SharePoint since they share the reporter.
- `packages/cli/tests/unit/drive-version-restore-exit-code.test.ts`: new. Errors, skips, both together, and a clean run.
- `docs/reference/cli.md`: states the contract under `restore-version`.

## Evidence

Three of the four cases fail on `dev` and pass here. The clean-run case passes on both, which is the point: it is the case that was already correct by accident.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] `pnpm run docs:build` succeeds
- [x] Targets `dev`
- [x] Labelled for release notes (`bug`)