### PR TITLE
fix(backup): stop a revoked permission degrading every message to JSON

### DIFF
--- a/packages/outlook/src/services/backup/message-payload-store.ts
+++ b/packages/outlook/src/services/backup/message-payload-store.ts
@@ -6,6 +6,7 @@ import type {
   ObjectLockPolicy,
   TenantContext,
 } from '@wisecom/atlas-types';
+import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
 export interface StoredMessage {
@@ -29,6 +30,11 @@ export async function capture_mime_payload(
   try {
     return await connector.fetch_mime(tenant_id, owner_id, message.message_id);
   } catch (err) {
+    // The fallback is for per-message faults such as ErrorItemNotFound. A revoked permission or
+    // an unlicensed mailbox is neither: swallowing those degraded every message in the run to
+    // the JSON payload, lost the original MIME, and still exited 0. `fetch_message_mime` already
+    // raises them as typed errors; this is the catch that used to eat them (issue #372).
+    if (err instanceof AuthError || err instanceof MailboxNotLicensedError) throw err;
     const reason = err instanceof Error ? err.message : String(err);
     logger.warn(`MIME capture failed for message ${message.message_id}: ${reason}`);
     return undefined;

--- a/packages/outlook/tests/unit/services/backup/mime-permission-failure.test.ts
+++ b/packages/outlook/tests/unit/services/backup/mime-permission-failure.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
+import type { MailboxConnector, MailMessage } from '@wisecom/atlas-types';
+import { capture_mime_payload } from '@/services/backup/message-payload-store';
+
+/**
+ * Issue #372. The MIME fallback exists for per-message faults, but the catch was unconditional,
+ * so a revoked permission degraded every message in the run to the JSON payload, warn-logged
+ * once per message, and still exited 0. The original MIME was lost for the whole run and nothing
+ * surfaced it. The connector already raises these as typed errors; this catch ate them.
+ */
+
+const MESSAGE = { message_id: 'AAMkAG...', subject: 'Example subject' } as unknown as MailMessage;
+
+function make_connector(failure: Error): MailboxConnector {
+  return {
+    fetch_mime: vi.fn().mockRejectedValue(failure),
+  } as unknown as MailboxConnector;
+}
+
+describe('MIME capture failures', () => {
+  it('stops the run on a revoked permission', async () => {
+    await expect(
+      capture_mime_payload(make_connector(new AuthError('403 from Graph')), 't', 'o', MESSAGE),
+    ).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it('stops the run on an unlicensed mailbox', async () => {
+    await expect(
+      capture_mime_payload(
+        make_connector(new MailboxNotLicensedError('MailboxNotEnabledForRESTAPI')),
+        't',
+        'o',
+        MESSAGE,
+      ),
+    ).rejects.toBeInstanceOf(MailboxNotLicensedError);
+  });
+
+  it('still falls back to JSON for a per-message fault', async () => {
+    const payload = await capture_mime_payload(
+      make_connector(new Error('ErrorItemNotFound')),
+      't',
+      'o',
+      MESSAGE,
+    );
+
+    expect(payload).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #372. `capture_mime_payload` caught every `fetch_mime` failure and returned undefined, which sends the message down the JSON fallback. That is right for a per-message fault such as `ErrorItemNotFound`, and wrong for a permission or licensing failure: those apply to every message, so the whole run silently stored JSON instead of original MIME and still exited 0.

Worth naming precisely, because the issue attributes it to the connector: `fetch_message_mime` **does** call `rethrow_if_access_denied` and `rethrow_if_mailbox_not_licensed`, so `AuthError` and `MailboxNotLicensedError` were reaching the service correctly. This catch is where they died. The function's own doc comment already said they propagate, so the code now matches what it claimed.

## Changes

- `packages/outlook/src/services/backup/message-payload-store.ts`: `AuthError` and `MailboxNotLicensedError` are rethrown; everything else still falls back per message.
- `packages/outlook/tests/unit/services/backup/mime-permission-failure.test.ts`: new. Both propagating classes, plus the item-not-found fallback.

## Evidence

The two propagation cases fail on `dev` and pass here. The fallback case passes on both, which is the point: the per-message path is unchanged.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] `pnpm run lint` passes with no new errors
- [x] New/changed code has unit tests
- [x] Targets `dev`
- [x] Labelled for release notes (`bug`, `security`)