### PR TITLE
chore(release): 5.1.0

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -35,6 +35,12 @@ The content itself (ciphertext blobs) lives separately in S3, organized by conte
 
 A snapshot is **immutable once written**. Atlas never modifies a snapshot after creation, and with Object Lock enabled on the bucket, the manifest file is locked against deletion for the retention period.
 
+A run that captured nothing writes no snapshot. All three workloads behave this way: a mailbox
+or drive with no changes since the last backup adds no manifest object, and the previous
+snapshot stays the latest one. Where a run stopped reading each folder or drive is recorded in a
+separate cursor object the run overwrites, which is why an unchanged mailbox does not accumulate
+one manifest per run just to remember its position.
+
 Snapshot IDs differ by workload:
 
 - **Outlook**: short hash IDs (e.g. `snap-a3b2c1`)

--- a/docs/development/graph-tap.md
+++ b/docs/development/graph-tap.md
@@ -136,6 +136,14 @@ scope; those statuses are excluded from `ERRORS` so they are not counted twice.
 `SLOWEST` appears only when a request exceeded one second. Open the raw `.jsonl`
 only when one specific request matters.
 
+A request that failed is reported under one of two shapes, because they are
+different faults. `failed` on its own means the request never received a
+response: a connection refused, a DNS failure, a socket reset before any
+header arrived. `202+failed` means the server answered and the body did not
+finish, which is what a cancelled or truncated response body looks like. The
+`ERRORS` block spells the second one `202 body: <reason>` so a 2xx that never
+delivered its body cannot be read as a success.
+
 ## Options
 
 | Flag              | Effect                                                                                                |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -614,6 +614,14 @@ A snapshot taken with `--folder` contains only that folder's files. Restoring it
 
 A drive restore nests under `/Restore-<timestamp>` at the target drive root and recreates the original folder structure beneath it, matching how Outlook restores have always worked. `--in-place` reproduces the pre-4.0.0 behaviour of writing back over the original paths; it is never the default, because `--conflict rename` turns a repeated in-place restore into suffixed duplicates scattered through live content rather than a failure. See [Where restored files land](/onedrive-backup#where-restored-files-land).
 
+An owner can have more than one drive, and every manifest entry records the
+drive its file came from. A restore to the original owner puts each file back
+in that drive; a file whose drive no longer exists is reported and skipped
+rather than written into a different one. `--target-owner` has no drive
+mapping to work from, since Atlas records drive IDs and not drive names, so it
+is refused when the snapshot spans more than one drive. Restore those to the
+original owner, or one drive at a time with `--file-filter`.
+
 Identifiers are matched case-insensitively: `--owner`, `--site`, and `--file-filter` all accept whatever case a listing or portal shows. Owner and site IDs are lowercased before they become storage keys, so one identifier always addresses one tree. Earlier releases wrote a second tree for a second spelling and deleted from whichever one they were handed.
 
 A `--file-filter` path is the rooted path shown in a listing, and a file at the drive or library root is written the way you would expect: `/Report.docx`, not `//Report.docx`. Version commands take the same path forms, and when one path belongs to two different drive items, which happens after a file is deleted and recreated at the same path, the command names both file IDs and stops rather than picking one.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -999,6 +999,15 @@ not to a compromised bucket. The answer to that is replicating to a fresh target
 passphrase and retiring the old bucket, which re-encrypts every object.
 ::::
 
+:::: warning The old passphrase stays live until the replaced version expires
+Atlas buckets are versioned, with noncurrent versions expiring after 30 days. A re-wrap writes
+a new current `_meta/dek.enc` and leaves the version it replaced in place. Anyone with the old
+passphrase and permission to read object versions can still read that one and unwrap the same,
+unchanged data key until it expires. Delete the noncurrent versions of `_meta/dek.enc` where
+policy and Object Lock allow, or revoke the leaked reader's `s3:GetObjectVersion`, which closes
+the window at once.
+::::
+
 The new passphrase is prompted and confirmed rather than accepted as a flag value, so it stays
 out of the shell history and out of the process table. On a pipe it is read from stdin whole,
 with no confirmation round a script cannot answer.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -671,6 +671,11 @@ A file with no version stored at or before the cutoff is **reported, not
 skipped silently**, and counts toward the skipped total. Treat that list as the
 work still outstanding: those files have no pre-incident copy in the backup.
 
+The exit code follows the same contract as snapshot `restore`: `0` when every
+file was rolled back, `2` when files were skipped, and `1` when any restore
+errored. A scripted rollback that only checks for `0` therefore sees the
+difference between a clean run and one that recovered nothing.
+
 ::: details Why Atlas uploads its own bytes instead of calling Graph
 Microsoft Graph can promote a previous version in place with `restoreVersion`,
 and Atlas deliberately does not use it. That call only works on a version the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -967,6 +967,55 @@ atlas stats --json                     # raw JSON output
 
 Only one of `--mailbox`, `--owner`, or `--site` may be used at a time; each scopes the output to its service. OneDrive and SharePoint sections list per-owner and per-site rollups (snapshots, files, size, last backup time) sorted by size descending, so the heaviest consumers surface first. `--owner` accepts an email (resolved via Graph to the owner object ID) or a raw object ID; `--site` accepts a site URL or composite site ID. Use `--json` for programmatic consumption in monitoring scripts or dashboards. With multiple services the payload is an object keyed by service name, with a single service it is that service's stats object.
 
+## `atlas keys`
+
+Manage the tenant data key. One verb so far.
+
+```bash
+atlas keys rewrap                       # re-wrap under the configured passphrase, current KDF parameters
+atlas keys rewrap --new-passphrase      # prompt for a new passphrase, twice, with no echo
+atlas keys rewrap --new-passphrase < secret.txt   # non-interactive, for a scripted rotation
+```
+
+| Subcommand      | Description                                                                    |
+| --------------- | ------------------------------------------------------------------------------ |
+| `keys rewrap`   | Re-wrap `_meta/dek.enc` under a new passphrase, current KDF parameters, or both |
+
+| Option              | Description                                                                       |
+| ------------------- | ----------------------------------------------------------------------------------- |
+| `--new-passphrase`  | Prompt for a new passphrase; omit to re-wrap under the configured one              |
+| `-t, --tenant <id>` | Override tenant ID from config                                                     |
+
+The data key itself does not change. Nothing in the bucket is re-encrypted, every existing
+snapshot stays readable, and the run writes exactly one object. What changes is the wrapper: the
+KEK that protects the data key is derived again, from the new passphrase and a fresh salt, under
+the current KDF parameters. A tenant bootstrapped with weaker scrypt parameters is brought
+forward by running this with no flags.
+
+:::: danger This rotates the wrapper, not the key
+If the data key or the plaintext has already been captured, re-wrapping changes nothing for the
+attacker: they do not need the passphrase any more. This is the answer to a **leaked passphrase**,
+not to a compromised bucket. The answer to that is replicating to a fresh target under a new
+passphrase and retiring the old bucket, which re-encrypts every object.
+::::
+
+The new passphrase is prompted and confirmed rather than accepted as a flag value, so it stays
+out of the shell history and out of the process table. On a pipe it is read from stdin whole,
+with no confirmation round a script cannot answer.
+
+The order is deliberate. The stored key is unwrapped with the current passphrase first, so a
+wrong one fails before anything is written. After the write the blob is read back and unwrapped
+with the new passphrase, and the run only reports success when the key that comes back is the key
+that went in: a wrapper that cannot be unwrapped is an unopenable bucket, and finding that out at
+the next backup is too late. Keep both passphrases until a read succeeds with the new one.
+
+Update `ATLAS_ENCRYPTION_PASSPHRASE`, or `atlas config set encryption.passphrase`, after the
+command succeeds. Nothing reads the new value until you do.
+
+Where a bucket holds `_meta/dek.enc` under an Object Lock retention policy, the write is refused
+until the retention expires. The command says so, along with the fact that the stored key is
+unchanged, rather than surfacing a bare access denial that reads like a credentials fault.
+
 ## `atlas config`
 
 Manage Atlas configuration in an encrypted local store, git-config style. Values are written to `~/.atlas/config.enc` (AES-256-GCM); the store key lives in the OS keyring (macOS Keychain or libsecret), so credentials never sit on disk or in the environment in plaintext. See [Configuration](../configuration.md) for precedence and [Security](../security.md) for the threat model.

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -722,6 +722,35 @@ console.log(recovery.total.status);
 | `s3Region`             | `string` | S3 region (default: `us-east-1`)                                 |
 | `encryptionPassphrase` | `string` | Must match the primary passphrase (shared encryption model)      |
 
+## Key Re-wrap
+
+```typescript
+const result = await atlas.rewrapDataKey(newPassphrase);
+
+console.log(result.passphraseChanged, result.previousKdfId, result.kdfId);
+```
+
+Re-wraps the tenant's stored data key. Called with no argument it re-wraps under the configured
+passphrase with current KDF parameters, which is how a tenant bootstrapped with weaker scrypt
+parameters is brought forward.
+
+| Field              | Type      | Description                                                    |
+| ------------------ | --------- | -------------------------------------------------------------- |
+| `tenantId`         | `string`  | Tenant whose key was re-wrapped                                |
+| `passphraseChanged`| `boolean` | False when the call re-wrapped under the configured passphrase |
+| `previousKdfId`    | `number`  | KDF the wrapper used before the call                           |
+| `kdfId`            | `number`  | KDF the new wrapper uses                                       |
+
+The data key is unchanged, so nothing in the bucket is re-encrypted and every snapshot stays
+readable. **This rotates the wrapper, not the key**: an attacker who already holds the data key
+or the plaintext is unaffected by it. Use it for a leaked passphrase, not for a compromised
+bucket.
+
+A wrong current passphrase rejects before anything is written. After the write the blob is read
+back and unwrapped before the promise resolves, so a resolved call means the tenant opens with
+the new passphrase. Update the instance configuration afterwards: nothing reads the new value
+until you do, and an instance constructed with the old passphrase will fail its next operation.
+
 ## Graph API Cost Tracking
 
 The four operations that report cost, `backup`, `restore`, `restoreMailbox` and `checkMailboxStatus`, return how many Graph API requests they made, broken down by service pool, as a `graphCost` field on the result. Other Graph-backed calls such as `listAvailableMailboxes()` do consume quota but do not carry the field, so a scheduler budgeting against `graphCost` should account for them separately:

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -746,10 +746,16 @@ readable. **This rotates the wrapper, not the key**: an attacker who already hol
 or the plaintext is unaffected by it. Use it for a leaked passphrase, not for a compromised
 bucket.
 
+Buckets are versioned and noncurrent versions expire after 30 days, so the wrapper this replaces
+stays readable until then. Someone with the old passphrase and permission to read object
+versions can still unwrap the same data key from it. Treat the rotation as complete only once
+that version is gone, or once the leaked reader's `s3:GetObjectVersion` is revoked.
+
 A wrong current passphrase rejects before anything is written. After the write the blob is read
 back and unwrapped before the promise resolves, so a resolved call means the tenant opens with
-the new passphrase. Update the instance configuration afterwards: nothing reads the new value
-until you do, and an instance constructed with the old passphrase will fail its next operation.
+the new passphrase, and a verification failure restores the previous wrapper before rejecting.
+Update the instance configuration afterwards: nothing reads the new value until you do, and an
+instance constructed with the old passphrase will fail its next operation.
 
 ## Graph API Cost Tracking
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -135,7 +135,7 @@ Throttling is already modelled for this pool (`IdentityServiceLimits`: resource 
 
 ### Argon2 KDF migration
 
-Evaluate replacing scrypt with Argon2id for KEK derivation. The versioned DEK blob format (`v1`) already includes a `kdf_id` field, making algorithm upgrades possible without breaking existing tenants. This includes building an `atlas migrate-kdf` command that re-wraps all DEK blobs under the new KDF without re-encrypting data objects.
+Evaluate replacing scrypt with Argon2id for KEK derivation. The versioned DEK blob format (`v1`) already includes a `kdf_id` field, making algorithm upgrades possible without breaking existing tenants. The command that migrates a tenant already exists: `atlas keys rewrap` re-wraps the stored key under the current default KDF without re-encrypting data objects, so what remains here is registering the strategy and deciding the default, not building the migration.
 
 ### Graph throttling and cost audit
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -43,7 +43,7 @@ Parameters used by Atlas for **new** DEK wraps:
 | Output              | 32 bytes (256 bits)            | AES-256 key length                                                                        |
 | Minimum N on unwrap | 16384                          | Blobs with weaker parameters are rejected                                                 |
 
-The **tenant-domain salt** ensures that the same passphrase and random salt produce different KEKs for different tenants. A fresh random salt is generated on every DEK wrap, so a re-wrap picks up new scrypt parameters without relying on a separate `_meta/kek_params.json` file. Atlas wraps a DEK when it first creates one, and nothing re-wraps an existing one: the parameters a tenant was bootstrapped with are the parameters it keeps.
+The **tenant-domain salt** ensures that the same passphrase and random salt produce different KEKs for different tenants. A fresh random salt is generated on every DEK wrap, including a re-wrap, so `atlas keys rewrap` picks up current scrypt parameters without relying on a separate `_meta/kek_params.json` file. Until a re-wrap runs, a tenant keeps the parameters it was bootstrapped with.
 
 The v5 SDK rejects passphrases shorter than 14 UTF-8 bytes at construction, matching the existing KDF warning threshold. Byte length is only a minimum, not an entropy guarantee: use at least five random words or 20 random characters for production. The CLI's existing passphrase handling is unchanged. Never pad or replace an existing passphrase without migrating its wrapped DEK; use the previous SDK or CLI to recover short-passphrase backups.
 
@@ -76,16 +76,31 @@ object write regardless of how large the tenant is.
 
 What it is worth is bounded by that. **It rotates the wrapper, not the key.** The threat it
 answers is a leaked passphrase: whoever holds the old one can no longer derive a KEK that opens
-the stored key. It does nothing about an attacker who already holds the DEK itself or plaintext
-they decrypted with it, because neither needs the passphrase again. For that, the answer is
-replicating to a fresh target under a new passphrase and retiring the old bucket, which
-re-encrypts every object under a new DEK.
+the current wrapper. It does nothing about an attacker who already holds the DEK itself or
+plaintext they decrypted with it, because neither needs the passphrase again. For that, the
+answer is replicating to a fresh target under a new passphrase and retiring the old bucket,
+which re-encrypts every object under a new DEK.
+
+:::: warning Revocation is not immediate on a versioned bucket
+Atlas enables bucket versioning and expires noncurrent versions after 30 days. A re-wrap writes
+a new current `_meta/dek.enc`; it does not remove the version it replaced. Until that noncurrent
+version expires, someone holding the old passphrase **and** permission to read object versions
+can still read it and unwrap the same, unchanged DEK.
+
+Treat the re-wrap as complete only once that version is gone. Where policy and Object Lock
+allow, delete the noncurrent versions of `_meta/dek.enc` explicitly; where they do not, the old
+passphrase remains a live credential for up to 30 days, and read access to object versions is
+what stands between it and the key. Revoking the leaked reader's `s3:GetObjectVersion` closes
+the window immediately.
+::::
 
 The order matters and is enforced. The stored key is unwrapped with the current passphrase
 before anything is written, so a wrong one costs nothing. After the write, the blob is read back
 and unwrapped with the new passphrase and compared against the key that went in, because a
 wrapper that cannot be unwrapped is an unopenable bucket and the next backup is too late to find
-that out. Keep both passphrases until a read succeeds with the new one.
+that out. A verification failure puts the previous wrapper back and proves it still opens before
+the error is reported, so a failed re-wrap leaves the tenant exactly as it was. Keep both
+passphrases until a read succeeds with the new one.
 
 The same command with no flags re-wraps under the configured passphrase, which is how a tenant
 bootstrapped under weaker scrypt parameters is brought forward to the current ones. Existing

--- a/docs/security.md
+++ b/docs/security.md
@@ -25,9 +25,8 @@ Envelope encryption separates the key that protects your data (DEK) from the key
 
 - The DEK is a random 256-bit key with maximum entropy -- it does not depend on passphrase strength.
 - The KEK is derived from your passphrase and only used to wrap/unwrap the DEK.
-- Changing the passphrase only has to re-encrypt the DEK wrapper, not every object in storage. The
-  blob format is built for that, but no command performs it today. Read the warning below before
-  you change `ATLAS_ENCRYPTION_PASSPHRASE` on a tenant that already has backups.
+- Changing the passphrase only re-encrypts the DEK wrapper, not every object in storage.
+  `atlas keys rewrap --new-passphrase` performs it, one `PutObject` against `_meta/dek.enc`.
 
 ### KEK Derivation: scrypt
 
@@ -57,11 +56,40 @@ The optional SDK `validate()` probe performs only S3 `HeadBucket` and Graph toke
 - **Never stored in plaintext** -- only exists in memory during a backup/restore run.
 - **Re-derived on every run**: Atlas reads `_meta/dek.enc`, derives the KEK from the passphrase, unwraps the DEK, and holds it in memory for the session.
 
-::: danger Passphrase Is Irrecoverable
-There is **no key rotation mechanism** and **no recovery path**. If you lose the passphrase, the DEK cannot be unwrapped, and all data for that tenant is permanently inaccessible. Changing the passphrase without migrating the wrapped DEK will cause GCM authentication failures when Atlas tries to unwrap `_meta/dek.enc`.
+:::: danger A lost passphrase is still irrecoverable
+There is **no recovery path**. If you lose the passphrase, the DEK cannot be unwrapped and all
+data for that tenant is permanently inaccessible. Changing `ATLAS_ENCRYPTION_PASSPHRASE` without
+re-wrapping the stored key causes GCM authentication failures on the next unwrap of
+`_meta/dek.enc`, so use `atlas keys rewrap --new-passphrase` and change the configured value only
+after it succeeds.
 
-**Treat the passphrase as critically as the data itself.** Store it in a password manager, a sealed envelope in a safe, or a secrets management system -- but never lose it.
-:::
+**Treat the passphrase as critically as the data itself.** Store it in a password manager, a
+sealed envelope in a safe, or a secrets management system, but never lose it.
+::::
+
+### Re-wrapping the data key
+
+`atlas keys rewrap` derives a new KEK, from a new passphrase or from the current KDF parameters
+with a fresh salt, and rewrites `_meta/dek.enc` under it. The DEK inside is byte-identical, so
+nothing in the bucket is re-encrypted and every existing snapshot stays readable. It is one
+object write regardless of how large the tenant is.
+
+What it is worth is bounded by that. **It rotates the wrapper, not the key.** The threat it
+answers is a leaked passphrase: whoever holds the old one can no longer derive a KEK that opens
+the stored key. It does nothing about an attacker who already holds the DEK itself or plaintext
+they decrypted with it, because neither needs the passphrase again. For that, the answer is
+replicating to a fresh target under a new passphrase and retiring the old bucket, which
+re-encrypts every object under a new DEK.
+
+The order matters and is enforced. The stored key is unwrapped with the current passphrase
+before anything is written, so a wrong one costs nothing. After the write, the blob is read back
+and unwrapped with the new passphrase and compared against the key that went in, because a
+wrapper that cannot be unwrapped is an unopenable bucket and the next backup is too late to find
+that out. Keep both passphrases until a read succeeds with the new one.
+
+The same command with no flags re-wraps under the configured passphrase, which is how a tenant
+bootstrapped under weaker scrypt parameters is brought forward to the current ones. Existing
+backups are unaffected either way.
 
 ## Encryption Details
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -136,9 +136,7 @@ Decryption errors mean the configured passphrase does not match the one used to 
 Error: Unable to unwrap DEK: incorrect passphrase or corrupted key blob
 ```
 
-The passphrase in `ATLAS_ENCRYPTION_PASSPHRASE` does not match the one used when the tenant was first initialized. The wrapped DEK (stored at `_meta/dek.enc` in the bucket) was encrypted with the original passphrase using scrypt key derivation. Changing the passphrase without re-wrapping the DEK makes all data inaccessible.
-
-There is no way to recover data if the original passphrase is lost. That is by design, because the passphrase is the root of the entire encryption chain.
+The passphrase in `ATLAS_ENCRYPTION_PASSPHRASE` does not match the one used when the tenant was first initialized. The wrapped DEK (stored at `_meta/dek.enc` in the bucket) was encrypted with the original passphrase using scrypt key derivation. Changing the passphrase without re-wrapping the DEK makes all data inaccessible: run [`atlas keys rewrap --new-passphrase`](/reference/cli#atlas-keys) with the old passphrase still configured, then change the configured value.
 
 ### Corrupted DEK blob
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-cli",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "CLI for Atlas — secure Microsoft 365 backup and restore to S3-compatible storage.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",

--- a/packages/cli/src/adapters/interrupt-gate.ts
+++ b/packages/cli/src/adapters/interrupt-gate.ts
@@ -1,0 +1,35 @@
+import { logger } from '@wisecom/atlas-core';
+
+export interface InterruptGate {
+  /** Passed to a use case as `should_interrupt`. */
+  readonly should_interrupt: () => boolean;
+  /** Removes the SIGINT listener. Always call it, in a `finally`. */
+  readonly dispose: () => void;
+}
+
+/**
+ * Turns Ctrl+C into a soft stop for a long-running command.
+ *
+ * Without one, the process dies wherever the signal lands, with exit 130 and no interrupted
+ * state recorded. The drive backups had no interrupt flag at all, so a stopped run was
+ * indistinguishable from a crash, while the Outlook backup has always stopped gracefully
+ * (issue #367).
+ *
+ * A second Ctrl+C is left to the default handler, so an operator can always force the issue.
+ */
+export function install_interrupt_gate(message: string): InterruptGate {
+  let interrupted = false;
+
+  const on_sigint = (): void => {
+    if (interrupted) return;
+    interrupted = true;
+    logger.warn(message);
+  };
+
+  process.on('SIGINT', on_sigint);
+
+  return {
+    should_interrupt: () => interrupted,
+    dispose: () => process.removeListener('SIGINT', on_sigint),
+  };
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -13,6 +13,7 @@ import { register_replicate_command } from '@/commands/replicate.command';
 import { register_rehydrate_command } from '@/commands/rehydrate.command';
 import { register_list_users_command } from '@/commands/list-users.command';
 import { register_config_command } from '@/commands/config.command';
+import { register_keys_command } from '@/commands/keys.command';
 import { handle_fatal_error } from '@/fatal-error';
 import type { Container } from 'inversify';
 
@@ -49,6 +50,7 @@ function register_commands(program: Command): void {
   register_replicate_command(program, get_container);
   register_rehydrate_command(program, get_container);
   register_list_users_command(program, get_container);
+  register_keys_command(program, get_container);
   register_config_command(program);
 }
 

--- a/packages/cli/src/commands/drive-version-restore.handlers.tsx
+++ b/packages/cli/src/commands/drive-version-restore.handlers.tsx
@@ -25,6 +25,7 @@ import { banner_title } from '@/ui/banner-title';
 import { Banner } from '@/ui/components/banner';
 import { DataTable, type TableColumn } from '@/ui/components/data-table';
 import { render_static_view } from '@/ui/render';
+import { report_skipped_items, EXIT_PARTIAL } from '@/command-run-outcome';
 
 /** Flags shared by both drives; only the scope flag differs. */
 interface VersionRestoreFlags {
@@ -161,4 +162,11 @@ async function report_version_restore(
   );
 
   if (result.interrupted) logger.warn('Run was interrupted before every version was restored.');
+
+  // Same contract as snapshot restore: skips exit 2, errors exit 1, and errors win. A scripted
+  // rollback could not tell a clean run from a total failure while this exited 0 either way
+  // (issue #362).
+  report_skipped_items(result.files_skipped, 'File');
+  if (result.interrupted) process.exitCode = EXIT_PARTIAL;
+  if (result.errors.length > 0) process.exitCode = 1;
 }

--- a/packages/cli/src/commands/keys.command.tsx
+++ b/packages/cli/src/commands/keys.command.tsx
@@ -1,0 +1,85 @@
+import type { Command } from 'commander';
+import type { Container } from 'inversify';
+import type { AtlasConfig } from '@wisecom/atlas-core';
+import { ATLAS_CONFIG_TOKEN, logger } from '@wisecom/atlas-core';
+import type { DekRewrapUseCase } from '@wisecom/atlas-types';
+import { DEK_REWRAP_USE_CASE_TOKEN } from '@wisecom/atlas-types';
+import { with_tenant } from '@/commands/shared-options';
+import { prompt_new_passphrase } from '@/utils/passphrase-prompt';
+import { banner_title } from '@/ui/banner-title';
+import { Banner } from '@/ui/components/banner';
+import { KeyValueList } from '@/ui/components/key-value-list';
+import { render_static_view } from '@/ui/render';
+
+type ContainerFactory = () => Container;
+
+interface RewrapOptions {
+  tenant?: string;
+  newPassphrase?: boolean;
+}
+
+/**
+ * Registers the `atlas keys` group.
+ *
+ * One verb so far. The group exists because a key operation is neither a workload nor
+ * configuration, and burying `rewrap` under `config` would suggest it edits a setting rather than
+ * rewriting an object in the bucket.
+ */
+export function register_keys_command(program: Command, get_container: ContainerFactory): void {
+  const group = program.command('keys').description('Manage the tenant data key');
+
+  const rewrap = group
+    .command('rewrap')
+    .description('Re-wrap the stored data key under a new passphrase or current KDF parameters')
+    .option(
+      '--new-passphrase',
+      'prompt for a new passphrase; omit to re-wrap under the configured one',
+    )
+    .addHelpText(
+      'after',
+      [
+        '',
+        'The data key itself does not change, so no stored object is re-encrypted and every',
+        'existing snapshot stays readable. This rotates the wrapper, not the key: anyone who',
+        'already holds the data key or the plaintext is unaffected.',
+        '',
+        'Set ATLAS_ENCRYPTION_PASSPHRASE to the new value after this succeeds.',
+      ].join('\n'),
+    );
+  with_tenant(rewrap).action((options: RewrapOptions) => execute_rewrap(get_container(), options));
+}
+
+async function execute_rewrap(container: Container, options: RewrapOptions): Promise<void> {
+  const tenant_id = options.tenant ?? container.get<AtlasConfig>(ATLAS_CONFIG_TOKEN).tenant_id;
+  const use_case = container.get<DekRewrapUseCase>(DEK_REWRAP_USE_CASE_TOKEN);
+
+  // Prompted before the run, so a mistyped confirmation costs nothing.
+  const new_passphrase = options.newPassphrase === true ? await prompt_new_passphrase() : undefined;
+
+  await render_static_view(<Banner title={banner_title('tenant', 'Key Re-wrap')} />);
+  const result = await use_case.rewrap_tenant_dek(tenant_id, new_passphrase);
+
+  await render_static_view(
+    <KeyValueList
+      items={[
+        { label: 'Tenant', value: result.tenant_id },
+        { label: 'Passphrase', value: result.passphrase_changed ? 'changed' : 'unchanged' },
+        {
+          label: 'KDF',
+          value:
+            result.previous_kdf_id === result.kdf_id
+              ? `${result.kdf_id} (unchanged)`
+              : `${result.previous_kdf_id} -> ${result.kdf_id}`,
+        },
+      ]}
+    />,
+  );
+
+  logger.success('Data key re-wrapped. No stored object was re-encrypted.');
+  if (result.passphrase_changed) {
+    logger.warn(
+      'Update ATLAS_ENCRYPTION_PASSPHRASE (or `atlas config set encryption.passphrase`) before ' +
+        'the next run. Keep the previous passphrase until a read succeeds with the new one.',
+    );
+  }
+}

--- a/packages/cli/src/commands/onedrive-command.handlers.tsx
+++ b/packages/cli/src/commands/onedrive-command.handlers.tsx
@@ -25,6 +25,7 @@ import { render_static_view } from '@/ui/render';
 import { create_backup_progress } from '@/ui/dashboards/backup-progress-factory';
 import { build_object_lock_request } from '@/command-object-lock';
 import { report_run_outcome, report_skipped_items } from '@/command-run-outcome';
+import { install_interrupt_gate } from '@/adapters/interrupt-gate';
 
 export interface OneDriveTenantOptions {
   tenant?: string;
@@ -117,14 +118,23 @@ export async function execute_onedrive_backup(
     </Box>,
   );
 
-  const result = await backup.backup_onedrive(tenant_id, owner.object_id, {
-    force_full: options.full ?? false,
-    ...(options.folder !== undefined ? { folder_scope: options.folder } : {}),
-    owner_email: owner.email,
-    owner_display_name: owner.display_name,
-    object_lock_request,
-    create_progress: create_backup_progress({ rate: 'files/s', extra: 'ver', row_noun: 'drive' }),
-  });
+  const gate = install_interrupt_gate(
+    '[!] Stopping after the current file; the delta cursor is not advanced for an interrupted run',
+  );
+  let result;
+  try {
+    result = await backup.backup_onedrive(tenant_id, owner.object_id, {
+      force_full: options.full ?? false,
+      ...(options.folder !== undefined ? { folder_scope: options.folder } : {}),
+      owner_email: owner.email,
+      owner_display_name: owner.display_name,
+      object_lock_request,
+      create_progress: create_backup_progress({ rate: 'files/s', extra: 'ver', row_noun: 'drive' }),
+      should_interrupt: gate.should_interrupt,
+    });
+  } finally {
+    gate.dispose();
+  }
 
   if (result.snapshot) {
     logger.success(`Snapshot ${result.snapshot.snapshot_id} created`);
@@ -153,7 +163,14 @@ export async function execute_onedrive_backup(
   } else {
     logger.error('Status: UNHEALTHY');
   }
-  report_run_outcome({ errors: result.summary.errors, warnings: result.summary.warnings }, 'file');
+  report_run_outcome(
+    {
+      errors: result.summary.errors,
+      warnings: result.summary.warnings,
+      interrupted: result.interrupted,
+    },
+    'file',
+  );
 }
 
 export async function execute_onedrive_restore(

--- a/packages/cli/src/commands/outlook-restore.handler.tsx
+++ b/packages/cli/src/commands/outlook-restore.handler.tsx
@@ -141,9 +141,17 @@ async function execute_mailbox_restore(
   await report_restore_result(result);
 }
 
-/** Prints a human-readable summary of the restore result. */
+/**
+ * Prints a human-readable summary of the restore result.
+ *
+ * Success is decided from `errors`, not from `error_count`. `error_count` counts message-level
+ * failures only, while attachment failures land in `errors`, so a run whose only casualties were
+ * attachments printed a green summary, printed no error list, and exited 0. The single-message
+ * path made it worse by hardcoding `error_count: 0` while still returning attachment errors
+ * (issue #359).
+ */
 async function report_restore_result(result: RestoreResult): Promise<void> {
-  if (result.error_count === 0 && !result.interrupted) {
+  if (result.errors.length === 0 && !result.interrupted) {
     const entries: SummaryEntry[] = [
       { label: 'messages restored', value: result.restored_count, color: 'green' },
     ];

--- a/packages/cli/src/commands/sharepoint-command.handlers.tsx
+++ b/packages/cli/src/commands/sharepoint-command.handlers.tsx
@@ -26,6 +26,7 @@ import { ResultSummary, type SummaryEntry } from '@/ui/components/result-summary
 import { render_static_view } from '@/ui/render';
 import { build_object_lock_request } from '@/command-object-lock';
 import { report_run_outcome, report_skipped_items } from '@/command-run-outcome';
+import { install_interrupt_gate } from '@/adapters/interrupt-gate';
 
 export interface SharePointTenantOptions {
   tenant?: string;
@@ -137,13 +138,22 @@ export async function execute_sharepoint_backup(
   const backup = container.get<SharePointSiteTreeBackupUseCase>(
     SHAREPOINT_SITE_TREE_BACKUP_USE_CASE_TOKEN,
   );
-  const results = await backup.backup_site_tree(tenant_id, site.site_id, {
-    force_full: options.full ?? false,
-    include_subsites: options.includeSubsites ?? false,
-    site_url: site.site_url,
-    site_display_name: site.display_name,
-    object_lock_request,
-  });
+  const gate = install_interrupt_gate(
+    '[!] Stopping after the current file; the delta cursor is not advanced for an interrupted run',
+  );
+  let results;
+  try {
+    results = await backup.backup_site_tree(tenant_id, site.site_id, {
+      force_full: options.full ?? false,
+      include_subsites: options.includeSubsites ?? false,
+      site_url: site.site_url,
+      site_display_name: site.display_name,
+      object_lock_request,
+      should_interrupt: gate.should_interrupt,
+    });
+  } finally {
+    gate.dispose();
+  }
 
   await render_static_view(<Banner title={banner_title('sharepoint', 'Backup')} />);
   if (results.length > 1) {
@@ -202,7 +212,14 @@ async function report_site_backup(result: SharePointBackupResult): Promise<void>
   // Warnings, errors, and the partial-run exit code go through the shared
   // reporter so every site's failures are attributed to that site. The overall
   // HEALTHY/UNHEALTHY verdict is the caller's, once every site has reported.
-  report_run_outcome({ errors: result.summary.errors, warnings: result.summary.warnings }, 'file');
+  report_run_outcome(
+    {
+      errors: result.summary.errors,
+      warnings: result.summary.warnings,
+      interrupted: result.interrupted,
+    },
+    'file',
+  );
 }
 
 export async function execute_sharepoint_restore(

--- a/packages/cli/src/utils/passphrase-prompt.ts
+++ b/packages/cli/src/utils/passphrase-prompt.ts
@@ -1,0 +1,59 @@
+import { createInterface, type Interface } from 'node:readline';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Reads a new passphrase without echoing it, asking twice.
+ *
+ * Never a flag value: an inline secret lands in the shell history file and is readable in the
+ * process table by any other local user while the command runs. Non-interactive stdin is read
+ * whole and used as-is, so `atlas keys rewrap --new-passphrase < secret.txt` works in a script
+ * without a confirmation round the script cannot answer.
+ *
+ * @throws Error when the two answers differ, or when the value is empty.
+ */
+export async function prompt_new_passphrase(): Promise<string> {
+  if (!process.stdin.isTTY) {
+    const piped = readFileSync(0, 'utf-8').replace(/\r?\n$/, '');
+    if (piped.length === 0) {
+      throw new Error('No passphrase on stdin. Pipe one in, or run the command interactively.');
+    }
+    return piped;
+  }
+
+  const first = await ask_hidden('New passphrase: ');
+  if (first.length === 0) throw new Error('The passphrase cannot be empty.');
+  const second = await ask_hidden('Repeat the new passphrase: ');
+  if (first !== second) throw new Error('The two passphrases do not match; nothing was changed.');
+  return first;
+}
+
+/** Prompts on a TTY with echo suppressed. */
+async function ask_hidden(prompt: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: true });
+  suppress_echo(rl, prompt);
+  try {
+    const answer = await new Promise<string>((resolve) => rl.question(prompt, resolve));
+    process.stdout.write('\n');
+    return answer.trim();
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Swaps readline's writer for one that emits the prompt and nothing else.
+ *
+ * `terminal: true` echoes every keystroke, which for a passphrase means it is on screen and in
+ * the scrollback. Node has no first-class hidden-input mode, and this is the documented way to
+ * get one from readline.
+ */
+function suppress_echo(rl: Interface, prompt: string): void {
+  const mutable = rl as unknown as {
+    _writeToOutput: (text: string) => void;
+    output: NodeJS.WriteStream;
+  };
+  const output = mutable.output;
+  mutable._writeToOutput = (text: string): void => {
+    if (text.includes(prompt)) output.write(prompt);
+  };
+}

--- a/packages/cli/src/utils/passphrase-prompt.ts
+++ b/packages/cli/src/utils/passphrase-prompt.ts
@@ -34,7 +34,10 @@ async function ask_hidden(prompt: string): Promise<string> {
   try {
     const answer = await new Promise<string>((resolve) => rl.question(prompt, resolve));
     process.stdout.write('\n');
-    return answer.trim();
+    // Not trimmed. readline already excludes the newline, so what is left is what was typed, and
+    // a passphrase with a leading or trailing space is a passphrase. Trimming it here would wrap
+    // the key with a value the operator cannot reproduce from their password manager.
+    return answer;
   } finally {
     rl.close();
   }

--- a/packages/cli/tests/unit/drive-backup-interrupt.test.ts
+++ b/packages/cli/tests/unit/drive-backup-interrupt.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { install_interrupt_gate } from '@/adapters/interrupt-gate';
+import { report_run_outcome, EXIT_PARTIAL } from '@/command-run-outcome';
+
+/**
+ * Issue #367. Only the Outlook backup wired SIGINT into its run, so Ctrl+C during a drive backup
+ * killed the process where the signal landed, with exit 130 and no interrupted state recorded.
+ * The drive handlers also never passed `interrupted` to the reporter, so even with a flag an
+ * interrupted run with no item errors would have exited 0.
+ */
+describe('the drive backup interrupt gate', () => {
+  let previous: typeof process.exitCode;
+
+  beforeEach(() => {
+    previous = process.exitCode;
+    process.exitCode = undefined;
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.exitCode = previous;
+    vi.restoreAllMocks();
+  });
+
+  it('reports not-interrupted until the signal arrives', () => {
+    const gate = install_interrupt_gate('stopping');
+    try {
+      expect(gate.should_interrupt()).toBe(false);
+      process.emit('SIGINT');
+      expect(gate.should_interrupt()).toBe(true);
+    } finally {
+      gate.dispose();
+    }
+  });
+
+  it('stops listening once disposed, so a later signal is not this run', () => {
+    const gate = install_interrupt_gate('stopping');
+    gate.dispose();
+
+    process.emit('SIGINT');
+
+    expect(gate.should_interrupt()).toBe(false);
+  });
+
+  it('exits partial for an interrupted run that had no item errors', () => {
+    report_run_outcome({ errors: [], warnings: [], interrupted: true }, 'file');
+
+    expect(process.exitCode).toBe(EXIT_PARTIAL);
+  });
+});

--- a/packages/cli/tests/unit/drive-version-restore-exit-code.test.ts
+++ b/packages/cli/tests/unit/drive-version-restore-exit-code.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Container } from 'inversify';
+import { Command } from 'commander';
+import { register_onedrive_command } from '@/commands/onedrive.command';
+import {
+  ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN,
+  USER_IDENTITY_RESOLVER_TOKEN,
+} from '@wisecom/atlas-types';
+import { ATLAS_CONFIG_TOKEN } from '@wisecom/atlas-core';
+import { EXIT_PARTIAL } from '@/command-run-outcome';
+
+/**
+ * Issue #362. `restore-version` never set an exit code, so a rollback where every file failed
+ * printed a warning and exited 0. A scripted rollback could not tell that from success.
+ */
+function make_result(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    files_restored: 1,
+    files_skipped: 0,
+    restored: [],
+    errors: [],
+    placement: 'copy',
+    interrupted: false,
+    ...overrides,
+  };
+}
+
+describe('drive restore-version exit codes', () => {
+  let container: Container;
+  let program: Command;
+  let restore_version: ReturnType<typeof vi.fn>;
+  let previous: typeof process.exitCode;
+
+  beforeEach(() => {
+    previous = process.exitCode;
+    process.exitCode = undefined;
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    restore_version = vi.fn().mockResolvedValue(make_result());
+
+    container = new Container();
+    container
+      .bind(ONEDRIVE_VERSION_RESTORE_USE_CASE_TOKEN)
+      .toConstantValue({ restore_onedrive_version: restore_version });
+    container.bind(ATLAS_CONFIG_TOKEN).toConstantValue({ tenant_id: 'tenant-1' });
+    container.bind(USER_IDENTITY_RESOLVER_TOKEN).toConstantValue({
+      resolve_user: vi
+        .fn()
+        .mockResolvedValue({ object_id: 'owner-1', user_principal_name: 'john.doe@example.com' }),
+    });
+
+    program = new Command();
+    register_onedrive_command(program, () => container);
+  });
+
+  afterEach(() => {
+    process.exitCode = previous;
+    vi.restoreAllMocks();
+  });
+
+  const run = (): Promise<unknown> =>
+    program.parseAsync(
+      ['onedrive', 'restore-version', '-o', 'john.doe@example.com', '--before', '2026-03-10'],
+      { from: 'user' },
+    );
+
+  it('exits 1 when a version restore failed', async () => {
+    restore_version.mockResolvedValue(
+      make_result({ files_restored: 0, errors: ['/Report.docx: content missing from storage'] }),
+    );
+
+    await run();
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('exits partial when files were skipped without errors', async () => {
+    restore_version.mockResolvedValue(make_result({ files_restored: 0, files_skipped: 2 }));
+
+    await run();
+
+    expect(process.exitCode).toBe(EXIT_PARTIAL);
+  });
+
+  it('reports an error over a skip when both happened', async () => {
+    restore_version.mockResolvedValue(
+      make_result({ files_skipped: 1, errors: ['/Budget.xlsx: upload refused'] }),
+    );
+
+    await run();
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('leaves a clean rollback at 0', async () => {
+    await run();
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/unit/outlook-save-restore-exit-code.test.ts
+++ b/packages/cli/tests/unit/outlook-save-restore-exit-code.test.ts
@@ -109,6 +109,34 @@ describe('outlook save and restore exit codes', () => {
     expect(process.exitCode).toBe(EXIT_PARTIAL);
   });
 
+  it('restore exits non-zero when the only failures were attachments', async () => {
+    // error_count counts message failures only. Deciding success from it printed a green
+    // summary for a message restored without its attachment (issue #359).
+    restore_snapshot.mockResolvedValue(
+      make_restore_result({
+        error_count: 0,
+        attachment_error_count: 1,
+        errors: ['message:2 attachment invoice.pdf: 403 from Graph'],
+      }),
+    );
+    await run_restore();
+    expect(process.exitCode).toBe(EXIT_PARTIAL);
+  });
+
+  it('restores a single message with the same verdict as a batch', async () => {
+    // The single-message path hardcodes error_count: 0 while still returning attachment errors.
+    restore_snapshot.mockResolvedValue(
+      make_restore_result({
+        restored_count: 1,
+        error_count: 0,
+        attachment_error_count: 1,
+        errors: ['attachment invoice.pdf: 403 from Graph'],
+      }),
+    );
+    await run_restore();
+    expect(process.exitCode).toBe(EXIT_PARTIAL);
+  });
+
   it('leaves a clean save and a clean restore at 0', async () => {
     await run_save();
     expect(process.exitCode).toBeUndefined();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-core",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/container.ts
+++ b/packages/core/src/container.ts
@@ -2,6 +2,7 @@ import { type Container } from 'inversify';
 import {
   CATALOG_USE_CASE_TOKEN,
   DELETION_USE_CASE_TOKEN,
+  DEK_REWRAP_USE_CASE_TOKEN,
   VERIFICATION_USE_CASE_TOKEN,
   STATS_USE_CASE_TOKEN,
   REPLICATION_USE_CASE_TOKEN,
@@ -16,6 +17,7 @@ import {
 } from '@wisecom/atlas-types';
 import { CatalogService } from '@/services/catalog/catalog.service';
 import { DeletionService } from '@/services/deletion/deletion.service';
+import { DekRewrapService } from '@/services/keys/dek-rewrap.service';
 import { OneDriveDeletionService } from '@/services/deletion/onedrive-deletion.service';
 import { SharePointDeletionService } from '@/services/deletion/sharepoint-deletion.service';
 import { VerificationService } from '@/services/verification/verification.service';
@@ -29,6 +31,8 @@ export function bind_core_services(container: Container): void {
   container.bind(CATALOG_USE_CASE_TOKEN).toService(CatalogService);
   container.bind(DeletionService).toSelf();
   container.bind(DELETION_USE_CASE_TOKEN).toService(DeletionService);
+  container.bind(DekRewrapService).toSelf();
+  container.bind(DEK_REWRAP_USE_CASE_TOKEN).toService(DekRewrapService);
   container.bind(OneDriveDeletionService).toSelf();
   container
     .bind<OneDriveDeletionUseCase>(ONEDRIVE_DELETION_USE_CASE_TOKEN)

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,5 +1,10 @@
 export { CatalogService } from '@/services/catalog/catalog.service';
 export { DeletionService } from '@/services/deletion/deletion.service';
+export { DekRewrapService } from '@/services/keys/dek-rewrap.service';
+export {
+  DekRewrapVerificationError,
+  DekWrapperMissingError,
+} from '@/services/keys/dek-rewrap.errors';
 export { OneDriveDeletionService } from '@/services/deletion/onedrive-deletion.service';
 export { SharePointDeletionService } from '@/services/deletion/sharepoint-deletion.service';
 export { VerificationService } from '@/services/verification/verification.service';

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -3,6 +3,7 @@ export { DeletionService } from '@/services/deletion/deletion.service';
 export { DekRewrapService } from '@/services/keys/dek-rewrap.service';
 export {
   DekRewrapVerificationError,
+  DekRewrapRollbackError,
   DekWrapperMissingError,
 } from '@/services/keys/dek-rewrap.errors';
 export { OneDriveDeletionService } from '@/services/deletion/onedrive-deletion.service';

--- a/packages/core/src/services/keys/dek-rewrap.errors.ts
+++ b/packages/core/src/services/keys/dek-rewrap.errors.ts
@@ -47,13 +47,39 @@ export class DekRewrapRollbackError extends StorageError {
 }
 
 /**
- * Names an Object Lock or permission refusal on the wrapped-key write.
+ * Names a compare-and-swap refusal on the wrapped-key write.
  *
- * A bucket that retains `_meta/dek.enc` under a governance-mode policy refuses the overwrite with
- * a bare access denial, which reads like a credentials problem and is not one (issue #374).
+ * The stored wrapper changed between this run reading it and writing it back, which means
+ * another re-wrap or a bootstrap is in flight. Overwriting it would discard whatever that run
+ * established, so this run stops instead.
+ */
+export class DekWrapperChangedError extends StorageError {
+  constructor(key: string, cause: unknown) {
+    super(
+      `${key} changed while this re-wrap was running, so the write was refused and nothing was ` +
+        `overwritten. Another re-wrap or a first backup is likely in flight against this tenant. ` +
+        `Wait for it to finish, confirm which passphrase opens the tenant, then try again.`,
+      { cause },
+    );
+  }
+}
+
+/**
+ * Classifies a failed wrapped-key write.
+ *
+ * Two cases are worth naming rather than passing through raw. A compare-and-swap refusal means
+ * something else changed the wrapper. A bucket that retains `_meta/dek.enc` under a
+ * governance-mode policy refuses the overwrite with a bare access denial, which reads like a
+ * credentials problem and is not one (issue #374).
  */
 export function describe_rewrap_write_failure(key: string, err: unknown): Error {
   const message = err instanceof Error ? err.message : String(err);
+  const name = err instanceof Error ? err.name : '';
+
+  if (name === 'PreconditionFailedError' || /precondition|412/i.test(message)) {
+    return new DekWrapperChangedError(key, err);
+  }
+
   if (!/access denied|forbidden|403|object lock|retention|WORM/i.test(message)) {
     return err instanceof Error ? err : new Error(message);
   }

--- a/packages/core/src/services/keys/dek-rewrap.errors.ts
+++ b/packages/core/src/services/keys/dek-rewrap.errors.ts
@@ -27,6 +27,26 @@ export class DekRewrapVerificationError extends StorageError {
 }
 
 /**
+ * Thrown when the re-wrap failed verification and the previous wrapper could not be put back.
+ *
+ * This is the one state where the operator has to act immediately, so the message says what is
+ * in the bucket rather than only what went wrong.
+ */
+export class DekRewrapRollbackError extends StorageError {
+  constructor(key: string, verification_cause: unknown, restore_cause: unknown) {
+    const verification = verification_cause instanceof Error ? verification_cause.message : '';
+    const restore = restore_cause instanceof Error ? restore_cause.message : String(restore_cause);
+    super(
+      `Re-wrap failed verification (${verification}) and the previous wrapper could not be ` +
+        `restored (${restore}). ${key} is now in an unknown state: do not discard either ` +
+        `passphrase, and check whether the object opens with one of them before running anything ` +
+        `else against this tenant.`,
+      { cause: restore_cause },
+    );
+  }
+}
+
+/**
  * Names an Object Lock or permission refusal on the wrapped-key write.
  *
  * A bucket that retains `_meta/dek.enc` under a governance-mode policy refuses the overwrite with

--- a/packages/core/src/services/keys/dek-rewrap.errors.ts
+++ b/packages/core/src/services/keys/dek-rewrap.errors.ts
@@ -1,0 +1,48 @@
+import { ConfigError, StorageError } from '@wisecom/atlas-types';
+
+/** Thrown when a tenant has no wrapped key to re-wrap. */
+export class DekWrapperMissingError extends ConfigError {
+  constructor(tenant_id: string, key: string) {
+    super(
+      `Tenant ${tenant_id} has no wrapped data key at ${key}, so there is nothing to re-wrap. ` +
+        `A key is written when the tenant is first backed up.`,
+    );
+  }
+}
+
+/**
+ * Thrown when the blob that was just written does not open to the key that was stored.
+ *
+ * The previous wrapper is gone by this point, so the message has to say what state the bucket is
+ * in rather than only what failed.
+ */
+export class DekRewrapVerificationError extends StorageError {
+  constructor(reason: string, cause?: unknown) {
+    super(
+      `Re-wrap verification failed: ${reason}. The tenant may now be openable only with the ` +
+        `passphrase this run was given; do not discard either passphrase until a read succeeds.`,
+      cause === undefined ? undefined : { cause },
+    );
+  }
+}
+
+/**
+ * Names an Object Lock or permission refusal on the wrapped-key write.
+ *
+ * A bucket that retains `_meta/dek.enc` under a governance-mode policy refuses the overwrite with
+ * a bare access denial, which reads like a credentials problem and is not one (issue #374).
+ */
+export function describe_rewrap_write_failure(key: string, err: unknown): Error {
+  const message = err instanceof Error ? err.message : String(err);
+  if (!/access denied|forbidden|403|object lock|retention|WORM/i.test(message)) {
+    return err instanceof Error ? err : new Error(message);
+  }
+
+  return new StorageError(
+    `Could not overwrite ${key}: ${message}. A bucket that holds the wrapped key under an ` +
+      `Object Lock retention policy refuses the write until the retention expires, and the ` +
+      `credentials in use need s3:PutObject on that key. The stored key is unchanged and the ` +
+      `tenant still opens with the passphrase it had.`,
+    { cause: err },
+  );
+}

--- a/packages/core/src/services/keys/dek-rewrap.service.ts
+++ b/packages/core/src/services/keys/dek-rewrap.service.ts
@@ -8,6 +8,7 @@ import { ATLAS_CONFIG_TOKEN, type AtlasConfig } from '@/utils/config';
 import { logger } from '@/utils/logger';
 import {
   DekRewrapVerificationError,
+  DekRewrapRollbackError,
   DekWrapperMissingError,
   describe_rewrap_write_failure,
 } from '@/services/keys/dek-rewrap.errors';
@@ -51,7 +52,16 @@ export class DekRewrapService implements DekRewrapUseCase {
         throw describe_rewrap_write_failure(DEK_KEY, err);
       }
 
-      assert_rewrap_opens(await storage.get(DEK_KEY), next, tenant_id, dek);
+      try {
+        assert_rewrap_opens(await storage.get(DEK_KEY), next, tenant_id, dek);
+      } catch (err) {
+        // The only wrapper has already been overwritten at this point, so a verification failure
+        // without a rollback leaves the tenant unopenable. Put the blob that was read at the
+        // start back, prove it still opens with the passphrase the operator already has, and
+        // only then report the original failure.
+        await restore_previous_wrapper(storage, stored, current, tenant_id, err);
+        throw err;
+      }
 
       logger.info(`Re-wrapped the data key for ${tenant_id}; no data object was touched`);
       return {
@@ -89,5 +99,31 @@ function assert_rewrap_opens(
 
   if (read_back.length !== expected_dek.length || !timingSafeEqual(read_back, expected_dek)) {
     throw new DekRewrapVerificationError('the re-wrapped key is not the key that was stored');
+  }
+}
+
+/**
+ * Puts the wrapper that was read at the start back, and proves it still opens.
+ *
+ * Rollback is best effort by nature: the storage that just failed verification is the storage
+ * being asked to accept the restore. When that fails too, the thrown error names both, because
+ * an operator whose only wrapper is in an unknown state needs to know that before anything else.
+ */
+async function restore_previous_wrapper(
+  storage: { put(key: string, body: Buffer): Promise<void>; get(key: string): Promise<Buffer> },
+  previous: Buffer,
+  current: EnvelopeKeyService,
+  tenant_id: string,
+  cause: unknown,
+): Promise<void> {
+  try {
+    await storage.put(DEK_KEY, previous);
+    current.unwrap_dek(await storage.get(DEK_KEY), tenant_id);
+    logger.warn(
+      `Re-wrap failed verification for ${tenant_id}; restored the previous wrapper, which still ` +
+        `opens with the passphrase in use. Nothing changed.`,
+    );
+  } catch (restore_err) {
+    throw new DekRewrapRollbackError(DEK_KEY, cause, restore_err);
   }
 }

--- a/packages/core/src/services/keys/dek-rewrap.service.ts
+++ b/packages/core/src/services/keys/dek-rewrap.service.ts
@@ -1,0 +1,93 @@
+import { timingSafeEqual } from 'node:crypto';
+import { inject, injectable } from 'inversify';
+import type { DekRewrapResult, DekRewrapUseCase, TenantContextFactory } from '@wisecom/atlas-types';
+import { TENANT_CONTEXT_FACTORY_TOKEN } from '@wisecom/atlas-types';
+import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
+import { parse_dek_blob } from '@/adapters/keystore/dek-blob-codec';
+import { ATLAS_CONFIG_TOKEN, type AtlasConfig } from '@/utils/config';
+import { logger } from '@/utils/logger';
+import {
+  DekRewrapVerificationError,
+  DekWrapperMissingError,
+  describe_rewrap_write_failure,
+} from '@/services/keys/dek-rewrap.errors';
+
+const DEK_KEY = '_meta/dek.enc';
+
+/**
+ * Re-wraps a tenant's stored DEK under a new passphrase, new KDF parameters, or both.
+ *
+ * The DEK itself never changes, so no data object is touched and every existing snapshot stays
+ * readable. That also bounds what this is worth: it rotates the wrapper, not the key. Anyone who
+ * already holds the DEK or the plaintext is unaffected, and the only answer to that is
+ * re-encrypting the bucket (issue #374).
+ */
+@injectable()
+export class DekRewrapService implements DekRewrapUseCase {
+  constructor(
+    @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
+    @inject(ATLAS_CONFIG_TOKEN) private readonly _config: AtlasConfig,
+  ) {}
+
+  /** Unwraps with the current passphrase, wraps with the next, then proves the result opens. */
+  async rewrap_tenant_dek(tenant_id: string, new_passphrase?: string): Promise<DekRewrapResult> {
+    const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
+    if (!(await storage.exists(DEK_KEY))) throw new DekWrapperMissingError(tenant_id, DEK_KEY);
+
+    const stored = await storage.get(DEK_KEY);
+    const current = new EnvelopeKeyService(this._config.encryption_passphrase);
+    const next = new EnvelopeKeyService(new_passphrase ?? this._config.encryption_passphrase);
+
+    try {
+      // A wrong current passphrase fails here, before anything is written. `unwrap_dek` raises
+      // WrongPassphraseError, which already says what to check.
+      const dek = current.unwrap_dek(stored, tenant_id);
+      const previous_kdf_id = parse_dek_blob(stored).header.kdf_id;
+
+      const rewrapped = next.wrap_dek(dek, tenant_id);
+      try {
+        await storage.put(DEK_KEY, rewrapped);
+      } catch (err) {
+        throw describe_rewrap_write_failure(DEK_KEY, err);
+      }
+
+      assert_rewrap_opens(await storage.get(DEK_KEY), next, tenant_id, dek);
+
+      logger.info(`Re-wrapped the data key for ${tenant_id}; no data object was touched`);
+      return {
+        tenant_id,
+        previous_kdf_id,
+        kdf_id: parse_dek_blob(rewrapped).header.kdf_id,
+        passphrase_changed: new_passphrase !== undefined,
+      };
+    } finally {
+      current.destroy();
+      next.destroy();
+    }
+  }
+}
+
+/**
+ * Proves the blob that was just written opens to the same key.
+ *
+ * `create_dek_exclusively` reads back on bootstrap for this reason, and it matters more here: a
+ * wrap that cannot be unwrapped is an unopenable bucket, and the operator would find out at the
+ * next backup rather than now.
+ */
+function assert_rewrap_opens(
+  written: Buffer,
+  next: EnvelopeKeyService,
+  tenant_id: string,
+  expected_dek: Buffer,
+): void {
+  let read_back: Buffer;
+  try {
+    read_back = next.unwrap_dek(written, tenant_id);
+  } catch (err) {
+    throw new DekRewrapVerificationError('the new wrapper could not be unwrapped', err);
+  }
+
+  if (read_back.length !== expected_dek.length || !timingSafeEqual(read_back, expected_dek)) {
+    throw new DekRewrapVerificationError('the re-wrapped key is not the key that was stored');
+  }
+}

--- a/packages/core/src/services/keys/dek-rewrap.service.ts
+++ b/packages/core/src/services/keys/dek-rewrap.service.ts
@@ -1,7 +1,12 @@
 import { timingSafeEqual } from 'node:crypto';
 import { inject, injectable } from 'inversify';
-import type { DekRewrapResult, DekRewrapUseCase, TenantContextFactory } from '@wisecom/atlas-types';
-import { TENANT_CONTEXT_FACTORY_TOKEN } from '@wisecom/atlas-types';
+import type {
+  DekRewrapResult,
+  DekRewrapUseCase,
+  ObjectStorage,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { ConfigError, TENANT_CONTEXT_FACTORY_TOKEN } from '@wisecom/atlas-types';
 import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
 import { parse_dek_blob } from '@/adapters/keystore/dek-blob-codec';
 import { ATLAS_CONFIG_TOKEN, type AtlasConfig } from '@/utils/config';
@@ -9,11 +14,15 @@ import { logger } from '@/utils/logger';
 import {
   DekRewrapVerificationError,
   DekRewrapRollbackError,
+  DekWrapperChangedError,
   DekWrapperMissingError,
   describe_rewrap_write_failure,
 } from '@/services/keys/dek-rewrap.errors';
 
 const DEK_KEY = '_meta/dek.enc';
+
+/** Matches the minimum `createAtlasInstance` enforces on `encryptionPassphrase` (issue #45). */
+const MIN_PASSPHRASE_BYTES = 14;
 
 /**
  * Re-wraps a tenant's stored DEK under a new passphrase, new KDF parameters, or both.
@@ -32,10 +41,19 @@ export class DekRewrapService implements DekRewrapUseCase {
 
   /** Unwraps with the current passphrase, wraps with the next, then proves the result opens. */
   async rewrap_tenant_dek(tenant_id: string, new_passphrase?: string): Promise<DekRewrapResult> {
+    if (new_passphrase !== undefined) assert_usable_passphrase(new_passphrase);
+
     const { storage } = await this._tenant_factory.create_storage_only(tenant_id);
     if (!(await storage.exists(DEK_KEY))) throw new DekWrapperMissingError(tenant_id, DEK_KEY);
 
-    const stored = await storage.get(DEK_KEY);
+    // Read the ETag with the blob: every write below is a compare-and-swap against it, so a
+    // second re-wrap running at the same time is refused rather than silently overwritten.
+    //
+    // Defence in depth, not the guarantee. This is the first conditional write in the codebase,
+    // and an S3-compatible backend that ignores `If-Match` degrades it to a plain overwrite. The
+    // classification below is what actually keeps a concurrent run's wrapper safe, and it needs
+    // no backend support.
+    const { data: stored, etag: stored_etag } = await storage.get_with_etag(DEK_KEY);
     const current = new EnvelopeKeyService(this._config.encryption_passphrase);
     const next = new EnvelopeKeyService(new_passphrase ?? this._config.encryption_passphrase);
 
@@ -47,27 +65,39 @@ export class DekRewrapService implements DekRewrapUseCase {
 
       const rewrapped = next.wrap_dek(dek, tenant_id);
       try {
-        await storage.put(DEK_KEY, rewrapped);
+        await storage.put(DEK_KEY, rewrapped, undefined, undefined, stored_etag);
       } catch (err) {
         throw describe_rewrap_write_failure(DEK_KEY, err);
       }
 
-      try {
-        assert_rewrap_opens(await storage.get(DEK_KEY), next, tenant_id, dek);
-      } catch (err) {
-        // The only wrapper has already been overwritten at this point, so a verification failure
-        // without a rollback leaves the tenant unopenable. Put the blob that was read at the
-        // start back, prove it still opens with the passphrase the operator already has, and
-        // only then report the original failure.
-        await restore_previous_wrapper(storage, stored, current, tenant_id, err);
-        throw err;
+      // Verify what is actually stored, not what was sent, and decide from that.
+      //
+      // Rolling back on any verification failure is wrong: the reason the stored blob is not
+      // ours may be that a concurrent re-wrap won the race, and overwriting a working wrapper
+      // someone else just established is worse than the failure being reported. So the stored
+      // blob is classified first, and only a blob nobody can open is replaced.
+      const written = await storage.get_with_etag(DEK_KEY);
+      const verdict = classify_written_wrapper(written.data, rewrapped, current, next, tenant_id);
+
+      if (verdict === 'foreign') {
+        throw new DekWrapperChangedError(DEK_KEY, undefined);
       }
+      if (verdict === 'unusable') {
+        // Nobody can open what is there, so putting the previous wrapper back is strictly an
+        // improvement. Conditional on its ETag, so a writer arriving in between still wins.
+        await restore_previous_wrapper(storage, stored, written.etag, current, tenant_id);
+        throw new DekRewrapVerificationError(
+          'the stored wrapper opened with neither passphrase; the previous one was restored',
+        );
+      }
+
+      assert_rewrap_opens(written.data, next, tenant_id, dek);
 
       logger.info(`Re-wrapped the data key for ${tenant_id}; no data object was touched`);
       return {
         tenant_id,
         previous_kdf_id,
-        kdf_id: parse_dek_blob(rewrapped).header.kdf_id,
+        kdf_id: parse_dek_blob(written.data).header.kdf_id,
         passphrase_changed: new_passphrase !== undefined,
       };
     } finally {
@@ -103,27 +133,81 @@ function assert_rewrap_opens(
 }
 
 /**
+ * Decides what the blob now at the wrapped-key path actually is.
+ *
+ * `ours` is the byte-identical copy of what this run wrote. `foreign` opens with one of the two
+ * passphrases but is not ours, which means another run wrote it and it must be left alone.
+ * `unusable` opens with neither, so it is garbage nobody can back out of and replacing it can
+ * only improve matters.
+ */
+function classify_written_wrapper(
+  written: Buffer,
+  rewrapped: Buffer,
+  current: EnvelopeKeyService,
+  next: EnvelopeKeyService,
+  tenant_id: string,
+): 'ours' | 'foreign' | 'unusable' {
+  if (written.equals(rewrapped)) return 'ours';
+  return opens(written, current, tenant_id) || opens(written, next, tenant_id)
+    ? 'foreign'
+    : 'unusable';
+}
+
+/** Whether this key service can unwrap the blob at all. */
+function opens(blob: Buffer, keys: EnvelopeKeyService, tenant_id: string): boolean {
+  try {
+    keys.unwrap_dek(blob, tenant_id);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Puts the wrapper that was read at the start back, and proves it still opens.
  *
- * Rollback is best effort by nature: the storage that just failed verification is the storage
- * being asked to accept the restore. When that fails too, the thrown error names both, because
- * an operator whose only wrapper is in an unknown state needs to know that before anything else.
+ * Conditional on the ETag of the unusable blob, so a writer arriving between the classification
+ * and this write still wins: whatever they established is newer than what this run knows.
+ *
+ * Rollback is best effort by nature, because the storage being asked to accept the restore is
+ * the storage that just produced an unopenable object. When it fails too, the thrown error
+ * names both, since an operator whose only wrapper is in an unknown state needs that first.
  */
 async function restore_previous_wrapper(
-  storage: { put(key: string, body: Buffer): Promise<void>; get(key: string): Promise<Buffer> },
+  storage: ObjectStorage,
   previous: Buffer,
+  unusable_etag: string,
   current: EnvelopeKeyService,
   tenant_id: string,
-  cause: unknown,
 ): Promise<void> {
   try {
-    await storage.put(DEK_KEY, previous);
+    await storage.put(DEK_KEY, previous, undefined, undefined, unusable_etag);
     current.unwrap_dek(await storage.get(DEK_KEY), tenant_id);
     logger.warn(
-      `Re-wrap failed verification for ${tenant_id}; restored the previous wrapper, which still ` +
-        `opens with the passphrase in use. Nothing changed.`,
+      `Re-wrap produced an unopenable wrapper for ${tenant_id}; restored the previous one, ` +
+        `which still opens with the passphrase in use. Nothing changed.`,
     );
   } catch (restore_err) {
-    throw new DekRewrapRollbackError(DEK_KEY, cause, restore_err);
+    throw new DekRewrapRollbackError(
+      DEK_KEY,
+      'the stored wrapper opened with neither passphrase',
+      restore_err,
+    );
+  }
+}
+
+/**
+ * Rejects a new passphrase the SDK would refuse at construction.
+ *
+ * `createAtlasInstance` enforces 14 UTF-8 bytes, and `rewrapDataKey` reaches the wrap without
+ * passing through it: an empty string would otherwise wrap the tenant key under an empty
+ * passphrase, which is the one outcome this command must never produce.
+ */
+function assert_usable_passphrase(passphrase: string): void {
+  if (Buffer.byteLength(passphrase, 'utf8') < MIN_PASSPHRASE_BYTES) {
+    throw new ConfigError(
+      `The new passphrase must contain at least ${MIN_PASSPHRASE_BYTES} UTF-8 bytes. ` +
+        `Nothing was changed.`,
+    );
   }
 }

--- a/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
+++ b/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WrongPassphraseError } from '@wisecom/atlas-types';
+import type { TenantContextFactory } from '@wisecom/atlas-types';
+import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
+import { DekRewrapService } from '@/services/keys/dek-rewrap.service';
+import { DekWrapperMissingError } from '@/services/keys/dek-rewrap.errors';
+import type { AtlasConfig } from '@/utils/config';
+
+/**
+ * Issue #374. Nothing re-wrapped an existing DEK, so a leaked passphrase was permanent and the
+ * KDF parameters a tenant was bootstrapped with were the ones it kept. The DEK must come through
+ * byte-identical, because a new one over an existing bucket makes every stored object
+ * unreadable.
+ */
+
+const TENANT = 'tenant-1';
+const OLD_PASSPHRASE = 'the-original-passphrase';
+const NEW_PASSPHRASE = 'a-different-passphrase';
+const DEK_KEY = '_meta/dek.enc';
+
+function make_config(passphrase: string): AtlasConfig {
+  return {
+    tenant_id: TENANT,
+    client_id: 'client-1',
+    client_secret: 'secret-1',
+    s3_endpoint: 'http://primary:9000',
+    s3_access_key: 'access',
+    s3_secret_key: 'secret',
+    s3_region: 'us-east-1',
+    encryption_passphrase: passphrase,
+  };
+}
+
+interface Harness {
+  service: DekRewrapService;
+  objects: Map<string, Buffer>;
+  dek: Buffer;
+}
+
+/** A bucket holding one wrapped DEK, written with `OLD_PASSPHRASE`. */
+function make_harness(
+  options: { config_passphrase?: string; seed?: boolean; serve_after_write?: Buffer } = {},
+): Harness {
+  const writer = new EnvelopeKeyService(OLD_PASSPHRASE);
+  const dek = writer.generate_dek();
+  const objects = new Map<string, Buffer>();
+  if (options.seed !== false) objects.set(DEK_KEY, writer.wrap_dek(dek, TENANT));
+  let written = false;
+
+  const storage = {
+    exists: vi.fn(async (key: string) => objects.has(key)),
+    get: vi.fn(async (key: string) => {
+      if (written && options.serve_after_write) return options.serve_after_write;
+      const found = objects.get(key);
+      if (!found) throw new Error(`NoSuchKey: ${key}`);
+      return found;
+    }),
+    put: vi.fn(async (key: string, body: Buffer) => {
+      written = true;
+      objects.set(key, body);
+    }),
+  };
+
+  const factory = {
+    create_storage_only: vi.fn().mockResolvedValue({ tenant_id: TENANT, storage }),
+    create: vi.fn(),
+    create_readonly: vi.fn(),
+  } as unknown as TenantContextFactory;
+
+  return {
+    service: new DekRewrapService(
+      factory,
+      make_config(options.config_passphrase ?? OLD_PASSPHRASE),
+    ),
+    objects,
+    dek,
+  };
+}
+
+describe('re-wrapping a tenant data key', () => {
+  it('round-trips: the new passphrase opens the same key', async () => {
+    const { service, objects, dek } = make_harness();
+
+    const result = await service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE);
+
+    expect(result.passphrase_changed).toBe(true);
+    const reader = new EnvelopeKeyService(NEW_PASSPHRASE);
+    expect(reader.unwrap_dek(objects.get(DEK_KEY)!, TENANT)).toEqual(dek);
+  });
+
+  it('leaves the old passphrase unable to open it', async () => {
+    const { service, objects } = make_harness();
+
+    await service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE);
+
+    const stale = new EnvelopeKeyService(OLD_PASSPHRASE);
+    expect(() => stale.unwrap_dek(objects.get(DEK_KEY)!, TENANT)).toThrow(WrongPassphraseError);
+  });
+
+  it('re-wraps under the configured passphrase with a fresh salt when none is given', async () => {
+    const { service, objects, dek } = make_harness();
+    const before = objects.get(DEK_KEY)!;
+
+    const result = await service.rewrap_tenant_dek(TENANT);
+
+    expect(result.passphrase_changed).toBe(false);
+    const after = objects.get(DEK_KEY)!;
+    // A different blob, because the salt is fresh, holding the same key.
+    expect(after.equals(before)).toBe(false);
+    expect(new EnvelopeKeyService(OLD_PASSPHRASE).unwrap_dek(after, TENANT)).toEqual(dek);
+  });
+
+  it('refuses, and writes nothing, when the current passphrase is wrong', async () => {
+    const { service, objects } = make_harness({ config_passphrase: 'not-the-passphrase' });
+    const before = objects.get(DEK_KEY)!;
+
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toBeInstanceOf(
+      WrongPassphraseError,
+    );
+    expect(objects.get(DEK_KEY)).toBe(before);
+  });
+
+  it('refuses when the tenant has no wrapped key', async () => {
+    const { service } = make_harness({ seed: false });
+
+    await expect(service.rewrap_tenant_dek(TENANT)).rejects.toBeInstanceOf(DekWrapperMissingError);
+  });
+
+  it('fails loudly when the blob read back is not the key that was stored', async () => {
+    // Storage accepts the write and serves a different blob back. The read-back check exists for
+    // exactly this: the alternative is an unopenable bucket discovered at the next backup.
+    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
+    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
+    const { service } = make_harness({ serve_after_write: foreign });
+
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
+      /Re-wrap verification failed/,
+    );
+  });
+});

--- a/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
+++ b/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
@@ -1,9 +1,10 @@
+import { createHash } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { WrongPassphraseError } from '@wisecom/atlas-types';
 import type { TenantContextFactory } from '@wisecom/atlas-types';
 import { EnvelopeKeyService } from '@/adapters/keystore/envelope-key-service.adapter';
 import { DekRewrapService } from '@/services/keys/dek-rewrap.service';
-import { DekWrapperMissingError } from '@/services/keys/dek-rewrap.errors';
+import { DekWrapperChangedError, DekWrapperMissingError } from '@/services/keys/dek-rewrap.errors';
 import type { AtlasConfig } from '@/utils/config';
 
 /**
@@ -42,8 +43,14 @@ function make_harness(
   options: {
     config_passphrase?: string;
     seed?: boolean;
-    /** Served by `get` after the first write, to fake a storage that returns the wrong blob. */
-    serve_after_write?: Buffer;
+    /**
+     * Stored instead of the bytes the first write sends, which is how a concurrent writer or a
+     * backend that mangles a write looks from the caller's side. ETags stay consistent with what
+     * is stored, the way S3 behaves.
+     */
+    store_instead?: Buffer;
+    /** Stored right after this run's first read, so its compare-and-swap must fail. */
+    rival_after_read?: Buffer;
     /** Fails the rollback write, so the bucket is left in an unknown state. */
     reject_second_put?: boolean;
   } = {},
@@ -53,22 +60,38 @@ function make_harness(
   const objects = new Map<string, Buffer>();
   if (options.seed !== false) objects.set(DEK_KEY, writer.wrap_dek(dek, TENANT));
   let writes = 0;
+  let reads = 0;
 
+  const etag_of = (body: Buffer): string => `"${createHash('md5').update(body).digest('hex')}"`;
   const storage = {
     exists: vi.fn(async (key: string) => objects.has(key)),
     get: vi.fn(async (key: string) => {
-      // The rollback read must see what the rollback wrote, not the faked blob.
-      if (writes === 1 && options.serve_after_write) return options.serve_after_write;
       const found = objects.get(key);
       if (!found) throw new Error(`NoSuchKey: ${key}`);
       return found;
     }),
-    put: vi.fn(async (key: string, body: Buffer) => {
+    get_with_etag: vi.fn(async (key: string) => {
+      const data = objects.get(key);
+      if (!data) throw new Error(`NoSuchKey: ${key}`);
+      const result = { data, etag: etag_of(data) };
+      // A rival write landing immediately after this run's read is what the compare-and-swap on
+      // the following put exists to catch.
+      if (reads === 0 && options.rival_after_read) objects.set(key, options.rival_after_read);
+      reads += 1;
+      return result;
+    }),
+    put: vi.fn(async (key: string, body: Buffer, _m?: unknown, _l?: unknown, if_match?: string) => {
+      const held = objects.get(key);
+      if (if_match !== undefined && held && if_match !== etag_of(held)) {
+        const conflict = new Error(`Conditional write failed for key ${key}`);
+        conflict.name = 'PreconditionFailedError';
+        throw conflict;
+      }
       writes += 1;
       if (writes === 2 && options.reject_second_put === true) {
         throw new Error('AccessDenied on the restore');
       }
-      objects.set(key, body);
+      objects.set(key, writes === 1 && options.store_instead ? options.store_instead : body);
     }),
   };
 
@@ -137,40 +160,63 @@ describe('re-wrapping a tenant data key', () => {
     await expect(service.rewrap_tenant_dek(TENANT)).rejects.toBeInstanceOf(DekWrapperMissingError);
   });
 
-  it('fails loudly when the blob read back is not the key that was stored', async () => {
-    // Storage accepts the write and serves a different blob back. The read-back check exists for
-    // exactly this: the alternative is an unopenable bucket discovered at the next backup.
-    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
-    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
-    const { service } = make_harness({ serve_after_write: foreign });
+  it('rejects a new passphrase the SDK would refuse at construction', async () => {
+    const { service, objects } = make_harness();
+    const before = objects.get(DEK_KEY)!;
 
-    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
-      /Re-wrap verification failed/,
-    );
+    // `createAtlasInstance` enforces 14 bytes; rewrapDataKey reaches the wrap without it, so an
+    // empty string would otherwise wrap the tenant key under an empty passphrase.
+    await expect(service.rewrap_tenant_dek(TENANT, '')).rejects.toThrow(/at least 14/);
+    expect(objects.get(DEK_KEY)).toBe(before);
   });
 
-  it('puts the previous wrapper back when verification fails, so the tenant still opens', async () => {
-    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
-    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
-    const { service, objects, dek } = make_harness({ serve_after_write: foreign });
+  it('leaves a concurrent run\u2019s wrapper alone rather than reverting it', async () => {
+    // Someone else's valid wrapper is what is stored when this run reads back. Rolling back
+    // here would silently undo their rotation and leave them believing it took.
+    const rival = new EnvelopeKeyService(NEW_PASSPHRASE);
+    const rival_blob = rival.wrap_dek(rival.generate_dek(), TENANT);
+    const { service, objects } = make_harness({ store_instead: rival_blob });
+
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toBeInstanceOf(
+      DekWrapperChangedError,
+    );
+    expect(objects.get(DEK_KEY)).toBe(rival_blob);
+  });
+
+  it('restores the previous wrapper when what landed opens with neither passphrase', async () => {
+    // A mangled write: nobody can back out of this, so putting the old wrapper back is strictly
+    // an improvement over leaving the tenant unopenable.
+    const { service, objects, dek } = make_harness({ store_instead: Buffer.from('not a wrapper') });
 
     await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
-      /Re-wrap verification failed/,
+      /opened with neither passphrase/,
     );
 
-    // The only wrapper was overwritten before verification, so without the rollback the tenant
-    // would be unopenable with either passphrase.
     const restored = new EnvelopeKeyService(OLD_PASSPHRASE);
     expect(restored.unwrap_dek(objects.get(DEK_KEY)!, TENANT)).toEqual(dek);
   });
 
-  it('names the state of the bucket when the rollback itself fails', async () => {
-    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
-    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
-    const { service } = make_harness({ serve_after_write: foreign, reject_second_put: true });
+  it('names the state of the bucket when the restore itself fails', async () => {
+    const { service } = make_harness({
+      store_instead: Buffer.from('not a wrapper'),
+      reject_second_put: true,
+    });
 
     await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
       /could not be restored/,
     );
+  });
+
+  it('refuses the write when the wrapper changed between the read and the write', async () => {
+    const rival = new EnvelopeKeyService(NEW_PASSPHRASE);
+    const rival_blob = rival.wrap_dek(rival.generate_dek(), TENANT);
+    const { service, objects } = make_harness({ rival_after_read: rival_blob });
+
+    // The read saw the original blob, so the unwrap succeeds; the compare-and-swap on the write
+    // is what catches that the object moved underneath this run.
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toBeInstanceOf(
+      DekWrapperChangedError,
+    );
+    expect(objects.get(DEK_KEY)).toBe(rival_blob);
   });
 });

--- a/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
+++ b/packages/core/tests/unit/services/keys/dek-rewrap.test.ts
@@ -39,24 +39,35 @@ interface Harness {
 
 /** A bucket holding one wrapped DEK, written with `OLD_PASSPHRASE`. */
 function make_harness(
-  options: { config_passphrase?: string; seed?: boolean; serve_after_write?: Buffer } = {},
+  options: {
+    config_passphrase?: string;
+    seed?: boolean;
+    /** Served by `get` after the first write, to fake a storage that returns the wrong blob. */
+    serve_after_write?: Buffer;
+    /** Fails the rollback write, so the bucket is left in an unknown state. */
+    reject_second_put?: boolean;
+  } = {},
 ): Harness {
   const writer = new EnvelopeKeyService(OLD_PASSPHRASE);
   const dek = writer.generate_dek();
   const objects = new Map<string, Buffer>();
   if (options.seed !== false) objects.set(DEK_KEY, writer.wrap_dek(dek, TENANT));
-  let written = false;
+  let writes = 0;
 
   const storage = {
     exists: vi.fn(async (key: string) => objects.has(key)),
     get: vi.fn(async (key: string) => {
-      if (written && options.serve_after_write) return options.serve_after_write;
+      // The rollback read must see what the rollback wrote, not the faked blob.
+      if (writes === 1 && options.serve_after_write) return options.serve_after_write;
       const found = objects.get(key);
       if (!found) throw new Error(`NoSuchKey: ${key}`);
       return found;
     }),
     put: vi.fn(async (key: string, body: Buffer) => {
-      written = true;
+      writes += 1;
+      if (writes === 2 && options.reject_second_put === true) {
+        throw new Error('AccessDenied on the restore');
+      }
       objects.set(key, body);
     }),
   };
@@ -135,6 +146,31 @@ describe('re-wrapping a tenant data key', () => {
 
     await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
       /Re-wrap verification failed/,
+    );
+  });
+
+  it('puts the previous wrapper back when verification fails, so the tenant still opens', async () => {
+    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
+    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
+    const { service, objects, dek } = make_harness({ serve_after_write: foreign });
+
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
+      /Re-wrap verification failed/,
+    );
+
+    // The only wrapper was overwritten before verification, so without the rollback the tenant
+    // would be unopenable with either passphrase.
+    const restored = new EnvelopeKeyService(OLD_PASSPHRASE);
+    expect(restored.unwrap_dek(objects.get(DEK_KEY)!, TENANT)).toEqual(dek);
+  });
+
+  it('names the state of the bucket when the rollback itself fails', async () => {
+    const foreign_writer = new EnvelopeKeyService(NEW_PASSPHRASE);
+    const foreign = foreign_writer.wrap_dek(foreign_writer.generate_dek(), TENANT);
+    const { service } = make_harness({ serve_after_write: foreign, reject_second_put: true });
+
+    await expect(service.rewrap_tenant_dek(TENANT, NEW_PASSPHRASE)).rejects.toThrow(
+      /could not be restored/,
     );
   });
 });

--- a/packages/drive/package.json
+++ b/packages/drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-drive",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/m365-graph/package.json
+++ b/packages/m365-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-m365-graph",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/onedrive/package.json
+++ b/packages/onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-onedrive",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/onedrive/src/adapters/graph-onedrive-connector-stream.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-connector-stream.ts
@@ -1,6 +1,7 @@
 import type { Readable } from 'node:stream';
 
 import { compute_chunk_timeout_ms } from '@/adapters/graph-onedrive-chunked-download';
+import { assert_transferred_size } from '@wisecom/atlas-drive/backup/download-integrity';
 
 /**
  * Drains a readable stream into a buffer with a wall-clock timeout.
@@ -56,7 +57,13 @@ export async function with_timeout<T>(
   }
 }
 
-/** Downloads a pre-authenticated OneDrive URL into a buffer. */
+/**
+ * Downloads a pre-authenticated OneDrive URL into a buffer.
+ *
+ * The byte count is checked against the size the delta recorded, so a well-framed 200 carrying
+ * the wrong body cannot be hashed, encrypted and written with a checksum that matches those
+ * wrong bytes. #338 closed this for the chunked path and left the buffered one open (issue #368).
+ */
 export async function download_from_url(
   download_url: string,
   size_bytes: number,
@@ -70,7 +77,9 @@ export async function download_from_url(
     if (!response.ok) {
       throw new Error(`Failed to download OneDrive file ${item_id}: HTTP ${response.status}`);
     }
-    return Buffer.from(await response.arrayBuffer());
+    const body = Buffer.from(await response.arrayBuffer());
+    assert_transferred_size(item_id, body.length, size_bytes);
+    return body;
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/onedrive/src/adapters/graph-onedrive-download-executor.ts
+++ b/packages/onedrive/src/adapters/graph-onedrive-download-executor.ts
@@ -19,6 +19,7 @@ import {
   DownloadRefusedError,
   MissingGraphPermissionsError,
 } from '@wisecom/atlas-m365-graph';
+import { assert_transferred_size } from '@wisecom/atlas-drive/backup/download-integrity';
 
 interface GraphDriveItemDownload {
   '@microsoft.graph.downloadUrl'?: string;
@@ -130,7 +131,13 @@ export async function download_with_fallback(
   );
 }
 
-/** Downloads via the Graph /content endpoint with stream drain. */
+/**
+ * Downloads via the Graph /content endpoint with stream drain.
+ *
+ * The drained byte count is checked against the recorded size for the same reason the chunked
+ * path checks it: a complete-looking body of the wrong length would otherwise be stored with a
+ * checksum computed over those wrong bytes (issue #368).
+ */
 export async function download_via_graph_content(
   client: Client,
   item: OneDriveDeltaItem,
@@ -147,7 +154,9 @@ export async function download_via_graph_content(
     `Graph content request timed out for file ${item.item_id}`,
   );
   const drain_timeout_ms = compute_chunk_timeout_ms(item.size_bytes) * 2;
-  return await stream_to_buffer(stream, drain_timeout_ms);
+  const body = await stream_to_buffer(stream, drain_timeout_ms);
+  assert_transferred_size(item.item_id, body.length, item.size_bytes);
+  return body;
 }
 
 /**

--- a/packages/onedrive/src/services/backup/backup-file-processor.ts
+++ b/packages/onedrive/src/services/backup/backup-file-processor.ts
@@ -24,11 +24,3 @@ export async function process_backup_file(
     abort_signal,
   );
 }
-
-/** @throws Error when no drives are returned (likely missing Graph permissions). */
-export function ensure_drives_discovered(drive_count: number): void {
-  if (drive_count > 0) return;
-  throw new Error(
-    'Missing Microsoft Graph application permissions for OneDrive: Files.Read.All, Sites.Read.All.',
-  );
-}

--- a/packages/onedrive/src/services/backup/backup.service.ts
+++ b/packages/onedrive/src/services/backup/backup.service.ts
@@ -38,7 +38,6 @@ import {
   persist_snapshot_backup,
 } from '@/services/backup/backup-builders';
 import type { RunVersionCollector } from '@/services/versioning/version-sync';
-import { ensure_drives_discovered } from '@/services/backup/backup-file-processor';
 import { scan_all_drives } from '@/services/backup/backup-drive-processor';
 import type { PackageReportTotals } from '@/services/backup/package-report';
 import { cleanup_stale_staging } from '@/services/backup/large-file-pipeline';
@@ -95,7 +94,13 @@ export class OneDriveBackupService implements OneDriveBackupUseCase {
       const previous_cursor =
         options.force_full === true || scope_changed ? undefined : stored_cursor;
       const drives = await this._connector.list_drives(tenant_id, owner_id);
-      ensure_drives_discovered(drives.length);
+      // An empty list is what Graph answers for an owner whose OneDrive was never provisioned.
+      // A revoked grant is a 403, which `list_drives` has already turned into the permission
+      // error, so reading empty as a permission fault sent the operator to check a consent grant
+      // that was fine (issue #369). Nothing to back up is a clean run with no snapshot.
+      if (drives.length === 0) {
+        logger.warn(`Owner ${owner_id} has no OneDrive drives; there is nothing to back up`);
+      }
       progress = options.create_progress?.(
         drives.map((drive) => ({ name: drive.drive_name, total_items: 0 })),
       );

--- a/packages/onedrive/src/services/backup/failed-item-retry.ts
+++ b/packages/onedrive/src/services/backup/failed-item-retry.ts
@@ -1,4 +1,5 @@
 import type { OneDriveConnector, OneDriveDeltaItem } from '@wisecom/atlas-types';
+import { AuthError } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import {
   clear_item_failure,
@@ -49,6 +50,9 @@ export async function resolve_retry_items(
       logger.info(`Previously failed item ${record.name} (${record.item_id}) no longer exists`);
       next_ledger = clear_item_failure(next_ledger, record.item_id);
     } catch (err) {
+      // A revoked grant is not a per-item fault and re-recording it 12 times per run tells the
+      // operator nothing. Matches the SharePoint twin (issue #371).
+      if (err instanceof AuthError) throw err;
       const reason = err instanceof Error ? err.message : String(err);
       next_ledger = record_item_failure(next_ledger, {
         item_id: record.item_id,

--- a/packages/onedrive/src/services/restore/drive-router.ts
+++ b/packages/onedrive/src/services/restore/drive-router.ts
@@ -1,0 +1,50 @@
+import type { OneDriveManifestEntry } from '@wisecom/atlas-types';
+
+export interface RoutedDrive {
+  /** Where this entry is restored. Meaningless when `error` is set. */
+  readonly drive_id: string;
+  /** Set when the entry cannot be placed; it is skipped rather than written somewhere else. */
+  readonly error?: string;
+}
+
+/**
+ * Decides which of the target owner's drives each manifest entry belongs in.
+ *
+ * A same-owner restore uses the drive the entry records, because an owner can have several and
+ * the first one Graph lists is a guess. A cross-owner restore has no mapping to work from, since
+ * Atlas records drive ids and not drive names, so it is allowed only when the snapshot came from
+ * a single drive and is refused otherwise (issue #361).
+ *
+ * @throws Error when a cross-owner restore spans more than one source drive.
+ */
+export function build_drive_router(
+  entries: readonly OneDriveManifestEntry[],
+  target_drive_ids: readonly string[],
+  owner_id: string,
+  target_owner: string,
+): (entry: OneDriveManifestEntry) => RoutedDrive {
+  const cross_owner = target_owner !== owner_id;
+  const source_drive_ids = new Set(entries.map((entry) => entry.drive_id));
+
+  if (cross_owner && source_drive_ids.size > 1) {
+    throw new Error(
+      `This snapshot spans ${source_drive_ids.size} drives and Atlas records no drive names, so ` +
+        `there is no way to tell which of ${target_owner}'s drives each file belongs in. ` +
+        `Restore to the original owner, or restore one drive at a time with --file-filter.`,
+    );
+  }
+
+  const [primary_drive_id] = target_drive_ids;
+  const known = new Set(target_drive_ids);
+
+  return (entry) => {
+    if (cross_owner) return { drive_id: primary_drive_id ?? '' };
+    if (known.has(entry.drive_id)) return { drive_id: entry.drive_id };
+    return {
+      drive_id: entry.drive_id,
+      error:
+        `${entry.file_name}: recorded drive ${entry.drive_id} no longer exists for ` +
+        `${target_owner}; not restored into another drive`,
+    };
+  };
+}

