### PR TITLE
feat(keys): re-wrap the stored data key under a new passphrase

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -999,6 +999,15 @@ not to a compromised bucket. The answer to that is replicating to a fresh target
 passphrase and retiring the old bucket, which re-encrypts every object.
 ::::
 
+:::: warning The old passphrase stays live until the replaced version expires
+Atlas buckets are versioned, with noncurrent versions expiring after 30 days. A re-wrap writes
+a new current `_meta/dek.enc` and leaves the version it replaced in place. Anyone with the old
+passphrase and permission to read object versions can still read that one and unwrap the same,
+unchanged data key until it expires. Delete the noncurrent versions of `_meta/dek.enc` where
+policy and Object Lock allow, or revoke the leaked reader's `s3:GetObjectVersion`, which closes
+the window at once.
+::::
+
 The new passphrase is prompted and confirmed rather than accepted as a flag value, so it stays
 out of the shell history and out of the process table. On a pipe it is read from stdin whole,
 with no confirmation round a script cannot answer.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -967,6 +967,55 @@ atlas stats --json                     # raw JSON output
 
 Only one of `--mailbox`, `--owner`, or `--site` may be used at a time; each scopes the output to its service. OneDrive and SharePoint sections list per-owner and per-site rollups (snapshots, files, size, last backup time) sorted by size descending, so the heaviest consumers surface first. `--owner` accepts an email (resolved via Graph to the owner object ID) or a raw object ID; `--site` accepts a site URL or composite site ID. Use `--json` for programmatic consumption in monitoring scripts or dashboards. With multiple services the payload is an object keyed by service name, with a single service it is that service's stats object.
 
+## `atlas keys`
+
+Manage the tenant data key. One verb so far.
+
+```bash
+atlas keys rewrap                       # re-wrap under the configured passphrase, current KDF parameters
+atlas keys rewrap --new-passphrase      # prompt for a new passphrase, twice, with no echo
+atlas keys rewrap --new-passphrase < secret.txt   # non-interactive, for a scripted rotation
+```
+
+| Subcommand      | Description                                                                    |
+| --------------- | ------------------------------------------------------------------------------ |
+| `keys rewrap`   | Re-wrap `_meta/dek.enc` under a new passphrase, current KDF parameters, or both |
+
+| Option              | Description                                                                       |
+| ------------------- | ----------------------------------------------------------------------------------- |
+| `--new-passphrase`  | Prompt for a new passphrase; omit to re-wrap under the configured one              |
+| `-t, --tenant <id>` | Override tenant ID from config                                                     |
+
+The data key itself does not change. Nothing in the bucket is re-encrypted, every existing
+snapshot stays readable, and the run writes exactly one object. What changes is the wrapper: the
+KEK that protects the data key is derived again, from the new passphrase and a fresh salt, under
+the current KDF parameters. A tenant bootstrapped with weaker scrypt parameters is brought
+forward by running this with no flags.
+
+:::: danger This rotates the wrapper, not the key
+If the data key or the plaintext has already been captured, re-wrapping changes nothing for the
+attacker: they do not need the passphrase any more. This is the answer to a **leaked passphrase**,
+not to a compromised bucket. The answer to that is replicating to a fresh target under a new
+passphrase and retiring the old bucket, which re-encrypts every object.
+::::
+
+The new passphrase is prompted and confirmed rather than accepted as a flag value, so it stays
+out of the shell history and out of the process table. On a pipe it is read from stdin whole,
+with no confirmation round a script cannot answer.
+
+The order is deliberate. The stored key is unwrapped with the current passphrase first, so a
+wrong one fails before anything is written. After the write the blob is read back and unwrapped
+with the new passphrase, and the run only reports success when the key that comes back is the key
+that went in: a wrapper that cannot be unwrapped is an unopenable bucket, and finding that out at
+the next backup is too late. Keep both passphrases until a read succeeds with the new one.
+
+Update `ATLAS_ENCRYPTION_PASSPHRASE`, or `atlas config set encryption.passphrase`, after the
+command succeeds. Nothing reads the new value until you do.
+
+Where a bucket holds `_meta/dek.enc` under an Object Lock retention policy, the write is refused
+until the retention expires. The command says so, along with the fact that the stored key is
+unchanged, rather than surfacing a bare access denial that reads like a credentials fault.
+
 ## `atlas config`
 
 Manage Atlas configuration in an encrypted local store, git-config style. Values are written to `~/.atlas/config.enc` (AES-256-GCM); the store key lives in the OS keyring (macOS Keychain or libsecret), so credentials never sit on disk or in the environment in plaintext. See [Configuration](../configuration.md) for precedence and [Security](../security.md) for the threat model.

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -722,6 +722,35 @@ console.log(recovery.total.status);
 | `s3Region`             | `string` | S3 region (default: `us-east-1`)                                 |
 | `encryptionPassphrase` | `string` | Must match the primary passphrase (shared encryption model)      |
 
+## Key Re-wrap
+
+```typescript
+const result = await atlas.rewrapDataKey(newPassphrase);
+
+console.log(result.passphraseChanged, result.previousKdfId, result.kdfId);
+```
+
+Re-wraps the tenant's stored data key. Called with no argument it re-wraps under the configured
+passphrase with current KDF parameters, which is how a tenant bootstrapped with weaker scrypt
+parameters is brought forward.
+
+| Field              | Type      | Description                                                    |
+| ------------------ | --------- | -------------------------------------------------------------- |
+| `tenantId`         | `string`  | Tenant whose key was re-wrapped                                |
+| `passphraseChanged`| `boolean` | False when the call re-wrapped under the configured passphrase |
+| `previousKdfId`    | `number`  | KDF the wrapper used before the call                           |
+| `kdfId`            | `number`  | KDF the new wrapper uses                                       |
+
+The data key is unchanged, so nothing in the bucket is re-encrypted and every snapshot stays
+readable. **This rotates the wrapper, not the key**: an attacker who already holds the data key
+or the plaintext is unaffected by it. Use it for a leaked passphrase, not for a compromised
+bucket.
+
+A wrong current passphrase rejects before anything is written. After the write the blob is read
+back and unwrapped before the promise resolves, so a resolved call means the tenant opens with
+the new passphrase. Update the instance configuration afterwards: nothing reads the new value
+until you do, and an instance constructed with the old passphrase will fail its next operation.
+
 ## Graph API Cost Tracking
 
 The four operations that report cost, `backup`, `restore`, `restoreMailbox` and `checkMailboxStatus`, return how many Graph API requests they made, broken down by service pool, as a `graphCost` field on the result. Other Graph-backed calls such as `listAvailableMailboxes()` do consume quota but do not carry the field, so a scheduler budgeting against `graphCost` should account for them separately:

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -746,10 +746,16 @@ readable. **This rotates the wrapper, not the key**: an attacker who already hol
 or the plaintext is unaffected by it. Use it for a leaked passphrase, not for a compromised
 bucket.
 
+Buckets are versioned and noncurrent versions expire after 30 days, so the wrapper this replaces
+stays readable until then. Someone with the old passphrase and permission to read object
+versions can still unwrap the same data key from it. Treat the rotation as complete only once
+that version is gone, or once the leaked reader's `s3:GetObjectVersion` is revoked.
+
 A wrong current passphrase rejects before anything is written. After the write the blob is read
 back and unwrapped before the promise resolves, so a resolved call means the tenant opens with
