### PR TITLE
fix(backup): stop writing an empty snapshot on every quiet outlook run

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -35,6 +35,12 @@ The content itself (ciphertext blobs) lives separately in S3, organized by conte
 
 A snapshot is **immutable once written**. Atlas never modifies a snapshot after creation, and with Object Lock enabled on the bucket, the manifest file is locked against deletion for the retention period.
 
+A run that captured nothing writes no snapshot. All three workloads behave this way: a mailbox
+or drive with no changes since the last backup adds no manifest object, and the previous
+snapshot stays the latest one. Where a run stopped reading each folder or drive is recorded in a
+separate cursor object the run overwrites, which is why an unchanged mailbox does not accumulate
+one manifest per run just to remember its position.
+
 Snapshot IDs differ by workload:
 
 - **Outlook**: short hash IDs (e.g. `snap-a3b2c1`)

--- a/packages/outlook/src/services/backup/mailbox-run-persister.ts
+++ b/packages/outlook/src/services/backup/mailbox-run-persister.ts
@@ -1,0 +1,104 @@
+import type {
+  BackupSyncMode,
+  MailboxDeltaCursorRepository,
+  Manifest,
+  ManifestRepository,
+  Snapshot,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import {
+  mark_snapshot_completed,
+  resolve_saved_delta_links,
+  resolve_sync_mode,
+} from '@/services/backup/snapshot-manifest-builder';
+
+export interface MailboxResumeState {
+  /** The head manifest, for the stale-delta safeguard and the quiet-run decision. */
+  readonly previous: Manifest | undefined;
+  readonly saved_links: Record<string, string>;
+  readonly previous_entry_count: number;
+  readonly mode: BackupSyncMode;
+}
+
+/**
+ * Reads where the last run left off.
+ *
+ * Delta links live in the cursor as of #370. A mailbox last backed up by an older release has
+ * no cursor, so the head manifest's links are the fallback and the first run after the upgrade
+ * resumes instead of re-enumerating the whole mailbox.
+ */
+export async function resolve_resume_state(
+  deps: MailboxRunPersistence,
+  ctx: TenantContext,
+  owner_id: string,
+  force_full: boolean,
+): Promise<MailboxResumeState> {
+  if (force_full) {
+    return {
+      previous: undefined,
+      saved_links: {},
+      previous_entry_count: 0,
+      mode: resolve_sync_mode(true, {}),
+    };
+  }
+
+  const previous = await deps.manifests.find_latest_by_owner(ctx, owner_id);
+  const cursor = await deps.cursors.load(ctx, owner_id);
+  const saved_links = cursor?.delta_links ?? resolve_saved_delta_links(previous);
+
+  return {
+    previous,
+    saved_links,
+    previous_entry_count: previous?.total_objects ?? 0,
+    mode: resolve_sync_mode(false, saved_links),
+  };
+}
+
+export interface MailboxRunPersistence {
+  readonly manifests: ManifestRepository;
+  readonly cursors: MailboxDeltaCursorRepository;
+}
+
+export interface MailboxRunOutcome {
+  /** The snapshot to report: the one written, or the head a quiet run left in place. */
+  readonly snapshot: Snapshot;
+  /** False when the run captured nothing and the mailbox already had a snapshot. */
+  readonly wrote_snapshot: boolean;
+}
+
+/**
+ * Writes what a completed mailbox run produced: the snapshot manifest, then the delta cursor.
+ *
+ * A run that captured nothing has nothing to snapshot. Writing one anyway added a manifest
+ * object per quiet run forever, only to carry the delta links, and a snapshot is immutable once
+ * written so the head could not be rewritten instead. The links live in the cursor now, which
+ * the run overwrites, the way the drive providers have always done it (issue #370).
+ *
+ * The cursor is saved after the manifest, never before. A cursor that lands first tells the next
+ * run to skip changes no manifest recorded, which is what #339 was.
+ */
+export async function persist_mailbox_run(
+  deps: MailboxRunPersistence,
+  ctx: TenantContext,
+  manifest: Manifest,
+  snapshot: Snapshot,
+  previous: Manifest | undefined,
+  entry_count: number,
+): Promise<MailboxRunOutcome> {
+  const wrote_snapshot = entry_count > 0 || previous === undefined;
+  if (wrote_snapshot) await deps.manifests.save(ctx, manifest);
+
+  await deps.cursors.save(ctx, {
+    owner_id: manifest.owner_id,
+    delta_links: manifest.delta_links,
+    updated_at: new Date().toISOString(),
+  });
+
+  return {
+    snapshot: mark_snapshot_completed(
+      wrote_snapshot ? snapshot : { ...snapshot, id: previous.snapshot_id },
+      entry_count,
+    ),
+    wrote_snapshot,
+  };
+}

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -2,6 +2,7 @@ import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifi
 import { inject, injectable } from 'inversify';
 import type { TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
 import type { MailboxConnector, MailFolder, ManifestRepository } from '@wisecom/atlas-types';
+import type { MailboxDeltaCursorRepository } from '@wisecom/atlas-types';
 import type { ManifestEntry, ManifestObjectLockPolicy } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { assert_mailbox_exists } from '@wisecom/atlas-core/services/shared/mailbox-assertions';
@@ -11,6 +12,8 @@ import {
   finish_operation_progress,
 } from '@wisecom/atlas-core/services/shared/operation-progress';
 import { sync_single_folder } from '@/services/backup/folder-sync-executor';
+import { persist_mailbox_run, resolve_resume_state } from '@/services/backup/mailbox-run-persister';
+import { warn_if_replica } from '@/services/backup/replica-marker-warning';
 import { resolve_backup_folders } from '@/services/shared/folder-selector';
 import { resolve_progress_reporter } from '@/services/shared/backup-progress-resolver';
 import {
@@ -34,6 +37,7 @@ import {
   TENANT_CONTEXT_FACTORY_TOKEN,
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -45,6 +49,8 @@ export class MailboxSyncService implements BackupUseCase {
     @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
     @inject(MAILBOX_CONNECTOR_TOKEN) private readonly _connector: MailboxConnector,
     @inject(MANIFEST_REPOSITORY_TOKEN) private readonly _manifests: ManifestRepository,
+    @inject(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+    private readonly _cursors: MailboxDeltaCursorRepository,
   ) {}
 
   /** Orchestrates a full or incremental mailbox backup across all (or filtered) folders. */
@@ -62,7 +68,7 @@ export class MailboxSyncService implements BackupUseCase {
     const mailbox_purpose = await this._connector.get_mailbox_purpose?.(tenant_id, owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
-      await this.warn_if_replica(ctx);
+      await warn_if_replica(ctx);
       const snapshot = create_pending_snapshot(tenant_id, owner_id, {
         owner_email: options.owner_email,
         owner_display_name: options.owner_display_name,
@@ -71,12 +77,12 @@ export class MailboxSyncService implements BackupUseCase {
       const should_interrupt: () => boolean = options.should_interrupt ?? always_false;
       const should_force_stop: () => boolean = options.should_force_stop ?? always_false;
 
-      const previous = options.force_full
-        ? undefined
-        : await this._manifests.find_latest_by_owner(ctx, owner_id);
-      const saved_links = resolve_saved_delta_links(previous);
-      const previous_entry_count = previous?.total_objects ?? 0;
-      const mode = resolve_sync_mode(options.force_full, saved_links);
+      const { previous, saved_links, previous_entry_count, mode } = await resolve_resume_state(
+        { manifests: this._manifests, cursors: this._cursors },
+        ctx,
+        owner_id,
+        options.force_full === true,
+      );
 
       const folder_selection = await resolve_backup_folders(this._connector, tenant_id, owner_id, {
         folder_filter: options.folder_filter,
@@ -168,7 +174,16 @@ export class MailboxSyncService implements BackupUseCase {
         mailbox_purpose,
         excluded_folders,
       });
-      await this._manifests.save(ctx, manifest);
+
+      const persisted = await persist_mailbox_run(
+        { manifests: this._manifests, cursors: this._cursors },
+        ctx,
+        manifest,
+        snapshot,
+        previous,
+        all_entries.length,
+      );
+
       interrupted ||= should_interrupt();
       emit_operation_progress(options, {
         operation: 'backup',
@@ -178,7 +193,7 @@ export class MailboxSyncService implements BackupUseCase {
         total: global_total,
       });
 
-      const completed = mark_snapshot_completed(snapshot, all_entries.length);
+      const completed = persisted.snapshot;
       return {
         snapshot: completed,
         manifest,
@@ -295,20 +310,5 @@ export class MailboxSyncService implements BackupUseCase {
         retain_until: options.object_lock_policy.retain_until,
       },
     };
-  }
-
-  private async warn_if_replica(ctx: {
-    storage: { exists(key: string): Promise<boolean> };
-  }): Promise<void> {
-    try {
-      if (await ctx.storage.exists('_meta/replica.marker')) {
-        logger.warn(
-          'This storage target contains a replica marker (_meta/replica.marker). ' +
-            'Running backup against a replica is not recommended -- use the primary storage.',
-        );
-      }
-    } catch {
-      /* non-critical: do not block backup if marker check fails */
-    }
   }
 }

--- a/packages/outlook/src/services/backup/replica-marker-warning.ts
+++ b/packages/outlook/src/services/backup/replica-marker-warning.ts
@@ -1,0 +1,23 @@
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+/**
+ * Warns when a backup is pointed at a replication target rather than the primary bucket.
+ *
+ * A replica is written by the replication service, and backing up into one leaves two stores
+ * that each believe they are authoritative. The check never blocks the run: an unreadable marker
+ * is not a reason to refuse a backup.
+ */
+export async function warn_if_replica(ctx: {
+  storage: { exists(key: string): Promise<boolean> };
+}): Promise<void> {
+  try {
+    if (await ctx.storage.exists('_meta/replica.marker')) {
+      logger.warn(
+        'This storage target contains a replica marker (_meta/replica.marker). ' +
+          'Running backup against a replica is not recommended -- use the primary storage.',
+      );
+    }
+  } catch {
+    /* non-critical: do not block backup if marker check fails */
+  }
+}

--- a/packages/outlook/src/services/status/mailbox-status.service.ts
+++ b/packages/outlook/src/services/status/mailbox-status.service.ts
@@ -2,13 +2,14 @@ import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifi
 import { inject, injectable } from 'inversify';
 import type { TenantContextFactory } from '@wisecom/atlas-types';
 import type { MailboxConnector, MailFolder } from '@wisecom/atlas-types';
-import type { ManifestRepository } from '@wisecom/atlas-types';
+import type { ManifestRepository, MailboxDeltaCursorRepository } from '@wisecom/atlas-types';
 import type { StatusUseCase, MailboxStatusResult, FolderStatus } from '@wisecom/atlas-types';
 import { assert_mailbox_exists } from '@wisecom/atlas-core/services/shared/mailbox-assertions';
 import {
   TENANT_CONTEXT_FACTORY_TOKEN,
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -18,6 +19,8 @@ export class MailboxStatusService implements StatusUseCase {
     @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
     @inject(MAILBOX_CONNECTOR_TOKEN) private readonly _connector: MailboxConnector,
     @inject(MANIFEST_REPOSITORY_TOKEN) private readonly _manifests: ManifestRepository,
+    @inject(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+    private readonly _cursors: MailboxDeltaCursorRepository,
   ) {}
 
   /** Peeks at Graph delta state to report whether a mailbox backup is current. */
@@ -31,7 +34,12 @@ export class MailboxStatusService implements StatusUseCase {
       // Legacy manifests carry mutable-ID delta links (issue #48); resuming
       // them with the immutable preference would mix ID formats, so peek
       // treats them as "no saved state" — every folder reports pending.
-      const saved_links = previous?.id_format === 'immutable' ? (previous?.delta_links ?? {}) : {};
+      // Delta links live in the cursor as of #370; a mailbox last backed up by an older release
+      // still has them only in its head manifest.
+      const cursor = await this._cursors.load(ctx, owner_id);
+      const saved_links =
+        cursor?.delta_links ??
+        (previous?.id_format === 'immutable' ? (previous?.delta_links ?? {}) : {});
 
       const all_folders = await this._connector.list_mail_folders(tenant_id, owner_id);
       const folder_statuses = await this.peek_all_folders(

--- a/packages/outlook/tests/unit/services/backup/delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/services/backup/delta-safeguard.test.ts
@@ -5,6 +5,7 @@ import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
   type MailboxConnector,
   type MailMessage,
@@ -116,6 +117,9 @@ describe('MailboxSyncService – force_full / stale-delta safeguard', () => {
     const container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+    container
+      .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+      .toConstantValue({ load: vi.fn().mockResolvedValue(undefined), save: vi.fn() });
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
     container.bind(MailboxSyncService).toSelf();
     service = container.get(MailboxSyncService);

--- a/packages/outlook/tests/unit/services/backup/interrupt-delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/services/backup/interrupt-delta-safeguard.test.ts
@@ -5,6 +5,7 @@ import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
 import type {
@@ -15,6 +16,7 @@ import type {
   MailFolder,
   MailMessage,
   ManifestRepository,
+  MailboxDeltaCursorRepository,
   ObjectStorage,
   TenantContext,
   TenantContextFactory,
@@ -94,6 +96,7 @@ function make_streaming_fetch_delta(
 describe('interrupt delta-link safeguard (issue #23)', () => {
   let storage: ObjectStorage;
   let manifests: ManifestRepository;
+  let cursors: MailboxDeltaCursorRepository;
   let connector: MailboxConnector;
   let service: MailboxSyncService;
 
@@ -154,16 +157,27 @@ describe('interrupt delta-link safeguard (issue #23)', () => {
       fetch_attachments: vi.fn().mockResolvedValue([]),
     };
 
+    cursors = {
+      load: vi.fn().mockResolvedValue(undefined),
+      save: vi.fn(),
+    };
+
     const container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(manifests);
+    container.bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN).toConstantValue(cursors);
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(factory);
     container.bind(MailboxSyncService).toSelf();
     service = container.get(MailboxSyncService);
   });
 
+  /**
+   * Delta links moved out of the manifest and into the cursor in #370, so this is where the
+   * safeguard is now observable. The invariant is unchanged: a folder that did not finish every
+   * page keeps the link it had.
+   */
   function saved_delta_links(): Record<string, string> {
-    const calls = vi.mocked(manifests.save).mock.calls;
+    const calls = vi.mocked(cursors.save).mock.calls;
     expect(calls.length).toBe(1);
     return calls[0]![1].delta_links;
   }

--- a/packages/outlook/tests/unit/services/backup/mailbox-sync.fixtures.ts
+++ b/packages/outlook/tests/unit/services/backup/mailbox-sync.fixtures.ts
@@ -6,9 +6,10 @@ import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
 } from '@wisecom/atlas-types';
 import type { MailboxConnector, MailMessage, DeltaSyncResult } from '@wisecom/atlas-types';
-import type { ManifestRepository } from '@wisecom/atlas-types';
+import type { ManifestRepository, MailboxDeltaCursorRepository } from '@wisecom/atlas-types';
 import type { TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
 import type { ObjectStorage } from '@wisecom/atlas-types';
 import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
@@ -82,6 +83,7 @@ export interface MailboxSyncHarness {
   readonly mock_connector: MailboxConnector;
   readonly mock_context: TenantContext;
   readonly mock_manifests: ManifestRepository;
+  readonly mock_cursors: MailboxDeltaCursorRepository;
 }
 
 export function create_mailbox_sync_harness(): MailboxSyncHarness {
@@ -115,9 +117,15 @@ export function create_mailbox_sync_harness(): MailboxSyncHarness {
     create_storage_only: vi.fn().mockResolvedValue(mock_context),
   };
 
+  const mock_cursors: MailboxDeltaCursorRepository = {
+    load: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn(),
+  };
+
   const container = new Container();
   container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
   container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+  container.bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN).toConstantValue(mock_cursors);
   container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
   container.bind(MailboxSyncService).toSelf();
 
@@ -126,5 +134,6 @@ export function create_mailbox_sync_harness(): MailboxSyncHarness {
     mock_connector,
     mock_context,
     mock_manifests,
+    mock_cursors,
   };
 }

--- a/packages/outlook/tests/unit/services/backup/mailbox-sync.service.test.ts
+++ b/packages/outlook/tests/unit/services/backup/mailbox-sync.service.test.ts
@@ -5,6 +5,7 @@ import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
 import type {
@@ -125,6 +126,9 @@ describe('MailboxSyncService', () => {
     container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+    container
+      .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+      .toConstantValue({ load: vi.fn().mockResolvedValue(undefined), save: vi.fn() });
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
     container.bind(MailboxSyncService).toSelf();
 

--- a/packages/outlook/tests/unit/services/backup/nested-folders.test.ts
+++ b/packages/outlook/tests/unit/services/backup/nested-folders.test.ts
@@ -5,6 +5,7 @@ import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
 import type {
@@ -81,6 +82,9 @@ describe('MailboxSyncService - nested folders', () => {
     const container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+    container
+      .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+      .toConstantValue({ load: vi.fn().mockResolvedValue(undefined), save: vi.fn() });
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
     container.bind(MailboxSyncService).toSelf();
 

--- a/packages/outlook/tests/unit/services/backup/no-change-manifest.test.ts
+++ b/packages/outlook/tests/unit/services/backup/no-change-manifest.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  MailboxDeltaCursor,
+  MailboxDeltaCursorRepository,
+  Manifest,
+} from '@wisecom/atlas-types';
+import { create_mailbox_sync_harness, make_delta } from './mailbox-sync.fixtures';
+
+/**
+ * Issue #370. Outlook backup wrote a snapshot manifest on every run, including runs where the
+ * delta came back empty, because the manifest was where the folder delta links lived. A quiet
+ * mailbox therefore grew one manifest object per run forever. Snapshots are immutable once
+ * written, so the links moved to a cursor the run overwrites instead.
+ */
+function make_head(delta_links: Record<string, string>): Manifest {
+  return {
+    id: 'manifest-head',
+    tenant_id: 'test-tenant',
+    owner_id: 'john.doe@example.com',
+    snapshot_id: 'snap-head',
+    created_at: new Date('2026-08-17T00:00:00.000Z'),
+    total_objects: 12,
+    total_size_bytes: 4096,
+    delta_links,
+    id_format: 'immutable',
+    entries: [],
+  } as unknown as Manifest;
+}
+
+function saved_cursor(harness: { mock_cursors: MailboxDeltaCursorRepository }): MailboxDeltaCursor {
+  return vi.mocked(harness.mock_cursors.save).mock.calls.at(-1)![1];
+}
+
+describe('an outlook backup that captured nothing', () => {
+  it('writes no snapshot manifest, and still persists the delta link', async () => {
+    const harness = create_mailbox_sync_harness();
+    vi.mocked(harness.mock_manifests.find_latest_by_owner).mockResolvedValue(make_head({}));
+    vi.mocked(harness.mock_cursors.load).mockResolvedValue({
+      owner_id: 'john.doe@example.com',
+      delta_links: { 'folder-1': 'https://delta/old' },
+      updated_at: '2026-08-17T00:00:00.000Z',
+    });
+    vi.mocked(harness.mock_connector.fetch_delta).mockResolvedValue(
+      make_delta([], 'https://delta/new'),
+    );
+
+    const result = await harness.service.sync_mailbox('test-tenant', 'john.doe@example.com');
+
+    expect(harness.mock_manifests.save).not.toHaveBeenCalled();
+    expect(saved_cursor(harness).delta_links['folder-1']).toBe('https://delta/new');
+    // The run reports the snapshot the mailbox has, not one it did not write.
+    expect(result.snapshot.id).toBe('snap-head');
+  });
+
+  it('keeps a link for a folder this run did not visit', async () => {
+    const harness = create_mailbox_sync_harness();
+    vi.mocked(harness.mock_manifests.find_latest_by_owner).mockResolvedValue(make_head({}));
+    vi.mocked(harness.mock_cursors.load).mockResolvedValue({
+      owner_id: 'john.doe@example.com',
+      delta_links: { 'folder-1': 'https://delta/old', 'folder-2': 'https://delta/other' },
+      updated_at: '2026-08-17T00:00:00.000Z',
+    });
+    vi.mocked(harness.mock_connector.fetch_delta).mockResolvedValue(
+      make_delta([], 'https://delta/new'),
+    );
+
+    await harness.service.sync_mailbox('test-tenant', 'john.doe@example.com');
+
+    expect(saved_cursor(harness).delta_links['folder-2']).toBe('https://delta/other');
+  });
+
+  it('falls back to the head manifest links for a mailbox with no cursor yet', async () => {
+    const harness = create_mailbox_sync_harness();
+    vi.mocked(harness.mock_manifests.find_latest_by_owner).mockResolvedValue(
+      make_head({ 'folder-1': 'https://delta/from-manifest' }),
+    );
+    vi.mocked(harness.mock_connector.fetch_delta).mockResolvedValue(make_delta([]));
+
+    await harness.service.sync_mailbox('test-tenant', 'john.doe@example.com');
+
+    // Resumed rather than re-enumerated: the link it was given is the one it asked Graph with.
+    expect(harness.mock_connector.fetch_delta).toHaveBeenCalledWith(
+      'test-tenant',
+      'john.doe@example.com',
+      'folder-1',
+      'https://delta/from-manifest',
+      expect.anything(),
+      undefined,
+    );
+  });
+
+  it('writes the first manifest for a mailbox that has none', async () => {
+    const harness = create_mailbox_sync_harness();
+
+    await harness.service.sync_mailbox('test-tenant', 'john.doe@example.com');
+
+    expect(harness.mock_manifests.save).toHaveBeenCalledOnce();
+  });
+
+  it('writes the cursor only after the manifest is durable', async () => {
+    const order: string[] = [];
+    const harness = create_mailbox_sync_harness();
+    vi.mocked(harness.mock_manifests.save).mockImplementation(async () => {
+      order.push('manifest');
+    });
+    vi.mocked(harness.mock_cursors.save).mockImplementation(async () => {
+      order.push('cursor');
+    });
+
+    await harness.service.sync_mailbox('test-tenant', 'john.doe@example.com');
+
+    // A cursor that lands first tells the next run to skip changes no manifest recorded (#339).
+    expect(order).toEqual(['manifest', 'cursor']);
+  });
+});

--- a/packages/outlook/tests/unit/services/backup/object-lock.test.ts
+++ b/packages/outlook/tests/unit/services/backup/object-lock.test.ts
@@ -5,6 +5,7 @@ import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
   type MailboxConnector,
   type ManifestRepository,
@@ -103,6 +104,9 @@ describe('MailboxSyncService object lock', () => {
     const container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+    container
+      .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+      .toConstantValue({ load: vi.fn().mockResolvedValue(undefined), save: vi.fn() });
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(factory);
     container.bind(MailboxSyncService).toSelf();
     service = container.get(MailboxSyncService);

--- a/packages/outlook/tests/unit/services/operation-pre-abort.test.ts
+++ b/packages/outlook/tests/unit/services/operation-pre-abort.test.ts
@@ -9,7 +9,7 @@ describe('Outlook operation cancellation', () => {
     const factory = { create: vi.fn() } as unknown as TenantContextFactory;
     const callbacks = Array.from({ length: 5 }, () => vi.fn());
     const should_interrupt = (): boolean => true;
-    const backup = new MailboxSyncService(factory, {} as never, {} as never);
+    const backup = new MailboxSyncService(factory, {} as never, {} as never, {} as never);
     const restore = new RestoreService(factory, {} as never, {} as never, {} as never);
     const save = new SaveService(factory, {} as never, {} as never);
 

--- a/packages/outlook/tests/unit/services/status/mailbox-status.service.test.ts
+++ b/packages/outlook/tests/unit/services/status/mailbox-status.service.test.ts
@@ -5,6 +5,7 @@ import { MailboxStatusService } from '@/services/status/mailbox-status.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
 import type { MailboxConnector, MailFolder, DeltaSyncResult } from '@wisecom/atlas-types';
@@ -108,6 +109,9 @@ describe('MailboxStatusService', () => {
     const container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+    container
+      .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+      .toConstantValue({ load: vi.fn().mockResolvedValue(undefined), save: vi.fn() });
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
     container.bind(MailboxStatusService).toSelf();
 

--- a/packages/s3/src/adapters/s3-mailbox-delta-cursor-repository.adapter.ts
+++ b/packages/s3/src/adapters/s3-mailbox-delta-cursor-repository.adapter.ts
@@ -1,0 +1,45 @@
+import { injectable } from 'inversify';
+import type {
+  MailboxDeltaCursor,
+  MailboxDeltaCursorRepository,
+  TenantContext,
+} from '@wisecom/atlas-types';
+
+const CURSOR_PREFIX = '_meta/outlook-cursors';
+
+/** Constructs the S3 key for a mailbox's delta cursor. */
+function cursor_key(owner_id: string): string {
+  return `${CURSOR_PREFIX}/${owner_id}.json`;
+}
+
+/**
+ * Persists a mailbox's folder delta links as one encrypted object the run overwrites.
+ *
+ * The links used to live in the snapshot manifest, which made a run that changed nothing write a
+ * whole snapshot object just to record them. Snapshots are immutable once written, so this is a
+ * separate object rather than a rewrite of the head (issue #370).
+ */
+@injectable()
+export class S3MailboxDeltaCursorRepository implements MailboxDeltaCursorRepository {
+  /** Loads the cursor; undefined before the first save, or when it cannot be read. */
+  async load(ctx: TenantContext, owner_id: string): Promise<MailboxDeltaCursor | undefined> {
+    const key = cursor_key(owner_id);
+    if (!(await ctx.storage.exists(key))) return undefined;
+
+    try {
+      const payload = await ctx.storage.get(key);
+      return JSON.parse(ctx.decrypt(payload, key).toString('utf-8')) as MailboxDeltaCursor;
+    } catch {
+      // An unreadable cursor is not fatal: the manifest links are still there to fall back on,
+      // and the worst case is one re-enumeration.
+      return undefined;
+    }
+  }
+
+  /** Encrypts and stores the cursor. */
+  async save(ctx: TenantContext, cursor: MailboxDeltaCursor): Promise<void> {
+    const key = cursor_key(cursor.owner_id);
+    const payload = Buffer.from(JSON.stringify(cursor));
+    await ctx.storage.put(key, ctx.encrypt(payload, key));
+  }
+}

--- a/packages/s3/src/container.ts
+++ b/packages/s3/src/container.ts
@@ -2,6 +2,7 @@ import { type Container } from 'inversify';
 import type { S3Config, CryptoConfig } from '@wisecom/atlas-core';
 import {
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
   DEK_VALIDATION_FN_TOKEN,
   STORAGE_TARGET_FACTORY_TOKEN,
@@ -12,6 +13,7 @@ import {
 import type { StorageDisposer, StorageTargetFactory } from '@wisecom/atlas-types';
 import { create_s3_client, S3_CLIENT_TOKEN } from '@/adapters/s3-client.factory';
 import { S3ManifestRepository } from '@/adapters/s3-manifest-repository.adapter';
+import { S3MailboxDeltaCursorRepository } from '@/adapters/s3-mailbox-delta-cursor-repository.adapter';
 import { S3IdentityRegistryRepository } from '@/adapters/s3-identity-registry-repository.adapter';
 import { DefaultTenantContextFactory } from '@/adapters/tenant-context.factory';
 import { validate_dek_match } from '@/adapters/dek-validator';
@@ -28,6 +30,10 @@ export function bind_s3_storage(container: Container, config: S3Config & CryptoC
 
   container.bind(TENANT_CONTEXT_FACTORY_TOKEN).to(DefaultTenantContextFactory).inSingletonScope();
   container.bind(MANIFEST_REPOSITORY_TOKEN).to(S3ManifestRepository).inSingletonScope();
+  container
+    .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+    .to(S3MailboxDeltaCursorRepository)
+    .inSingletonScope();
   container
     .bind(IDENTITY_REGISTRY_REPOSITORY_TOKEN)
     .to(S3IdentityRegistryRepository)

--- a/packages/types/src/domain/index.ts
+++ b/packages/types/src/domain/index.ts
@@ -5,6 +5,7 @@ export type { BackupObject } from './backup-object';
 export type { FailedItemRecord, FailedItemLedger } from './failed-item';
 export type {
   Manifest,
+  MailboxDeltaCursor,
   MailboxPurpose,
   ManifestEntry,
   AttachmentEntry,

--- a/packages/types/src/domain/manifest.ts
+++ b/packages/types/src/domain/manifest.ts
@@ -89,3 +89,19 @@ export interface ManifestEntry {
    */
   readonly recoverable_items?: boolean | undefined;
 }
+
+/**
+ * A mailbox's folder delta links, kept outside the snapshot manifests.
+ *
+ * Manifests carried these until v5.1.0, which meant a run that changed nothing still had to
+ * write a whole snapshot object to record where each folder's delta stopped, so a quiet mailbox
+ * grew one manifest per run forever. A snapshot is immutable once written, so rewriting the head
+ * was not an option: the links moved to a cursor the run overwrites, the way the drive providers
+ * have always done it (issue #370).
+ */
+export interface MailboxDeltaCursor {
+  readonly owner_id: string;
+  /** Delta link per Graph folder id, for folders whose last pass completed. */
+  readonly delta_links: Record<string, string>;
+  readonly updated_at: string;
+}

--- a/packages/types/src/ports/backup/delta-cursor-repository.port.ts
+++ b/packages/types/src/ports/backup/delta-cursor-repository.port.ts
@@ -1,0 +1,15 @@
+import type { MailboxDeltaCursor } from '../../domain/manifest';
+import type { TenantContext } from '../tenant/context.port';
+
+export interface MailboxDeltaCursorRepository {
+  /** Loads the persisted delta cursor for a mailbox; undefined before the first save. */
+  load(ctx: TenantContext, owner_id: string): Promise<MailboxDeltaCursor | undefined>;
+
+  /**
+   * Saves the cursor after a sync.
+   *
+   * Call it after the snapshot manifest is durable. A cursor that lands first tells the next run
+   * to skip changes the manifest never recorded, which is what #339 was.
+   */
+  save(ctx: TenantContext, cursor: MailboxDeltaCursor): Promise<void>;
+}

--- a/packages/types/src/ports/index.ts
+++ b/packages/types/src/ports/index.ts
@@ -28,6 +28,7 @@ export type {
 } from './mail/discovery.port';
 
 export type { ManifestRepository } from './storage/manifest-repository.port';
+export type { MailboxDeltaCursorRepository } from './backup/delta-cursor-repository.port';
 
 export type { KeyService } from './crypto/key-service.port';
 
@@ -280,6 +281,7 @@ export {
   MAILBOX_CONNECTOR_TOKEN,
   MAILBOX_DISCOVERY_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   KEY_SERVICE_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
   RESTORE_CONNECTOR_TOKEN,

--- a/packages/types/src/ports/tokens/outgoing.tokens.ts
+++ b/packages/types/src/ports/tokens/outgoing.tokens.ts
@@ -1,6 +1,7 @@
 export const OBJECT_STORAGE_TOKEN = Symbol.for('ObjectStorage');
 export const MAILBOX_CONNECTOR_TOKEN = Symbol.for('MailboxConnector');
 export const MANIFEST_REPOSITORY_TOKEN = Symbol.for('ManifestRepository');
+export const MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN = Symbol.for('MailboxDeltaCursorRepository');
 export const KEY_SERVICE_TOKEN = Symbol.for('KeyService');
 export const TENANT_CONTEXT_FACTORY_TOKEN = Symbol.for('TenantContextFactory');
 export const RESTORE_CONNECTOR_TOKEN = Symbol.for('RestoreConnector');


### PR DESCRIPTION
## Summary

Fixes #370. Outlook backup wrote a snapshot manifest on every run, including runs where the delta came back empty, because the manifest was where the folder delta links lived. A quiet mailbox added one manifest object per run forever. The drive providers already skip the snapshot write when nothing changed.

I tried the small version first and backed it out. `save` keys by owner and snapshot id, so rewriting the head with merged links replaces one object instead of adding one, and it worked. Then `docs/concepts.md`:

> A snapshot is **immutable once written**. Atlas never modifies a snapshot after creation.

That is not a phrasing accident, and under Object Lock an in-place rewrite is a new retained version every quiet run, which is the same unbounded growth somewhere harder to see. Trading a documented immutability guarantee for a storage optimisation is the wrong way round.

So the links moved out of the manifest into a cursor the run overwrites, which is the mechanism OneDrive and SharePoint have always used.

## The ordering, which is the part that matters

#339 was the delta cursor committing before the snapshot manifest, so a failed manifest write left the next run reporting healthy with the change unrecoverable. Giving Outlook a cursor puts it in reach of the same trap, so:

- The cursor is saved **after** the manifest. There is a test asserting the call order, not just the effect.
- `new_delta_links` only holds folders that completed every page, and it is merged **over** the previously saved links, so an interrupt can neither advance a folder past work it did not finish nor drop a link the mailbox already had. The #23 interrupt safeguard tests now read the cursor and still pass unchanged in substance.

## Compatibility

A mailbox last backed up by an older release has no cursor. Both readers fall back to the head manifest's links, so the first run after upgrade resumes rather than re-enumerating the whole mailbox, and it writes the cursor on the way out.

## Changes

- `packages/types`: `MailboxDeltaCursor`, the `MailboxDeltaCursorRepository` port, and its token.
- `packages/s3/src/adapters/s3-mailbox-delta-cursor-repository.adapter.ts`: new, keyed `_meta/outlook-cursors/{owner}.json`, encrypted like every other metadata object.
- `packages/outlook/src/services/backup/mailbox-run-persister.ts`: new. Resume-state resolution and the manifest-then-cursor write. Extracted because `mailbox-sync.service.ts` hit both the 300-line limit and the complexity ceiling.
- `packages/outlook/src/services/backup/replica-marker-warning.ts`: moved out of the service for the same reason, unchanged.
- `packages/outlook/src/services/status/mailbox-status.service.ts`: reads the cursor, with the same fallback.
- `docs/concepts.md`: a run that captured nothing writes no snapshot, and where the position is kept instead.

## Evidence

Pre-fix, the new tests fail on the two things that matter:

```
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
AssertionError: expected [ 'manifest' ] to deeply equal [ 'manifest', 'cursor' ]
```

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run docs:build` succeeds
- [x] New/changed code has unit tests
- [x] No file exceeds 300 effective lines
- [x] Targets `dev`
- [x] Labelled for release notes (`bug`)