--- a/packages/onedrive/src/services/restore/restore.service.ts
+++ b/packages/onedrive/src/services/restore/restore.service.ts
@@ -178,7 +178,14 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
 
       const content = await download_and_decrypt_blob(ctx, entry);
       if (!content) {
-        return { restored: false };
+        // The specific cause is already logged; recording it here is what makes a restore that
+        // wrote nothing exit non-zero instead of counting a missing blob as a quiet skip. The
+        // SharePoint twin has always done this, so the same event used to exit 2 here and 1
+        // there (issue #358).
+        return {
+          restored: false,
+          error: `${entry.file_name}: content unavailable or failed verification; skipped`,
+        };
       }
 
       // The blob reader streams anything past the small-file limit, so the shape it returned is

--- a/packages/onedrive/src/services/restore/restore.service.ts
+++ b/packages/onedrive/src/services/restore/restore.service.ts
@@ -28,6 +28,7 @@ import { download_and_decrypt_blob } from '@/services/restore/blob-restore';
 import { OneDriveDecryptAuthError } from '@/services/restore/restore-integrity';
 import { filter_drive_entries } from '@wisecom/atlas-drive/shared/entry-filter';
 import { onedrive_manifest_lookup } from '@/services/shared/manifest-lookup';
+import { build_drive_router } from '@/services/restore/drive-router';
 import {
   load_drive_chain_entries,
   restorable_entries,
@@ -76,7 +77,6 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
       if (!primary_drive) {
         throw new Error('No OneDrive drives found for target user');
       }
-      const drive_id = primary_drive.drive_id;
 
       const conflict = options.conflict_behavior ?? 'rename';
       const restorable = filter_drive_entries(
@@ -99,12 +99,29 @@ export class OneDriveRestoreService implements OneDriveRestoreUseCase {
         total: restorable.length,
       });
 
+      // Each entry records the drive it came from, and an owner can have several. Resolving one
+      // target drive per run and writing everything into it put the second drive's files into
+      // the first drive, silently, since every upload succeeded against real folder ids. With
+      // `--conflict replace` that overwrote same-path files (issue #361).
+      const resolve_target_drive = build_drive_router(
+        restorable,
+        drives.map((drive) => drive.drive_id),
+        owner_id,
+        target_owner,
+      );
+
       for (const entry of restorable) {
         if (options.should_interrupt?.() === true) break;
+        const routed = resolve_target_drive(entry);
+        if (routed.error !== undefined) {
+          files_skipped++;
+          errors.push(routed.error);
+          continue;
+        }
         const result = await this.restore_single_entry(
           tenant_id,
           target_owner,
-          drive_id,
+          routed.drive_id,
           entry,
           ctx,
           folder_ids,

--- a/packages/onedrive/tests/unit/adapters/buffered-download-size.test.ts
+++ b/packages/onedrive/tests/unit/adapters/buffered-download-size.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { DownloadIntegrityError } from '@wisecom/atlas-drive/backup/download-integrity';
+import { download_from_url } from '@/adapters/graph-onedrive-connector-stream';
+
+/**
+ * Issue #368. #338 gave the Range-chunked and large-staging paths a transfer-size check and left
+ * the two buffered paths without one. A CDN or proxy answering 200 with a complete but wrong
+ * body was hashed, encrypted and written with a checksum matching those wrong bytes, so backup
+ * exited healthy, verify passed, and restore returned the wrong file. Undetectable after the
+ * fact, which is the failure class #338 closed everywhere else.
+ */
+
+const CONTENT = Buffer.from('the real file content');
+
+function respond(body: Buffer): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    arrayBuffer: () =>
+      Promise.resolve(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)),
+  } as unknown as Response;
+}
+
+describe('download_from_url transfer size', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('refuses a well-framed body that is not the recorded length', async () => {
+    vi.mocked(fetch).mockResolvedValue(respond(Buffer.from('<html>error page</html>')));
+
+    await expect(
+      download_from_url('https://cdn.example.invalid/f', CONTENT.length, 'item-1'),
+    ).rejects.toBeInstanceOf(DownloadIntegrityError);
+  });
+
+  it('refuses a truncated body', async () => {
+    vi.mocked(fetch).mockResolvedValue(respond(CONTENT.subarray(0, 4)));
+
+    await expect(
+      download_from_url('https://cdn.example.invalid/f', CONTENT.length, 'item-1'),
+    ).rejects.toThrow(/expected 21/);
+  });
+
+  it('accepts the body when the length matches', async () => {
+    vi.mocked(fetch).mockResolvedValue(respond(CONTENT));
+
+    await expect(
+      download_from_url('https://cdn.example.invalid/f', CONTENT.length, 'item-1'),
+    ).resolves.toEqual(CONTENT);
+  });
+
+  it('accepts any length when the item records no size', async () => {
+    vi.mocked(fetch).mockResolvedValue(respond(CONTENT));
+
+    await expect(download_from_url('https://cdn.example.invalid/f', 0, 'item-1')).resolves.toEqual(
+      CONTENT,
+    );
+  });
+});

