### PR TITLE
fix(restore): put each file back in the drive it came from

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -614,6 +614,14 @@ A snapshot taken with `--folder` contains only that folder's files. Restoring it
 
 A drive restore nests under `/Restore-<timestamp>` at the target drive root and recreates the original folder structure beneath it, matching how Outlook restores have always worked. `--in-place` reproduces the pre-4.0.0 behaviour of writing back over the original paths; it is never the default, because `--conflict rename` turns a repeated in-place restore into suffixed duplicates scattered through live content rather than a failure. See [Where restored files land](/onedrive-backup#where-restored-files-land).
 
+An owner can have more than one drive, and every manifest entry records the
+drive its file came from. A restore to the original owner puts each file back
+in that drive; a file whose drive no longer exists is reported and skipped
+rather than written into a different one. `--target-owner` has no drive
+mapping to work from, since Atlas records drive IDs and not drive names, so it
+is refused when the snapshot spans more than one drive. Restore those to the
+original owner, or one drive at a time with `--file-filter`.
+
 Identifiers are matched case-insensitively: `--owner`, `--site`, and `--file-filter` all accept whatever case a listing or portal shows. Owner and site IDs are lowercased before they become storage keys, so one identifier always addresses one tree. Earlier releases wrote a second tree for a second spelling and deleted from whichever one they were handed.
 
 A `--file-filter` path is the rooted path shown in a listing, and a file at the drive or library root is written the way you would expect: `/Report.docx`, not `//Report.docx`. Version commands take the same path forms, and when one path belongs to two different drive items, which happens after a file is deleted and recreated at the same path, the command names both file IDs and stops rather than picking one.

--- a/packages/onedrive/src/services/restore/drive-router.ts
+++ b/packages/onedrive/src/services/restore/drive-router.ts
@@ -1,0 +1,50 @@
+import type { OneDriveManifestEntry } from '@wisecom/atlas-types';
+
+export interface RoutedDrive {
+  /** Where this entry is restored. Meaningless when `error` is set. */
+  readonly drive_id: string;
+  /** Set when the entry cannot be placed; it is skipped rather than written somewhere else. */
+  readonly error?: string;
+}
+
+/**
+ * Decides which of the target owner's drives each manifest entry belongs in.
+ *
+ * A same-owner restore uses the drive the entry records, because an owner can have several and
+ * the first one Graph lists is a guess. A cross-owner restore has no mapping to work from, since
+ * Atlas records drive ids and not drive names, so it is allowed only when the snapshot came from
+ * a single drive and is refused otherwise (issue #361).
+ *
+ * @throws Error when a cross-owner restore spans more than one source drive.
+ */
+export function build_drive_router(
+  entries: readonly OneDriveManifestEntry[],
+  target_drive_ids: readonly string[],
+  owner_id: string,
+  target_owner: string,
+): (entry: OneDriveManifestEntry) => RoutedDrive {
+  const cross_owner = target_owner !== owner_id;
+  const source_drive_ids = new Set(entries.map((entry) => entry.drive_id));
+
+  if (cross_owner && source_drive_ids.size > 1) {
+    throw new Error(
+      `This snapshot spans ${source_drive_ids.size} drives and Atlas records no drive names, so ` +
+        `there is no way to tell which of ${target_owner}'s drives each file belongs in. ` +
+        `Restore to the original owner, or restore one drive at a time with --file-filter.`,
+    );
+  }
+
+  const [primary_drive_id] = target_drive_ids;
+  const known = new Set(target_drive_ids);
+
+  return (entry) => {
+    if (cross_owner) return { drive_id: primary_drive_id ?? '' };
+    if (known.has(entry.drive_id)) return { drive_id: entry.drive_id };
+    return {
+      drive_id: entry.drive_id,
+      error:
+        `${entry.file_name}: recorded drive ${entry.drive_id} no longer exists for ` +
+        `${target_owner}; not restored into another drive`,
+    };
+  };
+}

--- a/packages/onedrive/src/services/restore/restore.service.ts
+++ b/packages/onedrive/src/services/restore/restore.service.ts
@@ -28,6 +28,7 @@ import { download_and_decrypt_blob } from '@/services/restore/blob-restore';
 import { OneDriveDecryptAuthError } from '@/services/restore/restore-integrity';
 import { filter_drive_entries } from '@wisecom/atlas-drive/shared/entry-filter';
 import { onedrive_manifest_lookup } from '@/services/shared/manifest-lookup';
+import { build_drive_router } from '@/services/restore/drive-router';
 import {
   load_drive_chain_entries,
   restorable_entries,
@@ -76,7 +77,6 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       if (!primary_drive) {
         throw new Error('No OneDrive drives found for target user');
       }
-      const drive_id = primary_drive.drive_id;
 
       const conflict = options.conflict_behavior ?? 'rename';
       const restorable = filter_drive_entries(
@@ -99,12 +99,29 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
         total: restorable.length,
       });
 
+      // Each entry records the drive it came from, and an owner can have several. Resolving one
+      // target drive per run and writing everything into it put the second drive's files into
+      // the first drive, silently, since every upload succeeded against real folder ids. With
+      // `--conflict replace` that overwrote same-path files (issue #361).
+      const resolve_target_drive = build_drive_router(
+        restorable,
+        drives.map((drive) => drive.drive_id),
+        owner_id,
+        target_owner,
+      );
+
       for (const entry of restorable) {
         if (options.should_interrupt?.() === true) break;
+        const routed = resolve_target_drive(entry);
+        if (routed.error !== undefined) {
+          files_skipped++;
+          errors.push(routed.error);
+          continue;
+        }
         const result = await this.restore_single_entry(
           tenant_id,
           target_owner,
-          drive_id,
+          routed.drive_id,
           entry,
           ctx,
           folder_ids,

--- a/packages/onedrive/tests/unit/services/restore/multi-drive-routing.test.ts
+++ b/packages/onedrive/tests/unit/services/restore/multi-drive-routing.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Issue #361. Snapshot restore resolved the target drive once, by taking the first drive Graph
+ * listed, and wrote every entry into it. Each entry records its own `drive_id` and the restore
+ * never read it, so a second drive's files landed in the first drive: duplicates under the
+ * default rename policy, overwrites under `--conflict replace`, and silent either way because
+ * every upload succeeded against real folder ids.
+ */
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  OneDriveConnector,
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveRestoreService } from '@/services/restore/restore.service';
+
+const CONTENT = Buffer.from('file-content');
+const CHECKSUM = createHash('sha256').update(CONTENT).digest('hex');
+
+function make_entry(file_id: string, drive_id: string): OneDriveManifestEntry {
+  return {
+    file_id,
+    drive_id,
+    file_name: `${file_id}.txt`,
+    parent_path: '/Projects',
+    size_bytes: CONTENT.length,
+    change_type: 'updated',
+    backup_at: '2026-08-17T00:00:00.000Z',
+    storage_key: `onedrive/data/${file_id}`,
+    checksum: CHECKSUM,
+  } as OneDriveManifestEntry;
+}
+
+interface Harness {
+  service: OneDriveRestoreService;
+  connector: OneDriveConnector;
+}
+
+function make_harness(entries: OneDriveManifestEntry[], target_drives: string[]): Harness {
+  const manifest = {
+    id: 'manifest-1',
+    tenant_id: 'tenant-1',
+    snapshot_id: 'snap-1',
+    owner_id: 'owner-1',
+    created_at: new Date('2026-08-17T00:00:00.000Z'),
+    total_files: entries.length,
+    total_size_bytes: entries.length * CONTENT.length,
+    entries,
+  } as OneDriveSnapshotManifest;
+
+  const ctx = {
+    tenant_id: 'tenant-1',
+    storage: { get: vi.fn().mockResolvedValue(CONTENT) },
+    encrypt: vi.fn((data: Buffer) => data),
+    decrypt: vi.fn((data: Buffer) => data),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const factory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+  } as unknown as TenantContextFactory;
+
+  // Folder ids carry their drive, so where an upload landed is readable from its parent id.
+  const connector = {
+    list_drives: vi
+      .fn()
+      .mockResolvedValue(target_drives.map((id) => ({ drive_id: id, drive_name: id }))),
+    create_folder: vi
+      .fn()
+      .mockImplementation(
+        async (_t: string, _o: string, drive_id: string, _p: string, name: string) =>
+          `${drive_id}/${String(name)}`,
+      ),
+    upload_small_file: vi.fn().mockResolvedValue(undefined),
+    upload_large_file: vi.fn().mockResolvedValue(undefined),
+  } as unknown as OneDriveConnector;
+
+  const manifests = {
+    find_by_snapshot: vi.fn().mockResolvedValue(manifest),
+    list_snapshots_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveManifestRepository;
+
+  return { service: new OneDriveRestoreService(factory, connector, manifests), connector };
+}
+
+/** The drive id each upload was addressed to, in call order. */
+function upload_drives(connector: OneDriveConnector): string[] {
+  return vi.mocked(connector.upload_small_file).mock.calls.map((call) => String(call[2]));
+}
+
+describe('a snapshot spanning two drives', () => {
+  it('restores each entry into the drive it was backed up from', async () => {
+    const { service, connector } = make_harness(
+      [make_entry('file-1', 'drive-a'), make_entry('file-2', 'drive-b')],
+      ['drive-a', 'drive-b'],
+    );
+
+    const result = await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+    });
+
+    expect(result.files_restored).toBe(2);
+    expect(upload_drives(connector).sort()).toEqual(['drive-a', 'drive-b']);
+  });
+
+  it('fails the entry whose drive is gone rather than writing it elsewhere', async () => {
+    const { service, connector } = make_harness(
+      [make_entry('file-1', 'drive-a'), make_entry('file-2', 'drive-gone')],
+      ['drive-a'],
+    );
+
+    const result = await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+    });
+
+    expect(result.files_restored).toBe(1);
+    expect(result.files_skipped).toBe(1);
+    expect(result.errors[0]).toContain('drive-gone');
+    expect(upload_drives(connector)).toEqual(['drive-a']);
+  });
+
+  it('refuses a cross-owner restore it cannot map', async () => {
+    const { service } = make_harness(
+      [make_entry('file-1', 'drive-a'), make_entry('file-2', 'drive-b')],
+      ['drive-target'],
+    );
+
+    await expect(
+      service.restore_onedrive('tenant-1', 'owner-1', {
+        snapshot_id: 'snap-1',
+        target_owner_id: 'owner-2',
+      }),
+    ).rejects.toThrow(/spans 2 drives/);
+  });
+
+  it('allows a cross-owner restore from a single-drive snapshot', async () => {
+    const { service, connector } = make_harness(
+      [make_entry('file-1', 'drive-a'), make_entry('file-2', 'drive-a')],
+      ['drive-target'],
+    );
+
+    const result = await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+      target_owner_id: 'owner-2',
+    });
+
+    expect(result.files_restored).toBe(2);
+    expect(upload_drives(connector)).toEqual(['drive-target', 'drive-target']);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #361. OneDrive snapshot restore picked `drives[0]` once per run and passed that drive for every entry. Backup records `drive_id` on each entry and the restore never read it, so for an owner with two drives everything landed in the first one: duplicates under the default rename policy, overwrites of same-path files under `--conflict replace`, and no error either way, because every upload succeeded against real folder ids.

#316 fixed the folder-id memo for exactly this scenario. The assumption it flagged sat one level up, in the drive resolution itself. The version-restore path already routes by the recorded drive and says why in a comment: "the first drive would be a guess".

Three behaviours now:

- Same-owner: each entry goes to the drive it was backed up from.
- An entry whose recorded drive no longer exists is skipped with a reason naming the drive, rather than written into another one.
- Cross-owner: Atlas records drive IDs, not names, so there is nothing to map with. A single-drive snapshot restores into the target's drive; a snapshot spanning more is refused with an error that says what to do instead.

## Changes

- `packages/onedrive/src/services/restore/drive-router.ts`: new. Extracted rather than inlined because the restore loop was already at the cognitive-complexity ceiling.
- `packages/onedrive/src/services/restore/restore.service.ts`: routes per entry.
- `packages/onedrive/tests/unit/services/restore/multi-drive-routing.test.ts`: new.
- `docs/reference/cli.md`: placement across drives, and the cross-owner limit.

## Evidence

Pre-fix, the two-drive case puts both files in `drive-a`:

```
AssertionError: expected [ 'drive-a', 'drive-a' ] to deeply equal [ 'drive-a', 'drive-b' ]
AssertionError: expected 2 to be 1
AssertionError: promise resolved instead of rejecting
```

The folder memo needed no change: `ensure_drive_folder_path` already keys by `drive_id:path`, which is what #316 landed.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run docs:build` succeeds
- [x] New/changed code has unit tests
- [x] Targets `dev`
- [x] Labelled for release notes (`bug`)