### PR TITLE
fix(backup): keep a folder's entries when one attachment fetch fails

### DIFF
--- a/packages/outlook/src/services/backup/folder-sync-executor.ts
+++ b/packages/outlook/src/services/backup/folder-sync-executor.ts
@@ -1,4 +1,6 @@
 import type { TenantContext } from '@wisecom/atlas-types';
+import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
 import {
   capture_mime_payload,
   store_single_message,
@@ -22,6 +24,13 @@ export interface FolderSyncResult {
   stored: number;
   deduplicated: number;
   attachments_stored: number;
+  /**
+   * Messages whose attachments could not be fetched, one line each.
+   *
+   * A folder-level error would discard the folder's other entries, and their blobs are already
+   * in storage, so they would be orphans until a later run deduplicated them (issue #366).
+   */
+  attachment_errors: string[];
   folder_processed: number;
 }
 
@@ -82,7 +91,17 @@ async function process_message(
   }
 }
 
-/** Drains all pending attachment fetches in parallel batches of `concurrency`. */
+/**
+ * Drains all pending attachment fetches in parallel batches of `concurrency`.
+ *
+ * One failure used to reject the whole `Promise.all`, and the throw travelled out of
+ * `sync_single_folder` into a folder-level error that discarded every entry already processed in
+ * that folder. A message deleted between the delta page and the attachment fetch is enough to
+ * trigger it, and Graph answers `ErrorItemNotFound` for that (issue #366).
+ *
+ * A permission or licensing failure still propagates: those are the operator's to fix, and
+ * degrading the whole run quietly is the failure #372 describes.
+ */
 async function flush_pending_attachments(
   ctx: TenantContext,
   connector: MailboxConnector,
@@ -91,24 +110,38 @@ async function flush_pending_attachments(
   entries: ManifestEntry[],
   stats: { stored: number; deduplicated: number; att_stored: number },
   pending: PendingAttachment[],
+  attachment_errors: string[],
+  is_interrupted: () => boolean,
   object_lock_policy?: ObjectLockPolicy,
   concurrency = DEFAULT_ATTACHMENT_CONCURRENCY,
 ): Promise<void> {
   while (pending.length > 0) {
+    // An interrupted run stops scheduling; what is already in flight finishes.
+    if (is_interrupted()) {
+      pending.length = 0;
+      return;
+    }
     const batch = pending.splice(0, concurrency);
     const tasks = batch.map(async (p) => {
-      const att = await fetch_and_store_attachments(
-        ctx,
-        connector,
-        tenant_id,
-        owner_id,
-        p.message_id,
-        undefined,
-        object_lock_policy,
-      );
-      if (att && att.length > 0) {
-        stats.att_stored += att.length;
-        entries[p.entry_index] = { ...entries[p.entry_index]!, attachments: att };
+      try {
+        const att = await fetch_and_store_attachments(
+          ctx,
+          connector,
+          tenant_id,
+          owner_id,
+          p.message_id,
+          undefined,
+          object_lock_policy,
+        );
+        if (att && att.length > 0) {
+          stats.att_stored += att.length;
+          entries[p.entry_index] = { ...entries[p.entry_index]!, attachments: att };
+        }
+      } catch (err) {
+        if (err instanceof AuthError || err instanceof MailboxNotLicensedError) throw err;
+        const reason = err instanceof Error ? err.message : String(err);
+        logger.warn(`Attachments for message ${p.message_id} could not be fetched: ${reason}`);
+        attachment_errors.push(`message ${p.message_id}: attachments not backed up (${reason})`);
       }
     });
 
@@ -142,6 +175,7 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
   const entries: ManifestEntry[] = [];
   const stats = { stored: 0, deduplicated: 0, att_stored: 0 };
   const pending_attachments: PendingAttachment[] = [];
+  const attachment_errors: string[] = [];
   let folder_processed = 0;
   let streamed = false;
   // Set whenever any page or message is skipped; blocks delta-link persistence (issue #23).
@@ -212,6 +246,8 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
       entries,
       stats,
       pending_attachments,
+      attachment_errors,
+      is_interrupted,
       object_lock_policy,
     );
 
@@ -286,6 +322,8 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
       entries,
       stats,
       pending_attachments,
+      attachment_errors,
+      is_interrupted,
       object_lock_policy,
     );
   }
@@ -297,6 +335,7 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
     stored: stats.stored,
     deduplicated: stats.deduplicated,
     attachments_stored: stats.att_stored,
+    attachment_errors,
     folder_processed,
   };
 }

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -132,6 +132,12 @@ export class MailboxSyncService implements BackupUseCase {
           continue;
         }
 