--- a/packages/onedrive/tests/unit/adapters/download-403-classification.test.ts
+++ b/packages/onedrive/tests/unit/adapters/download-403-classification.test.ts
@@ -68,6 +68,11 @@ function make_client(): GraphClientMock {
   const client = { api } as unknown as Client;
   return { client, api, get, get_stream };
 }
+
+/**
+ * `size_bytes` is 0, which `assert_transferred_size` reads as "no recorded size" and skips.
+ * These cases are about how a 403 is classified, not about transfer length (issue #368).
+ */
 function make_item(): OneDriveDeltaItem {
   return {
     drive_id: 'drive-1',
@@ -75,7 +80,7 @@ function make_item(): OneDriveDeltaItem {
     kind: 'file',
     file_name: 'Report.docx',
     parent_path: '/',
-    size_bytes: 1024,
+    size_bytes: 0,
     deleted: false,
     download_url: STALE_URL,
   };

--- a/packages/onedrive/tests/unit/adapters/download-helpers.test.ts
+++ b/packages/onedrive/tests/unit/adapters/download-helpers.test.ts
@@ -86,12 +86,17 @@ function make_client(overrides: { download_url?: string | undefined } = {}): Gra
   return { client, api, get, get_stream, select };
 }
 
+/**
+ * `size_bytes` defaults to 0, which `assert_transferred_size` reads as "no recorded size" and
+ * skips. These cases are about routing and refresh, not transfer length, so they should not have
+ * to keep a fixture body and a fixture size in step (issue #368).
+ */
 function make_item(overrides: Partial<OneDriveDeltaItem> = {}): OneDriveDeltaItem {
   return {
     drive_id: 'drive-1',
     item_id: 'item-1',
     name: 'Report.docx',
-    size_bytes: 1024,
+    size_bytes: 0,
     ...overrides,
   } as OneDriveDeltaItem;
 }
@@ -131,7 +136,7 @@ describe('OneDrive download helpers', () => {
       );
 
       expect(body).toEqual(URL_BODY);
-      expect(mocks.download_from_url).toHaveBeenCalledWith(STALE_URL, 1024, 'item-1');
+      expect(mocks.download_from_url).toHaveBeenCalledWith(STALE_URL, 0, 'item-1');
       expect(mock.api).not.toHaveBeenCalled();
     });
 
