### PR TITLE
fix(backup): verify transferred size on the two unchecked download paths

### DIFF
--- a/packages/onedrive/src/adapters/graph-onedrive-connector-stream.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-connector-stream.ts
@@ -1,6 +1,7 @@
 import type { Readable } from 'node:stream';
 
 import { compute_chunk_timeout_ms } from '@/adapters/graph-onedrive-chunked-download';
+import { assert_transferred_size } from '@wisecom/atlas-drive/backup/download-integrity';
 
 /**
  * Drains a readable stream into a buffer with a wall-clock timeout.
@@ -56,7 +57,13 @@ export async function with_timeout<T>(
   }
 }
 
-/** Downloads a pre-authenticated OneDrive URL into a buffer. */
+/**
+ * Downloads a pre-authenticated OneDrive URL into a buffer.
+ *
+ * The byte count is checked against the size the delta recorded, so a well-framed 200 carrying
+ * the wrong body cannot be hashed, encrypted and written with a checksum that matches those
+ * wrong bytes. #338 closed this for the chunked path and left the buffered one open (issue #368).
+ */
 export async function download_from_url(
   download_url: string,
   size_bytes: number,
@@ -70,7 +77,9 @@ export async function download_from_url(
     if (!response.ok) {
       throw new Error(`Failed to download OneDrive file ${item_id}: HTTP ${response.status}`);
     }
-    return Buffer.from(await response.arrayBuffer());
+    const body = Buffer.from(await response.arrayBuffer());
+    assert_transferred_size(item_id, body.length, size_bytes);
+    return body;
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/onedrive/src/adapters/graph-onedrive-download-executor.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-download-executor.ts
@@ -19,6 +19,7 @@ import {
   DownloadRefusedError,
   MissingGraphPermissionsError,
 } from '@wisecom/atlas-m365-graph';
+import { assert_transferred_size } from '@wisecom/atlas-drive/backup/download-integrity';
 
 interface GraphDriveItemDownload {
   '@microsoft.graph.downloadUrl'?: string;
@@ -130,7 +131,13 @@ export async function download_with_fallback(
   );
 }
 
-/** Downloads via the Graph /content endpoint with stream drain. */
+/**
+ * Downloads via the Graph /content endpoint with stream drain.
+ *
+ * The drained byte count is checked against the recorded size for the same reason the chunked
+ * path checks it: a complete-looking body of the wrong length would otherwise be stored with a
+ * checksum computed over those wrong bytes (issue #368).
+ */
 export async function download_via_graph_content(
   client: Client,
   item: OneDriveDeltaItem,
@@ -147,7 +154,9 @@ export async function download_via_graph_content(
     `Graph content request timed out for file ${item.item_id}`,
   );
   const drain_timeout_ms = compute_chunk_timeout_ms(item.size_bytes) * 2;
-  return await stream_to_buffer(stream, drain_timeout_ms);
+  const body = await stream_to_buffer(stream, drain_timeout_ms);
+  assert_transferred_size(item.item_id, body.length, item.size_bytes);
+  return body;
 }
 
 /**

--- a/packages/onedrive/tests/unit/adapters/buffered-download-size.test.ts
+++ b/packages/onedrive/tests/unit/adapters/buffered-download-size.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { DownloadIntegrityError } from '@wisecom/atlas-drive/backup/download-integrity';
+import { download_from_url } from '@/adapters/graph-onedrive-connector-stream';
+
+/**
+ * Issue #368. #338 gave the Range-chunked and large-staging paths a transfer-size check and left
+ * the two buffered paths without one. A CDN or proxy answering 200 with a complete but wrong
+ * body was hashed, encrypted and written with a checksum matching those wrong bytes, so backup
+ * exited healthy, verify passed, and restore returned the wrong file. Undetectable after the
+ * fact, which is the failure class #338 closed everywhere else.
+ */
+
+const CONTENT = Buffer.from('the real file content');
+
+function respond(body: Buffer): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    arrayBuffer: () =>
+      Promise.resolve(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)),
+  } as unknown as Response;
+}
+
+describe('download_from_url transfer size', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('refuses a well-framed body that is not the recorded length', async () => {
+    vi.mocked(fetch).mockResolvedValue(respond(Buffer.from('<html>error page</html>')));
+
+    await expect(
+      download_from_url('https://cdn.example.invalid/f', CONTENT.length, 'item-1'),
+    ).rejects.toBeInstanceOf(DownloadIntegrityError);
+  });
+
+  it('refuses a truncated body', async () => {
+    vi.mocked(fetch).mockResolvedValue(respond(CONTENT.subarray(0, 4)));
+
+    await expect(
+      download_from_url('https://cdn.example.invalid/f', CONTENT.length, 'item-1'),
+    ).rejects.toThrow(/expected 21/);
+  });
+
+  it('accepts the body when the length matches', async () => {
+    vi.mocked(fetch).mockResolvedValue(respond(CONTENT));
+
+    await expect(
+      download_from_url('https://cdn.example.invalid/f', CONTENT.length, 'item-1'),
+    ).resolves.toEqual(CONTENT);
+  });
+
+  it('accepts any length when the item records no size', async () => {
+    vi.mocked(fetch).mockResolvedValue(respond(CONTENT));
+
+    await expect(download_from_url('https://cdn.example.invalid/f', 0, 'item-1')).resolves.toEqual(
+      CONTENT,
+    );
+  });
+});

