### PR TITLE
fix(cli): let Ctrl+C stop a drive backup instead of killing it

### DIFF
--- a/packages/cli/src/adapters/interrupt-gate.ts
+++ b/packages/cli/src/adapters/interrupt-gate.ts
@@ -1,0 +1,35 @@
+import { logger } from '@wisecom/atlas-core';
+
+export interface InterruptGate {
+  /** Passed to a use case as `should_interrupt`. */
+  readonly should_interrupt: () => boolean;
+  /** Removes the SIGINT listener. Always call it, in a `finally`. */
+  readonly dispose: () => void;
+}
+
+/**
+ * Turns Ctrl+C into a soft stop for a long-running command.
+ *
+ * Without one, the process dies wherever the signal lands, with exit 130 and no interrupted
+ * state recorded. The drive backups had no interrupt flag at all, so a stopped run was
+ * indistinguishable from a crash, while the Outlook backup has always stopped gracefully
+ * (issue #367).
+ *
+ * A second Ctrl+C is left to the default handler, so an operator can always force the issue.
+ */
+export function install_interrupt_gate(message: string): InterruptGate {
+  let interrupted = false;
+
+  const on_sigint = (): void => {
+    if (interrupted) return;
+    interrupted = true;
+    logger.warn(message);
+  };
+
+  process.on('SIGINT', on_sigint);
+
+  return {
+    should_interrupt: () => interrupted,
+    dispose: () => process.removeListener('SIGINT', on_sigint),
+  };
+}

--- a/packages/cli/src/commands/onedrive-command.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-command.handlers.tsx
@@ -25,6 +25,7 @@ import { render_static_view } from '@/ui/render';
 import { create_backup_progress } from '@/ui/dashboards/backup-progress-factory';
 import { build_object_lock_request } from '@/command-object-lock';
 import { report_run_outcome, report_skipped_items } from '@/command-run-outcome';