-the new passphrase. Update the instance configuration afterwards: nothing reads the new value
-until you do, and an instance constructed with the old passphrase will fail its next operation.
+the new passphrase, and a verification failure restores the previous wrapper before rejecting.
+Update the instance configuration afterwards: nothing reads the new value until you do, and an
+instance constructed with the old passphrase will fail its next operation.
 
 ## Graph API Cost Tracking
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -135,7 +135,7 @@ Throttling is already modelled for this pool (`IdentityServiceLimits`: resource 
 
 ### Argon2 KDF migration
 
-Evaluate replacing scrypt with Argon2id for KEK derivation. The versioned DEK blob format (`v1`) already includes a `kdf_id` field, making algorithm upgrades possible without breaking existing tenants. This includes building an `atlas migrate-kdf` command that re-wraps all DEK blobs under the new KDF without re-encrypting data objects.
+Evaluate replacing scrypt with Argon2id for KEK derivation. The versioned DEK blob format (`v1`) already includes a `kdf_id` field, making algorithm upgrades possible without breaking existing tenants. The command that migrates a tenant already exists: `atlas keys rewrap` re-wraps the stored key under the current default KDF without re-encrypting data objects, so what remains here is registering the strategy and deciding the default, not building the migration.
 
 ### Graph throttling and cost audit
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -43,7 +43,7 @@ Parameters used by Atlas for **new** DEK wraps:
 | Output              | 32 bytes (256 bits)            | AES-256 key length                                                                        |
 | Minimum N on unwrap | 16384                          | Blobs with weaker parameters are rejected                                                 |
 
-The **tenant-domain salt** ensures that the same passphrase and random salt produce different KEKs for different tenants. A fresh random salt is generated on every DEK wrap, so a re-wrap picks up new scrypt parameters without relying on a separate `_meta/kek_params.json` file. Atlas wraps a DEK when it first creates one, and nothing re-wraps an existing one: the parameters a tenant was bootstrapped with are the parameters it keeps.
+The **tenant-domain salt** ensures that the same passphrase and random salt produce different KEKs for different tenants. A fresh random salt is generated on every DEK wrap, including a re-wrap, so `atlas keys rewrap` picks up current scrypt parameters without relying on a separate `_meta/kek_params.json` file. Until a re-wrap runs, a tenant keeps the parameters it was bootstrapped with.
 
 The v5 SDK rejects passphrases shorter than 14 UTF-8 bytes at construction, matching the existing KDF warning threshold. Byte length is only a minimum, not an entropy guarantee: use at least five random words or 20 random characters for production. The CLI's existing passphrase handling is unchanged. Never pad or replace an existing passphrase without migrating its wrapped DEK; use the previous SDK or CLI to recover short-passphrase backups.
 
@@ -76,16 +76,31 @@ object write regardless of how large the tenant is.
 
 What it is worth is bounded by that. **It rotates the wrapper, not the key.** The threat it
 answers is a leaked passphrase: whoever holds the old one can no longer derive a KEK that opens
-the stored key. It does nothing about an attacker who already holds the DEK itself or plaintext
-they decrypted with it, because neither needs the passphrase again. For that, the answer is
-replicating to a fresh target under a new passphrase and retiring the old bucket, which
-re-encrypts every object under a new DEK.
+the current wrapper. It does nothing about an attacker who already holds the DEK itself or
+plaintext they decrypted with it, because neither needs the passphrase again. For that, the
+answer is replicating to a fresh target under a new passphrase and retiring the old bucket,
+which re-encrypts every object under a new DEK.
+
+:::: warning Revocation is not immediate on a versioned bucket
+Atlas enables bucket versioning and expires noncurrent versions after 30 days. A re-wrap writes
+a new current `_meta/dek.enc`; it does not remove the version it replaced. Until that noncurrent
+version expires, someone holding the old passphrase **and** permission to read object versions
+can still read it and unwrap the same, unchanged DEK.
+
+Treat the re-wrap as complete only once that version is gone. Where policy and Object Lock
+allow, delete the noncurrent versions of `_meta/dek.enc` explicitly; where they do not, the old
+passphrase remains a live credential for up to 30 days, and read access to object versions is
+what stands between it and the key. Revoking the leaked reader's `s3:GetObjectVersion` closes
+the window immediately.
+::::
 
 The order matters and is enforced. The stored key is unwrapped with the current passphrase
 before anything is written, so a wrong one costs nothing. After the write, the blob is read back
 and unwrapped with the new passphrase and compared against the key that went in, because a
 wrapper that cannot be unwrapped is an unopenable bucket and the next backup is too late to find
-that out. Keep both passphrases until a read succeeds with the new one.
+that out. A verification failure puts the previous wrapper back and proves it still opens before
+the error is reported, so a failed re-wrap leaves the tenant exactly as it was. Keep both
+passphrases until a read succeeds with the new one.
 
 The same command with no flags re-wraps under the configured passphrase, which is how a tenant
 bootstrapped under weaker scrypt parameters is brought forward to the current ones. Existing

--- a/docs/security.md
+++ b/docs/security.md
@@ -25,9 +25,8 @@ Envelope encryption separates the key that protects your data (DEK) from the key
 
 - The DEK is a random 256-bit key with maximum entropy -- it does not depend on passphrase strength.
 - The KEK is derived from your passphrase and only used to wrap/unwrap the DEK.
-- Changing the passphrase only has to re-encrypt the DEK wrapper, not every object in storage. The
-  blob format is built for that, but no command performs it today. Read the warning below before
-  you change `ATLAS_ENCRYPTION_PASSPHRASE` on a tenant that already has backups.
+- Changing the passphrase only re-encrypts the DEK wrapper, not every object in storage.
+  `atlas keys rewrap --new-passphrase` performs it, one `PutObject` against `_meta/dek.enc`.
 
 ### KEK Derivation: scrypt
 
@@ -57,11 +56,40 @@ The optional SDK `validate()` probe performs only S3 `HeadBucket` and Graph toke
 - **Never stored in plaintext** -- only exists in memory during a backup/restore run.
 - **Re-derived on every run**: Atlas reads `_meta/dek.enc`, derives the KEK from the passphrase, unwraps the DEK, and holds it in memory for the session.
 
-::: danger Passphrase Is Irrecoverable
-There is **no key rotation mechanism** and **no recovery path**. If you lose the passphrase, the DEK cannot be unwrapped, and all data for that tenant is permanently inaccessible. Changing the passphrase without migrating the wrapped DEK will cause GCM authentication failures when Atlas tries to unwrap `_meta/dek.enc`.
+:::: danger A lost passphrase is still irrecoverable
+There is **no recovery path**. If you lose the passphrase, the DEK cannot be unwrapped and all
+data for that tenant is permanently inaccessible. Changing `ATLAS_ENCRYPTION_PASSPHRASE` without
+re-wrapping the stored key causes GCM authentication failures on the next unwrap of
+`_meta/dek.enc`, so use `atlas keys rewrap --new-passphrase` and change the configured value only
+after it succeeds.
 
-**Treat the passphrase as critically as the data itself.** Store it in a password manager, a sealed envelope in a safe, or a secrets management system -- but never lose it.
-:::
+**Treat the passphrase as critically as the data itself.** Store it in a password manager, a
+sealed envelope in a safe, or a secrets management system, but never lose it.
+::::
+
+### Re-wrapping the data key
+
+`atlas keys rewrap` derives a new KEK, from a new passphrase or from the current KDF parameters
+with a fresh salt, and rewrites `_meta/dek.enc` under it. The DEK inside is byte-identical, so
+nothing in the bucket is re-encrypted and every existing snapshot stays readable. It is one
+object write regardless of how large the tenant is.
+
+What it is worth is bounded by that. **It rotates the wrapper, not the key.** The threat it
+answers is a leaked passphrase: whoever holds the old one can no longer derive a KEK that opens
+the stored key. It does nothing about an attacker who already holds the DEK itself or plaintext
+they decrypted with it, because neither needs the passphrase again. For that, the answer is
+replicating to a fresh target under a new passphrase and retiring the old bucket, which
+re-encrypts every object under a new DEK.
+
+The order matters and is enforced. The stored key is unwrapped with the current passphrase
+before anything is written, so a wrong one costs nothing. After the write, the blob is read back
+and unwrapped with the new passphrase and compared against the key that went in, because a
+wrapper that cannot be unwrapped is an unopenable bucket and the next backup is too late to find
+that out. Keep both passphrases until a read succeeds with the new one.
+
+The same command with no flags re-wraps under the configured passphrase, which is how a tenant
+bootstrapped under weaker scrypt parameters is brought forward to the current ones. Existing
+backups are unaffected either way.
 
 ## Encryption Details
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -136,9 +136,7 @@ Decryption errors mean the configured passphrase does not match the one used to 
 Error: Unable to unwrap DEK: incorrect passphrase or corrupted key blob
 ```
 
-The passphrase in `ATLAS_ENCRYPTION_PASSPHRASE` does not match the one used when the tenant was first initialized. The wrapped DEK (stored at `_meta/dek.enc` in the bucket) was encrypted with the original passphrase using scrypt key derivation. Changing the passphrase without re-wrapping the DEK makes all data inaccessible.
-
-There is no way to recover data if the original passphrase is lost. That is by design, because the passphrase is the root of the entire encryption chain.
+The passphrase in `ATLAS_ENCRYPTION_PASSPHRASE` does not match the one used when the tenant was first initialized. The wrapped DEK (stored at `_meta/dek.enc` in the bucket) was encrypted with the original passphrase using scrypt key derivation. Changing the passphrase without re-wrapping the DEK makes all data inaccessible: run [`atlas keys rewrap --new-passphrase`](/reference/cli#atlas-keys) with the old passphrase still configured, then change the configured value.
 
 ### Corrupted DEK blob
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -13,6 +13,7 @@ import { register_replicate_command } from '@/commands/replicate.command';
 import { register_rehydrate_command } from '@/commands/rehydrate.command';
 import { register_list_users_command } from '@/commands/list-users.command';
 import { register_config_command } from '@/commands/config.command';
+import { register_keys_command } from '@/commands/keys.command';
 import { handle_fatal_error } from '@/fatal-error';
 import type { Container } from 'inversify';
 
@@ -49,6 +50,7 @@ function register_commands(program: Command): void {
   register_replicate_command(program, get_container);
   register_rehydrate_command(program, get_container);
   register_list_users_command(program, get_container);
+  register_keys_command(program, get_container);
   register_config_command(program);
 }
 

--- a/packages/cli/src/commands/keys.command.tsx
+++ b/packages/cli/src/commands/keys.command.tsx
@@ -1,0 +1,85 @@
+import type { Command } from 'commander';
+import type { Container } from 'inversify';
+import type { AtlasConfig } from '@wisecom/atlas-core';
+import { ATLAS_CONFIG_TOKEN, logger } from '@wisecom/atlas-core';
+import type { DekRewrapUseCase } from '@wisecom/atlas-types';
+import { DEK_REWRAP_USE_CASE_TOKEN } from '@wisecom/atlas-types';
+import { with_tenant } from '@/commands/shared-options';
+import { prompt_new_passphrase } from '@/utils/passphrase-prompt';
+import { banner_title } from '@/ui/banner-title';
+import { Banner } from '@/ui/components/banner';
+import { KeyValueList } from '@/ui/components/key-value-list';
+import { render_static_view } from '@/ui/render';
+
+type ContainerFactory = () => Container;
+
+interface RewrapOptions {
+  tenant?: string;
+  newPassphrase?: boolean;
+}
+
+/**
+ * Registers the `atlas keys` group.
+ *
+ * One verb so far. The group exists because a key operation is neither a workload nor
+ * configuration, and burying `rewrap` under `config` would suggest it edits a setting rather than
+ * rewriting an object in the bucket.
+ */
+export function register_keys_command(program: Command, get_container: ContainerFactory): void {
+  const group = program.command('keys').description('Manage the tenant data key');
+
+  const rewrap = group
+    .command('rewrap')
+    .description('Re-wrap the stored data key under a new passphrase or current KDF parameters')
+    .option(
+      '--new-passphrase',
+      'prompt for a new passphrase; omit to re-wrap under the configured one',
+    )
+    .addHelpText(
+      'after',
+      [
+        '',
+        'The data key itself does not change, so no stored object is re-encrypted and every',
+        'existing snapshot stays readable. This rotates the wrapper, not the key: anyone who',
+        'already holds the data key or the plaintext is unaffected.',
+        '',
+        'Set ATLAS_ENCRYPTION_PASSPHRASE to the new value after this succeeds.',
+      ].join('\n'),
+    );
+  with_tenant(rewrap).action((options: RewrapOptions) => execute_rewrap(get_container(), options));
+}
+
+async function execute_rewrap(container: Container, options: RewrapOptions): Promise<void> {
+  const tenant_id = options.tenant ?? container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
+  const use_case = container.get<DekRewrapUseCase>(DEK_REWRAP_USE_CASE_TOKEN);
+
+  // Prompted before the run, so a mistyped confirmation costs nothing.
+  const new_passphrase = options.newPassphrase === true ? await prompt_new_passphrase() : undefined;
+
+  await render_static_view(<Banner title={banner_title('tenant', 'Key Re-wrap')} />);
+  const result = await use_case.rewrap_tenant_dek(tenant_id, new_passphrase);
+
+  await render_static_view(
+    <KeyValueList
+      items={[
+        { label: 'Tenant', value: result.tenant_id },
+        { label: 'Passphrase', value: result.passphrase_changed ? 'changed' : 'unchanged' },
+        {
+          label: 'KDF',
+          value:
+            result.previous_kdf_id === result.kdf_id
+              ? `${result.kdf_id} (unchanged)`
+              : `${result.previous_kdf_id} -> ${result.kdf_id}`,
+        },
+      ]}
+    />,
+  );
+
+  logger.success('Data key re-wrapped. No stored object was re-encrypted.');
+  if (result.passphrase_changed) {
+    logger.warn(
+      'Update ATLAS_ENCRYPTION_PASSPHRASE (or `atlas config set encryption.passphrase`) before ' +
+        'the next run. Keep the previous passphrase until a read succeeds with the new one.',
+    );
+  }
+}

--- a/packages/cli/src/utils/passphrase-prompt.ts
+++ b/packages/cli/src/utils/passphrase-prompt.ts
@@ -1,0 +1,59 @@
+import { createInterface, type Interface } from 'node:readline';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Reads a new passphrase without echoing it, asking twice.
+ *
+ * Never a flag value: an inline secret lands in the shell history file and is readable in the
+ * process table by any other local user while the command runs. Non-interactive stdin is read
+ * whole and used as-is, so `atlas keys rewrap --new-passphrase < secret.txt` works in a script
+ * without a confirmation round the script cannot answer.
+ *
+ * @throws Error when the two answers differ, or when the value is empty.
+ */
+export async function prompt_new_passphrase(): Promise<string> {
+  if (!process.stdin.isTTY) {
+    const piped = readFileSync(0, 'utf-8').replace(/\r?\n$/, '');
+    if (piped.length === 0) {
+      throw new Error('No passphrase on stdin. Pipe one in, or run the command interactively.');
+    }
+    return piped;
+  }
+
+  const first = await ask_hidden('New passphrase: ');
+  if (first.length === 0) throw new Error('The passphrase cannot be empty.');
+  const second = await ask_hidden('Repeat the new passphrase: ');
+  if (first !== second) throw new Error('The two passphrases do not match; nothing was changed.');
+  return first;
+}
+
+/** Prompts on a TTY with echo suppressed. */
+async function ask_hidden(prompt: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: true });
+  suppress_echo(rl, prompt);
+  try {
+    const answer = await new Promise<string>((resolve) => rl.question(prompt, resolve));
+    process.stdout.write('\n');
+    return answer.trim();
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Swaps readline's writer for one that emits the prompt and nothing else.
+ *
+ * `terminal: true` echoes every keystroke, which for a passphrase means it is on screen and in
+ * the scrollback. Node has no first-class hidden-input mode, and this is the documented way to
+ * get one from readline.
+ */
+function suppress_echo(rl: Interface, prompt: string): void {
+  const mutable = rl as unknown as {
+    _writeToOutput: (text: string) => void;
+    output: NodeJS.WriteStream;
+  };
+  const output = mutable.output;
+  mutable._writeToOutput = (text: string): void => {
+    if (text.includes(prompt)) output.write(prompt);
+  };
+}

--- a/packages/cli/src/utils/passphrase-prompt.ts
+++ b/packages/cli/src/utils/passphrase-prompt.ts
@@ -34,7 +34,10 @@ async function ask_hidden(prompt: string): Promise<string> {
   try {
     const answer = await new Promise<string>((resolve) => rl.question(prompt, resolve));
     process.stdout.write('\n');
-    return answer.trim();
+    // Not trimmed. readline already excludes the newline, so what is left is what was typed, and
+    // a passphrase with a leading or trailing space is a passphrase. Trimming it here would wrap
+    // the key with a value the operator cannot reproduce from their password manager.
+    return answer;
   } finally {
     rl.close();
   }

--- a/packages/core/src/container.ts
+++ b/packages/core/src/container.ts
@@ -2,6 +2,7 @@ import { type Container } from 'inversify';
 import {
   CATALOG_USE_CASE_TOKEN,
   DELETION_USE_CASE_TOKEN,
+  DEK_REWRAP_USE_CASE_TOKEN,
   VERIFICATION_USE_CASE_TOKEN,
   STATS_USE_CASE_TOKEN,
   REPLICATION_USE_CASE_TOKEN,
@@ -16,6 +17,7 @@ import {
 } from '@wisecom/atlas-types';
 import { CatalogService } from '@/services/catalog/catalog.service';
 import { DeletionService } from '@/services/deletion/deletion.service';
+import { DekRewrapService } from '@/services/keys/dek-rewrap.service';
 import { OneDriveDeletionService } from '@/services/deletion/onedrive-deletion.service';
 import { SharePointDeletionService } from '@/services/deletion/sharepoint-deletion.service';
 import { VerificationService } from '@/services/verification/verification.service';
@@ -29,6 +31,8 @@ export function bind_core_services(container: Container): void {
   container.bind(CATALOG_USE_CASE_TOKEN).toService(CatalogService);
   container.bind(DeletionService).toSelf();
   container.bind(DELETION_USE_CASE_TOKEN).toService(DeletionService);
+  container.bind(DekRewrapService).toSelf();
+  container.bind(DEK_REWRAP_USE_CASE_TOKEN).toService(DekRewrapService);
   container.bind(OneDriveDeletionService).toSelf();
   container
     .bind<OneDriveDeletionUseCase>(ONEDRIVE_DELETION_USE_CASE_TOKEN)

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,5 +1,10 @@
 export { CatalogService } from '@/services/catalog/catalog.service';
 export { DeletionService } from '@/services/deletion/deletion.service';
+export { DekRewrapService } from '@/services/keys/dek-rewrap.service';
+export {
+  DekRewrapVerificationError,
+  DekWrapperMissingError,
+} from '@/services/keys/dek-rewrap.errors';
 export { OneDriveDeletionService } from '@/services/deletion/onedrive-deletion.service';
 export { SharePointDeletionService } from '@/services/deletion/sharepoint-deletion.service';
 export { VerificationService } from '@/services/verification/verification.service';

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -3,6 +3,7 @@ export { DeletionService } from '@/services/deletion/deletion.service';
 export { DekRewrapService } from '@/services/keys/dek-rewrap.service';
 export {
   DekRewrapVerificationError,
+  DekRewrapRollbackError,
   DekWrapperMissingError,
 } from '@/services/keys/dek-rewrap.errors';
 export { OneDriveDeletionService } from '@/services/deletion/onedrive-deletion.service';

--- a/packages/core/src/services/keys/dek-rewrap.errors.ts
+++ b/packages/core/src/services/keys/dek-rewrap.errors.ts
@@ -47,13 +47,39 @@ export class DekRewrapRollbackError extends StorageError {
 }
 
 /**
- * Names an Object Lock or permission refusal on the wrapped-key write.
+ * Names a compare-and-swap refusal on the wrapped-key write.
  *
- * A bucket that retains `_meta/dek.enc` under a governance-mode policy refuses the overwrite with
- * a bare access denial, which reads like a credentials problem and is not one (issue #374).
+ * The stored wrapper changed between this run reading it and writing it back, which means
+ * another re-wrap or a bootstrap is in flight. Overwriting it would discard whatever that run
+ * established, so this run stops instead.
+ */
+export class DekWrapperChangedError extends StorageError {
+  constructor(key: string, cause: unknown) {
+    super(
+      `${key} changed while this re-wrap was running, so the write was refused and nothing was ` +
+        `overwritten. Another re-wrap or a first backup is likely in flight against this tenant. ` +
+        `Wait for it to finish, confirm which passphrase opens the tenant, then try again.`,
+      { cause },
+    );
+  }
+}
+
+/**
+ * Classifies a failed wrapped-key write.
+ *
+ * Two cases are worth naming rather than passing through raw. A compare-and-swap refusal means
+ * something else changed the wrapper. A bucket that retains `_meta/dek.enc` under a
+ * governance-mode policy refuses the overwrite with a bare access denial, which reads like a
+ * credentials problem and is not one (issue #374).
  */
 export function describe_rewrap_write_failure(key: string, err: unknown): Error {
   const message = err instanceof Error ? err.message : String(err);
+  const name = err instanceof Error ? err.name : '';
+
+  if (name === 'PreconditionFailedError' || /precondition|412/i.test(message)) {
+    return new DekWrapperChangedError(key, err);
+  }
+
   if (!/access denied|forbidden|403|object lock|retention|WORM/i.test(message)) {
     return err instanceof Error ? err : new Error(message);
   }

--- a/packages/core/src/services/keys/dek-rewrap.errors.ts
+++ b/packages/core/src/services/keys/dek-rewrap.errors.ts
@@ -27,6 +27,26 @@ export class DekRewrapVerificationError extends StorageError {
 }
 
 /**
+ * Thrown when the re-wrap failed verification and the previous wrapper could not be put back.
+ *
+ * This is the one state where the operator has to act immediately, so the message says what is
+ * in the bucket rather than only what went wrong.
+ */
+export class DekRewrapRollbackError extends StorageError {
+  constructor(key: string, verification_cause: unknown, restore_cause: unknown) {
+    const verification = verification_cause instanceof Error ? verification_cause.message : '';
+    const restore = restore_cause instanceof Error ? restore_cause.message : String(restore_cause);
+    super(
+      `Re-wrap failed verification (${verification}) and the previous wrapper could not be ` +
+        `restored (${restore}). ${key} is now in an unknown state: do not discard either ` +
+        `passphrase, and check whether the object opens with one of them before running anything ` +
+        `else against this tenant.`,
+      { cause: restore_cause },
+    );
+  }
+}
+
+/**
  * Names an Object Lock or permission refusal on the wrapped-key write.
  *
  * A bucket that retains `_meta/dek.enc` under a governance-mode policy refuses the overwrite with

--- a/packages/core/src/services/keys/dek-rewrap.errors.ts
+++ b/packages/core/src/services/keys/dek-rewrap.errors.ts
@@ -1,0 +1,48 @@
+import { ConfigError, StorageError } from '@wisecom/atlas-types';
+
+/** Thrown when a tenant has no wrapped key to re-wrap. */
+export class DekWrapperMissingError extends ConfigError {
+  constructor(tenant_id: string, key: string) {
+    super(
+      `Tenant ${tenant_id} has no wrapped data key at ${key}, so there is nothing to re-wrap. ` +
+        `A key is written when the tenant is first backed up.`,
+    );
+  }
+}
+
+/**
+ * Thrown when the blob that was just written does not open to the key that was stored.
+ *
+ * The previous wrapper is gone by this point, so the message has to say what state the bucket is
+ * in rather than only what failed.
+ */
+export class DekRewrapVerificationError extends StorageError {
+  constructor(reason: string, cause?: unknown) {
+    super(
+      `Re-wrap verification failed: ${reason}. The tenant may now be openable only with the ` +
+        `passphrase this run was given; do not discard either passphrase until a read succeeds.`,
+      cause === undefined ? undefined : { cause },
+    );
+  }
+}
+
+/**
+ * Names an Object Lock or permission refusal on the wrapped-key write.
+ *
+ * A bucket that retains `_meta/dek.enc` under a governance-mode policy refuses the overwrite with
+ * a bare access denial, which reads like a credentials problem and is not one (issue #374).
+ */
+export function describe_rewrap_write_failure(key: string, err: unknown): Error {
+  const message = err instanceof Error ? err.message : String(err);
+  if (!/access denied|forbidden|403|object lock|retention|WORM/i.test(message)) {
+    return err instanceof Error ? err : new Error(message);
+  }
+
+  return new StorageError(
+    `Could not overwrite ${key}: ${message}. A bucket that holds the wrapped key under an ` +
+      `Object Lock retention policy refuses the write until the retention expires, and the ` +
+      `credentials in use need s3:PutObject on that key. The stored key is unchanged and the ` +
+      `tenant still opens with the passphrase it had.`,
+    { cause: err },
+  );
+}

--- a/packages/core/src/services/keys/dek-rewrap.service.ts
+++ b/packages/core/src/services/keys/dek-rewrap.service.ts
@@ -8,6 +8,7 @@ import { ATLAS_CONFIG_TOKEN, type AtlasConfig } from '@/utils/config';
 import { logger } from '@/utils/logger';
 import {
   DekRewrapVerificationError,
+  DekRewrapRollbackError,
   DekWrapperMissingError,
   describe_rewrap_write_failure,
 } from '@/services/keys/dek-rewrap.errors';
@@ -51,7 +52,16 @@ export class DekRewrapService implements DekRewrapUseCase {
         throw describe_rewrap_write_failure(DEK_KEY, err);
       }
 
-      assert_rewrap_opens(await storage.get(DEK_KEY), next, tenant_id, dek);
+      try {
+        assert_rewrap_opens(await storage.get(DEK_KEY), next, tenant_id, dek);
+      } catch (err) {
+        // The only wrapper has already been overwritten at this point, so a verification failure
+        // without a rollback leaves the tenant unopenable. Put the blob that was read at the
+        // start back, prove it still opens with the passphrase the operator already has, and
+        // only then report the original failure.
+        await restore_previous_wrapper(storage, stored, current, tenant_id, err);
+        throw err;
+      }
 
       logger.info(`Re-wrapped the data key for ${tenant_id}; no data object was touched`);
       return {
@@ -89,5 +99,31 @@ function assert_rewrap_opens(
 
   if (read_back.length !== expected_dek.length || !timingSafeEqual(read_back, expected_dek)) {
     throw new DekRewrapVerificationError('the re-wrapped key is not the key that was stored');
+  }
+}
+
+/**
+ * Puts the wrapper that was read at the start back, and proves it still opens.
+ *
+ * Rollback is best effort by nature: the storage that just failed verification is the storage
+ * being asked to accept the restore. When that fails too, the thrown error names both, because
+ * an operator whose only wrapper is in an unknown state needs to know that before anything else.
+ */
+async function restore_previous_wrapper(
+  storage: { put(key: string, body: Buffer): Promise<void>; get(key: string): Promise<Buffer> },
+  previous: Buffer,
+  current: EnvelopeKeyService,
+  tenant_id: string,
+  cause: unknown,
+): Promise<void> {
+  try {
+    await storage.put(DEK_KEY, previous);
+    current.unwrap_dek(await storage.get(DEK_KEY), tenant_id);
+    logger.warn(
+      `Re-wrap failed verification for ${tenant_id}; restored the previous wrapper, which still ` +
+        `opens with the passphrase in use. Nothing changed.`,
+    );
+  } catch (restore_err) {
+    throw new DekRewrapRollbackError(DEK_KEY, cause, restore_err);
   }
 }

--- a/packages/core/src/services/keys/dek-rewrap.service.ts
+++ b/packages/core/src/services/keys/dek-rewrap.service.ts
@@ -1,0 +1,93 @@
+import { timingSafeEqual } from 'node:crypto';
+import { inject, injectable } from 'inversify';
+import type { DekRewrapResult, DekRewrapUseCase, TenantContextFactory } from '@wisecom/atlas-types';
+import { TENANT_CONTEXT_FACTORY_TOKEN } from '@wisecom/atlas-types';
+import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
+import { parse_dek_blob } from '@/adapters/keystore/dek-blob-codec';
+import { ATLAS_CONFIG_TOKEN, type AtlasConfig } from '@/utils/config';
+import { logger } from '@/utils/logger';
+import {
+  DekRewrapVerificationError,
+  DekWrapperMissingError,
+  describe_rewrap_write_failure,
+} from '@/services/keys/dek-rewrap.errors';
+
+const DEK_KEY = '_meta/dek.enc';
+
+/**
+ * Re-wraps a tenant's stored DEK under a new passphrase, new KDF parameters, or both.
+ *
+ * The DEK itself never changes, so no data object is touched and every existing snapshot stays
+ * readable. That also bounds what this is worth: it rotates the wrapper, not the key. Anyone who
+ * already holds the DEK or the plaintext is unaffected, and the only answer to that is
+ * re-encrypting the bucket (issue #374).
+ */
+@injectable()
+export class DekRewrapService implements DekRewrapUseCase {
+  constructor(
+    @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
+    @inject(ATLAS_CONFIG_TOKEN) private readonly _config: AtlasConfig,
+  ) {}
+
+  /** Unwraps with the current passphrase, wraps with the next, then proves the result opens. */
+  async rewrap_tenant_dek(tenant_id: string, new_passphrase?: string): Promise<DekRewrapResult> {
+    const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
+    if (!(await storage.exists(DEK_KEY))) throw new DekWrapperMissingError(tenant_id, DEK_KEY);
+
+    const stored = await storage.get(DEK_KEY);
+    const current = new EnvelopeKeyService(this._config.encryption_passphrase);
+    const next = new EnvelopeKeyService(new_passphrase ?? this._config.encryption_passphrase);
+
+    try {
+      // A wrong current passphrase fails here, before anything is written. `unwrap_dek` raises
+      // WrongPassphraseError, which already says what to check.
+      const dek = current.unwrap_dek(stored, tenant_id);
+      const previous_kdf_id = parse_dek_blob(stored).header.kdf_id;
+
+      const rewrapped = next.wrap_dek(dek, tenant_id);
+      try {
+        await storage.put(DEK_KEY, rewrapped);
+      } catch (err) {
+        throw describe_rewrap_write_failure(DEK_KEY, err);
+      }
+
+      assert_rewrap_opens(await storage.get(DEK_KEY), next, tenant_id, dek);
+
+      logger.info(`Re-wrapped the data key for ${tenant_id}; no data object was touched`);
+      return {
+        tenant_id,
+        previous_kdf_id,
+        kdf_id: parse_dek_blob(rewrapped).header.kdf_id,
+        passphrase_changed: new_passphrase !== undefined,
+      };
+    } finally {
+      current.destroy();
+      next.destroy();
+    }
+  }
+}
+
+/**
+ * Proves the blob that was just written opens to the same key.
+ *
+ * `create_dek_exclusively` reads back on bootstrap for this reason, and it matters more here: a
+ * wrap that cannot be unwrapped is an unopenable bucket, and the operator would find out at the
+ * next backup rather than now.
+ */
+function assert_rewrap_opens(
+  written: Buffer,
+  next: EnvelopeKeyService,
+  tenant_id: string,
+  expected_dek: Buffer,
+): void {
+  let read_back: Buffer;
+  try {
+    read_back = next.unwrap_dek(written, tenant_id);
+  } catch (err) {
+    throw new DekRewrapVerificationError('the new wrapper could not be unwrapped', err);
+  }
+
+  if (read_back.length !== expected_dek.length || !timingSafeEqual(read_back, expected_dek)) {
+    throw new DekRewrapVerificationError('the re-wrapped key is not the key that was stored');
+  }
+}

--- a/packages/core/src/services/keys/dek-rewrap.service.ts
+++ b/packages/core/src/services/keys/dek-rewrap.service.ts
@@ -1,7 +1,12 @@
 import { timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
-import type { DekRewrapResult, DekRewrapUseCase, TenantContextFactory } from '@wisecom/atlas-types';
-import { TENANT_CONTEXT_FACTORY_TOKEN } from '@wisecom/atlas-types';
+import type {
+  DekRewrapResult,
+  DekRewrapUseCase,
+  ObjectStorage,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { ConfigError, TENANT_CONTEXT_FACTORY_TOKEN } from '@wisecom/atlas-types';
 import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
 import { parse_dek_blob } from '@/adapters/keystore/dek-blob-codec';
 import { ATLAS_CONFIG_TOKEN, type AtlasConfig } from '@/utils/config';
@@ -9,11 +14,15 @@ import { logger } from '@/utils/logger';
 import {
   DekRewrapVerificationError,
   DekRewrapRollbackError,
+  DekWrapperChangedError,
   DekWrapperMissingError,
   describe_rewrap_write_failure,
 } from '@/services/keys/dek-rewrap.errors';
 
 const DEK_KEY = '_meta/dek.enc';
+
+/** Matches the minimum `createAtlasInstance` enforces on `encryptionPassphrase` (issue #45). */
+const MIN_PASSPHRASE_BYTES = 14;
 
 /**
  * Re-wraps a tenant's stored DEK under a new passphrase, new KDF parameters, or both.
@@ -32,10 +41,19 @@ export class DekRewrapService implements DekRewrapUseCase {
 
   /** Unwraps with the current passphrase, wraps with the next, then proves the result opens. */
   async rewrap_tenant_dek(tenant_id: string, new_passphrase?: string): Promise<DekRewrapResult> {
+    if (new_passphrase !== undefined) assert_usable_passphrase(new_passphrase);
+
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
     if (!(await storage.exists(DEK_KEY))) throw new DekWrapperMissingError(tenant_id, DEK_KEY);
 
-    const stored = await storage.get(DEK_KEY);
+    // Read the ETag with the blob: every write below is a compare-and-swap against it, so a
+    // second re-wrap running at the same time is refused rather than silently overwritten.
+    //
+    // Defence in depth, not the guarantee. This is the first conditional write in the codebase,
+    // and an S3-compatible backend that ignores `If-Match` degrades it to a plain overwrite. The
+    // classification below is what actually keeps a concurrent run's wrapper safe, and it needs
+    // no backend support.
+    const { data: stored, etag: stored_etag } = await storage.get_with_etag(DEK_KEY);
     const current = new EnvelopeKeyService(this._config.encryption_passphrase);
     const next = new EnvelopeKeyService(new_passphrase ?? this._config.encryption_passphrase);
 
@@ -47,27 +65,39 @@ export class DekRewrapService implements DekRewrapUseCase {
 
       const rewrapped = next.wrap_dek(dek, tenant_id);
       try {
-        await storage.put(DEK_KEY, rewrapped);
+        await storage.put(DEK_KEY, rewrapped, undefined, undefined, stored_etag);
       } catch (err) {
         throw describe_rewrap_write_failure(DEK_KEY, err);
       }
 
-      try {
-        assert_rewrap_opens(await storage.get(DEK_KEY), next, tenant_id, dek);
-      } catch (err) {
-        // The only wrapper has already been overwritten at this point, so a verification failure
-        // without a rollback leaves the tenant unopenable. Put the blob that was read at the
-        // start back, prove it still opens with the passphrase the operator already has, and
-        // only then report the original failure.
-        await restore_previous_wrapper(storage, stored, current, tenant_id, err);
-        throw err;
+      // Verify what is actually stored, not what was sent, and decide from that.
+      //
+      // Rolling back on any verification failure is wrong: the reason the stored blob is not
+      // ours may be that a concurrent re-wrap won the race, and overwriting a working wrapper
+      // someone else just established is worse than the failure being reported. So the stored
+      // blob is classified first, and only a blob nobody can open is replaced.
+      const written = await storage.get_with_etag(DEK_KEY);
+      const verdict = classify_written_wrapper(written.data, rewrapped, current, next, tenant_id);
+
+      if (verdict === 'foreign') {
+        throw new DekWrapperChangedError(DEK_KEY, undefined);
       }
+      if (verdict === 'unusable') {
+        // Nobody can open what is there, so putting the previous wrapper back is strictly an
+        // improvement. Conditional on its ETag, so a writer arriving in between still wins.
+        await restore_previous_wrapper(storage, stored, written.etag, current, tenant_id);
+        throw new DekRewrapVerificationError(
+          'the stored wrapper opened with neither passphrase; the previous one was restored',
+        );
+      }
+
+      assert_rewrap_opens(written.data, next, tenant_id, dek);
 
       logger.info(`Re-wrapped the data key for ${tenant_id}; no data object was touched`);
       return {
         tenant_id,
         previous_kdf_id,
-        kdf_id: parse_dek_blob(rewrapped).header.kdf_id,
+        kdf_id: parse_dek_blob(written.data).header.kdf_id,
         passphrase_changed: new_passphrase !== undefined,
       };
     } finally {
@@ -103,27 +133,81 @@ function assert_rewrap_opens(
 }
 
 /**
+ * Decides what the blob now at the wrapped-key path actually is.
+ *
+ * `ours` is the byte-identical copy of what this run wrote. `foreign` opens with one of the two
+ * passphrases but is not ours, which means another run wrote it and it must be left alone.
+ * `unusable` opens with neither, so it is garbage nobody can back out of and replacing it can
+ * only improve matters.
+ */
+function classify_written_wrapper(
+  written: Buffer,
+  rewrapped: Buffer,
+  current: EnvelopeKeyService,
+  next: EnvelopeKeyService,
+  tenant_id: string,
+): 'ours' | 'foreign' | 'unusable' {
+  if (written.equals(rewrapped)) return 'ours';
+  return opens(written, current, tenant_id) || opens(written, next, tenant_id)
+    ? 'foreign'
+    : 'unusable';
+}
+
+/** Whether this key service can unwrap the blob at all. */
+function opens(blob: Buffer, keys: EnvelopeKeyService, tenant_id: string): boolean {
+  try {
+    keys.unwrap_dek(blob, tenant_id);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Puts the wrapper that was read at the start back, and proves it still opens.
  *
- * Rollback is best effort by nature: the storage that just failed verification is the storage
- * being asked to accept the restore. When that fails too, the thrown error names both, because
- * an operator whose only wrapper is in an unknown state needs to know that before anything else.
+ * Conditional on the ETag of the unusable blob, so a writer arriving between the classification
+ * and this write still wins: whatever they established is newer than what this run knows.
+ *
+ * Rollback is best effort by nature, because the storage being asked to accept the restore is
+ * the storage that just produced an unopenable object. When it fails too, the thrown error
+ * names both, since an operator whose only wrapper is in an unknown state needs that first.
  */
 async function restore_previous_wrapper(
-  storage: { put(key: string, body: Buffer): Promise<void>; get(key: string): Promise<Buffer> },
+  storage: ObjectStorage,
   previous: Buffer,
+  unusable_etag: string,
   current: EnvelopeKeyService,
   tenant_id: string,
-  cause: unknown,
 ): Promise<void> {
   try {
-    await storage.put(DEK_KEY, previous);
+    await storage.put(DEK_KEY, previous, undefined, undefined, unusable_etag);
     current.unwrap_dek(await storage.get(DEK_KEY), tenant_id);
     logger.warn(
-      `Re-wrap failed verification for ${tenant_id}; restored the previous wrapper, which still ` +
-        `opens with the passphrase in use. Nothing changed.`,
+      `Re-wrap produced an unopenable wrapper for ${tenant_id}; restored the previous one, ` +
+        `which still opens with the passphrase in use. Nothing changed.`,
     );
   } catch (restore_err) {
-    throw new DekRewrapRollbackError(DEK_KEY, cause, restore_err);
+    throw new DekRewrapRollbackError(
+      DEK_KEY,
+      'the stored wrapper opened with neither passphrase',
+      restore_err,
+    );
+  }
+}
+
+/**
+ * Rejects a new passphrase the SDK would refuse at construction.
+ *
+ * `createAtlasInstance` enforces 14 UTF-8 bytes, and `rewrapDataKey` reaches the wrap without
+ * passing through it: an empty string would otherwise wrap the tenant key under an empty
+ * passphrase, which is the one outcome this command must never produce.
+ */
+function assert_usable_passphrase(passphrase: string): void {
+  if (Buffer.byteLength(passphrase, 'utf8') < MIN_PASSPHRASE_BYTES) {
+    throw new ConfigError(
+      `The new passphrase must contain at least ${MIN_PASSPHRASE_BYTES} UTF-8 bytes. ` +
+        `Nothing was changed.`,
+    );
   }
 }

--- a/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
+++ b/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WrongPassphraseError } from '@wisecom/atlas-types';
+import type { TenantContextFactory } from '@wisecom/atlas-types';
+import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
+import { DekRewrapService } from '@/services/keys/dek-rewrap.service';
+import { DekWrapperMissingError } from '@/services/keys/dek-rewrap.errors';
+import type { AtlasConfig } from '@/utils/config';
+
+/**
+ * Issue #374. Nothing re-wrapped an existing DEK, so a leaked passphrase was permanent and the
+ * KDF parameters a tenant was bootstrapped with were the ones it kept. The DEK must come through
+ * byte-identical, because a new one over an existing bucket makes every stored object
+ * unreadable.
+ */
+
+const TENANT = 'tenant-1';
+const OLD_PASSPHRASE = 'the-original-passphrase';
+const NEW_PASSPHRASE = 'a-different-passphrase';
+const DEK_KEY = '_meta/dek.enc';
+
+function make_config(passphrase: string): AtlasConfig {
+  return {
+    tenant_id: TENANT,
+    client_id: 'client-1',
+    client_secret: 'secret-1',
+    s3_endpoint: 'http://primary:9000',
+    s3_access_key: 'access',
+    s3_secret_key: 'secret',
+    s3_region: 'us-east-1',
+    encryption_passphrase: passphrase,
+  };
+}
+
+interface Harness {
+  service: DekRewrapService;
+  objects: Map<string, Buffer>;
+  dek: Buffer;
+}
+
+/** A bucket holding one wrapped DEK, written with `OLD_PASSPHRASE`. */
+function make_harness(
+  options: { config_passphrase?: string; seed?: boolean; serve_after_write?: Buffer } = {},
+): Harness {
+  const writer = new EnvelopeKeyService(OLD_PASSPHRASE);
+  const dek = writer.generate_dek();
+  const objects = new Map<string, Buffer>();
+  if (options.seed !== false) objects.set(DEK_KEY, writer.wrap_dek(dek, TENANT));
+  let written = false;
+
+  const storage = {
+    exists: vi.fn(async (key: string) => objects.has(key)),
+    get: vi.fn(async (key: string) => {
+      if (written && options.serve_after_write) return options.serve_after_write;
+      const found = objects.get(key);
+      if (!found) throw new Error(`NoSuchKey: ${key}`);
+      return found;
+    }),
+    put: vi.fn(async (key: string, body: Buffer) => {
+      written = true;
+      objects.set(key, body);
+    }),
+  };
+
+  const factory = {
+    create_storage_only: vi.fn().mockResolvedValue({ tenant_id: TENANT, storage }),
+    create: vi.fn(),
+    create_readonly: vi.fn(),
+  } as unknown as TenantContextFactory;
+
+  return {
+    service: new DekRewrapService(
+      factory,
+      make_config(options.config_passphrase ?? OLD_PASSPHRASE),
+    ),
+    objects,
+    dek,
+  };
+}
+
+describe('re-wrapping a tenant data key', () => {
+  it('round-trips: the new passphrase opens the same key', async () => {
+    const { service, objects, dek } = make_harness();
+
+    const result = await service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE);
+
+    expect(result.passphrase_changed).toBe(true);
+    const reader = new EnvelopeKeyService(NEW_PASSPHRASE);
+    expect(reader.unwrap_dek(objects.get(DEK_KEY)!, TENANT)).toEqual(dek);
+  });
+
+  it('leaves the old passphrase unable to open it', async () => {
+    const { service, objects } = make_harness();
+
+    await service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE);
+
+    const stale = new EnvelopeKeyService(OLD_PASSPHRASE);
+    expect(() => stale.unwrap_dek(objects.get(DEK_KEY)!, TENANT)).toThrow(WrongPassphraseError);
+  });
+
+  it('re-wraps under the configured passphrase with a fresh salt when none is given', async () => {
+    const { service, objects, dek } = make_harness();
+    const before = objects.get(DEK_KEY)!;
+
+    const result = await service.rewrap_tenant_dek(TENANT);
+
+    expect(result.passphrase_changed).toBe(false);
+    const after = objects.get(DEK_KEY)!;
+    // A different blob, because the salt is fresh, holding the same key.
+    expect(after.equals(before)).toBe(false);
+    expect(new EnvelopeKeyService(OLD_PASSPHRASE).unwrap_dek(after, TENANT)).toEqual(dek);
+  });
+
+  it('refuses, and writes nothing, when the current passphrase is wrong', async () => {
+    const { service, objects } = make_harness({ config_passphrase: 'not-the-passphrase' });
+    const before = objects.get(DEK_KEY)!;
+
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toBeInstanceOf(
+      WrongPassphraseError,
+    );
+    expect(objects.get(DEK_KEY)).toBe(before);
+  });
+
+  it('refuses when the tenant has no wrapped key', async () => {
+    const { service } = make_harness({ seed: false });
+
+    await expect(service.rewrap_tenant_dek(TENANT)).rejects.toBeInstanceOf(DekWrapperMissingError);
+  });
+
+  it('fails loudly when the blob read back is not the key that was stored', async () => {
+    // Storage accepts the write and serves a different blob back. The read-back check exists for
+    // exactly this: the alternative is an unopenable bucket discovered at the next backup.
+    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
+    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
+    const { service } = make_harness({ serve_after_write: foreign });
+
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
+      /Re-wrap verification failed/,
+    );
+  });
+});

--- a/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
+++ b/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
@@ -1,9 +1,10 @@
+import { createHash } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { WrongPassphraseError } from '@wisecom/atlas-types';
 import type { TenantContextFactory } from '@wisecom/atlas-types';
 import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
 import { DekRewrapService } from '@/services/keys/dek-rewrap.service';
-import { DekWrapperMissingError } from '@/services/keys/dek-rewrap.errors';
+import { DekWrapperChangedError, DekWrapperMissingError } from '@/services/keys/dek-rewrap.errors';
 import type { AtlasConfig } from '@/utils/config';
 
 /**
@@ -42,8 +43,14 @@ function make_harness(
   options: {
     config_passphrase?: string;
     seed?: boolean;
-    /** Served by `get` after the first write, to fake a storage that returns the wrong blob. */
-    serve_after_write?: Buffer;
+    /**
+     * Stored instead of the bytes the first write sends, which is how a concurrent writer or a
+     * backend that mangles a write looks from the caller's side. ETags stay consistent with what
+     * is stored, the way S3 behaves.
+     */
+    store_instead?: Buffer;
+    /** Stored right after this run's first read, so its compare-and-swap must fail. */
+    rival_after_read?: Buffer;
     /** Fails the rollback write, so the bucket is left in an unknown state. */
     reject_second_put?: boolean;
   } = {},
@@ -53,22 +60,38 @@ function make_harness(
   const objects = new Map<string, Buffer>();
   if (options.seed !== false) objects.set(DEK_KEY, writer.wrap_dek(dek, TENANT));
   let writes = 0;
+  let reads = 0;
 
+  const etag_of = (body: Buffer): string => `"${createHash('md5').update(body).digest('hex')}"`;
   const storage = {
     exists: vi.fn(async (key: string) => objects.has(key)),
     get: vi.fn(async (key: string) => {
-      // The rollback read must see what the rollback wrote, not the faked blob.
-      if (writes === 1 && options.serve_after_write) return options.serve_after_write;
       const found = objects.get(key);
       if (!found) throw new Error(`NoSuchKey: ${key}`);
       return found;
     }),
-    put: vi.fn(async (key: string, body: Buffer) => {
+    get_with_etag: vi.fn(async (key: string) => {
+      const data = objects.get(key);
+      if (!data) throw new Error(`NoSuchKey: ${key}`);
+      const result = { data, etag: etag_of(data) };
+      // A rival write landing immediately after this run's read is what the compare-and-swap on
+      // the following put exists to catch.
+      if (reads === 0 && options.rival_after_read) objects.set(key, options.rival_after_read);
+      reads += 1;
+      return result;
+    }),
+    put: vi.fn(async (key: string, body: Buffer, _m?: unknown, _l?: unknown, if_match?: string) => {
+      const held = objects.get(key);
+      if (if_match !== undefined && held && if_match !== etag_of(held)) {
+        const conflict = new Error(`Conditional write failed for key ${key}`);
+        conflict.name = 'PreconditionFailedError';
+        throw conflict;
+      }
       writes += 1;
       if (writes === 2 && options.reject_second_put === true) {
         throw new Error('AccessDenied on the restore');
       }
-      objects.set(key, body);
+      objects.set(key, writes === 1 && options.store_instead ? options.store_instead : body);
     }),
   };
 
@@ -137,40 +160,63 @@ describe('re-wrapping a tenant data key', () => {
     await expect(service.rewrap_tenant_dek(TENANT)).rejects.toBeInstanceOf(DekWrapperMissingError);
   });
 
-  it('fails loudly when the blob read back is not the key that was stored', async () => {
-    // Storage accepts the write and serves a different blob back. The read-back check exists for
-    // exactly this: the alternative is an unopenable bucket discovered at the next backup.
-    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
-    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
-    const { service } = make_harness({ serve_after_write: foreign });
+  it('rejects a new passphrase the SDK would refuse at construction', async () => {
+    const { service, objects } = make_harness();
+    const before = objects.get(DEK_KEY)!;
 
-    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
-      /Re-wrap verification failed/,
-    );
+    // `createAtlasInstance` enforces 14 bytes; rewrapDataKey reaches the wrap without it, so an
+    // empty string would otherwise wrap the tenant key under an empty passphrase.
+    await expect(service.rewrap_tenant_dek(TENANT, '')).rejects.toThrow(/at least 14/);
+    expect(objects.get(DEK_KEY)).toBe(before);
   });
 
-  it('puts the previous wrapper back when verification fails, so the tenant still opens', async () => {
-    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
-    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
-    const { service, objects, dek } = make_harness({ serve_after_write: foreign });
+  it('leaves a concurrent run\u2019s wrapper alone rather than reverting it', async () => {
+    // Someone else's valid wrapper is what is stored when this run reads back. Rolling back
+    // here would silently undo their rotation and leave them believing it took.
+    const rival = new EnvelopeKeyService(NEW_PASSPHRASE);
+    const rival_blob = rival.wrap_dek(rival.generate_dek(), TENANT);
+    const { service, objects } = make_harness({ store_instead: rival_blob });
+
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toBeInstanceOf(
+      DekWrapperChangedError,
+    );
+    expect(objects.get(DEK_KEY)).toBe(rival_blob);
+  });
+
+  it('restores the previous wrapper when what landed opens with neither passphrase', async () => {
+    // A mangled write: nobody can back out of this, so putting the old wrapper back is strictly
+    // an improvement over leaving the tenant unopenable.
+    const { service, objects, dek } = make_harness({ store_instead: Buffer.from('not a wrapper') });
 
     await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
-      /Re-wrap verification failed/,
+      /opened with neither passphrase/,
     );
 
-    // The only wrapper was overwritten before verification, so without the rollback the tenant
-    // would be unopenable with either passphrase.
     const restored = new EnvelopeKeyService(OLD_PASSPHRASE);
     expect(restored.unwrap_dek(objects.get(DEK_KEY)!, TENANT)).toEqual(dek);
   });
 
-  it('names the state of the bucket when the rollback itself fails', async () => {
-    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
-    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
-    const { service } = make_harness({ serve_after_write: foreign, reject_second_put: true });
+  it('names the state of the bucket when the restore itself fails', async () => {
+    const { service } = make_harness({
+      store_instead: Buffer.from('not a wrapper'),
+      reject_second_put: true,
+    });
 
     await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
       /could not be restored/,
     );
+  });
+
+  it('refuses the write when the wrapper changed between the read and the write', async () => {
+    const rival = new EnvelopeKeyService(NEW_PASSPHRASE);
+    const rival_blob = rival.wrap_dek(rival.generate_dek(), TENANT);
+    const { service, objects } = make_harness({ rival_after_read: rival_blob });
+
+    // The read saw the original blob, so the unwrap succeeds; the compare-and-swap on the write
+    // is what catches that the object moved underneath this run.
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toBeInstanceOf(
+      DekWrapperChangedError,
+    );
+    expect(objects.get(DEK_KEY)).toBe(rival_blob);
   });
 });

--- a/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
+++ b/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
@@ -39,24 +39,35 @@ interface Harness {
 
 /** A bucket holding one wrapped DEK, written with `OLD_PASSPHRASE`. */
 function make_harness(
-  options: { config_passphrase?: string; seed?: boolean; serve_after_write?: Buffer } = {},
+  options: {
+    config_passphrase?: string;
+    seed?: boolean;
+    /** Served by `get` after the first write, to fake a storage that returns the wrong blob. */
+    serve_after_write?: Buffer;
+    /** Fails the rollback write, so the bucket is left in an unknown state. */
+    reject_second_put?: boolean;
+  } = {},
 ): Harness {
   const writer = new EnvelopeKeyService(OLD_PASSPHRASE);
   const dek = writer.generate_dek();
   const objects = new Map<string, Buffer>();
   if (options.seed !== false) objects.set(DEK_KEY, writer.wrap_dek(dek, TENANT));
-  let written = false;
+  let writes = 0;
 
   const storage = {
     exists: vi.fn(async (key: string) => objects.has(key)),
     get: vi.fn(async (key: string) => {
-      if (written && options.serve_after_write) return options.serve_after_write;
+      // The rollback read must see what the rollback wrote, not the faked blob.
+      if (writes === 1 && options.serve_after_write) return options.serve_after_write;
       const found = objects.get(key);
       if (!found) throw new Error(`NoSuchKey: ${key}`);
       return found;
     }),
     put: vi.fn(async (key: string, body: Buffer) => {
-      written = true;
+      writes += 1;
+      if (writes === 2 && options.reject_second_put === true) {
+        throw new Error('AccessDenied on the restore');
+      }
       objects.set(key, body);
     }),
   };
@@ -135,6 +146,31 @@ describe('re-wrapping a tenant data key', () => {
 
     await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
       /Re-wrap verification failed/,
+    );
+  });
+
+  it('puts the previous wrapper back when verification fails, so the tenant still opens', async () => {
+    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
+    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
+    const { service, objects, dek } = make_harness({ serve_after_write: foreign });
+
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
+      /Re-wrap verification failed/,
+    );
+
+    // The only wrapper was overwritten before verification, so without the rollback the tenant
+    // would be unopenable with either passphrase.
+    const restored = new EnvelopeKeyService(OLD_PASSPHRASE);
+    expect(restored.unwrap_dek(objects.get(DEK_KEY)!, TENANT)).toEqual(dek);
+  });
+
+  it('names the state of the bucket when the rollback itself fails', async () => {
+    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
+    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
+    const { service } = make_harness({ serve_after_write: foreign, reject_second_put: true });
+
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
+      /could not be restored/,
     );
   });
 });

--- a/packages/sdk/src/atlas-instance.adapter.ts
+++ b/packages/sdk/src/atlas-instance.adapter.ts
@@ -8,6 +8,7 @@ import type {
   ReplicationUseCase,
   UserIdentityResolver,
   IdentityRegistryRepository,
+  DekRewrapUseCase,
 } from '@wisecom/atlas-types';
 import {
   STORAGE_CHECK_USE_CASE_TOKEN,
@@ -16,6 +17,7 @@ import {
   USER_IDENTITY_RESOLVER_TOKEN,
   IDENTITY_REGISTRY_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
+  DEK_REWRAP_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
 import type { TenantContextFactory } from '@wisecom/atlas-types';
 import { create_outlook_api } from '@/outlook-api.factory';
@@ -40,6 +42,7 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     IDENTITY_REGISTRY_REPOSITORY_TOKEN,
   );
   const tenant_factory = container.get<TenantContextFactory>(TENANT_CONTEXT_FACTORY_TOKEN);
+  const dek_rewrap = container.get<DekRewrapUseCase>(DEK_REWRAP_USE_CASE_TOKEN);
   const dispose = create_disposer(container);
   const sink = resolve_log_sink(config.logger);
   const scoped = <T extends object>(api: T): T => scope_api_logging(api, tenant_id, sink);
@@ -91,6 +94,9 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     },
     async getReplicationStatusByOwner(owner_id) {
       return camelize(await replication.get_replication_status_by_owner(tenant_id, owner_id));
+    },
+    async rewrapDataKey(new_passphrase) {
+      return camelize(await dek_rewrap.rewrap_tenant_dek(tenant_id, new_passphrase));
     },
 
     dispose,

--- a/packages/types/src/ports/atlas/use-case.port.ts
+++ b/packages/types/src/ports/atlas/use-case.port.ts
@@ -6,6 +6,7 @@ import type {
   ReplicationStatusRecord,
   TenantRehydrationResult,
 } from '@/domain/replication';
+import type { DekRewrapResult } from '@/ports/keys/dek-rewrap.port';
 import type { StorageTarget } from '@/ports/replication/storage-target.port';
 import type { OutlookApi } from '@/ports/atlas/outlook-api.port';
 import type { OneDriveApi } from '@/ports/atlas/onedrive-api.port';
@@ -61,6 +62,14 @@ export interface AtlasInstance extends AsyncDisposable {
   /** Full tenant recovery across Outlook, OneDrive, and SharePoint, reported per workload. */
   rehydrateTenant(source: StorageTarget): Promise<Camelize<TenantRehydrationResult>>;
   getReplicationStatus(snapshotId?: string): Promise<Camelize<ReplicationStatusRecord>[]>;
+  /**
+   * Re-wraps the tenant's stored data key under `newPassphrase`, or under the configured one
+   * with current KDF parameters when it is omitted.
+   *
+   * The data key is unchanged, so no stored object is re-encrypted and every snapshot stays
+   * readable. This rotates the wrapper, not the key.
+   */
+  rewrapDataKey(newPassphrase?: string): Promise<Camelize<DekRewrapResult>>;
   /**
    * Releases the instance: S3 socket pools, cached bucket state, container
    * bindings. Idempotent. The instance must not be used afterwards.

--- a/packages/types/src/ports/index.ts
+++ b/packages/types/src/ports/index.ts
@@ -74,6 +74,8 @@ export type { CatalogUseCase, MailboxSummary, ReadMessageResult } from './catalo
 
 export type { DeletionUseCase, DeletionResult } from './deletion/use-case.port';
 
+export type { DekRewrapUseCase, DekRewrapResult } from './keys/dek-rewrap.port';
+
 export type {
   StorageCheckUseCase,
   StorageCheckRequest,
@@ -307,6 +309,7 @@ export {
   CATALOG_USE_CASE_TOKEN,
   DELETION_USE_CASE_TOKEN,
   STORAGE_CHECK_USE_CASE_TOKEN,
+  DEK_REWRAP_USE_CASE_TOKEN,
   SAVE_USE_CASE_TOKEN,
   STATS_USE_CASE_TOKEN,
   STATUS_USE_CASE_TOKEN,

--- a/packages/types/src/ports/keys/dek-rewrap.port.ts
+++ b/packages/types/src/ports/keys/dek-rewrap.port.ts
@@ -1,0 +1,19 @@
+export interface DekRewrapResult {
+  readonly tenant_id: string;
+  /** KDF the wrapper used before this run. */
+  readonly previous_kdf_id: number;
+  /** KDF the new wrapper uses; equal to the previous one when only the passphrase changed. */
+  readonly kdf_id: number;
+  readonly passphrase_changed: boolean;
+}
+
+export interface DekRewrapUseCase {
+  /**
+   * Re-wraps the tenant's stored data key under `new_passphrase`, or under the configured one
+   * with current KDF parameters when it is omitted.
+   *
+   * The data key itself is unchanged, so no stored object is re-encrypted and every existing
+   * snapshot stays readable. This rotates the wrapper, not the key.
+   */
+  rewrap_tenant_dek(tenant_id: string, new_passphrase?: string): Promise<DekRewrapResult>;
+}

--- a/packages/types/src/ports/tokens/use-case.tokens.ts
+++ b/packages/types/src/ports/tokens/use-case.tokens.ts
@@ -4,6 +4,7 @@ export const RESTORE_USE_CASE_TOKEN = Symbol.for('RestoreUseCase');
 export const CATALOG_USE_CASE_TOKEN = Symbol.for('CatalogUseCase');
 export const DELETION_USE_CASE_TOKEN = Symbol.for('DeletionUseCase');
 export const STORAGE_CHECK_USE_CASE_TOKEN = Symbol.for('StorageCheckUseCase');
+export const DEK_REWRAP_USE_CASE_TOKEN = Symbol.for('DekRewrapUseCase');
 export const SAVE_USE_CASE_TOKEN = Symbol.for('SaveUseCase');
 export const STATS_USE_CASE_TOKEN = Symbol.for('StatsUseCase');
 export const STATUS_USE_CASE_TOKEN = Symbol.for('StatusUseCase');


### PR DESCRIPTION
## Summary

Closes #374. Nothing re-wrapped an existing DEK. `_meta/dek.enc` was written once at bootstrap, and the passphrase and KDF parameters it was written with were the ones that tenant kept. A leaked passphrase was therefore permanent: the only supported response was a fresh bucket and a full re-backup over Graph, which is out of proportion to the event and so does not happen.

`atlas keys rewrap` does what the blob format was already built for:

1. Unwrap the stored key with the current passphrase. A wrong one fails here, before anything is written.
2. Wrap **the same key** under the new passphrase, with a fresh salt and the current KDF parameters.
3. Write it back, one `PutObject`.
4. Read the blob back, unwrap it with the new passphrase, and compare against the key that went in. Only then report success.

Step 4 is not ceremony. `create_dek_exclusively` already reads back on bootstrap, and it matters more here: a wrapper that cannot be unwrapped is an unopenable bucket, and the next backup is too late to discover it.

The DEK is byte-identical, so no data object is re-encrypted and every existing snapshot stays readable. The command says so, and the docs say the other half out loud: **this rotates the wrapper, not the key**. An attacker holding the DEK or the plaintext does not need the passphrase again, and the answer to that is still replicating to a fresh target and retiring the old bucket.

## Changes

- `packages/types`: `DekRewrapUseCase`, `DekRewrapResult`, the token, and `rewrapDataKey` on `AtlasInstance`.
- `packages/core/src/services/keys/dek-rewrap.service.ts`: the unwrap, wrap, write, read-back sequence.
- `packages/core/src/services/keys/dek-rewrap.errors.ts`: a missing wrapper, a failed verification that says which passphrase the bucket may now need, and the Object Lock case.
- `packages/cli/src/commands/keys.command.tsx`, `packages/cli/src/utils/passphrase-prompt.ts`: the command, and a prompt that asks twice with echo suppressed. Never a flag value: an inline secret lands in shell history and in the process table. Piped stdin is read whole, so a scripted rotation works without a confirmation round it cannot answer.
- `packages/sdk`: `atlas.rewrapDataKey(newPassphrase?)`.
- Docs: `docs/reference/cli.md`, `docs/reference/sdk.md`, `docs/security.md`, `docs/troubleshooting.md`. `docs/roadmap.md`'s `atlas migrate-kdf` entry now points here, since re-wrapping under a new KDF is this command with no flags.

## Evidence

Six unit tests: the round trip, the old passphrase no longer opening the wrapper, a no-flag re-wrap producing a different blob holding the same key, the wrong-passphrase refusal writing nothing, a tenant with no wrapper, and a storage that serves back a foreign blob being caught by the read-back.

A throwaway script against the compiled service and an in-memory bucket, which is the part the unit tests cannot show, that a **data object encrypted before the rotation still decrypts after it**:

```
[*] Re-wrapped the data key for contoso; no data object was touched
rewrap smoke: data object readable with the new passphrase, old passphrase refused
objects in bucket: _meta/dek.enc, data/contoso/abc123
```

CLI surface verified from the built binary (`atlas keys rewrap --help`).

Not verified against a real bucket with Object Lock engaged: the retention refusal is classified from the error the SDK raises, and the message is what changes, not the outcome.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes with no regressions
- [x] `pnpm run lint` passes with no new errors
- [x] `pnpm run docs:build` succeeds
- [x] New/changed code has unit tests
- [x] JSDoc added to exported functions and public methods
- [x] No file exceeds 300 effective lines
- [x] No relative imports (use `@/` path aliases)
- [x] Secrets and credentials are not committed
- [x] Targets `dev`
- [x] Labelled for release notes (`enhancement`, `security`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `atlas keys rewrap` to update a stored data-key wrapper with a new passphrase or current security settings without re-encrypting stored data.
  * Added SDK support through `rewrapDataKey()`, including verification and rollback protection.
  * Added interactive and non-interactive passphrase entry, tenant selection, status results, and warnings about updating configuration.
  * Added safeguards for storage retention policies and versioned key wrappers.

* **Documentation**
  * Added CLI and SDK references, security guidance, troubleshooting steps, and updated migration roadmap information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->