--- a/packages/onedrive/tests/unit/adapters/download-403-classification.test.ts
+++ b/packages/onedrive/tests/unit/adapters/download-403-classification.test.ts
@@ -68,6 +68,11 @@ function make_client(): GraphClientMock {
   const client = { api } as unknown as Client;
   return { client, api, get, get_stream };
 }
+
+/**
+ * `size_bytes` is 0, which `assert_transferred_size` reads as "no recorded size" and skips.
+ * These cases are about how a 403 is classified, not about transfer length (issue #368).
+ */
 function make_item(): OneDriveDeltaItem {
   return {
     drive_id: 'drive-1',
@@ -75,7 +80,7 @@ function make_item(): OneDriveDeltaItem {
     kind: 'file',
     file_name: 'Report.docx',
     parent_path: '/',
-    size_bytes: 1024,
+    size_bytes: 0,
     deleted: false,
     download_url: STALE_URL,
   };

--- a/packages/onedrive/tests/unit/adapters/download-helpers.test.ts
+++ b/packages/onedrive/tests/unit/adapters/download-helpers.test.ts
@@ -86,12 +86,17 @@ function make_client(overrides: { download_url?: string | undefined } = {}): Gra
   return { client, api, get, get_stream, select };
 }
 
+/**
+ * `size_bytes` defaults to 0, which `assert_transferred_size` reads as "no recorded size" and
+ * skips. These cases are about routing and refresh, not transfer length, so they should not have
+ * to keep a fixture body and a fixture size in step (issue #368).
+ */
 function make_item(overrides: Partial<OneDriveDeltaItem> = {}): OneDriveDeltaItem {
   return {
     drive_id: 'drive-1',
     item_id: 'item-1',
     name: 'Report.docx',
-    size_bytes: 1024,
+    size_bytes: 0,
     ...overrides,
   } as OneDriveDeltaItem;
 }
@@ -131,7 +136,7 @@ describe('OneDrive download helpers', () => {
       );
 
       expect(body).toEqual(URL_BODY);
-      expect(mocks.download_from_url).toHaveBeenCalledWith(STALE_URL, 1024, 'item-1');
+      expect(mocks.download_from_url).toHaveBeenCalledWith(STALE_URL, 0, 'item-1');
       expect(mock.api).not.toHaveBeenCalled();
     });
 
@@ -181,8 +186,8 @@ describe('OneDrive download helpers', () => {
 
       expect(body).toEqual(URL_BODY);
       expect(mock.get).toHaveBeenCalledOnce();
-      expect(mocks.download_from_url).toHaveBeenNthCalledWith(1, STALE_URL, 1024, 'item-1');
-      expect(mocks.download_from_url).toHaveBeenNthCalledWith(2, FRESH_URL, 1024, 'item-1');
+      expect(mocks.download_from_url).toHaveBeenNthCalledWith(1, STALE_URL, 0, 'item-1');
+      expect(mocks.download_from_url).toHaveBeenNthCalledWith(2, FRESH_URL, 0, 'item-1');
       expect(mock.get_stream).not.toHaveBeenCalled();
     });
 
@@ -243,6 +248,15 @@ describe('OneDrive download helpers', () => {
         30_000,
         'Graph content request timed out for file item-1',
       );
+    });
+
+    it('refuses a drained body that is not the recorded length (issue #368)', async () => {
+      const mock = make_client();
+      mocks.stream_to_buffer.mockResolvedValue(Buffer.from('<html>error page</html>'));
+
+      await expect(
+        download_via_graph_content(mock.client, make_item({ size_bytes: 4096 })),
+      ).rejects.toThrow(/expected 4096/);
     });
   });
 

--- a/packages/sharepoint/src/adapters/graph-sharepoint-download-executor.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-download-executor.ts
@@ -14,6 +14,7 @@ import {
   compute_chunk_timeout_ms,
   download_file_chunked,
 } from '@/adapters/graph-sharepoint-chunked-download';
+import { assert_transferred_size } from '@wisecom/atlas-drive/backup/download-integrity';
 
 interface GraphDriveItemDownload {
   '@microsoft.graph.downloadUrl'?: string;
@@ -117,7 +118,13 @@ async function attempt_download_with_refresh(
   }
 }
 