+        // Per-message attachment failures, not folder failures: the folder's entries are kept
+        // and the run reports itself incomplete rather than losing the folder (issue #366).
+        folder_errors.push(
+          ...outcome.attachment_errors.map((line) => `${folder.folder_path}: ${line}`),
+        );
+
         all_entries.push(...outcome.entries);
         // Persist a folder's delta link only when every page was fully processed;
         // an interrupted folder keeps its previous link and is re-enumerated next run (issue #23).
@@ -226,6 +232,7 @@ export class MailboxSyncService implements BackupUseCase {
     stored: number;
     deduplicated: number;
     attachments_stored: number;
+    attachment_errors: string[];
     folder_processed: number;
     error?: string;
   }> {
@@ -265,6 +272,7 @@ export class MailboxSyncService implements BackupUseCase {
         stored: result.stored,
         deduplicated: result.deduplicated,
         attachments_stored: result.attachments_stored,
+        attachment_errors: result.attachment_errors,
         folder_processed: result.folder_processed,
       };
     } catch (err) {
@@ -275,6 +283,7 @@ export class MailboxSyncService implements BackupUseCase {
         stored: 0,
         deduplicated: 0,
         attachments_stored: 0,
+        attachment_errors: [],
         folder_processed: 0,
         error: msg,
       };

--- a/packages/outlook/tests/unit/services/backup/attachment-flush-containment.test.ts
+++ b/packages/outlook/tests/unit/services/backup/attachment-flush-containment.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthError } from '@wisecom/atlas-types';
+import type {
+  BackupProgressReporter,
+  MailMessage,
+  MailboxConnector,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { sync_single_folder } from '@/services/backup/folder-sync-executor';
+
+/**
+ * Issue #366. The per-folder attachment flush used a bare `Promise.all`, so one failing fetch
+ * rejected the batch, the throw left `sync_single_folder`, and the mailbox sync recorded a
+ * folder-level error that discarded every entry already processed in that folder. Those blobs
+ * were already in storage, so they became orphans. A message deleted between the delta page and
+ * the attachment fetch is enough to trigger it.
+ */
+
+function make_message(message_id: string): MailMessage {
+  return {
+    message_id,
+    subject: 'Example subject',
+    has_attachments: true,
+    received_at: '2026-08-17T00:00:00.000Z',
+    raw_body: Buffer.from(`body-${message_id}`),
+  } as unknown as MailMessage;
+}
+
+function make_ctx(): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: {
+      exists: vi.fn().mockResolvedValue(false),
+      put: vi.fn().mockResolvedValue(undefined),
+      get: vi.fn(),
+    },
+    encrypt: (data: Buffer) => data,
+    decrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+function make_progress(): BackupProgressReporter {
+  return {
+    mark_active: vi.fn(),
+    mark_done: vi.fn(),
+    mark_error: vi.fn(),
+    update_active: vi.fn(),
+    update_total: vi.fn(),
+    finish: vi.fn(),
+  } as unknown as BackupProgressReporter;
+}
+
+/** MIME capture off, so every message with attachments goes through the pending flush. */
+function make_connector(fail_for: (message_id: string) => Error | undefined): MailboxConnector {
+  return {
+    fetch_delta: vi.fn().mockResolvedValue({
+      messages: [make_message('msg-1'), make_message('msg-2'), make_message('msg-3')],
+      delta_link: 'delta-2',
+    }),
+    fetch_mime: vi.fn().mockRejectedValue(new Error('not available')),
+    fetch_attachments: vi.fn(async (_t: string, _o: string, message_id: string) => {
+      const failure = fail_for(message_id);
+      if (failure) throw failure;
+      return [
+        {
+          attachment_id: `att-${message_id}`,
+          name: 'Report.docx',
+          content_type: 'application/vnd.openxmlformats',
+          size_bytes: 4,
+          content: Buffer.from('abcd'),
+          is_inline: false,
+        },
+      ];
+    }),
+  } as unknown as MailboxConnector;
+}
+
+async function run(
+  fail_for: (message_id: string) => Error | undefined,
+  is_interrupted: () => boolean = () => false,
+): ReturnType<typeof sync_single_folder> {
+  return sync_single_folder({
+    ctx: make_ctx(),
+    connector: make_connector(fail_for),
+    tenant_id: 'tenant-1',
+    owner_id: 'john.doe@example.com',
+    folder_id: 'inbox',
+    folder_index: 0,
+    folder_total: 3,
+    global_total: 3,
+    global_processed_before: 0,
+    sync_start: Date.now(),
+    progress: make_progress(),
+    is_interrupted,
+    is_hard_stopped: () => false,
+    operation_control: {},
+    previous_manifest_entries: 0,
+  });
+}
+
+describe('one attachment fetch failing during a folder flush', () => {
+  it('keeps the folder entries and records the message', async () => {
+    const result = await run((id) => (id === 'msg-2' ? new Error('ErrorItemNotFound') : undefined));
+
+    expect(result.entries).toHaveLength(3);
+    expect(result.attachment_errors).toHaveLength(1);
+    expect(result.attachment_errors[0]).toContain('msg-2');
+    // The other two still carry their attachments.
+    expect(result.attachments_stored).toBe(2);
+  });
+
+  it('still stops the run for a permission failure', async () => {
+    await expect(
+      run((id) => (id === 'msg-2' ? new AuthError('403 from Graph') : undefined)),
+    ).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it('records nothing when every fetch succeeds', async () => {
+    const result = await run(() => undefined);
+
+    expect(result.attachment_errors).toEqual([]);
+    expect(result.attachments_stored).toBe(3);
+  });
+
+  it('stops scheduling attachment fetches once the run is interrupted', async () => {
+    const result = await run(
+      () => undefined,
+      () => true,
+    );
+
+    expect(result.attachments_stored).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #366. Outlook backup flushes pending attachment fetches per folder with `Promise.all`. One failing `fetch_and_store_attachments` rejected the whole flush, the throw propagated out of `sync_single_folder`, and the mailbox sync recorded a folder-level error that discarded every entry already processed in that folder. Those messages were already encrypted and written, so they became orphans until a later run deduplicated them.

The trigger is ordinary: a message deleted between its delta page and its attachment fetch, which Graph answers with `ErrorItemNotFound`.

Three changes, all in the flush:

- Each task catches its own failure and records the message. The folder's other entries are kept, and the run reports itself incomplete through the existing error bucket, so the exit code follows.
- `AuthError` and `MailboxNotLicensedError` still propagate. Those are the operator's to fix, and swallowing them per message is the failure #372 is about.
- The drain loop checks the interrupt flag between batches. A soft-stopped run used to drain every pending fetch before stopping.

## Changes

- `packages/outlook/src/services/backup/folder-sync-executor.ts`: per-task error handling, interrupt check, and `attachment_errors` on `FolderSyncResult`.
- `packages/outlook/src/services/backup/mailbox-sync.service.ts`: threads the per-message errors into the run's error list, prefixed with the folder path.
- `packages/outlook/tests/unit/services/backup/attachment-flush-containment.test.ts`: new.

## Evidence

Pre-fix the containment cases throw `ErrorItemNotFound` out of the run rather than failing an assertion, which is the bug exactly. Post-fix: three messages, the middle one failing, keeps all three entries and two attachment sets; a permission failure still rejects; an interrupted run stores none.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] New/changed code has unit tests
- [x] Targets `dev`
- [x] Labelled for release notes (`bug`)