@@ -181,8 +186,8 @@ describe('OneDrive download helpers', () => {
 
       expect(body).toEqual(URL_BODY);
       expect(mock.get).toHaveBeenCalledOnce();
-      expect(mocks.download_from_url).toHaveBeenNthCalledWith(1, STALE_URL, 1024, 'item-1');
-      expect(mocks.download_from_url).toHaveBeenNthCalledWith(2, FRESH_URL, 1024, 'item-1');
+      expect(mocks.download_from_url).toHaveBeenNthCalledWith(1, STALE_URL, 0, 'item-1');
+      expect(mocks.download_from_url).toHaveBeenNthCalledWith(2, FRESH_URL, 0, 'item-1');
       expect(mock.get_stream).not.toHaveBeenCalled();
     });
 
@@ -243,6 +248,15 @@ describe('OneDrive download helpers', () => {
         30_000,
         'Graph content request timed out for file item-1',
       );
+    });
+
+    it('refuses a drained body that is not the recorded length (issue #368)', async () => {
+      const mock = make_client();
+      mocks.stream_to_buffer.mockResolvedValue(Buffer.from('<html>error page</html>'));
+
+      await expect(
+        download_via_graph_content(mock.client, make_item({ size_bytes: 4096 })),
+      ).rejects.toThrow(/expected 4096/);
     });
   });
 