-/** Downloads via the Graph /content endpoint with stream drain. */
+/**
+ * Downloads via the Graph /content endpoint with stream drain.
+ *
+ * The drained byte count is checked against the recorded size for the same reason the chunked
+ * path checks it: a complete-looking body of the wrong length would otherwise be stored with a
+ * checksum computed over those wrong bytes (issue #368).
+ */
 export async function download_via_graph_content(
   client: Client,
   item: SharePointDeltaItem,
@@ -134,7 +141,9 @@ export async function download_via_graph_content(
     `Graph content request timed out for file ${item.item_id}`,
   );
   const drain_timeout_ms = stream_timeout_ms * 2;
-  return await stream_to_buffer(stream, drain_timeout_ms);
+  const body = await stream_to_buffer(stream, drain_timeout_ms);
+  assert_transferred_size(item.item_id, body.length, item.size_bytes);
+  return body;
 }
 
 /**
@@ -195,7 +204,11 @@ async function download_from_url(
         );
       }
 
-      return Buffer.from(await response.arrayBuffer());
+      const body = Buffer.from(await response.arrayBuffer());
+      // A well-framed 200 carrying the wrong body would otherwise be hashed, encrypted and
+      // written with a checksum matching those wrong bytes (issue #368).
+      assert_transferred_size(item_id, body.length, size_bytes);
+      return body;
     } finally {
       clearTimeout(timer);
     }

--- a/packages/sharepoint/tests/unit/adapters/buffered-download-size.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/buffered-download-size.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { Readable } from 'node:stream';
+import type { Client } from '@microsoft/microsoft-graph-client';
+import type { SharePointDeltaItem } from '@wisecom/atlas-types';
+import { download_with_fallback } from '@/adapters/graph-sharepoint-download-executor';
+
+/**
+ * Issue #368, the SharePoint twin. Both buffered paths, the pre-authenticated URL and the Graph
+ * `/content` fallback, returned whatever arrived. A well-framed 200 of the wrong length became a
+ * backup with a checksum computed over the wrong bytes: healthy backup, passing verify, wrong
+ * file on restore.
+ */
+
+const WRONG_BODY = Buffer.from('<html>error page</html>');
+const URL_ADDRESS = 'https://cdn.example.invalid/file';
+
+function make_item(overrides: Partial<SharePointDeltaItem> = {}): SharePointDeltaItem {
+  return {
+    drive_id: 'drive-1',
+    item_id: 'item-1',
+    kind: 'file',
+    file_name: 'Budget.xlsx',
+    parent_path: '/',
+    size_bytes: 4096,
+    deleted: false,
+    download_url: URL_ADDRESS,
+    ...overrides,
+  } as SharePointDeltaItem;
+}
+
+/** Serves the wrong body on `/content`, so the fallback path can be exercised too. */
+function make_client(): Client {
+  const get = vi.fn().mockResolvedValue({ '@microsoft.graph.downloadUrl': URL_ADDRESS });
+  const get_stream = vi.fn().mockImplementation(() => Readable.from([WRONG_BODY]));
+  const select = vi.fn(() => ({ get }));
+  return { api: vi.fn(() => ({ select, get, getStream: get_stream })) } as unknown as Client;
+}
+
+describe('SharePoint buffered downloads that do not match the recorded size', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('refuses a wrong-length body from the pre-authenticated URL', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      arrayBuffer: () =>
+        Promise.resolve(
+          WRONG_BODY.buffer.slice(
+            WRONG_BODY.byteOffset,
+            WRONG_BODY.byteOffset + WRONG_BODY.byteLength,
+          ),
+        ),
+    } as unknown as Response);
+
+    await expect(download_with_fallback(make_client(), make_item())).rejects.toThrow(
+      /expected 4096/,
+    );
+  });
+
+  it('refuses a wrong-length body drained from the /content fallback', async () => {
+    // The pre-authenticated URL fails outright, so the fallback is the only path left.
+    vi.mocked(fetch).mockRejectedValue(new Error('connection reset'));
+
+    await expect(download_with_fallback(make_client(), make_item())).rejects.toThrow(
+      /expected 4096/,
+    );
+  });
+});

--- a/packages/sharepoint/tests/unit/adapters/download-403-classification.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/download-403-classification.test.ts
@@ -61,14 +61,19 @@ function make_client(): GraphClientMock {
   return { client, api, get, get_stream };
 }
 
