### PR TITLE
fix(restore): keep an outlook restore going past a folder it cannot create

### DIFF
--- a/packages/outlook/src/services/restore/restore-loop-executor.ts
+++ b/packages/outlook/src/services/restore/restore-loop-executor.ts
@@ -56,15 +56,32 @@ export async function execute_restore_loop(
       if (is_interrupted()) break;
       dashboard.mark_active(folder_index);
 
-      const target_fid = await ensure_subfolder(
-        restore_connector,
-        tenant_id,
-        target_mailbox,
-        root.folder_id,
-        fid,
-        folder_map,
-        created_folders,
-      );
+      // A folder that cannot be created costs its own messages, not the rest of the plan. The
+      // drive restores have always degraded per folder; this was the one path where one Graph
+      // 4xx on create_mail_folder aborted the run and left every later folder untouched, in a
+      // state indistinguishable from an interrupt (issue #360).
+      let target_fid: string;
+      try {
+        target_fid = await ensure_subfolder(
+          restore_connector,
+          tenant_id,
+          target_mailbox,
+          root.folder_id,
+          fid,
+          folder_map,
+          created_folders,
+        );
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        all_errors.push(
+          `folder ${folder_map.get(fid) ?? fid}: could not be created (${reason}); ` +
+            `${folder_items.length} message(s) not restored`,
+        );
+        global_errors++;
+        dashboard.mark_done(folder_index, 0, 0);
+        folder_index++;
+        continue;
+      }
 
       const result = await restore_folder_entries(
         ctx,

--- a/packages/outlook/tests/unit/services/restore/folder-creation-failure.test.ts
+++ b/packages/outlook/tests/unit/services/restore/folder-creation-failure.test.ts
@@ -1,0 +1,123 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  ManifestEntry,
+  RestoreConnector,
+  TenantContext,
+  TransferProgressReporter,
+} from '@wisecom/atlas-types';
+import { execute_restore_loop } from '@/services/restore/restore-loop-executor';
+
+/**
+ * Issue #360. `ensure_subfolder` ran outside any error handling, so one Graph 4xx on
+ * `create_mail_folder` propagated out of the loop and abandoned every folder after it. The drive
+ * restores degrade per folder; this was the one path that discarded the rest of the run.
+ */
+
+const MESSAGE = Buffer.from(JSON.stringify({ subject: 'Example subject', parentFolderId: 'f1' }));
+
+function make_entry(object_id: string, folder_id: string): ManifestEntry {
+  return {
+    object_id,
+    storage_key: `data/user/${object_id}`,
+    checksum: createHash('sha256').update(MESSAGE).digest('hex'),
+    size_bytes: MESSAGE.length,
+    folder_id,
+  };
+}
+
+function make_ctx(): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: { get: vi.fn(async () => MESSAGE), put: vi.fn() },
+    encrypt: (data: Buffer) => data,
+    decrypt: vi.fn(() => MESSAGE),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+function make_dashboard(): TransferProgressReporter {
+  return {
+    mark_active: vi.fn(),
+    update_active: vi.fn(),
+    update_total: vi.fn(),
+    mark_done: vi.fn(),
+    mark_all_pending_interrupted: vi.fn(),
+    finish: vi.fn(),
+  } as unknown as TransferProgressReporter;
+}
+
+/** Refuses to create exactly one folder, by the display name the folder map gives it. */
+function make_connector(refused: string): RestoreConnector {
+  return {
+    create_mail_folder: vi.fn(async (_t: string, _o: string, name: string, _parent: string) => {
+      if (name === refused) throw new Error('ErrorAccessDenied');
+      return { folder_id: `created-${name}`, display_name: name };
+    }),
+    create_message: vi.fn().mockResolvedValue('new-msg'),
+    add_attachment: vi.fn(),
+    create_upload_session: vi.fn(),
+    upload_attachment_chunk: vi.fn(),
+    count_folder_messages: vi.fn(),
+  } as unknown as RestoreConnector;
+}
+
+async function run(refused: string): Promise<{
+  restored_count: number;
+  errors: readonly string[];
+  created: readonly string[];
+}> {
+  const connector = make_connector(refused);
+  const groups = new Map<string, ManifestEntry[]>([
+    ['f1', [make_entry('msg-1', 'f1')]],
+    ['f2', [make_entry('msg-2', 'f2'), make_entry('msg-3', 'f2')]],
+    ['f3', [make_entry('msg-4', 'f3')]],
+  ]);
+  const folder_map = new Map<string, string>([
+    ['f1', 'Inbox'],
+    ['f2', 'Projects'],
+    ['f3', 'Archive'],
+  ]);
+
+  const result = await execute_restore_loop(
+    make_ctx(),
+    connector,
+    'tenant-1',
+    'john.doe@example.com',
+    'snap-1',
+    { folder_id: 'root-1', display_name: 'Restore-2026' },
+    groups,
+    folder_map,
+    new Map<string, string>(),
+    make_dashboard(),
+    {},
+  );
+
+  const created = vi.mocked(connector.create_mail_folder).mock.calls.map((call) => String(call[2]));
+  return { restored_count: result.restored_count, errors: result.errors, created };
+}
+
+describe('a folder that cannot be created during outlook restore', () => {
+  it('costs its own messages and leaves the later folders restored', async () => {
+    const { restored_count, errors, created } = await run('Projects');
+
+    // Inbox before it and Archive after it both land; only Projects is lost.
+    expect(restored_count).toBe(2);
+    expect(created).toContain('Archive');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Projects');
+  });
+
+  it('names how many messages the failed folder took with it', async () => {
+    const { errors } = await run('Projects');
+
+    expect(errors[0]).toContain('2 message(s) not restored');
+  });
+
+  it('restores every folder when none of them refuse', async () => {
+    const { restored_count, errors } = await run('nothing-refuses-this');
+
+    expect(restored_count).toBe(4);
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #360. Outlook batch restore called `ensure_subfolder` with no error handling around it. One `create_mail_folder` failure propagated out of the folder loop and aborted the run, so every folder after the failing one was never attempted. Drive restores catch the same failure per folder, record the entry, and continue: this was the one path that discarded the rest of the run.

The failing folder now becomes one error naming the folder and how many messages went with it, and the loop moves to the next folder. The exit code follows from that automatically, since `report_run_outcome` already exits partial on a non-empty error list.

## Changes

- `packages/outlook/src/services/restore/restore-loop-executor.ts`: the `ensure_subfolder` call is guarded per folder; a failure records the error, marks the folder done with zero restored, and continues.
- `packages/outlook/tests/unit/services/restore/folder-creation-failure.test.ts`: new. Three folders with the middle one refused.

## Evidence

Pre-fix the new tests do not fail an assertion, they throw `ErrorAccessDenied` out of the run, which is the bug stated exactly. Post-fix: Inbox and Archive restore, Projects is reported with its two messages, and a run where nothing refuses restores all four.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] Targets `dev`
- [x] Labelled for release notes (`bug`)