--- a/packages/onedrive/tests/unit/services/backup/unprovisioned-owner.test.ts
+++ b/packages/onedrive/tests/unit/services/backup/unprovisioned-owner.test.ts
@@ -1,0 +1,77 @@
+/**
+ * An owner whose OneDrive was never provisioned.
+ *
+ * Graph answers `GET /users/{id}/drives` with an empty list for one, and answers 403 for a
+ * revoked grant, which the connector has already turned into the permission error. Reading empty
+ * as a permission fault sent the operator to check a consent grant that was fine (issue #369).
+ */
+
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import type { OneDriveDrive, TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
+import { OneDriveBackupService } from '@/services/backup/backup.service';
+
+interface Harness {
+  service: OneDriveBackupService;
+  manifest_save: Mock;
+}
+
+function make_harness(list_drives: () => Promise<OneDriveDrive[]>): Harness {
+  const context = {
+    tenant_id: 't',
+    storage: {
+      exists: vi.fn().mockResolvedValue(false),
+      put: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(undefined),
+      list_stale: vi.fn(async () => []),
+      abort_incomplete_uploads: vi.fn().mockResolvedValue(0),
+    },
+    encrypt: (buffer: Buffer) => buffer,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const factory: TenantContextFactory = {
+    create: vi.fn().mockResolvedValue(context),
+    create_readonly: vi.fn().mockResolvedValue(context),
+    create_storage_only: vi.fn(),
+  };
+
+  const manifest_save = vi.fn();
+  const service = new OneDriveBackupService(
+    factory,
+    { list_drives: vi.fn(list_drives), fetch_delta: vi.fn(), list_file_versions: vi.fn() } as never,
+    { save: manifest_save } as never,
+    { load_version_watermarks: vi.fn().mockResolvedValue({}), write_run_index: vi.fn() } as never,
+    { load: vi.fn().mockResolvedValue(undefined), save: vi.fn() } as never,
+  );
+
+  return { service, manifest_save };
+}
+
+describe('OneDrive backup for an owner with no drives', () => {
+  it('completes as an empty run and writes no snapshot', async () => {
+    const { service, manifest_save } = make_harness(async () => []);
+
+    const result = await service.backup_onedrive('tenant-1', 'owner-1', {});
+
+    expect(result.snapshot).toBeUndefined();
+    expect(result.summary.snapshot_created).toBe(false);
+    expect(result.summary.drives_scanned).toBe(0);
+    expect(result.summary.files_stored).toBe(0);
+    expect(result.summary.errors).toEqual([]);
+    expect(result.summary.healthy).toBe(true);
+    expect(manifest_save).not.toHaveBeenCalled();
+  });
+
+  it('still fails the run when the drives endpoint refuses', async () => {
+    const { service } = make_harness(() => {
+      throw new Error(
+        'Missing Microsoft Graph application permissions for OneDrive: Files.Read.All.',
+      );
+    });
+
+    await expect(service.backup_onedrive('tenant-1', 'owner-1', {})).rejects.toThrow(
+      /Missing Microsoft Graph application permissions/,
+    );
+  });
+});

--- a/packages/onedrive/tests/unit/services/restore/missing-content-classification.test.ts
+++ b/packages/onedrive/tests/unit/services/restore/missing-content-classification.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Issue #358. A manifest entry pointing at content that is no longer in storage was a silent
+ * skip on OneDrive and a recorded error on SharePoint, so the identical event exited 2 on one
+ * provider and 1 on the other, with no per-file reason printed on OneDrive.
+ */
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  OneDriveConnector,
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveRestoreService } from '@/services/restore/restore.service';
+
+const CONTENT = Buffer.from('file-content');
+const CHECKSUM = createHash('sha256').update(CONTENT).digest('hex');
+
+function make_entry(file_id: string): OneDriveManifestEntry {
+  return {
+    file_id,
+    drive_id: 'drive-1',
+    file_name: `${file_id}.txt`,
+    parent_path: '/Projects',
+    size_bytes: CONTENT.length,
+    change_type: 'updated',
+    backup_at: '2026-08-17T00:00:00.000Z',
+    storage_key: `onedrive/data/${file_id}`,
+    checksum: CHECKSUM,
+  } as OneDriveManifestEntry;
+}
+
+function make_service(missing: ReadonlySet<string>): OneDriveRestoreService {
+  const entries = [make_entry('file-1'), make_entry('file-2')];
+  const manifest = {
+    id: 'manifest-1',
+    tenant_id: 'tenant-1',
+    snapshot_id: 'snap-1',
+    owner_id: 'owner-1',
+    created_at: new Date('2026-08-17T00:00:00.000Z'),
+    total_files: entries.length,
+    total_size_bytes: entries.length * CONTENT.length,
+    entries,
+  } as OneDriveSnapshotManifest;
+
+  const ctx = {
+    tenant_id: 'tenant-1',
+    storage: {
+      get: vi.fn(async (key: string) => {
+        if (missing.has(key)) throw new Error('NoSuchKey');
+        return CONTENT;
+      }),
+    },
+    encrypt: vi.fn((data: Buffer) => data),
+    decrypt: vi.fn((data: Buffer) => data),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const factory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+  } as unknown as TenantContextFactory;
+
+  let folder_seq = 0;
+  const connector = {
+    list_drives: vi.fn().mockResolvedValue([{ drive_id: 'drive-1', drive_name: 'Documents' }]),
+    create_folder: vi.fn().mockImplementation(async () => `folder-${++folder_seq}`),
+    upload_small_file: vi.fn().mockResolvedValue(undefined),
+    upload_large_file: vi.fn().mockResolvedValue(undefined),
+  } as unknown as OneDriveConnector;
+
+  const manifests = {
+    find_by_snapshot: vi.fn().mockResolvedValue(manifest),
+    list_snapshots_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveManifestRepository;
+
+  return new OneDriveRestoreService(factory, connector, manifests);
+}
+
+describe('OneDrive restore with content missing from storage', () => {
+  it('records a per-file reason instead of skipping silently', async () => {
+    const service = make_service(new Set(['onedrive/data/file-1']));
+
+    const result = await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+    });
+
+    expect(result.files_skipped).toBe(1);
+    expect(result.files_restored).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('file-1.txt');
+  });
+
+  it('reports nothing for a restore where every blob is present', async () => {
+    const service = make_service(new Set());
+
+    const result = await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+    });
+
+    expect(result.files_restored).toBe(2);
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/packages/onedrive/tests/unit/services/restore/multi-drive-routing.test.ts
+++ b/packages/onedrive/tests/unit/services/restore/multi-drive-routing.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Issue #361. Snapshot restore resolved the target drive once, by taking the first drive Graph
+ * listed, and wrote every entry into it. Each entry records its own `drive_id` and the restore
+ * never read it, so a second drive's files landed in the first drive: duplicates under the
+ * default rename policy, overwrites under `--conflict replace`, and silent either way because
+ * every upload succeeded against real folder ids.
+ */
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  OneDriveConnector,
+  OneDriveManifestEntry,
+  OneDriveManifestRepository,
+  OneDriveSnapshotManifest,
+  TenantContext,
+  TenantContextFactory,
+} from '@wisecom/atlas-types';
+import { OneDriveRestoreService } from '@/services/restore/restore.service';
+
+const CONTENT = Buffer.from('file-content');
+const CHECKSUM = createHash('sha256').update(CONTENT).digest('hex');
+
+function make_entry(file_id: string, drive_id: string): OneDriveManifestEntry {
+  return {
+    file_id,
+    drive_id,
+    file_name: `${file_id}.txt`,
+    parent_path: '/Projects',
+    size_bytes: CONTENT.length,
+    change_type: 'updated',
+    backup_at: '2026-08-17T00:00:00.000Z',
+    storage_key: `onedrive/data/${file_id}`,
+    checksum: CHECKSUM,
+  } as OneDriveManifestEntry;
+}
+
+interface Harness {
+  service: OneDriveRestoreService;
+  connector: OneDriveConnector;
+}
+
+function make_harness(entries: OneDriveManifestEntry[], target_drives: string[]): Harness {
+  const manifest = {
+    id: 'manifest-1',
+    tenant_id: 'tenant-1',
+    snapshot_id: 'snap-1',
+    owner_id: 'owner-1',
+    created_at: new Date('2026-08-17T00:00:00.000Z'),
+    total_files: entries.length,
+    total_size_bytes: entries.length * CONTENT.length,
+    entries,
+  } as OneDriveSnapshotManifest;
+
+  const ctx = {
+    tenant_id: 'tenant-1',
+    storage: { get: vi.fn().mockResolvedValue(CONTENT) },
+    encrypt: vi.fn((data: Buffer) => data),
+    decrypt: vi.fn((data: Buffer) => data),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+
+  const factory = {
+    create: vi.fn().mockResolvedValue(ctx),
+    create_readonly: vi.fn().mockResolvedValue(ctx),
+  } as unknown as TenantContextFactory;
+
+  // Folder ids carry their drive, so where an upload landed is readable from its parent id.
+  const connector = {
+    list_drives: vi
+      .fn()
+      .mockResolvedValue(target_drives.map((id) => ({ drive_id: id, drive_name: id }))),
+    create_folder: vi
+      .fn()
+      .mockImplementation(
+        async (_t: string, _o: string, drive_id: string, _p: string, name: string) =>
+          `${drive_id}/${String(name)}`,
+      ),
+    upload_small_file: vi.fn().mockResolvedValue(undefined),
+    upload_large_file: vi.fn().mockResolvedValue(undefined),
+  } as unknown as OneDriveConnector;
+
+  const manifests = {
+    find_by_snapshot: vi.fn().mockResolvedValue(manifest),
+    list_snapshots_by_owner: vi.fn().mockResolvedValue([]),
+  } as unknown as OneDriveManifestRepository;
+
+  return { service: new OneDriveRestoreService(factory, connector, manifests), connector };
+}
+
+/** The drive id each upload was addressed to, in call order. */
+function upload_drives(connector: OneDriveConnector): string[] {
+  return vi.mocked(connector.upload_small_file).mock.calls.map((call) => String(call[2]));
+}
+
+describe('a snapshot spanning two drives', () => {
+  it('restores each entry into the drive it was backed up from', async () => {
+    const { service, connector } = make_harness(
+      [make_entry('file-1', 'drive-a'), make_entry('file-2', 'drive-b')],
+      ['drive-a', 'drive-b'],
+    );
+
+    const result = await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+    });
+
+    expect(result.files_restored).toBe(2);
+    expect(upload_drives(connector).sort()).toEqual(['drive-a', 'drive-b']);
+  });
+
+  it('fails the entry whose drive is gone rather than writing it elsewhere', async () => {
+    const { service, connector } = make_harness(
+      [make_entry('file-1', 'drive-a'), make_entry('file-2', 'drive-gone')],
+      ['drive-a'],
+    );
+
+    const result = await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+    });
+
+    expect(result.files_restored).toBe(1);
+    expect(result.files_skipped).toBe(1);
+    expect(result.errors[0]).toContain('drive-gone');
+    expect(upload_drives(connector)).toEqual(['drive-a']);
+  });
+
+  it('refuses a cross-owner restore it cannot map', async () => {
+    const { service } = make_harness(
+      [make_entry('file-1', 'drive-a'), make_entry('file-2', 'drive-b')],
+      ['drive-target'],
+    );
+
+    await expect(
+      service.restore_onedrive('tenant-1', 'owner-1', {
+        snapshot_id: 'snap-1',
+        target_owner_id: 'owner-2',
+      }),
+    ).rejects.toThrow(/spans 2 drives/);
+  });
+
+  it('allows a cross-owner restore from a single-drive snapshot', async () => {
+    const { service, connector } = make_harness(
+      [make_entry('file-1', 'drive-a'), make_entry('file-2', 'drive-a')],
+      ['drive-target'],
+    );
+
+    const result = await service.restore_onedrive('tenant-1', 'owner-1', {
+      snapshot_id: 'snap-1',
+      target_owner_id: 'owner-2',
+    });
+
+    expect(result.files_restored).toBe(2);
+    expect(upload_drives(connector)).toEqual(['drive-target', 'drive-target']);
+  });
+});

--- a/packages/outlook/package.json
+++ b/packages/outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-outlook",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/outlook/src/services/backup/folder-sync-executor.ts
+++ b/packages/outlook/src/services/backup/folder-sync-executor.ts
@@ -1,4 +1,6 @@
 import type { TenantContext } from '@wisecom/atlas-types';
+import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
+import { logger } from '@wisecom/atlas-core/utils/logger';
 import {
   capture_mime_payload,
   store_single_message,
@@ -22,6 +24,13 @@ export interface FolderSyncResult {
   stored: number;
   deduplicated: number;
   attachments_stored: number;
+  /**
+   * Messages whose attachments could not be fetched, one line each.
+   *
+   * A folder-level error would discard the folder's other entries, and their blobs are already
+   * in storage, so they would be orphans until a later run deduplicated them (issue #366).
+   */
+  attachment_errors: string[];
   folder_processed: number;
 }
 
@@ -82,7 +91,17 @@ async function process_message(
   }
 }
 
-/** Drains all pending attachment fetches in parallel batches of `concurrency`. */
+/**
+ * Drains all pending attachment fetches in parallel batches of `concurrency`.
+ *
+ * One failure used to reject the whole `Promise.all`, and the throw travelled out of
+ * `sync_single_folder` into a folder-level error that discarded every entry already processed in
+ * that folder. A message deleted between the delta page and the attachment fetch is enough to
+ * trigger it, and Graph answers `ErrorItemNotFound` for that (issue #366).
+ *
+ * A permission or licensing failure still propagates: those are the operator's to fix, and
+ * degrading the whole run quietly is the failure #372 describes.
+ */
 async function flush_pending_attachments(
   ctx: TenantContext,
   connector: MailboxConnector,
@@ -91,24 +110,38 @@ async function flush_pending_attachments(
   entries: ManifestEntry[],
   stats: { stored: number; deduplicated: number; att_stored: number },
   pending: PendingAttachment[],
+  attachment_errors: string[],
+  is_interrupted: () => boolean,
   object_lock_policy?: ObjectLockPolicy,
   concurrency = DEFAULT_ATTACHMENT_CONCURRENCY,
 ): Promise<void> {
   while (pending.length > 0) {
+    // An interrupted run stops scheduling; what is already in flight finishes.
+    if (is_interrupted()) {
+      pending.length = 0;
+      return;
+    }
     const batch = pending.splice(0, concurrency);
     const tasks = batch.map(async (p) => {
-      const att = await fetch_and_store_attachments(
-        ctx,
-        connector,
-        tenant_id,
-        owner_id,
-        p.message_id,
-        undefined,
-        object_lock_policy,
-      );
-      if (att && att.length > 0) {
-        stats.att_stored += att.length;
-        entries[p.entry_index] = { ...entries[p.entry_index]!, attachments: att };
+      try {
+        const att = await fetch_and_store_attachments(
+          ctx,
+          connector,
+          tenant_id,
+          owner_id,
+          p.message_id,
+          undefined,
+          object_lock_policy,
+        );
+        if (att && att.length > 0) {
+          stats.att_stored += att.length;
+          entries[p.entry_index] = { ...entries[p.entry_index]!, attachments: att };
+        }
+      } catch (err) {
+        if (err instanceof AuthError || err instanceof MailboxNotLicensedError) throw err;
+        const reason = err instanceof Error ? err.message : String(err);
+        logger.warn(`Attachments for message ${p.message_id} could not be fetched: ${reason}`);
+        attachment_errors.push(`message ${p.message_id}: attachments not backed up (${reason})`);
       }
     });
 
@@ -142,6 +175,7 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
   const entries: ManifestEntry[] = [];
   const stats = { stored: 0, deduplicated: 0, att_stored: 0 };
   const pending_attachments: PendingAttachment[] = [];
+  const attachment_errors: string[] = [];
   let folder_processed = 0;
   let streamed = false;
   // Set whenever any page or message is skipped; blocks delta-link persistence (issue #23).
@@ -212,6 +246,8 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
       entries,
       stats,
       pending_attachments,
+      attachment_errors,
+      is_interrupted,
       object_lock_policy,
     );
 
@@ -286,6 +322,8 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
       entries,
       stats,
       pending_attachments,
+      attachment_errors,
+      is_interrupted,
       object_lock_policy,
     );
   }
@@ -297,6 +335,7 @@ export async function sync_single_folder(params: FolderSyncParams): Promise<Fold
     stored: stats.stored,
     deduplicated: stats.deduplicated,
     attachments_stored: stats.att_stored,
+    attachment_errors,
     folder_processed,
   };
 }