+import { install_interrupt_gate } from '@/adapters/interrupt-gate';
 
 export interface OneDriveTenantOptions {
   tenant?: string;
@@ -117,14 +118,23 @@ export async function execute_onedrive_backup(
     </Box>,
   );
 
-  const result = await backup.backup_onedrive(tenant_id, owner.object_id, {
-    force_full: options.full ?? false,
-    ...(options.folder !== undefined ? { folder_scope: options.folder } : {}),
-    owner_email: owner.email,
-    owner_display_name: owner.display_name,
-    object_lock_request,
-    create_progress: create_backup_progress({ rate: 'files/s', extra: 'ver', row_noun: 'drive' }),
-  });
+  const gate = install_interrupt_gate(
+    '[!] Stopping after the current file; the delta cursor is not advanced for an interrupted run',
+  );
+  let result;
+  try {
+    result = await backup.backup_onedrive(tenant_id, owner.object_id, {
+      force_full: options.full ?? false,
+      ...(options.folder !== undefined ? { folder_scope: options.folder } : {}),
+      owner_email: owner.email,
+      owner_display_name: owner.display_name,
+      object_lock_request,
+      create_progress: create_backup_progress({ rate: 'files/s', extra: 'ver', row_noun: 'drive' }),
+      should_interrupt: gate.should_interrupt,
+    });
+  } finally {
+    gate.dispose();
+  }
 
   if (result.snapshot) {
     logger.success(`Snapshot ${result.snapshot.snapshot_id} created`);
@@ -153,7 +163,14 @@ export async function execute_onedrive_backup(
   } else {
     logger.error('Status: UNHEALTHY');
   }
-  report_run_outcome({ errors: result.summary.errors, warnings: result.summary.warnings }, 'file');
+  report_run_outcome(
+    {
+      errors: result.summary.errors,
+      warnings: result.summary.warnings,
+      interrupted: result.interrupted,
+    },
+    'file',
+  );
 }
 
 export async function execute_onedrive_restore(

--- a/packages/cli/src/commands/sharepoint-command.handlers.tsx
+++ b/packages/cli/src/commands/sharepoint-command.handlers.tsx
@@ -26,6 +26,7 @@ import { ResultSummary, type SummaryEntry } from '@/ui/components/result-summary
 import { render_static_view } from '@/ui/render';
 import { build_object_lock_request } from '@/command-object-lock';
 import { report_run_outcome, report_skipped_items } from '@/command-run-outcome';
+import { install_interrupt_gate } from '@/adapters/interrupt-gate';
 
 export interface SharePointTenantOptions {
   tenant?: string;
@@ -137,13 +138,22 @@ export async function execute_sharepoint_backup(
   const backup = container.get<SharePointSiteTreeBackupUseCase>(
     SHAREPOINT_SITE_TREE_BACKUP_USE_CASE_TOKEN,
   );
-  const results = await backup.backup_site_tree(tenant_id, site.site_id, {
-    force_full: options.full ?? false,
-    include_subsites: options.includeSubsites ?? false,
-    site_url: site.site_url,
-    site_display_name: site.display_name,
-    object_lock_request,
-  });
+  const gate = install_interrupt_gate(
+    '[!] Stopping after the current file; the delta cursor is not advanced for an interrupted run',
+  );
+  let results;
+  try {
+    results = await backup.backup_site_tree(tenant_id, site.site_id, {
+      force_full: options.full ?? false,
+      include_subsites: options.includeSubsites ?? false,
+      site_url: site.site_url,
+      site_display_name: site.display_name,
+      object_lock_request,
+      should_interrupt: gate.should_interrupt,
+    });
+  } finally {
+    gate.dispose();
+  }
 
   await render_static_view(<Banner title={banner_title('sharepoint', 'Backup')} />);
   if (results.length > 1) {
@@ -202,7 +212,14 @@ async function report_site_backup(result: SharePointBackupResult): Promise<void>
   // Warnings, errors, and the partial-run exit code go through the shared
   // reporter so every site's failures are attributed to that site. The overall
   // HEALTHY/UNHEALTHY verdict is the caller's, once every site has reported.
-  report_run_outcome({ errors: result.summary.errors, warnings: result.summary.warnings }, 'file');
+  report_run_outcome(
+    {
+      errors: result.summary.errors,
+      warnings: result.summary.warnings,
+      interrupted: result.interrupted,
+    },
+    'file',
+  );
 }
 
 export async function execute_sharepoint_restore(

--- a/packages/cli/tests/unit/drive-backup-interrupt.test.ts
+++ b/packages/cli/tests/unit/drive-backup-interrupt.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { install_interrupt_gate } from '@/adapters/interrupt-gate';
+import { report_run_outcome, EXIT_PARTIAL } from '@/command-run-outcome';
+
+/**
+ * Issue #367. Only the Outlook backup wired SIGINT into its run, so Ctrl+C during a drive backup
+ * killed the process where the signal landed, with exit 130 and no interrupted state recorded.
+ * The drive handlers also never passed `interrupted` to the reporter, so even with a flag an
+ * interrupted run with no item errors would have exited 0.
+ */
+describe('the drive backup interrupt gate', () => {
+  let previous: typeof process.exitCode;
+
+  beforeEach(() => {
+    previous = process.exitCode;
+    process.exitCode = undefined;
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.exitCode = previous;
+    vi.restoreAllMocks();
+  });
+
+  it('reports not-interrupted until the signal arrives', () => {
+    const gate = install_interrupt_gate('stopping');
+    try {
+      expect(gate.should_interrupt()).toBe(false);
+      process.emit('SIGINT');
+      expect(gate.should_interrupt()).toBe(true);
+    } finally {
+      gate.dispose();
+    }
+  });
+
+  it('stops listening once disposed, so a later signal is not this run', () => {
+    const gate = install_interrupt_gate('stopping');
+    gate.dispose();
+
+    process.emit('SIGINT');
+
+    expect(gate.should_interrupt()).toBe(false);
+  });
+
+  it('exits partial for an interrupted run that had no item errors', () => {
+    report_run_outcome({ errors: [], warnings: [], interrupted: true }, 'file');
+
+    expect(process.exitCode).toBe(EXIT_PARTIAL);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #367. `backup-operation.adapter.tsx` wires SIGINT for Outlook only. The OneDrive and SharePoint backup handlers passed no `should_interrupt` at all, so Ctrl+C killed the process wherever the signal landed: exit 130, no interrupted state, and nothing to distinguish a deliberate stop from a crash. They also never passed `interrupted` to `report_run_outcome`, so even once a flag existed an interrupted run with zero item errors would have exited 0.

Both handlers now install a small soft-stop gate and forward `interrupted` to the reporter. The services already read `should_interrupt` and already refuse to advance a delta link for an interrupted drive or library, so nothing below the CLI had to change and an interrupted run still re-enumerates on the next pass. A second Ctrl+C falls through to the default handler, so an operator can always force the issue.

`docs/reference/cli.md` already documented this contract under "all backup commands: Outlook, OneDrive, SharePoint". It is now true for all three, which is why there is no doc change here.

## Changes

- `packages/cli/src/adapters/interrupt-gate.ts`: new. Installs the listener, exposes `should_interrupt`, and removes itself on `dispose`.
- `packages/cli/src/commands/onedrive-command.handlers.tsx` and the SharePoint twin: install the gate around the backup call and report `interrupted`.
- `packages/cli/tests/unit/drive-backup-interrupt.test.ts`: new.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] `pnpm run lint` passes with no new errors
- [x] New/changed code has unit tests
- [x] Targets `dev`
- [x] Labelled for release notes (`bug`)