### PR TITLE
fix(cli): fail an outlook restore whose only casualties were attachments

### DIFF
--- a/packages/cli/src/commands/outlook-restore.handler.tsx
+++ b/packages/cli/src/commands/outlook-restore.handler.tsx
@@ -141,9 +141,17 @@ async function execute_mailbox_restore(
   await report_restore_result(result);
 }
 
-/** Prints a human-readable summary of the restore result. */
+/**
+ * Prints a human-readable summary of the restore result.
+ *
+ * Success is decided from `errors`, not from `error_count`. `error_count` counts message-level
+ * failures only, while attachment failures land in `errors`, so a run whose only casualties were
+ * attachments printed a green summary, printed no error list, and exited 0. The single-message
+ * path made it worse by hardcoding `error_count: 0` while still returning attachment errors
+ * (issue #359).
+ */
 async function report_restore_result(result: RestoreResult): Promise<void> {
-  if (result.error_count === 0 && !result.interrupted) {
+  if (result.errors.length === 0 && !result.interrupted) {
     const entries: SummaryEntry[] = [
       { label: 'messages restored', value: result.restored_count, color: 'green' },
     ];

--- a/packages/cli/tests/unit/outlook-save-restore-exit-code.test.ts
+++ b/packages/cli/tests/unit/outlook-save-restore-exit-code.test.ts
@@ -109,6 +109,34 @@ describe('outlook save and restore exit codes', () => {
     expect(process.exitCode).toBe(EXIT_PARTIAL);
   });
 
+  it('restore exits non-zero when the only failures were attachments', async () => {
+    // error_count counts message failures only. Deciding success from it printed a green
+    // summary for a message restored without its attachment (issue #359).
+    restore_snapshot.mockResolvedValue(
+      make_restore_result({
+        error_count: 0,
+        attachment_error_count: 1,
+        errors: ['message:2 attachment invoice.pdf: 403 from Graph'],
+      }),
+    );
+    await run_restore();
+    expect(process.exitCode).toBe(EXIT_PARTIAL);
+  });
+
+  it('restores a single message with the same verdict as a batch', async () => {
+    // The single-message path hardcodes error_count: 0 while still returning attachment errors.
+    restore_snapshot.mockResolvedValue(
+      make_restore_result({
+        restored_count: 1,
+        error_count: 0,
+        attachment_error_count: 1,
+        errors: ['attachment invoice.pdf: 403 from Graph'],
+      }),
+    );
+    await run_restore();
+    expect(process.exitCode).toBe(EXIT_PARTIAL);
+  });
+
   it('leaves a clean save and a clean restore at 0', async () => {
     await run_save();
     expect(process.exitCode).toBeUndefined();


### PR DESCRIPTION
## Summary

Fixes #359. #341 made attachment failures visible in the restore result and nothing read them. `report_restore_result` took its success branch on `result.error_count === 0`, which counts message-level failures only, and returned before the error list and `report_run_outcome`. Attachment failures live in `result.errors`. A restore that wrote every message and no attachment printed a green summary and exited 0.

The single-message path is worse in the same way: it hardcodes `error_count: 0` while returning the attachment errors it collected.

Success is now decided from `errors`, which both paths already fill and which is a superset of `error_count`. That covers the batch and single-message paths with one condition rather than teaching each path to count attachments, and it leaves `error_count` meaning what its name says for the summary line.

The verdict stays partial (2) rather than 1, consistent with the rest of this handler: a restore that dropped items is incomplete, not fatal.

## Changes

- `packages/cli/src/commands/outlook-restore.handler.tsx`: the success branch requires `errors.length === 0`.
- `packages/cli/tests/unit/outlook-save-restore-exit-code.test.ts`: two cases, batch and single-message, each with an attachment failure and no message failure.

## Evidence

Both new cases fail on `dev` and pass here. The five existing cases are untouched and still pass, including the one that pins verification warnings as not partial.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] Targets `dev`
- [x] Labelled for release notes (`bug`)