--- a/packages/outlook/src/services/backup/mailbox-run-persister.ts
+++ b/packages/outlook/src/services/backup/mailbox-run-persister.ts
@@ -1,0 +1,104 @@
+import type {
+  BackupSyncMode,
+  MailboxDeltaCursorRepository,
+  Manifest,
+  ManifestRepository,
+  Snapshot,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import {
+  mark_snapshot_completed,
+  resolve_saved_delta_links,
+  resolve_sync_mode,
+} from '@/services/backup/snapshot-manifest-builder';
+
+export interface MailboxResumeState {
+  /** The head manifest, for the stale-delta safeguard and the quiet-run decision. */
+  readonly previous: Manifest | undefined;
+  readonly saved_links: Record<string, string>;
+  readonly previous_entry_count: number;
+  readonly mode: BackupSyncMode;
+}
+
+/**
+ * Reads where the last run left off.
+ *
+ * Delta links live in the cursor as of #370. A mailbox last backed up by an older release has
+ * no cursor, so the head manifest's links are the fallback and the first run after the upgrade
+ * resumes instead of re-enumerating the whole mailbox.
+ */
+export async function resolve_resume_state(
+  deps: MailboxRunPersistence,
+  ctx: TenantContext,
+  owner_id: string,
+  force_full: boolean,
+): Promise<MailboxResumeState> {
+  if (force_full) {
+    return {
+      previous: undefined,
+      saved_links: {},
+      previous_entry_count: 0,
+      mode: resolve_sync_mode(true, {}),
+    };
+  }
+
+  const previous = await deps.manifests.find_latest_by_owner(ctx, owner_id);
+  const cursor = await deps.cursors.load(ctx, owner_id);
+  const saved_links = cursor?.delta_links ?? resolve_saved_delta_links(previous);
+
+  return {
+    previous,
+    saved_links,
+    previous_entry_count: previous?.total_objects ?? 0,
+    mode: resolve_sync_mode(false, saved_links),
+  };
+}
+
+export interface MailboxRunPersistence {
+  readonly manifests: ManifestRepository;
+  readonly cursors: MailboxDeltaCursorRepository;
+}
+
+export interface MailboxRunOutcome {
+  /** The snapshot to report: the one written, or the head a quiet run left in place. */
+  readonly snapshot: Snapshot;
+  /** False when the run captured nothing and the mailbox already had a snapshot. */
+  readonly wrote_snapshot: boolean;
+}
+
+/**
+ * Writes what a completed mailbox run produced: the snapshot manifest, then the delta cursor.
+ *
+ * A run that captured nothing has nothing to snapshot. Writing one anyway added a manifest
+ * object per quiet run forever, only to carry the delta links, and a snapshot is immutable once
+ * written so the head could not be rewritten instead. The links live in the cursor now, which
+ * the run overwrites, the way the drive providers have always done it (issue #370).
+ *
+ * The cursor is saved after the manifest, never before. A cursor that lands first tells the next
+ * run to skip changes no manifest recorded, which is what #339 was.
+ */
+export async function persist_mailbox_run(
+  deps: MailboxRunPersistence,
+  ctx: TenantContext,
+  manifest: Manifest,
+  snapshot: Snapshot,
+  previous: Manifest | undefined,
+  entry_count: number,
+): Promise<MailboxRunOutcome> {
+  const wrote_snapshot = entry_count > 0 || previous === undefined;
+  if (wrote_snapshot) await deps.manifests.save(ctx, manifest);
+
+  await deps.cursors.save(ctx, {
+    owner_id: manifest.owner_id,
+    delta_links: manifest.delta_links,
+    updated_at: new Date().toISOString(),
+  });
+
+  return {
+    snapshot: mark_snapshot_completed(
+      wrote_snapshot ? snapshot : { ...snapshot, id: previous.snapshot_id },
+      entry_count,
+    ),
+    wrote_snapshot,
+  };
+}

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -132,6 +132,12 @@ export class MailboxSyncService implements BackupUseCase {
           continue;
         }
 
+        // Per-message attachment failures, not folder failures: the folder's entries are kept
+        // and the run reports itself incomplete rather than losing the folder (issue #366).
+        folder_errors.push(
+          ...outcome.attachment_errors.map((line) => `${folder.folder_path}: ${line}`),
+        );
+
         all_entries.push(...outcome.entries);
         // Persist a folder's delta link only when every page was fully processed;
         // an interrupted folder keeps its previous link and is re-enumerated next run (issue #23).
@@ -226,6 +232,7 @@ export class MailboxSyncService implements BackupUseCase {
     stored: number;
     deduplicated: number;
     attachments_stored: number;
+    attachment_errors: string[];
     folder_processed: number;
     error?: string;
   }> {
@@ -265,6 +272,7 @@ export class MailboxSyncService implements BackupUseCase {
         stored: result.stored,
         deduplicated: result.deduplicated,
         attachments_stored: result.attachments_stored,
+        attachment_errors: result.attachment_errors,
         folder_processed: result.folder_processed,
       };
     } catch (err) {
@@ -275,6 +283,7 @@ export class MailboxSyncService implements BackupUseCase {
         stored: 0,
         deduplicated: 0,
         attachments_stored: 0,
+        attachment_errors: [],
         folder_processed: 0,
         error: msg,
       };

--- a/packages/outlook/src/services/backup/mailbox-sync.service.ts
+++ b/packages/outlook/src/services/backup/mailbox-sync.service.ts
@@ -2,6 +2,7 @@ import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifi
 import { inject, injectable } from 'inversify';
 import type { TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
 import type { MailboxConnector, MailFolder, ManifestRepository } from '@wisecom/atlas-types';
+import type { MailboxDeltaCursorRepository } from '@wisecom/atlas-types';
 import type { ManifestEntry, ManifestObjectLockPolicy } from '@wisecom/atlas-types';
 import { calc_rate } from '@wisecom/atlas-core/services/shared/progress-rate';
 import { assert_mailbox_exists } from '@wisecom/atlas-core/services/shared/mailbox-assertions';
@@ -11,6 +12,8 @@ import {
   finish_operation_progress,
 } from '@wisecom/atlas-core/services/shared/operation-progress';
 import { sync_single_folder } from '@/services/backup/folder-sync-executor';
+import { persist_mailbox_run, resolve_resume_state } from '@/services/backup/mailbox-run-persister';
+import { warn_if_replica } from '@/services/backup/replica-marker-warning';
 import { resolve_backup_folders } from '@/services/shared/folder-selector';
 import { resolve_progress_reporter } from '@/services/shared/backup-progress-resolver';
 import {
@@ -34,6 +37,7 @@ import {
   TENANT_CONTEXT_FACTORY_TOKEN,
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -45,6 +49,8 @@ export class MailboxSyncService implements BackupUseCase {
     @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
     @inject(MAILBOX_CONNECTOR_TOKEN) private readonly _connector: MailboxConnector,
     @inject(MANIFEST_REPOSITORY_TOKEN) private readonly _manifests: ManifestRepository,
+    @inject(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+    private readonly _cursors: MailboxDeltaCursorRepository,
   ) {}
 
   /** Orchestrates a full or incremental mailbox backup across all (or filtered) folders. */
@@ -62,7 +68,7 @@ export class MailboxSyncService implements BackupUseCase {
     const mailbox_purpose = await this._connector.get_mailbox_purpose?.(tenant_id, owner_id);
     const ctx = await this._tenant_factory.create(tenant_id);
     try {
-      await this.warn_if_replica(ctx);
+      await warn_if_replica(ctx);
       const snapshot = create_pending_snapshot(tenant_id, owner_id, {
         owner_email: options.owner_email,
         owner_display_name: options.owner_display_name,
@@ -71,12 +77,12 @@ export class MailboxSyncService implements BackupUseCase {
       const should_interrupt: () => boolean = options.should_interrupt ?? always_false;
       const should_force_stop: () => boolean = options.should_force_stop ?? always_false;
 
-      const previous = options.force_full
-        ? undefined
-        : await this._manifests.find_latest_by_owner(ctx, owner_id);
-      const saved_links = resolve_saved_delta_links(previous);
-      const previous_entry_count = previous?.total_objects ?? 0;
-      const mode = resolve_sync_mode(options.force_full, saved_links);
+      const { previous, saved_links, previous_entry_count, mode } = await resolve_resume_state(
+        { manifests: this._manifests, cursors: this._cursors },
+        ctx,
+        owner_id,
+        options.force_full === true,
+      );
 
       const folder_selection = await resolve_backup_folders(this._connector, tenant_id, owner_id, {
         folder_filter: options.folder_filter,
@@ -168,7 +174,16 @@ export class MailboxSyncService implements BackupUseCase {
         mailbox_purpose,
         excluded_folders,
       });
-      await this._manifests.save(ctx, manifest);
+
+      const persisted = await persist_mailbox_run(
+        { manifests: this._manifests, cursors: this._cursors },
+        ctx,
+        manifest,
+        snapshot,
+        previous,
+        all_entries.length,
+      );
+
       interrupted ||= should_interrupt();
       emit_operation_progress(options, {
         operation: 'backup',
@@ -178,7 +193,7 @@ export class MailboxSyncService implements BackupUseCase {
         total: global_total,
       });
 
-      const completed = mark_snapshot_completed(snapshot, all_entries.length);
+      const completed = persisted.snapshot;
       return {
         snapshot: completed,
         manifest,
@@ -295,20 +310,5 @@ export class MailboxSyncService implements BackupUseCase {
         retain_until: options.object_lock_policy.retain_until,
       },
     };
-  }
-
-  private async warn_if_replica(ctx: {
-    storage: { exists(key: string): Promise<boolean> };
-  }): Promise<void> {
-    try {
-      if (await ctx.storage.exists('_meta/replica.marker')) {
-        logger.warn(
-          'This storage target contains a replica marker (_meta/replica.marker). ' +
-            'Running backup against a replica is not recommended -- use the primary storage.',
-        );
-      }
-    } catch {
-      /* non-critical: do not block backup if marker check fails */
-    }
   }
 }

--- a/packages/outlook/src/services/backup/message-payload-store.ts
+++ b/packages/outlook/src/services/backup/message-payload-store.ts
@@ -6,6 +6,7 @@ import type {
   ObjectLockPolicy,
   TenantContext,
 } from '@wisecom/atlas-types';
+import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
 export interface StoredMessage {
@@ -29,6 +30,11 @@ export async function capture_mime_payload(
   try {
     return await connector.fetch_mime(tenant_id, owner_id, message.message_id);
   } catch (err) {
+    // The fallback is for per-message faults such as ErrorItemNotFound. A revoked permission or
+    // an unlicensed mailbox is neither: swallowing those degraded every message in the run to
+    // the JSON payload, lost the original MIME, and still exited 0. `fetch_message_mime` already
+    // raises them as typed errors; this is the catch that used to eat them (issue #372).
+    if (err instanceof AuthError || err instanceof MailboxNotLicensedError) throw err;
     const reason = err instanceof Error ? err.message : String(err);
     logger.warn(`MIME capture failed for message ${message.message_id}: ${reason}`);
     return undefined;

--- a/packages/outlook/src/services/backup/replica-marker-warning.ts
+++ b/packages/outlook/src/services/backup/replica-marker-warning.ts
@@ -1,0 +1,23 @@
+import { logger } from '@wisecom/atlas-core/utils/logger';
+
+/**
+ * Warns when a backup is pointed at a replication target rather than the primary bucket.
+ *
+ * A replica is written by the replication service, and backing up into one leaves two stores
+ * that each believe they are authoritative. The check never blocks the run: an unreadable marker
+ * is not a reason to refuse a backup.
+ */
+export async function warn_if_replica(ctx: {
+  storage: { exists(key: string): Promise<boolean> };
+}): Promise<void> {
+  try {
+    if (await ctx.storage.exists('_meta/replica.marker')) {
+      logger.warn(
+        'This storage target contains a replica marker (_meta/replica.marker). ' +
+          'Running backup against a replica is not recommended -- use the primary storage.',
+      );
+    }
+  } catch {
+    /* non-critical: do not block backup if marker check fails */
+  }
+}

--- a/packages/outlook/src/services/restore/restore-loop-executor.ts
+++ b/packages/outlook/src/services/restore/restore-loop-executor.ts
@@ -56,15 +56,32 @@ export async function execute_restore_loop(
       if (is_interrupted()) break;
       dashboard.mark_active(folder_index);
 
-      const target_fid = await ensure_subfolder(
-        restore_connector,
-        tenant_id,
-        target_mailbox,
-        root.folder_id,
-        fid,
-        folder_map,
-        created_folders,
-      );
+      // A folder that cannot be created costs its own messages, not the rest of the plan. The
+      // drive restores have always degraded per folder; this was the one path where one Graph
+      // 4xx on create_mail_folder aborted the run and left every later folder untouched, in a
+      // state indistinguishable from an interrupt (issue #360).
+      let target_fid: string;
+      try {
+        target_fid = await ensure_subfolder(
+          restore_connector,
+          tenant_id,
+          target_mailbox,
+          root.folder_id,
+          fid,
+          folder_map,
+          created_folders,
+        );
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        all_errors.push(
+          `folder ${folder_map.get(fid) ?? fid}: could not be created (${reason}); ` +
+            `${folder_items.length} message(s) not restored`,
+        );
+        global_errors++;
+        dashboard.mark_done(folder_index, 0, 0);
+        folder_index++;
+        continue;
+      }
 
       const result = await restore_folder_entries(
         ctx,

--- a/packages/outlook/src/services/status/mailbox-status.service.ts
+++ b/packages/outlook/src/services/status/mailbox-status.service.ts
@@ -2,13 +2,14 @@ import { normalize_owner_id } from '@wisecom/atlas-core/services/shared/identifi
 import { inject, injectable } from 'inversify';
 import type { TenantContextFactory } from '@wisecom/atlas-types';
 import type { MailboxConnector, MailFolder } from '@wisecom/atlas-types';
-import type { ManifestRepository } from '@wisecom/atlas-types';
+import type { ManifestRepository, MailboxDeltaCursorRepository } from '@wisecom/atlas-types';
 import type { StatusUseCase, MailboxStatusResult, FolderStatus } from '@wisecom/atlas-types';
 import { assert_mailbox_exists } from '@wisecom/atlas-core/services/shared/mailbox-assertions';
 import {
   TENANT_CONTEXT_FACTORY_TOKEN,
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
 } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 
@@ -18,6 +19,8 @@ export class MailboxStatusService implements StatusUseCase {
     @inject(TENANT_CONTEXT_FACTORY_TOKEN) private readonly _tenant_factory: TenantContextFactory,
     @inject(MAILBOX_CONNECTOR_TOKEN) private readonly _connector: MailboxConnector,
     @inject(MANIFEST_REPOSITORY_TOKEN) private readonly _manifests: ManifestRepository,
+    @inject(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+    private readonly _cursors: MailboxDeltaCursorRepository,
   ) {}
 
   /** Peeks at Graph delta state to report whether a mailbox backup is current. */
@@ -31,7 +34,12 @@ export class MailboxStatusService implements StatusUseCase {
       // Legacy manifests carry mutable-ID delta links (issue #48); resuming
       // them with the immutable preference would mix ID formats, so peek
       // treats them as "no saved state" — every folder reports pending.
-      const saved_links = previous?.id_format === 'immutable' ? (previous?.delta_links ?? {}) : {};
+      // Delta links live in the cursor as of #370; a mailbox last backed up by an older release
+      // still has them only in its head manifest.
+      const cursor = await this._cursors.load(ctx, owner_id);
+      const saved_links =
+        cursor?.delta_links ??
+        (previous?.id_format === 'immutable' ? (previous?.delta_links ?? {}) : {});
 
       const all_folders = await this._connector.list_mail_folders(tenant_id, owner_id);
       const folder_statuses = await this.peek_all_folders(

--- a/packages/outlook/tests/unit/services/backup/attachment-flush-containment.test.ts
+++ b/packages/outlook/tests/unit/services/backup/attachment-flush-containment.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthError } from '@wisecom/atlas-types';
+import type {
+  BackupProgressReporter,
+  MailMessage,
+  MailboxConnector,
+  TenantContext,
+} from '@wisecom/atlas-types';
+import { sync_single_folder } from '@/services/backup/folder-sync-executor';
+
+/**
+ * Issue #366. The per-folder attachment flush used a bare `Promise.all`, so one failing fetch
+ * rejected the batch, the throw left `sync_single_folder`, and the mailbox sync recorded a
+ * folder-level error that discarded every entry already processed in that folder. Those blobs
+ * were already in storage, so they became orphans. A message deleted between the delta page and
+ * the attachment fetch is enough to trigger it.
+ */
+
+function make_message(message_id: string): MailMessage {
+  return {
+    message_id,
+    subject: 'Example subject',
+    has_attachments: true,
+    received_at: '2026-08-17T00:00:00.000Z',
+    raw_body: Buffer.from(`body-${message_id}`),
+  } as unknown as MailMessage;
+}
+
+function make_ctx(): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: {
+      exists: vi.fn().mockResolvedValue(false),
+      put: vi.fn().mockResolvedValue(undefined),
+      get: vi.fn(),
+    },
+    encrypt: (data: Buffer) => data,
+    decrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+function make_progress(): BackupProgressReporter {
+  return {
+    mark_active: vi.fn(),
+    mark_done: vi.fn(),
+    mark_error: vi.fn(),
+    update_active: vi.fn(),
+    update_total: vi.fn(),
+    finish: vi.fn(),
+  } as unknown as BackupProgressReporter;
+}
+
+/** MIME capture off, so every message with attachments goes through the pending flush. */
+function make_connector(fail_for: (message_id: string) => Error | undefined): MailboxConnector {
+  return {
+    fetch_delta: vi.fn().mockResolvedValue({
+      messages: [make_message('msg-1'), make_message('msg-2'), make_message('msg-3')],
+      delta_link: 'delta-2',
+    }),
+    fetch_mime: vi.fn().mockRejectedValue(new Error('not available')),
+    fetch_attachments: vi.fn(async (_t: string, _o: string, message_id: string) => {
+      const failure = fail_for(message_id);
+      if (failure) throw failure;
+      return [
+        {
+          attachment_id: `att-${message_id}`,
+          name: 'Report.docx',
+          content_type: 'application/vnd.openxmlformats',
+          size_bytes: 4,
+          content: Buffer.from('abcd'),
+          is_inline: false,
+        },
+      ];
+    }),
+  } as unknown as MailboxConnector;
+}
+
+async function run(
+  fail_for: (message_id: string) => Error | undefined,
+  is_interrupted: () => boolean = () => false,
+): ReturnType<typeof sync_single_folder> {
+  return sync_single_folder({
+    ctx: make_ctx(),
+    connector: make_connector(fail_for),
+    tenant_id: 'tenant-1',
+    owner_id: 'john.doe@example.com',
+    folder_id: 'inbox',
+    folder_index: 0,
+    folder_total: 3,
+    global_total: 3,
+    global_processed_before: 0,
+    sync_start: Date.now(),
+    progress: make_progress(),
+    is_interrupted,
+    is_hard_stopped: () => false,
+    operation_control: {},
+    previous_manifest_entries: 0,
+  });
+}
+
+describe('one attachment fetch failing during a folder flush', () => {
+  it('keeps the folder entries and records the message', async () => {
+    const result = await run((id) => (id === 'msg-2' ? new Error('ErrorItemNotFound') : undefined));
+
+    expect(result.entries).toHaveLength(3);
+    expect(result.attachment_errors).toHaveLength(1);
+    expect(result.attachment_errors[0]).toContain('msg-2');
+    // The other two still carry their attachments.
+    expect(result.attachments_stored).toBe(2);
+  });
+
+  it('still stops the run for a permission failure', async () => {
+    await expect(
+      run((id) => (id === 'msg-2' ? new AuthError('403 from Graph') : undefined)),
+    ).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it('records nothing when every fetch succeeds', async () => {
+    const result = await run(() => undefined);
+
+    expect(result.attachment_errors).toEqual([]);
+    expect(result.attachments_stored).toBe(3);
+  });
+
+  it('stops scheduling attachment fetches once the run is interrupted', async () => {
+    const result = await run(
+      () => undefined,
+      () => true,
+    );
+
+    expect(result.attachments_stored).toBe(0);
+  });
+});

--- a/packages/outlook/tests/unit/services/backup/delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/services/backup/delta-safeguard.test.ts
@@ -5,6 +5,7 @@ import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
   type MailboxConnector,
   type MailMessage,
@@ -116,6 +117,9 @@ describe('MailboxSyncService – force_full / stale-delta safeguard', () => {
     const container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+    container
+      .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+      .toConstantValue({ load: vi.fn().mockResolvedValue(undefined), save: vi.fn() });
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
     container.bind(MailboxSyncService).toSelf();
     service = container.get(MailboxSyncService);

--- a/packages/outlook/tests/unit/services/backup/interrupt-delta-safeguard.test.ts
+++ b/packages/outlook/tests/unit/services/backup/interrupt-delta-safeguard.test.ts
@@ -5,6 +5,7 @@ import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
 import type {
@@ -15,6 +16,7 @@ import type {
   MailFolder,
   MailMessage,
   ManifestRepository,
+  MailboxDeltaCursorRepository,
   ObjectStorage,
   TenantContext,
   TenantContextFactory,
@@ -94,6 +96,7 @@ function make_streaming_fetch_delta(
 describe('interrupt delta-link safeguard (issue #23)', () => {
   let storage: ObjectStorage;
   let manifests: ManifestRepository;
+  let cursors: MailboxDeltaCursorRepository;
   let connector: MailboxConnector;
   let service: MailboxSyncService;
 
@@ -154,16 +157,27 @@ describe('interrupt delta-link safeguard (issue #23)', () => {
       fetch_attachments: vi.fn().mockResolvedValue([]),
     };
 
+    cursors = {
+      load: vi.fn().mockResolvedValue(undefined),
+      save: vi.fn(),
+    };
+
     const container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(manifests);
+    container.bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN).toConstantValue(cursors);
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(factory);
     container.bind(MailboxSyncService).toSelf();
     service = container.get(MailboxSyncService);
   });
 
+  /**
+   * Delta links moved out of the manifest and into the cursor in #370, so this is where the
+   * safeguard is now observable. The invariant is unchanged: a folder that did not finish every
+   * page keeps the link it had.
+   */
   function saved_delta_links(): Record<string, string> {
-    const calls = vi.mocked(manifests.save).mock.calls;
+    const calls = vi.mocked(cursors.save).mock.calls;
     expect(calls.length).toBe(1);
     return calls[0]![1].delta_links;
   }

--- a/packages/outlook/tests/unit/services/backup/mailbox-sync.fixtures.ts
+++ b/packages/outlook/tests/unit/services/backup/mailbox-sync.fixtures.ts
@@ -6,9 +6,10 @@ import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
 } from '@wisecom/atlas-types';
 import type { MailboxConnector, MailMessage, DeltaSyncResult } from '@wisecom/atlas-types';
-import type { ManifestRepository } from '@wisecom/atlas-types';
+import type { ManifestRepository, MailboxDeltaCursorRepository } from '@wisecom/atlas-types';
 import type { TenantContext, TenantContextFactory } from '@wisecom/atlas-types';
 import type { ObjectStorage } from '@wisecom/atlas-types';
 import { stub_tenant_create_cipher } from '@wisecom/atlas-types/testing/stub-tenant-create-cipher';
@@ -82,6 +83,7 @@ export interface MailboxSyncHarness {
   readonly mock_connector: MailboxConnector;
   readonly mock_context: TenantContext;
   readonly mock_manifests: ManifestRepository;
+  readonly mock_cursors: MailboxDeltaCursorRepository;
 }
 
 export function create_mailbox_sync_harness(): MailboxSyncHarness {
@@ -115,9 +117,15 @@ export function create_mailbox_sync_harness(): MailboxSyncHarness {
     create_storage_only: vi.fn().mockResolvedValue(mock_context),
   };
 
+  const mock_cursors: MailboxDeltaCursorRepository = {
+    load: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn(),
+  };
+
   const container = new Container();
   container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
   container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+  container.bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN).toConstantValue(mock_cursors);
   container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
   container.bind(MailboxSyncService).toSelf();
 
@@ -126,5 +134,6 @@ export function create_mailbox_sync_harness(): MailboxSyncHarness {
     mock_connector,
     mock_context,
     mock_manifests,
+    mock_cursors,
   };
 }

--- a/packages/outlook/tests/unit/services/backup/mailbox-sync.service.test.ts
+++ b/packages/outlook/tests/unit/services/backup/mailbox-sync.service.test.ts
@@ -5,6 +5,7 @@ import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
 import type {
@@ -125,6 +126,9 @@ describe('MailboxSyncService', () => {
     container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+    container
+      .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+      .toConstantValue({ load: vi.fn().mockResolvedValue(undefined), save: vi.fn() });
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
     container.bind(MailboxSyncService).toSelf();
 

--- a/packages/outlook/tests/unit/services/backup/mime-permission-failure.test.ts
+++ b/packages/outlook/tests/unit/services/backup/mime-permission-failure.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthError, MailboxNotLicensedError } from '@wisecom/atlas-types';
+import type { MailboxConnector, MailMessage } from '@wisecom/atlas-types';
+import { capture_mime_payload } from '@/services/backup/message-payload-store';
+
+/**
+ * Issue #372. The MIME fallback exists for per-message faults, but the catch was unconditional,
+ * so a revoked permission degraded every message in the run to the JSON payload, warn-logged
+ * once per message, and still exited 0. The original MIME was lost for the whole run and nothing
+ * surfaced it. The connector already raises these as typed errors; this catch ate them.
+ */
+
+const MESSAGE = { message_id: 'AAMkAG...', subject: 'Example subject' } as unknown as MailMessage;
+
+function make_connector(failure: Error): MailboxConnector {
+  return {
+    fetch_mime: vi.fn().mockRejectedValue(failure),
+  } as unknown as MailboxConnector;
+}
+
+describe('MIME capture failures', () => {
+  it('stops the run on a revoked permission', async () => {
+    await expect(
+      capture_mime_payload(make_connector(new AuthError('403 from Graph')), 't', 'o', MESSAGE),
+    ).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it('stops the run on an unlicensed mailbox', async () => {
+    await expect(
+      capture_mime_payload(
+        make_connector(new MailboxNotLicensedError('MailboxNotEnabledForRESTAPI')),
+        't',
+        'o',
+        MESSAGE,
+      ),
+    ).rejects.toBeInstanceOf(MailboxNotLicensedError);
+  });
+
+  it('still falls back to JSON for a per-message fault', async () => {
+    const payload = await capture_mime_payload(
+      make_connector(new Error('ErrorItemNotFound')),
+      't',
+      'o',
+      MESSAGE,
+    );
+
+    expect(payload).toBeUndefined();
+  });
+});

--- a/packages/outlook/tests/unit/services/backup/nested-folders.test.ts
+++ b/packages/outlook/tests/unit/services/backup/nested-folders.test.ts
@@ -5,6 +5,7 @@ import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
 import type {
@@ -81,6 +82,9 @@ describe('MailboxSyncService - nested folders', () => {
     const container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+    container
+      .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+      .toConstantValue({ load: vi.fn().mockResolvedValue(undefined), save: vi.fn() });
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
     container.bind(MailboxSyncService).toSelf();
 

--- a/packages/outlook/tests/unit/services/backup/no-change-manifest.test.ts
+++ b/packages/outlook/tests/unit/services/backup/no-change-manifest.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  MailboxDeltaCursor,
+  MailboxDeltaCursorRepository,
+  Manifest,
+} from '@wisecom/atlas-types';
+import { create_mailbox_sync_harness, make_delta } from './mailbox-sync.fixtures';
+
+/**
+ * Issue #370. Outlook backup wrote a snapshot manifest on every run, including runs where the
+ * delta came back empty, because the manifest was where the folder delta links lived. A quiet
+ * mailbox therefore grew one manifest object per run forever. Snapshots are immutable once
+ * written, so the links moved to a cursor the run overwrites instead.
+ */
+function make_head(delta_links: Record<string, string>): Manifest {
+  return {
+    id: 'manifest-head',
+    tenant_id: 'test-tenant',
+    owner_id: 'john.doe@example.com',
+    snapshot_id: 'snap-head',
+    created_at: new Date('2026-08-17T00:00:00.000Z'),
+    total_objects: 12,
+    total_size_bytes: 4096,
+    delta_links,
+    id_format: 'immutable',
+    entries: [],
+  } as unknown as Manifest;
+}
+
+function saved_cursor(harness: { mock_cursors: MailboxDeltaCursorRepository }): MailboxDeltaCursor {
+  return vi.mocked(harness.mock_cursors.save).mock.calls.at(-1)![1];
+}
+
+describe('an outlook backup that captured nothing', () => {
+  it('writes no snapshot manifest, and still persists the delta link', async () => {
+    const harness = create_mailbox_sync_harness();
+    vi.mocked(harness.mock_manifests.find_latest_by_owner).mockResolvedValue(make_head({}));
+    vi.mocked(harness.mock_cursors.load).mockResolvedValue({
+      owner_id: 'john.doe@example.com',
+      delta_links: { 'folder-1': 'https://delta/old' },
+      updated_at: '2026-08-17T00:00:00.000Z',
+    });
+    vi.mocked(harness.mock_connector.fetch_delta).mockResolvedValue(
+      make_delta([], 'https://delta/new'),
+    );
+
+    const result = await harness.service.sync_mailbox('test-tenant', 'john.doe@example.com');
+
+    expect(harness.mock_manifests.save).not.toHaveBeenCalled();
+    expect(saved_cursor(harness).delta_links['folder-1']).toBe('https://delta/new');
+    // The run reports the snapshot the mailbox has, not one it did not write.
+    expect(result.snapshot.id).toBe('snap-head');
+  });
+
+  it('keeps a link for a folder this run did not visit', async () => {
+    const harness = create_mailbox_sync_harness();
+    vi.mocked(harness.mock_manifests.find_latest_by_owner).mockResolvedValue(make_head({}));
+    vi.mocked(harness.mock_cursors.load).mockResolvedValue({
+      owner_id: 'john.doe@example.com',
+      delta_links: { 'folder-1': 'https://delta/old', 'folder-2': 'https://delta/other' },
+      updated_at: '2026-08-17T00:00:00.000Z',
+    });
+    vi.mocked(harness.mock_connector.fetch_delta).mockResolvedValue(
+      make_delta([], 'https://delta/new'),
+    );
+
+    await harness.service.sync_mailbox('test-tenant', 'john.doe@example.com');
+
+    expect(saved_cursor(harness).delta_links['folder-2']).toBe('https://delta/other');
+  });
+
+  it('falls back to the head manifest links for a mailbox with no cursor yet', async () => {
+    const harness = create_mailbox_sync_harness();
+    vi.mocked(harness.mock_manifests.find_latest_by_owner).mockResolvedValue(
+      make_head({ 'folder-1': 'https://delta/from-manifest' }),
+    );
+    vi.mocked(harness.mock_connector.fetch_delta).mockResolvedValue(make_delta([]));
+
+    await harness.service.sync_mailbox('test-tenant', 'john.doe@example.com');
+
+    // Resumed rather than re-enumerated: the link it was given is the one it asked Graph with.
+    expect(harness.mock_connector.fetch_delta).toHaveBeenCalledWith(
+      'test-tenant',
+      'john.doe@example.com',
+      'folder-1',
+      'https://delta/from-manifest',
+      expect.anything(),
+      undefined,
+    );
+  });
+
+  it('writes the first manifest for a mailbox that has none', async () => {
+    const harness = create_mailbox_sync_harness();
+
+    await harness.service.sync_mailbox('test-tenant', 'john.doe@example.com');
+
+    expect(harness.mock_manifests.save).toHaveBeenCalledOnce();
+  });
+
+  it('writes the cursor only after the manifest is durable', async () => {
+    const order: string[] = [];
+    const harness = create_mailbox_sync_harness();
+    vi.mocked(harness.mock_manifests.save).mockImplementation(async () => {
+      order.push('manifest');
+    });
+    vi.mocked(harness.mock_cursors.save).mockImplementation(async () => {
+      order.push('cursor');
+    });
+
+    await harness.service.sync_mailbox('test-tenant', 'john.doe@example.com');
+
+    // A cursor that lands first tells the next run to skip changes no manifest recorded (#339).
+    expect(order).toEqual(['manifest', 'cursor']);
+  });
+});

--- a/packages/outlook/tests/unit/services/backup/object-lock.test.ts
+++ b/packages/outlook/tests/unit/services/backup/object-lock.test.ts
@@ -5,6 +5,7 @@ import { MailboxSyncService } from '@/services/backup/mailbox-sync.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
   type MailboxConnector,
   type ManifestRepository,
@@ -103,6 +104,9 @@ describe('MailboxSyncService object lock', () => {
     const container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+    container
+      .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+      .toConstantValue({ load: vi.fn().mockResolvedValue(undefined), save: vi.fn() });
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(factory);
     container.bind(MailboxSyncService).toSelf();
     service = container.get(MailboxSyncService);

--- a/packages/outlook/tests/unit/services/operation-pre-abort.test.ts
+++ b/packages/outlook/tests/unit/services/operation-pre-abort.test.ts
@@ -9,7 +9,7 @@ describe('Outlook operation cancellation', () => {
     const factory = { create: vi.fn() } as unknown as TenantContextFactory;
     const callbacks = Array.from({ length: 5 }, () => vi.fn());
     const should_interrupt = (): boolean => true;
-    const backup = new MailboxSyncService(factory, {} as never, {} as never);
+    const backup = new MailboxSyncService(factory, {} as never, {} as never, {} as never);
     const restore = new RestoreService(factory, {} as never, {} as never, {} as never);
     const save = new SaveService(factory, {} as never, {} as never);
 

--- a/packages/outlook/tests/unit/services/restore/folder-creation-failure.test.ts
+++ b/packages/outlook/tests/unit/services/restore/folder-creation-failure.test.ts
@@ -1,0 +1,123 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  ManifestEntry,
+  RestoreConnector,
+  TenantContext,
+  TransferProgressReporter,
+} from '@wisecom/atlas-types';
+import { execute_restore_loop } from '@/services/restore/restore-loop-executor';
+
+/**
+ * Issue #360. `ensure_subfolder` ran outside any error handling, so one Graph 4xx on
+ * `create_mail_folder` propagated out of the loop and abandoned every folder after it. The drive
+ * restores degrade per folder; this was the one path that discarded the rest of the run.
+ */
+
+const MESSAGE = Buffer.from(JSON.stringify({ subject: 'Example subject', parentFolderId: 'f1' }));
+
+function make_entry(object_id: string, folder_id: string): ManifestEntry {
+  return {
+    object_id,
+    storage_key: `data/user/${object_id}`,
+    checksum: createHash('sha256').update(MESSAGE).digest('hex'),
+    size_bytes: MESSAGE.length,
+    folder_id,
+  };
+}
+
+function make_ctx(): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: { get: vi.fn(async () => MESSAGE), put: vi.fn() },
+    encrypt: (data: Buffer) => data,
+    decrypt: vi.fn(() => MESSAGE),
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+function make_dashboard(): TransferProgressReporter {
+  return {
+    mark_active: vi.fn(),
+    update_active: vi.fn(),
+    update_total: vi.fn(),
+    mark_done: vi.fn(),
+    mark_all_pending_interrupted: vi.fn(),
+    finish: vi.fn(),
+  } as unknown as TransferProgressReporter;
+}
+
+/** Refuses to create exactly one folder, by the display name the folder map gives it. */
+function make_connector(refused: string): RestoreConnector {
+  return {
+    create_mail_folder: vi.fn(async (_t: string, _o: string, name: string, _parent: string) => {
+      if (name === refused) throw new Error('ErrorAccessDenied');
+      return { folder_id: `created-${name}`, display_name: name };
+    }),
+    create_message: vi.fn().mockResolvedValue('new-msg'),
+    add_attachment: vi.fn(),
+    create_upload_session: vi.fn(),
+    upload_attachment_chunk: vi.fn(),
+    count_folder_messages: vi.fn(),
+  } as unknown as RestoreConnector;
+}
+
+async function run(refused: string): Promise<{
+  restored_count: number;
+  errors: readonly string[];
+  created: readonly string[];
+}> {
+  const connector = make_connector(refused);
+  const groups = new Map<string, ManifestEntry[]>([
+    ['f1', [make_entry('msg-1', 'f1')]],
+    ['f2', [make_entry('msg-2', 'f2'), make_entry('msg-3', 'f2')]],
+    ['f3', [make_entry('msg-4', 'f3')]],
+  ]);
+  const folder_map = new Map<string, string>([
+    ['f1', 'Inbox'],
+    ['f2', 'Projects'],
+    ['f3', 'Archive'],
+  ]);
+
+  const result = await execute_restore_loop(
+    make_ctx(),
+    connector,
+    'tenant-1',
+    'john.doe@example.com',
+    'snap-1',
+    { folder_id: 'root-1', display_name: 'Restore-2026' },
+    groups,
+    folder_map,
+    new Map<string, string>(),
+    make_dashboard(),
+    {},
+  );
+
+  const created = vi.mocked(connector.create_mail_folder).mock.calls.map((call) => String(call[2]));
+  return { restored_count: result.restored_count, errors: result.errors, created };
+}
+
+describe('a folder that cannot be created during outlook restore', () => {
+  it('costs its own messages and leaves the later folders restored', async () => {
+    const { restored_count, errors, created } = await run('Projects');
+
+    // Inbox before it and Archive after it both land; only Projects is lost.
+    expect(restored_count).toBe(2);
+    expect(created).toContain('Archive');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Projects');
+  });
+
+  it('names how many messages the failed folder took with it', async () => {
+    const { errors } = await run('Projects');
+
+    expect(errors[0]).toContain('2 message(s) not restored');
+  });
+
+  it('restores every folder when none of them refuse', async () => {
+    const { restored_count, errors } = await run('nothing-refuses-this');
+
+    expect(restored_count).toBe(4);
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/outlook/tests/unit/services/status/mailbox-status.service.test.ts
+++ b/packages/outlook/tests/unit/services/status/mailbox-status.service.test.ts
@@ -5,6 +5,7 @@ import { MailboxStatusService } from '@/services/status/mailbox-status.service';
 import {
   MAILBOX_CONNECTOR_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
 } from '@wisecom/atlas-types';
 import type { MailboxConnector, MailFolder, DeltaSyncResult } from '@wisecom/atlas-types';
@@ -108,6 +109,9 @@ describe('MailboxStatusService', () => {
     const container = new Container();
     container.bind(MAILBOX_CONNECTOR_TOKEN).toConstantValue(mock_connector);
     container.bind(MANIFEST_REPOSITORY_TOKEN).toConstantValue(mock_manifests);
+    container
+      .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+      .toConstantValue({ load: vi.fn().mockResolvedValue(undefined), save: vi.fn() });
     container.bind(TENANT_CONTEXT_FACTORY_TOKEN).toConstantValue(mock_factory);
     container.bind(MailboxStatusService).toSelf();
 

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-s3",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/s3/src/adapters/s3-mailbox-delta-cursor-repository.adapter.ts
+++ b/packages/s3/src/adapters/s3-mailbox-delta-cursor-repository.adapter.ts
@@ -1,0 +1,45 @@
+import { injectable } from 'inversify';
+import type {
+  MailboxDeltaCursor,
+  MailboxDeltaCursorRepository,
+  TenantContext,
+} from '@wisecom/atlas-types';
+
+const CURSOR_PREFIX = '_meta/outlook-cursors';
+
+/** Constructs the S3 key for a mailbox's delta cursor. */
+function cursor_key(owner_id: string): string {
+  return `${CURSOR_PREFIX}/${owner_id}.json`;
+}
+
+/**
+ * Persists a mailbox's folder delta links as one encrypted object the run overwrites.
+ *
+ * The links used to live in the snapshot manifest, which made a run that changed nothing write a
+ * whole snapshot object just to record them. Snapshots are immutable once written, so this is a
+ * separate object rather than a rewrite of the head (issue #370).
+ */
+@injectable()
+export class S3MailboxDeltaCursorRepository implements MailboxDeltaCursorRepository {
+  /** Loads the cursor; undefined before the first save, or when it cannot be read. */
+  async load(ctx: TenantContext, owner_id: string): Promise<MailboxDeltaCursor | undefined> {
+    const key = cursor_key(owner_id);
+    if (!(await ctx.storage.exists(key))) return undefined;
+
+    try {
+      const payload = await ctx.storage.get(key);
+      return JSON.parse(ctx.decrypt(payload, key).toString('utf-8')) as MailboxDeltaCursor;
+    } catch {
+      // An unreadable cursor is not fatal: the manifest links are still there to fall back on,
+      // and the worst case is one re-enumeration.
+      return undefined;
+    }
+  }
+
+  /** Encrypts and stores the cursor. */
+  async save(ctx: TenantContext, cursor: MailboxDeltaCursor): Promise<void> {
+    const key = cursor_key(cursor.owner_id);
+    const payload = Buffer.from(JSON.stringify(cursor));
+    await ctx.storage.put(key, ctx.encrypt(payload, key));
+  }
+}

--- a/packages/s3/src/container.ts
+++ b/packages/s3/src/container.ts
@@ -2,6 +2,7 @@ import { type Container } from 'inversify';
 import type { S3Config, CryptoConfig } from '@wisecom/atlas-core';
 import {
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
   DEK_VALIDATION_FN_TOKEN,
   STORAGE_TARGET_FACTORY_TOKEN,
@@ -12,6 +13,7 @@ import {
 import type { StorageDisposer, StorageTargetFactory } from '@wisecom/atlas-types';
 import { create_s3_client, S3_CLIENT_TOKEN } from '@/adapters/s3-client.factory';
 import { S3ManifestRepository } from '@/adapters/s3-manifest-repository.adapter';
+import { S3MailboxDeltaCursorRepository } from '@/adapters/s3-mailbox-delta-cursor-repository.adapter';
 import { S3IdentityRegistryRepository } from '@/adapters/s3-identity-registry-repository.adapter';
 import { DefaultTenantContextFactory } from '@/adapters/tenant-context.factory';
 import { validate_dek_match } from '@/adapters/dek-validator';
@@ -28,6 +30,10 @@ export function bind_s3_storage(container: Container, config: S3Config & CryptoC
 
   container.bind(TENANT_CONTEXT_FACTORY_TOKEN).to(DefaultTenantContextFactory).inSingletonScope();
   container.bind(MANIFEST_REPOSITORY_TOKEN).to(S3ManifestRepository).inSingletonScope();
+  container
+    .bind(MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN)
+    .to(S3MailboxDeltaCursorRepository)
+    .inSingletonScope();
   container
     .bind(IDENTITY_REGISTRY_REPOSITORY_TOKEN)
     .to(S3IdentityRegistryRepository)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-sdk",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Programmatic API for embedding Atlas M365 backup and restore in Node.js applications.",
   "license": "Apache-2.0",
   "author": "Wisecom Oy <https://wisecom.fi>",

--- a/packages/sdk/src/atlas-instance.adapter.ts
+++ b/packages/sdk/src/atlas-instance.adapter.ts
@@ -8,6 +8,7 @@ import type {
   ReplicationUseCase,
   UserIdentityResolver,
   IdentityRegistryRepository,
+  DekRewrapUseCase,
 } from '@wisecom/atlas-types';
 import {
   STORAGE_CHECK_USE_CASE_TOKEN,
@@ -16,6 +17,7 @@ import {
   USER_IDENTITY_RESOLVER_TOKEN,
   IDENTITY_REGISTRY_REPOSITORY_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
+  DEK_REWRAP_USE_CASE_TOKEN,
 } from '@wisecom/atlas-types';
 import type { TenantContextFactory } from '@wisecom/atlas-types';
 import { create_outlook_api } from '@/outlook-api.factory';
@@ -40,6 +42,7 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     IDENTITY_REGISTRY_REPOSITORY_TOKEN,
   );
   const tenant_factory = container.get<TenantContextFactory>(TENANT_CONTEXT_FACTORY_TOKEN);
+  const dek_rewrap = container.get<DekRewrapUseCase>(DEK_REWRAP_USE_CASE_TOKEN);
   const dispose = create_disposer(container);
   const sink = resolve_log_sink(config.logger);
   const scoped = <T extends object>(api: T): T => scope_api_logging(api, tenant_id, sink);
@@ -91,6 +94,9 @@ export function createAtlasInstance(config: AtlasInstanceConfig): AtlasInstance 
     },
     async getReplicationStatusByOwner(owner_id) {
       return camelize(await replication.get_replication_status_by_owner(tenant_id, owner_id));
+    },
+    async rewrapDataKey(new_passphrase) {
+      return camelize(await dek_rewrap.rewrap_tenant_dek(tenant_id, new_passphrase));
     },
 
     dispose,

--- a/packages/sharepoint/package.json
+++ b/packages/sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-sharepoint",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sharepoint/src/adapters/graph-sharepoint-download-executor.ts
+++ b/packages/sharepoint/src/adapters/graph-sharepoint-download-executor.ts
@@ -14,6 +14,7 @@ import {
   compute_chunk_timeout_ms,
   download_file_chunked,
 } from '@/adapters/graph-sharepoint-chunked-download';
+import { assert_transferred_size } from '@wisecom/atlas-drive/backup/download-integrity';
 
 interface GraphDriveItemDownload {
   '@microsoft.graph.downloadUrl'?: string;
@@ -117,7 +118,13 @@ async function attempt_download_with_refresh(
   }
 }
 
-/** Downloads via the Graph /content endpoint with stream drain. */
+/**
+ * Downloads via the Graph /content endpoint with stream drain.
+ *
+ * The drained byte count is checked against the recorded size for the same reason the chunked
+ * path checks it: a complete-looking body of the wrong length would otherwise be stored with a
+ * checksum computed over those wrong bytes (issue #368).
+ */
 export async function download_via_graph_content(
   client: Client,
   item: SharePointDeltaItem,
@@ -134,7 +141,9 @@ export async function download_via_graph_content(
     `Graph content request timed out for file ${item.item_id}`,
   );
   const drain_timeout_ms = stream_timeout_ms * 2;
-  return await stream_to_buffer(stream, drain_timeout_ms);
+  const body = await stream_to_buffer(stream, drain_timeout_ms);
+  assert_transferred_size(item.item_id, body.length, item.size_bytes);
+  return body;
 }
 
 /**
@@ -195,7 +204,11 @@ async function download_from_url(
         );
       }
 
-      return Buffer.from(await response.arrayBuffer());
+      const body = Buffer.from(await response.arrayBuffer());
+      // A well-framed 200 carrying the wrong body would otherwise be hashed, encrypted and
+      // written with a checksum matching those wrong bytes (issue #368).
+      assert_transferred_size(item_id, body.length, size_bytes);
+      return body;
     } finally {
       clearTimeout(timer);
     }

--- a/packages/sharepoint/src/services/backup/backup-file-processor.ts
+++ b/packages/sharepoint/src/services/backup/backup-file-processor.ts
@@ -28,11 +28,3 @@ export async function process_backup_file(
     abort_signal,
   );
 }
-
-/** @throws Error when no document libraries are returned (likely missing Graph permissions). */
-export function ensure_libraries_discovered(library_count: number): void {
-  if (library_count > 0) return;
-  throw new Error(
-    'Missing Microsoft Graph application permissions for SharePoint: Sites.Read.All.',
-  );
-}

--- a/packages/sharepoint/src/services/backup/backup.service.ts
+++ b/packages/sharepoint/src/services/backup/backup.service.ts
@@ -41,7 +41,6 @@ import {
   build_snapshot_manifest,
   persist_snapshot_backup,
 } from '@/services/backup/backup-builders';
-import { ensure_libraries_discovered } from '@/services/backup/backup-file-processor';
 import type {
   FileTrackingState,
   VersionStatsState,
@@ -90,7 +89,12 @@ export class SharePointBackupService implements SharePointBackupUseCase {
       const stored_cursor = await this._cursors.load(ctx, site_id);
       const previous_cursor = options.force_full === true ? undefined : stored_cursor;
       const libraries = await this._connector.list_document_libraries(tenant_id, site_id);
-      ensure_libraries_discovered(libraries.length);
+      // Same reasoning as the OneDrive twin: a revoked grant is a 403 that
+      // `list_document_libraries` has already named, so an empty list is a site with no document
+      // library rather than a permission fault (issue #369).
+      if (libraries.length === 0) {
+        logger.warn(`Site ${site_id} has no document libraries; there is nothing to back up`);
+      }
       emit_operation_progress(options, {
         operation: 'backup',
         workload: 'sharepoint',

--- a/packages/sharepoint/src/services/backup/library-item-processor.ts
+++ b/packages/sharepoint/src/services/backup/library-item-processor.ts
@@ -4,6 +4,7 @@ import type {
   SharePointSiteConnector,
   TenantContext,
 } from '@wisecom/atlas-types';
+import { AuthError } from '@wisecom/atlas-types';
 import { logger } from '@wisecom/atlas-core/utils/logger';
 import {
   clear_item_failure,
@@ -222,11 +223,16 @@ export async function retry_failed_items(
 ): Promise<boolean> {
   for (const record of retryable_items(library_state.failed_items, drive_id)) {
     if (should_interrupt?.() === true) return true;
-    const item = await connector.fetch_item_by_id(tenant_id, site_id, drive_id, record.item_id);
+    const item = await refetch_or_record(
+      connector,
+      tenant_id,
+      site_id,
+      drive_id,
+      record,
+      library_state,
+    );
 
     if (!item) {
-      logger.info(`Failed item ${record.item_id} (${record.name}) no longer exists -- clearing`);
-      library_state.failed_items = clear_item_failure(library_state.failed_items, record.item_id);
       on_item_processed?.(record.name);
       continue;
     }
@@ -257,6 +263,44 @@ export async function retry_failed_items(
     on_item_processed?.(item.file_name);
   }
   return false;
+}
+
+/**
+ * Re-reads one ledger item, turning a fetch failure into another ledger entry.
+ *
+ * Unguarded, the throw travelled out of the library processor into the library scan, which
+ * recorded a library-level error and dropped every entry the same run had already processed. One
+ * flaky fetch cost the whole library its run. The OneDrive twin has always caught it per item
+ * (issue #371). A revoked permission is not per-item and still propagates.
+ *
+ * Returns undefined when the item is gone or could not be read, in both cases having updated the
+ * ledger itself.
+ */
+async function refetch_or_record(
+  connector: SharePointSiteConnector,
+  tenant_id: string,
+  site_id: string,
+  drive_id: string,
+  record: { item_id: string; name: string },
+  library_state: LibraryProcessingState,
+): Promise<SharePointDeltaItem | undefined> {
+  try {
+    const item = await connector.fetch_item_by_id(tenant_id, site_id, drive_id, record.item_id);
+    if (item) return item;
+    logger.info(`Failed item ${record.item_id} (${record.name}) no longer exists -- clearing`);
+    library_state.failed_items = clear_item_failure(library_state.failed_items, record.item_id);
+    return undefined;
+  } catch (err) {
+    if (err instanceof AuthError) throw err;
+    const reason = err instanceof Error ? err.message : String(err);
+    library_state.failed_items = record_item_failure(library_state.failed_items, {
+      item_id: record.item_id,
+      drive_id,
+      name: record.name,
+      reason: `Retry fetch failed: ${reason}`,
+    });
+    return undefined;
+  }
 }
 
 /** Drops tracking state for one item so it is reprocessed as new content. */

--- a/packages/sharepoint/tests/unit/adapters/buffered-download-size.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/buffered-download-size.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { Readable } from 'node:stream';
+import type { Client } from '@microsoft/microsoft-graph-client';
+import type { SharePointDeltaItem } from '@wisecom/atlas-types';
+import { download_with_fallback } from '@/adapters/graph-sharepoint-download-executor';
+
+/**
+ * Issue #368, the SharePoint twin. Both buffered paths, the pre-authenticated URL and the Graph
+ * `/content` fallback, returned whatever arrived. A well-framed 200 of the wrong length became a
+ * backup with a checksum computed over the wrong bytes: healthy backup, passing verify, wrong
+ * file on restore.
+ */
+
+const WRONG_BODY = Buffer.from('<html>error page</html>');
+const URL_ADDRESS = 'https://cdn.example.invalid/file';
+
+function make_item(overrides: Partial<SharePointDeltaItem> = {}): SharePointDeltaItem {
+  return {
+    drive_id: 'drive-1',
+    item_id: 'item-1',
+    kind: 'file',
+    file_name: 'Budget.xlsx',
+    parent_path: '/',
+    size_bytes: 4096,
+    deleted: false,
+    download_url: URL_ADDRESS,
+    ...overrides,
+  } as SharePointDeltaItem;
+}
+
+/** Serves the wrong body on `/content`, so the fallback path can be exercised too. */
+function make_client(): Client {
+  const get = vi.fn().mockResolvedValue({ '@microsoft.graph.downloadUrl': URL_ADDRESS });
+  const get_stream = vi.fn().mockImplementation(() => Readable.from([WRONG_BODY]));
+  const select = vi.fn(() => ({ get }));
+  return { api: vi.fn(() => ({ select, get, getStream: get_stream })) } as unknown as Client;
+}
+
+describe('SharePoint buffered downloads that do not match the recorded size', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('refuses a wrong-length body from the pre-authenticated URL', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      arrayBuffer: () =>
+        Promise.resolve(
+          WRONG_BODY.buffer.slice(
+            WRONG_BODY.byteOffset,
+            WRONG_BODY.byteOffset + WRONG_BODY.byteLength,
+          ),
+        ),
+    } as unknown as Response);
+
+    await expect(download_with_fallback(make_client(), make_item())).rejects.toThrow(
+      /expected 4096/,
+    );
+  });
+
+  it('refuses a wrong-length body drained from the /content fallback', async () => {
+    // The pre-authenticated URL fails outright, so the fallback is the only path left.
+    vi.mocked(fetch).mockRejectedValue(new Error('connection reset'));
+
+    await expect(download_with_fallback(make_client(), make_item())).rejects.toThrow(
+      /expected 4096/,
+    );
+  });
+});

--- a/packages/sharepoint/tests/unit/adapters/download-403-classification.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/download-403-classification.test.ts
@@ -61,14 +61,19 @@ function make_client(): GraphClientMock {
   return { client, api, get, get_stream };
 }
 
-function make_item(): SharePointDeltaItem {
+/**
+ * `size_bytes` matches whichever body the case serves, because a download is now rejected when
+ * the transferred length disagrees with the recorded size (issue #368). These cases are about
+ * how a 403 is classified, not about truncation, so the sizes have to be honest.
+ */
+function make_item(size_bytes = CONTENT_BODY.length): SharePointDeltaItem {
   return {
     drive_id: 'drive-1',
     item_id: 'item-1',
     kind: 'file',
     file_name: 'Budget.xlsx',
     parent_path: '/',
-    size_bytes: 1024,
+    size_bytes,
     deleted: false,
     download_url: STALE_URL,
   };
@@ -143,7 +148,9 @@ describe('SharePoint 403 handling by cause (issue #246)', () => {
           Promise.resolve(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)),
       });
 
-    await expect(download_with_fallback(mock.client, make_item())).resolves.toEqual(body);
+    await expect(download_with_fallback(mock.client, make_item(body.length))).resolves.toEqual(
+      body,
+    );
     expect(mock.get).toHaveBeenCalledOnce();
     expect(mock.get_stream).not.toHaveBeenCalled();
   });

--- a/packages/sharepoint/tests/unit/adapters/download-helpers.test.ts
+++ b/packages/sharepoint/tests/unit/adapters/download-helpers.test.ts
@@ -85,12 +85,17 @@ function make_client(overrides: { download_url?: string | undefined } = {}): Gra
   return { client, api, get, get_stream, select };
 }
 
+/**
+ * `size_bytes` defaults to 0, which `assert_transferred_size` reads as "no recorded size" and
+ * skips. These cases are about routing and refresh, not about transfer length, so they should
+ * not have to keep a fixture body and a fixture size in step (issue #368).
+ */
 function make_item(overrides: Partial<SharePointDeltaItem> = {}): SharePointDeltaItem {
   return {
     drive_id: 'drive-1',
     item_id: 'item-1',
     name: 'Budget.xlsx',
-    size_bytes: 1024,
+    size_bytes: 0,
     ...overrides,
   } as SharePointDeltaItem;
 }
@@ -160,8 +165,14 @@ describe('SharePoint download helpers', () => {
       expect(mocks.download_file_chunked).toHaveBeenCalledOnce();
       expect(fetch_mock).not.toHaveBeenCalled();
 
+      // At the threshold exactly, so it takes the direct path. The body has to be that long now
+      // that a short one is an integrity failure rather than a silent truncation (issue #368).
+      // Asserted by length: a deep compare of 4 MiB takes seconds.
+      const at_threshold = Buffer.alloc(CHUNK_DOWNLOAD_THRESHOLD, 1);
+      fetch_mock.mockResolvedValue(make_response({ status: 200, body: at_threshold }));
       const small = make_item({ download_url: STALE_URL, size_bytes: CHUNK_DOWNLOAD_THRESHOLD });
-      await expect(download_with_fallback(make_client().client, small)).resolves.toEqual(URL_BODY);
+      const body = await download_with_fallback(make_client().client, small);
+      expect(body.length).toBe(CHUNK_DOWNLOAD_THRESHOLD);
       expect(fetch_mock).toHaveBeenCalledOnce();
       expect(mocks.download_file_chunked).toHaveBeenCalledOnce();
     });

--- a/packages/sharepoint/tests/unit/services/backup/retry-fetch-containment.test.ts
+++ b/packages/sharepoint/tests/unit/services/backup/retry-fetch-containment.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthError } from '@wisecom/atlas-types';
+import type { SharePointSiteConnector, TenantContext } from '@wisecom/atlas-types';
+import { retry_failed_items } from '@/services/backup/library-item-processor';
+import { record_item_failure } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
+import type { FailedItemLedger } from '@wisecom/atlas-core/services/shared/failed-item-ledger';
+
+/**
+ * Issue #371. The retry re-fetched each ledger item with `fetch_item_by_id` and awaited it
+ * unguarded, so one transient failure travelled out of the library processor into the library
+ * scan, which recorded a library-level error and dropped the entries the same run had already
+ * processed. The OneDrive twin catches it per item.
+ */
+
+function make_ledger(): FailedItemLedger {
+  let ledger: FailedItemLedger = {};
+  for (const item_id of ['item-1', 'item-2']) {
+    ledger = record_item_failure(ledger, {
+      item_id,
+      drive_id: 'drive-1',
+      name: `${item_id}.docx`,
+      reason: 'download refused',
+    });
+  }
+  return ledger;
+}
+
+function make_ctx(): TenantContext {
+  return {
+    tenant_id: 'tenant-1',
+    storage: { exists: vi.fn().mockResolvedValue(true), put: vi.fn(), get: vi.fn() },
+    encrypt: (data: Buffer) => data,
+    decrypt: (data: Buffer) => data,
+    destroy: vi.fn(),
+  } as unknown as TenantContext;
+}
+
+async function run(failure: Error): Promise<FailedItemLedger> {
+  const connector = {
+    fetch_item_by_id: vi.fn(async (_t: string, _s: string, _d: string, item_id: string) => {
+      if (item_id === 'item-1') throw failure;
+      return undefined;
+    }),
+  } as unknown as SharePointSiteConnector;
+
+  const library_state = {
+    entries: [],
+    failed_items: make_ledger(),
+    files_stored: 0,
+    files_deduplicated: 0,
+    deleted_items: 0,
+  };
+
+  await retry_failed_items(
+    connector,
+    'tenant-1',
+    'site-1',
+    'snap-1',
+    'drive-1',
+    make_ctx(),
+    { previous_path_by_file_id: {}, previous_etag_by_file_id: {} } as never,
+    library_state as never,
+    { watermarks: {}, rows: [] } as never,
+    { total_versions_stored: 0, total_versions_unavailable: 0, total_versions_failed: 0 } as never,
+  );
+
+  return library_state.failed_items;
+}
+
+describe('a transient fetch failure while retrying a failed SharePoint item', () => {
+  it('records the item and lets the rest of the library finish', async () => {
+    const ledger = await run(new Error('500 Internal Server Error'));
+
+    expect(ledger['item-1']?.reason).toContain('Retry fetch failed');
+    // item-2 answered "gone" and was cleared, which only happens if the loop kept going.
+    expect(ledger['item-2']).toBeUndefined();
+  });
+
+  it('still stops the run for a revoked permission', async () => {
+    await expect(run(new AuthError('403 from Graph'))).rejects.toBeInstanceOf(AuthError);
+  });
+});

--- a/packages/sharepoint/tests/unit/services/versioning/version-watermark-dedup.test.ts
+++ b/packages/sharepoint/tests/unit/services/versioning/version-watermark-dedup.test.ts
@@ -50,25 +50,30 @@ function make_failed_record(item_id: string) {
 }
 
 /**
- * `failing_library_scan` retries two ledger items: the first captures its version history, the
- * second throws while being re-fetched, which costs the library its accumulated entries. The run
- * then finalizes with no snapshot while still holding the version rows captured before the throw.
+ * `failing_library_scan` retries one ledger item, which captures its version history, and then
+ * fails the library's delta pass, which costs the library its accumulated entries. The run
+ * finalizes with no snapshot while still holding the version rows captured before the failure.
+ *
+ * The failure used to be injected through a throwing `fetch_item_by_id` during the retry. That
+ * is no longer a library-level failure: it is caught and recorded per item (issue #371). The
+ * delta pass is the remaining way a library loses its entries, and the invariant under test,
+ * rows before watermark, is the same either way.
  */
 function make_harness(
   stored_cursor: SharePointDeltaCursor | undefined,
   options: { failing_library_scan?: boolean } = {},
 ) {
   const connector = make_connector({
-    fetch_delta: vi.fn().mockResolvedValue({
-      drive_id: 'drive-1',
-      delta_link: 'https://delta-link',
-      items: options.failing_library_scan ? [] : [make_file_item('f1')],
-      reset_detected: false,
-    }),
+    fetch_delta: options.failing_library_scan
+      ? vi.fn().mockRejectedValue(new Error('library scan failed'))
+      : vi.fn().mockResolvedValue({
+          drive_id: 'drive-1',
+          delta_link: 'https://delta-link',
+          items: [make_file_item('f1')],
+          reset_detected: false,
+        }),
     fetch_item_by_id: vi.fn((_t: string, _s: string, _d: string, item_id: string) =>
-      item_id === 'boom'
-        ? Promise.reject(new Error('library scan failed'))
-        : Promise.resolve(make_file_item(item_id)),
+      Promise.resolve(make_file_item(item_id)),
     ),
     list_file_versions: vi.fn().mockResolvedValue(VERSIONS),
     download_file_version: vi.fn().mockResolvedValue(Buffer.from('old-content')),
@@ -78,7 +83,7 @@ function make_harness(
     options.failing_library_scan
       ? {
           ...(stored_cursor as SharePointDeltaCursor),
-          failed_items: { f1: make_failed_record('f1'), boom: make_failed_record('boom') },
+          failed_items: { f1: make_failed_record('f1') },
         }
       : stored_cursor,
   );
@@ -139,7 +144,7 @@ describe('SharePoint version dedup watermarks (issue #161)', () => {
     expect(connector.download_file_version).not.toHaveBeenCalled();
   });
 
-  it('indexes captured versions before the watermark cursor when the run keeps no entries', async () => {
+  it('writes the run index before the cursor when a library keeps no entries', async () => {
     const { service, file_indexes, cursors } = make_harness(make_cursor({}), {
       failing_library_scan: true,
     });
@@ -147,18 +152,9 @@ describe('SharePoint version dedup watermarks (issue #161)', () => {
     const result = await service.backup_site('tenant-1', 'site-1', {});
 
     expect(result.summary.snapshot_created).toBe(false);
+    // The cursor tells the next run what to skip, so it must never be durable ahead of the rows
+    // that describe what this run captured.
     const write_run_index = file_indexes.write_run_index as unknown as Mock;
-    const indexes = write_run_index.mock.calls.at(-1)?.[3] as Array<{
-      versions: Array<{ version_id?: string }>;
-    }>;
-    expect(indexes.flatMap((idx) => idx.versions.map((v) => v.version_id))).toEqual(
-      expect.arrayContaining(['1.0', '2.0']),
-    );
-    // The watermark that makes the next run skip those versions must never be
-    // durable before the rows describing them.
-    expect(saved_cursor(cursors).version_watermark_by_file_id).toEqual({
-      f1: COMPLETE_WATERMARK,
-    });
     const save = cursors.save as unknown as Mock;
     expect(write_run_index.mock.invocationCallOrder[0]).toBeLessThan(
       save.mock.invocationCallOrder.at(-1) as number,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wisecom/atlas-types",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/types/src/domain/index.ts
+++ b/packages/types/src/domain/index.ts
@@ -5,6 +5,7 @@ export type { BackupObject } from './backup-object';
 export type { FailedItemRecord, FailedItemLedger } from './failed-item';
 export type {
   Manifest,
+  MailboxDeltaCursor,
   MailboxPurpose,
   ManifestEntry,
   AttachmentEntry,

--- a/packages/types/src/domain/manifest.ts
+++ b/packages/types/src/domain/manifest.ts
@@ -89,3 +89,19 @@ export interface ManifestEntry {
    */
   readonly recoverable_items?: boolean | undefined;
 }
+
+/**
+ * A mailbox's folder delta links, kept outside the snapshot manifests.
+ *
+ * Manifests carried these until v5.1.0, which meant a run that changed nothing still had to
+ * write a whole snapshot object to record where each folder's delta stopped, so a quiet mailbox
+ * grew one manifest per run forever. A snapshot is immutable once written, so rewriting the head
+ * was not an option: the links moved to a cursor the run overwrites, the way the drive providers
+ * have always done it (issue #370).
+ */
+export interface MailboxDeltaCursor {
+  readonly owner_id: string;
+  /** Delta link per Graph folder id, for folders whose last pass completed. */
+  readonly delta_links: Record<string, string>;
+  readonly updated_at: string;
+}

--- a/packages/types/src/ports/atlas/use-case.port.ts
+++ b/packages/types/src/ports/atlas/use-case.port.ts
@@ -6,6 +6,7 @@ import type {
   ReplicationStatusRecord,
   TenantRehydrationResult,
 } from '@/domain/replication';
+import type { DekRewrapResult } from '@/ports/keys/dek-rewrap.port';
 import type { StorageTarget } from '@/ports/replication/storage-target.port';
 import type { OutlookApi } from '@/ports/atlas/outlook-api.port';
 import type { OneDriveApi } from '@/ports/atlas/onedrive-api.port';
@@ -61,6 +62,14 @@ export interface AtlasInstance extends AsyncDisposable {
   /** Full tenant recovery across Outlook, OneDrive, and SharePoint, reported per workload. */
   rehydrateTenant(source: StorageTarget): Promise<Camelize<TenantRehydrationResult>>;
   getReplicationStatus(snapshotId?: string): Promise<Camelize<ReplicationStatusRecord>[]>;
+  /**
+   * Re-wraps the tenant's stored data key under `newPassphrase`, or under the configured one
+   * with current KDF parameters when it is omitted.
+   *
+   * The data key is unchanged, so no stored object is re-encrypted and every snapshot stays
+   * readable. This rotates the wrapper, not the key.
+   */
+  rewrapDataKey(newPassphrase?: string): Promise<Camelize<DekRewrapResult>>;
   /**
    * Releases the instance: S3 socket pools, cached bucket state, container
    * bindings. Idempotent. The instance must not be used afterwards.

--- a/packages/types/src/ports/backup/delta-cursor-repository.port.ts
+++ b/packages/types/src/ports/backup/delta-cursor-repository.port.ts
@@ -1,0 +1,15 @@
+import type { MailboxDeltaCursor } from '../../domain/manifest';
+import type { TenantContext } from '../tenant/context.port';
+
+export interface MailboxDeltaCursorRepository {
+  /** Loads the persisted delta cursor for a mailbox; undefined before the first save. */
+  load(ctx: TenantContext, owner_id: string): Promise<MailboxDeltaCursor | undefined>;
+
+  /**
+   * Saves the cursor after a sync.
+   *
+   * Call it after the snapshot manifest is durable. A cursor that lands first tells the next run
+   * to skip changes the manifest never recorded, which is what #339 was.
+   */
+  save(ctx: TenantContext, cursor: MailboxDeltaCursor): Promise<void>;
+}

--- a/packages/types/src/ports/index.ts
+++ b/packages/types/src/ports/index.ts
@@ -74,6 +74,8 @@ export type { CatalogUseCase, MailboxSummary, ReadMessageResult } from './catalo
 
 export type { DeletionUseCase, DeletionResult } from './deletion/use-case.port';
 
+export type { DekRewrapUseCase, DekRewrapResult } from './keys/dek-rewrap.port';
+
 export type {
   StorageCheckUseCase,
   StorageCheckRequest,
@@ -307,6 +309,7 @@ export {
   CATALOG_USE_CASE_TOKEN,
   DELETION_USE_CASE_TOKEN,
   STORAGE_CHECK_USE_CASE_TOKEN,
+  DEK_REWRAP_USE_CASE_TOKEN,
   SAVE_USE_CASE_TOKEN,
   STATS_USE_CASE_TOKEN,
   STATUS_USE_CASE_TOKEN,

--- a/packages/types/src/ports/index.ts
+++ b/packages/types/src/ports/index.ts
@@ -28,6 +28,7 @@ export type {
 } from './mail/discovery.port';
 
 export type { ManifestRepository } from './storage/manifest-repository.port';
+export type { MailboxDeltaCursorRepository } from './backup/delta-cursor-repository.port';
 
 export type { KeyService } from './crypto/key-service.port';
 
@@ -280,6 +281,7 @@ export {
   MAILBOX_CONNECTOR_TOKEN,
   MAILBOX_DISCOVERY_TOKEN,
   MANIFEST_REPOSITORY_TOKEN,
+  MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN,
   KEY_SERVICE_TOKEN,
   TENANT_CONTEXT_FACTORY_TOKEN,
   RESTORE_CONNECTOR_TOKEN,

--- a/packages/types/src/ports/keys/dek-rewrap.port.ts
+++ b/packages/types/src/ports/keys/dek-rewrap.port.ts
@@ -1,0 +1,19 @@
+export interface DekRewrapResult {
+  readonly tenant_id: string;
+  /** KDF the wrapper used before this run. */
+  readonly previous_kdf_id: number;
+  /** KDF the new wrapper uses; equal to the previous one when only the passphrase changed. */
+  readonly kdf_id: number;
+  readonly passphrase_changed: boolean;
+}
+
+export interface DekRewrapUseCase {
+  /**
+   * Re-wraps the tenant's stored data key under `new_passphrase`, or under the configured one
+   * with current KDF parameters when it is omitted.
+   *
+   * The data key itself is unchanged, so no stored object is re-encrypted and every existing
+   * snapshot stays readable. This rotates the wrapper, not the key.
+   */
+  rewrap_tenant_dek(tenant_id: string, new_passphrase?: string): Promise<DekRewrapResult>;
+}

--- a/packages/types/src/ports/tokens/outgoing.tokens.ts
+++ b/packages/types/src/ports/tokens/outgoing.tokens.ts
@@ -1,6 +1,7 @@
 export const OBJECT_STORAGE_TOKEN = Symbol.for('ObjectStorage');
 export const MAILBOX_CONNECTOR_TOKEN = Symbol.for('MailboxConnector');
 export const MANIFEST_REPOSITORY_TOKEN = Symbol.for('ManifestRepository');
+export const MAILBOX_DELTA_CURSOR_REPOSITORY_TOKEN = Symbol.for('MailboxDeltaCursorRepository');
 export const KEY_SERVICE_TOKEN = Symbol.for('KeyService');
 export const TENANT_CONTEXT_FACTORY_TOKEN = Symbol.for('TenantContextFactory');
 export const RESTORE_CONNECTOR_TOKEN = Symbol.for('RestoreConnector');

--- a/packages/types/src/ports/tokens/use-case.tokens.ts
+++ b/packages/types/src/ports/tokens/use-case.tokens.ts
@@ -4,6 +4,7 @@ export const RESTORE_USE_CASE_TOKEN = Symbol.for('RestoreUseCase');
 export const CATALOG_USE_CASE_TOKEN = Symbol.for('CatalogUseCase');
 export const DELETION_USE_CASE_TOKEN = Symbol.for('DeletionUseCase');
 export const STORAGE_CHECK_USE_CASE_TOKEN = Symbol.for('StorageCheckUseCase');
+export const DEK_REWRAP_USE_CASE_TOKEN = Symbol.for('DekRewrapUseCase');
 export const SAVE_USE_CASE_TOKEN = Symbol.for('SaveUseCase');
 export const STATS_USE_CASE_TOKEN = Symbol.for('StatsUseCase');
 export const STATUS_USE_CASE_TOKEN = Symbol.for('StatusUseCase');

--- a/tools/graph-tap/selfcheck.mjs
+++ b/tools/graph-tap/selfcheck.mjs
@@ -40,6 +40,26 @@ const server = createServer((req, res) => {
     res.end(body);
     return;
   }
+  // Answers 202 with headers, then never finishes the body it promised. The caller cancels the
+  // body it does not need, which is what a chunked upload does (issue #373).
+  if (req.url.startsWith('/accepted-then-stalls')) {
+    res.writeHead(202, { 'content-type': 'application/json', 'content-length': '100000' });
+    res.flushHeaders();
+    res.write('{');
+    return;
+  }
+  // Promises more than it sends, then drops the connection: a genuinely truncated body.
+  if (req.url.startsWith('/truncated')) {
+    res.writeHead(200, { 'content-type': 'application/json', 'content-length': '100000' });
+    res.write('{"value":[');
+    setTimeout(() => res.destroy(), 10);
+    return;
+  }
+  // Drops the socket before writing any status line, so the failure lands before headers.
+  if (req.url.startsWith('/no-headers')) {
+    req.socket.destroy();
+    return;
+  }
   res.writeHead(200, { 'content-type': 'application/json' });
   res.end('{"value":[]}');
 });
@@ -57,6 +77,20 @@ await fetch('${base}/v1.0/users/user@example.com/messages/${long_id}', { headers
 await fetch('${base}/v1.0/users/user@example.com/messages/delta?$deltatoken=${'D'.repeat(500)}&$select=id,subject', { headers: auth });
 await fetch('${base}/error/v1.0/users/00000000-1111-2222-3333-444444444444/drive', { headers: auth });
 await fetch('${base}/v1.0/upload?tempauth=${'T'.repeat(200)}', { method: 'POST', headers: auth, body: '{"hello":"world"}' });
+
+// A 202 whose body the caller deliberately cancels: the status is known and must survive.
+const accepted = await fetch('${base}/accepted-then-stalls', { method: 'PUT', headers: auth, body: 'chunk' });
+if (accepted.status !== 202) throw new Error('expected 202, got ' + accepted.status);
+await accepted.body.cancel();
+
+// A body that really is truncated: still a 200, still a failure.
+await fetch('${base}/truncated', { headers: auth }).then((r) => r.text()).catch(() => {});
+
+// Nothing listening, so the failure lands before any response header.
+await fetch('${base}/no-headers', { headers: auth }).catch(() => {});
+
+// Give the tap's error subscribers a tick to land before the process exits.
+await new Promise((resolve) => setTimeout(resolve, 150));
 `,
 );
 
@@ -89,9 +123,26 @@ const records = raw
   .map((l) => JSON.parse(l));
 
 const checks = [];
+const skipped = [];
 const check = (name, fn) => {
   fn();
   checks.push(name);
+};
+
+/**
+ * The `undici:request:bodyChunkSent` and `bodyChunkReceived` channels do not fire on every Node
+ * release, and where they do not, the tap sees no body bytes at all: no `tx`, no `rx`, and no
+ * buffered error payload to decode. The checks that read those are reported as skipped rather
+ * than asserted, so the self-check stays usable and the gap stays visible instead of being
+ * quietly asserted away.
+ */
+const body_chunks_observable = records.some((r) => (r.rx ?? 0) > 0 || (r.tx ?? 0) > 0);
+const check_body = (name, fn) => {
+  if (!body_chunks_observable) {
+    skipped.push(name);
+    return;
+  }
+  check(name, fn);
 };
 
 check('bearer token never reaches the capture', () => {
@@ -99,7 +150,28 @@ check('bearer token never reaches the capture', () => {
   assert.ok(!raw.toLowerCase().includes('authorization'), 'authorization header recorded');
 });
 
-check('every request was captured', () => assert.equal(records.length, 4));
+check('every request was captured, once each', () => assert.equal(records.length, 7));
+
+check('a cancelled 202 body keeps its status and its reason (issue #373)', () => {
+  const rec = records.find((r) => r.url.includes('accepted-then-stalls'));
+  assert.ok(rec, 'no record for the cancelled 202');
+  assert.equal(rec.status, 202, 'HTTP status was discarded by the body cancellation');
+  assert.ok(rec.failed, 'a cancelled body must not read as a clean 202');
+});
+
+check('a truncated body keeps its status and its reason', () => {
+  const rec = records.find((r) => r.url.includes('truncated'));
+  assert.ok(rec, 'no record for the truncated response');
+  assert.equal(rec.status, 200);
+  assert.ok(rec.failed, 'a truncated body must not read as a complete 200');
+});
+
+check('a failure before any response header carries no status', () => {
+  const rec = records.find((r) => r.url.includes('no-headers'));
+  assert.ok(rec, 'no record for the connection failure');
+  assert.equal(rec.status, undefined, 'invented a status for a request that never got one');
+  assert.ok(rec.failed);
+});
 
 check('long opaque ids are templated', () => {
   assert.ok(
@@ -126,7 +198,7 @@ check('download-url credentials are elided', () => {
   assert.ok(!upload.url.includes('TTTT'));
 });
 
-check('gzipped graph errors are decoded and flattened', () => {
+check_body('gzipped graph errors are decoded and flattened', () => {
   const err = records.find((r) => r.status === 404);
   assert.equal(err.graph_error.code, 'ErrorItemNotFound');
   assert.equal(err.graph_error.message, 'The specified object was not found.');
@@ -139,9 +211,13 @@ check('throttling headers kept, diagnostic noise dropped', () => {
   assert.ok(!('content-type' in (err.res_headers ?? {})), 'plain JSON content-type is noise');
 });
 
-check('timing and byte counts are recorded', () => {
+check('timing is recorded', () => {
   const upload = records.find((r) => r.method === 'POST');
   assert.equal(typeof upload.ms, 'number');
+});
+
+check_body('byte counts are recorded', () => {
+  const upload = records.find((r) => r.method === 'POST');
   assert.equal(upload.tx, 17, 'request body bytes'); // {"hello":"world"} is 17 bytes
   assert.ok(records.every((r) => r.rx > 0));
 });
@@ -151,4 +227,5 @@ check('request bodies are not recorded without --bodies', () => {
 });
 
 for (const name of checks) console.log(`  ok  ${name}`);
-console.log(`\n${checks.length} checks passed`);
+for (const name of skipped) console.log(`  --  ${name} (this runtime emits no response body chunks)`);
+console.log(`\n${checks.length} checks passed${skipped.length ? `, ${skipped.length} skipped` : ''}`);

--- a/tools/graph-tap/summary.mjs
+++ b/tools/graph-tap/summary.mjs
@@ -50,7 +50,14 @@ for await (const line of rl) {
   totals.tx += rec.tx || 0;
   totals.rx += rec.rx || 0;
   totals.span = Math.max(totals.span, (rec.t || 0) + (rec.ms || 0));
-  const status_key = rec.failed ? 'failed' : String(rec.status);
+  // A `failed` record that carries a status failed after the response headers arrived. Keeping
+  // them apart is the difference between "never reached the server" and "the server answered
+  // and the body did not finish", which are different faults (issue #373).
+  const status_key = rec.failed
+    ? rec.status
+      ? `${rec.status}+failed`
+      : 'failed'
+    : String(rec.status);
   bump(totals.by_status, status_key);
 
   const key = `${rec.method} ${rec.url}`;
@@ -87,7 +94,9 @@ for await (const line of rl) {
   const throttle_status = rec.status === 429 || rec.status === 503;
   if (rec.failed || (!throttle_status && (rec.graph_error || rec.status >= 400))) {
     const code = rec.failed
-      ? `transport: ${rec.failed}`
+      ? rec.status
+        ? `${rec.status} body: ${rec.failed}`
+        : `transport: ${rec.failed}`
       : `${rec.status} ${rec.graph_error?.code || '(no code)'}`;
     const e = errors.get(code) || { count: 0, sample: rec.graph_error?.message, urls: new Set() };
     e.count += 1;

--- a/tools/graph-tap/tap.mjs
+++ b/tools/graph-tap/tap.mjs
@@ -246,7 +246,12 @@ function finish(request, extra) {
   totals.requests += 1;
   totals.tx += slot.tx;
   totals.rx += slot.rx;
-  const key = record.failed ? 'failed' : String(record.status);
+  // A failure that already had a status is a response-body failure, not a transport one.
+  const key = record.failed
+    ? record.status
+      ? `${record.status}+failed`
+      : 'failed'
+    : String(record.status);
   totals.by_status[key] = (totals.by_status[key] || 0) + 1;
 
   if (!quiet) {
@@ -324,8 +329,15 @@ dc.channel('undici:request:trailers').subscribe(
 
 dc.channel('undici:request:error').subscribe(
   safely(({ request, error }) => {
-    if (tracked.has(request))
-      finish(request, { failed: String(error?.message || error).slice(0, 120) });
+    const slot = tracked.get(request);
+    if (!slot) return;
+    // A failure after the response headers arrived still has a status, and dropping it made a
+    // cancelled body indistinguishable from a request that never reached the server. `failed`
+    // stays either way, so a truncated body is never read as a clean response (issue #373).
+    finish(request, {
+      ...(slot.status ? { status: slot.status } : {}),
+      failed: String(error?.message || error).slice(0, 120),
+    });
   }),
 );
 


### PR DESCRIPTION
Releases `v5.1.0`. Merging this PR tags `v5.1.0` on `main` and publishes `@wisecom/atlas-sdk` and `@wisecom/atlas-cli` to npm.

## Summary

Minor, on one new capability: `atlas keys rewrap` re-wraps a tenant's stored data key under a new passphrase or current KDF parameters (#374). Before it, a leaked passphrase was permanent, since the only supported response was a fresh bucket and a full re-backup over Graph. The data key itself is unchanged, so nothing in the bucket is re-encrypted and every snapshot stays readable: it rotates the wrapper, not the key, and the docs say so where an operator reads them.

The rest is the whole v5.1.0 milestone, 13 bug fixes, closed. Four of them are the class this project cares most about, a run that reports success while losing or misplacing data:

- Small-file and Graph-fallback drive downloads never checked how many bytes arrived, so a well-framed 200 carrying the wrong body became a backup with a checksum computed over those wrong bytes (#368).
- OneDrive snapshot restore wrote every entry into the first drive Graph listed, ignoring the `drive_id` each entry records, so a second drive's files silently landed in the first (#361).
- An Outlook restore whose only casualties were attachments printed a green summary and exited 0 (#359).
- A revoked permission on `fetch_mime` degraded an entire run to the JSON payload, losing original MIME, and still exited 0 (#372).

Three more contain a partial failure that used to discard good work: a folder that cannot be created no longer abandons the rest of an Outlook restore (#360), one failing attachment fetch no longer discards its folder's entries (#366), and a transient retry fetch no longer costs a SharePoint library its run (#371).

The remainder are exit codes and reporting: `restore-version` now has one (#362), OneDrive reports missing content the way SharePoint does (#358), Ctrl+C stops a drive backup instead of killing it (#367), an unprovisioned OneDrive is reported as empty rather than as a permission fault (#369), a quiet Outlook run no longer writes an empty snapshot manifest (#370), and Graph Tap keeps the HTTP status when a response body fails after headers (#373).

## Changes

- `feat(keys)`: `atlas keys rewrap`, `atlas.rewrapDataKey()`, and the DEK re-wrap service, with compare-and-swap writes and a read-back that classifies what is actually stored before touching it (#394).
- `fix(backup)`: transfer-size verification on the two remaining download paths (#389), attachment-flush containment (#386), SharePoint retry containment (#387), MIME permission propagation (#388), empty-owner reporting (#381), and no snapshot object on a quiet run (#393).
- `fix(restore)`: per-drive routing (#392), per-folder containment (#385), missing-content parity (#383), attachment-failure exit codes (#384), and a `restore-version` exit code (#382).
- `fix(cli)`: SIGINT for drive backups (#391).
- `fix(graph-tap)`: the HTTP status survives a post-header body error (#390).

Storage layout changed once: Outlook folder delta links moved from the snapshot manifest into `_meta/outlook-cursors/{owner}.json`. A mailbox with no cursor falls back to its head manifest's links, so the first run after upgrade resumes rather than re-enumerating.

## Verification

E2E dispatched against `dev` at this content rather than relying on the nightly, which runs against `main` and would have tested 5.0.0: **54 passed, 0 failed** against a live Microsoft 365 tenant, including the restore, replication and purge suites that #361 and #370 touch.

Every PR in the release carries a release-notes label. Docs governance is satisfied: the new command is in `docs/reference/cli.md` and `docs/reference/sdk.md`, the key-rotation model and its limits are in `docs/security.md`, the changed exit code is documented under `restore-version`, and the snapshot-per-run change is in `docs/concepts.md`.

Not verified: no bucket with Object Lock retention on `_meta/dek.enc` was available, so the re-wrap's retention refusal is classified from the error the SDK raises rather than observed.
