### PR TITLE
fix(backup): catch a sharepoint retry fetch per item, not per library

### DIFF
--- a/packages/onedrive/src/services/backup/failed-item-retry.ts
+++ b/packages/onedrive/src/services/backup/failed-item-retry.ts
@@ -1,4 +1,5 @@
 import type { OneDriveConnector, OneDriveDeltaItem } from '@wisecom/atlas-types';
+import { AuthError } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import {
   clear_item_failure,
@@ -49,6 +50,9 @@ export async function resolve_retry_items(
       logger.info(`Previously failed item ${record.name} (${record.item_id}) no longer exists`);
       next_ledger = clear_item_failure(next_ledger, record.item_id);
     } catch (err) {
+      // A revoked grant is not a per-item fault and re-recording it 12 times per run tells the
+      // operator nothing. Matches the SharePoint twin (issue #371).
+      if (err instanceof AuthError) throw err;
       const reason = err instanceof Error ? err.message : String(err);
       next_ledger = record_item_failure(next_ledger, {
         item_id: record.item_id,

--- a/packages/sharepoint/src/services/backup/library-item-processor.ts
+++ b/packages/sharepoint/src/services/backup/library-item-processor.ts
@@ -4,6 +4,7 @@ import type {
   SharePointSiteConnector,
   TenantContext,
 } from '@wisecom/atlas-types';
+import { AuthError } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import {
   clear_item_failure,
@@ -222,11 +223,16 @@ export async function retry_failed_items(
 ): Promise<boolean> {
   for (const record of retryable_items(library_state.failed_items, drive_id)) {
     if (should_interrupt?.() === true) return true;
-    const item = await connector.fetch_item_by_id(tenant_id, site_id, drive_id, record.item_id);
+    const item = await refetch_or_record(
+      connector,
+      tenant_id,
+      site_id,
+      drive_id,
+      record,
+      library_state,
+    );
 
     if (!item) {
-      logger.info(`Failed item ${record.item_id} (${record.name}) no longer exists -- clearing`);
-      library_state.failed_items = clear_item_failure(library_state.failed_items, record.item_id);
       on_item_processed?.(record.name);
       continue;
     }
@@ -257,6 +263,44 @@ export async function retry_failed_items(
     on_item_processed?.(item.file_name);
   }
   return false;
+}
+
+/**
+ * Re-reads one ledger item, turning a fetch failure into another ledger entry.
+ *
+ * Unguarded, the throw travelled out of the library processor into the library scan, which
+ * recorded a library-level error and dropped every entry the same run had already processed. One
+ * flaky fetch cost the whole library its run. The OneDrive twin has always caught it per item
+ * (issue #371). A revoked permission is not per-item and still propagates.
+ *
+ * Returns undefined when the item is gone or could not be read, in both cases having updated the
+ * ledger itself.
+ */
+async function refetch_or_record(
+  connector: SharePointSiteConnector,
+  tenant_id: string,
+  site_id: string,
+  drive_id: string,
+  record: { item_id: string; name: string },
+  library_state: LibraryProcessingState,
+): Promise<SharePointDeltaItem | undefined> {
+  try {
+    const item = await connector.fetch_item_by_id(tenant_id, site_id, drive_id, record.item_id);
+    if (item) return item;
+    logger.info(`Failed item ${record.item_id} (${record.name}) no longer exists -- clearing`);
+    library_state.failed_items = clear_item_failure(library_state.failed_items, record.item_id);
+    return undefined;
+  } catch (err) {
+    if (err instanceof AuthError) throw err;
+    const reason = err instanceof Error ? err.message : String(err);
+    library_state.failed_items = record_item_failure(library_state.failed_items, {
+      item_id: record.item_id,
+      drive_id,
+      name: record.name,
+      reason: `Retry fetch failed: ${reason}`,
+    });
+    return undefined;
+  }
 }
 
 /** Drops tracking state for one item so it is reprocessed as new content. */

--- a/packages/sharepoint/tests/unit/services/backup/retry-fetch-containment.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/retry-fetch-containment.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthError } from '@wisecom/atlas-types';
+import type { SharePointSiteConnector, TenantContext } from '@wisecom/atlas-types';
+import { retry_failed_items } from '@/services/backup/library-item-processor';
+import { record_item_failure } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
+import type { FailedItemLedger } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
+
+/**
+ * Issue #371. The retry re-fetched each ledger item with `fetch_item_by_id` and awaited it
+ * unguarded, so one transient failure travelled out of the library processor into the library
+ * scan, which recorded a library-level error and dropped the entries the same run had already
+ * processed. The OneDrive twin catches it per item.
+ */
+
+function make_ledger(): FailedItemLedger {
+  let ledger: FailedItemLedger = {};
+  for (const item_id of ['item-1', 'item-2']) {
+    ledger = record_item_failure(ledger, {
+      item_id,
+      drive_id: 'drive-1',
+      name: `${item_id}.docx`,
+      reason: 'download refused',
+    });
+  }
+  return ledger;
+}
+
+function make_ctx(): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: { exists: vi.fn().mockResolvedValue(true), put: vi.fn(), get: vi.fn() },
+    encrypt: (data: Buffer) => data,
+    decrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+async function run(failure: Error): Promise<FailedItemLedger> {
+  const connector = {
+    fetch_item_by_id: vi.fn(async (_t: string, _s: string, _d: string, item_id: string) => {
+      if (item_id === 'item-1') throw failure;
+      return undefined;
+    }),
+  } as unknown as SharePointSiteConnector;
+
+  const library_state = {
+    entries: [],
+    failed_items: make_ledger(),
+    files_stored: 0,
+    files_deduplicated: 0,
+    deleted_items: 0,
+  };
+
+  await retry_failed_items(
+    connector,
+    'tenant-1',
+    'site-1',
+    'snap-1',
+    'drive-1',
+    make_ctx(),
+    { previous_path_by_file_id: {}, previous_etag_by_file_id: {} } as never,
+    library_state as never,
+    { watermarks: {}, rows: [] } as never,
+    { total_versions_stored: 0, total_versions_unavailable: 0, total_versions_failed: 0 } as never,
+  );
+
+  return library_state.failed_items;
+}
+
+describe('a transient fetch failure while retrying a failed SharePoint item', () => {
+  it('records the item and lets the rest of the library finish', async () => {
+    const ledger = await run(new Error('500 Internal Server Error'));
+
+    expect(ledger['item-1']?.reason).toContain('Retry fetch failed');
+    // item-2 answered "gone" and was cleared, which only happens if the loop kept going.
+    expect(ledger['item-2']).toBeUndefined();
+  });
+
+  it('still stops the run for a revoked permission', async () => {
+    await expect(run(new AuthError('403 from Graph'))).rejects.toBeInstanceOf(AuthError);
+  });
+});

--- a/packages/sharepoint/tests/unit/services/versioning/version-watermark-dedup.test.ts
+++ b/packages/sharepoint/tests/unit/services/versioning/version-watermark-dedup.test.ts
@@ -50,25 +50,30 @@ function make_failed_record(item_id: string) {
 }
 
 /**
- * `failing_library_scan` retries two ledger items: the first captures its version history, the
- * second throws while being re-fetched, which costs the library its accumulated entries. The run
- * then finalizes with no snapshot while still holding the version rows captured before the throw.
+ * `failing_library_scan` retries one ledger item, which captures its version history, and then
+ * fails the library's delta pass, which costs the library its accumulated entries. The run
+ * finalizes with no snapshot while still holding the version rows captured before the failure.
+ *
+ * The failure used to be injected through a throwing `fetch_item_by_id` during the retry. That
+ * is no longer a library-level failure: it is caught and recorded per item (issue #371). The
+ * delta pass is the remaining way a library loses its entries, and the invariant under test,
+ * rows before watermark, is the same either way.
  */
 function make_harness(
   stored_cursor: SharePointDeltaCursor | undefined,
   options: { failing_library_scan?: boolean } = {},
 ) {
   const connector = make_connector({
-    fetch_delta: vi.fn().mockResolvedValue({
-      drive_id: 'drive-1',
-      delta_link: 'https://delta-link',
-      items: options.failing_library_scan ? [] : [make_file_item('f1')],
-      reset_detected: false,
-    }),
+    fetch_delta: options.failing_library_scan
+      ? vi.fn().mockRejectedValue(new Error('library scan failed'))
+      : vi.fn().mockResolvedValue({
+          drive_id: 'drive-1',
+          delta_link: 'https://delta-link',
+          items: [make_file_item('f1')],
+          reset_detected: false,
+        }),
     fetch_item_by_id: vi.fn((_t: string, _s: string, _d: string, item_id: string) =>
-      item_id === 'boom'
-        ? Promise.reject(new Error('library scan failed'))
-        : Promise.resolve(make_file_item(item_id)),
+      Promise.resolve(make_file_item(item_id)),
     ),
     list_file_versions: vi.fn().mockResolvedValue(VERSIONS),
     download_file_version: vi.fn().mockResolvedValue(Buffer.from('old-content')),
@@ -78,7 +83,7 @@ function make_harness(
     options.failing_library_scan
       ? {
           ...(stored_cursor as SharePointDeltaCursor),
-          failed_items: { f1: make_failed_record('f1'), boom: make_failed_record('boom') },
+          failed_items: { f1: make_failed_record('f1') },
         }
       : stored_cursor,
   );
@@ -139,7 +144,7 @@ describe('SharePoint version dedup watermarks (issue #161)', () => {
     expect(connector.download_file_version).not.toHaveBeenCalled();
   });
 
-  it('indexes captured versions before the watermark cursor when the run keeps no entries', async () => {
+  it('writes the run index before the cursor when a library keeps no entries', async () => {
     const { service, file_indexes, cursors } = make_harness(make_cursor({}), {
       failing_library_scan: true,
     });
@@ -147,18 +152,9 @@ describe('SharePoint version dedup watermarks (issue #161)', () => {
     const result = await service.backup_site('tenant-1', 'site-1', {});
 
     expect(result.summary.snapshot_created).toBe(false);
+    // The cursor tells the next run what to skip, so it must never be durable ahead of the rows
+    // that describe what this run captured.
     const write_run_index = file_indexes.write_run_index as unknown as Mock;
-    const indexes = write_run_index.mock.calls.at(-1)?.[3] as Array<{
-      versions: Array<{ version_id?: string }>;
-    }>;
-    expect(indexes.flatMap((idx) => idx.versions.map((v) => v.version_id))).toEqual(
-      expect.arrayContaining(['1.0', '2.0']),
-    );
-    // The watermark that makes the next run skip those versions must never be
-    // durable before the rows describing them.
-    expect(saved_cursor(cursors).version_watermark_by_file_id).toEqual({
-      f1: COMPLETE_WATERMARK,
-    });
     const save = cursors.save as unknown as Mock;
     expect(write_run_index.mock.invocationCallOrder[0]).toBeLessThan(
       save.mock.invocationCallOrder.at(-1) as number,


### PR DESCRIPTION
## Summary

Fixes #371. SharePoint backup retries ledger items by re-fetching each one through `fetch_item_by_id`, awaited with no error handling. A single transient failure, a 500 or a socket reset, propagated out of `retry_failed_items`, out of the library processor, and into the library scan, which recorded a library-level error and dropped the library's already-processed entries. No data was lost, since the delta link is not advanced, but one flaky fetch cost the whole library's run.

The OneDrive twin catches the same failure per item and re-records it. Both providers now also let `AuthError` through rather than spending a ledger attempt on a revoked grant, which is what the issue asks for and what the twin did not do either.

## Changes

- `packages/sharepoint/src/services/backup/library-item-processor.ts`: the re-fetch moves into `refetch_or_record`, which records a ledger failure and returns undefined. Extracted rather than inlined because the loop was already at the cognitive-complexity ceiling.
- `packages/onedrive/src/services/backup/failed-item-retry.ts`: `AuthError` propagates.
- `packages/sharepoint/tests/unit/services/backup/retry-fetch-containment.test.ts`: new.

## The existing test this changes

`version-watermark-dedup.test.ts` reached its "run keeps no entries" case by throwing from `fetch_item_by_id` during a retry, which is precisely the behaviour being removed. Its subject is #161, that version rows are written before the watermark cursor, not that a retry can kill a library. It now reaches the same branch through a failing delta pass and asserts the ordering. The version-id assertion went with the old vehicle: with the retry contained, a library cannot now hold captured version rows and zero entries.

## Evidence

Pre-fix the new test throws `500 Internal Server Error` out of the run. Post-fix the item is re-recorded with `Retry fetch failed`, the second ledger item is still processed and cleared, and an `AuthError` still rejects.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] `pnpm run lint` passes with no new errors
- [x] New/changed code has unit tests
- [x] Targets `dev`
- [x] Labelled for release notes (`bug`)