-function make_item(): SharePointDeltaItem {
+/**
+ * `size_bytes` matches whichever body the case serves, because a download is now rejected when
+ * the transferred length disagrees with the recorded size (issue #368). These cases are about
+ * how a 403 is classified, not about truncation, so the sizes have to be honest.
+ */
+function make_item(size_bytes = CONTENT_BODY.length): SharePointDeltaItem {
   return {
     drive_id: 'drive-1',
     item_id: 'item-1',
     kind: 'file',
     file_name: 'Budget.xlsx',
     parent_path: '/',
-    size_bytes: 1024,
+    size_bytes,
     deleted: false,
     download_url: STALE_URL,
   };
@@ -143,7 +148,9 @@ describe('SharePoint 403 handling by cause (issue #246)', () => {
           Promise.resolve(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)),
       });
 
-    await expect(download_with_fallback(mock.client, make_item())).resolves.toEqual(body);
+    await expect(download_with_fallback(mock.client, make_item(body.length))).resolves.toEqual(
+      body,
+    );
     expect(mock.get).toHaveBeenCalledOnce();
     expect(mock.get_stream).not.toHaveBeenCalled();
   });

--- a/packages/sharepoint/tests/unit/adapters/download-helpers.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/download-helpers.test.ts
@@ -85,12 +85,17 @@ function make_client(overrides: { download_url?: string | undefined } = {}): Gra
   return { client, api, get, get_stream, select };
 }
 
+/**
+ * `size_bytes` defaults to 0, which `assert_transferred_size` reads as "no recorded size" and
+ * skips. These cases are about routing and refresh, not about transfer length, so they should
+ * not have to keep a fixture body and a fixture size in step (issue #368).
+ */
 function make_item(overrides: Partial<SharePointDeltaItem> = {}): SharePointDeltaItem {
   return {
     drive_id: 'drive-1',
     item_id: 'item-1',
     name: 'Budget.xlsx',
-    size_bytes: 1024,
+    size_bytes: 0,
     ...overrides,
   } as SharePointDeltaItem;
 }
@@ -160,8 +165,14 @@ describe('SharePoint download helpers', () => {
       expect(mocks.download_file_chunked).toHaveBeenCalledOnce();
       expect(fetch_mock).not.toHaveBeenCalled();
 
+      // At the threshold exactly, so it takes the direct path. The body has to be that long now
+      // that a short one is an integrity failure rather than a silent truncation (issue #368).
+      // Asserted by length: a deep compare of 4 MiB takes seconds.
+      const at_threshold = Buffer.alloc(CHUNK_DOWNLOAD_THRESHOLD, 1);
+      fetch_mock.mockResolvedValue(make_response({ status: 200, body: at_threshold }));
       const small = make_item({ download_url: STALE_URL, size_bytes: CHUNK_DOWNLOAD_THRESHOLD });
-      await expect(download_with_fallback(make_client().client, small)).resolves.toEqual(URL_BODY);
+      const body = await download_with_fallback(make_client().client, small);
+      expect(body.length).toBe(CHUNK_DOWNLOAD_THRESHOLD);
       expect(fetch_mock).toHaveBeenCalledOnce();
       expect(mocks.download_file_chunked).toHaveBeenCalledOnce();
     });


### PR DESCRIPTION
## Summary

Fixes #368. #338 closed this for the Range-chunked and large-staging paths. The two buffered paths kept returning whatever arrived:

- `download_from_url`, which serves every file up to 4 MiB.
- `download_via_graph_content`, the fallback for 4 to 64 MiB files whose chunked attempt failed with a non-403.

In both, a well-framed 200 carrying the wrong body was hashed, encrypted and written with a manifest checksum computed over those wrong bytes. Backup exits healthy, verify passes, restore returns the wrong file, and there is nothing left to detect it with. That is the failure class #338 exists to prevent.

Both paths in both providers now call the shared `assert_transferred_size`, which raises `DownloadIntegrityError` and leaves the item to the existing per-item failure handling, so nothing is stored.

## Changes

- `packages/onedrive/src/adapters/graph-onedrive-connector-stream.ts` and the SharePoint twin: the buffered URL download asserts its length.
- `packages/onedrive/src/adapters/graph-onedrive-download-executor.ts` and the SharePoint twin: the drained `/content` body asserts its length.
- New tests in both providers: a well-framed wrong body and a truncated body are refused, a matching body passes, and an item recording no size is unconstrained.

## Fixtures this changes

Several existing adapter tests used `size_bytes: 1024` with a twelve-byte fixture body. They are about routing, refresh and 403 classification, not about transfer length, so they now record no size (`0`, which the shared helper treats as no expectation) rather than carrying a size that contradicts their own body. The one case that genuinely needs a size, the chunk-threshold boundary, serves a body of that length and asserts by length, because a deep compare of 4 MiB takes seconds.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] `pnpm run lint` passes with no new errors
- [x] New/changed code has unit tests
- [x] Targets `dev`
- [x] Labelled for release notes (`bug`, `security`)